### PR TITLE
Unmask

### DIFF
--- a/nisl/io/base_masker.py
+++ b/nisl/io/base_masker.py
@@ -140,7 +140,6 @@ class BaseMasker(BaseEstimator, TransformerMixin):
         else:
             data = X.T
 
-        unmasked = masking.unmask_optimized(data,
-                                            mask.get_data().astype(np.bool))
+        unmasked = masking.unmask(data, mask.get_data().astype(np.bool))
 
         return _to_nifti(unmasked, mask.get_affine())

--- a/nisl/tests/test_masking.py
+++ b/nisl/tests/test_masking.py
@@ -10,8 +10,6 @@ from nibabel import Nifti1Image
 from numpy.testing import assert_array_equal
 
 from ..masking import apply_mask, compute_epi_mask, unmask, intersect_masks
-from ..masking import unmask_optimized
-
 
 def test_mask():
     mean_image = np.ones((9, 9))
@@ -35,7 +33,7 @@ def test_mask():
 
 
 def test_apply_mask():
-    """ Test the smoothing of the timeseries extraction
+    """ Test smoothing of timeseries extraction
     """
     # A delta in 3D
     data = np.zeros((40, 40, 40, 2))
@@ -64,45 +62,6 @@ def test_apply_mask():
 
 
 def test_unmask():
-    """ Test the unmasking function
-    """
-    # A delta in 3D
-    generator = np.random.RandomState(42)
-    data4D = generator.rand(10, 20, 30, 40)
-    data3D = data4D[0]
-    mask = generator.randint(2, size=(20, 30, 40)).astype(np.bool)
-    masked4D = data4D[:, mask]
-    unmasked4D = data4D.copy()
-    unmasked4D[:, -mask] = 0
-    masked3D = data3D[mask]
-    unmasked3D = data3D.copy()
-    unmasked3D[-mask] = 0
-    dummy = generator.rand(500)
-
-    # 4D Test
-    t = unmask(masked4D, mask)
-    assert_equal(len(t.shape), 4)
-    assert_array_equal(t, unmasked4D)
-    t = unmask([masked4D], mask)
-    assert_true(isinstance(t, types.ListType))
-    assert_equal(len(t[0].shape), 4)
-    assert_array_equal(t[0], unmasked4D)
-
-    # 3D Test
-    t = unmask(masked3D, mask)
-    assert_equal(len(t.shape), 3)
-    assert_array_equal(t, unmasked3D)
-    t = unmask([masked3D], mask)
-    assert_true(isinstance(t, types.ListType))
-    assert_equal(len(t[0].shape), 3)
-    assert_array_equal(t[0], unmasked3D)
-
-    # Error test
-    assert_raises(ValueError, unmask, dummy, mask)
-    assert_raises(ValueError, unmask, [dummy], mask)
-
-
-def test_unmask_optimized():
     """ Test the unmask_optimized function
     """
     # A delta in 3D
@@ -120,27 +79,44 @@ def test_unmask_optimized():
     unmasked3D[-mask] = 0
 
     # 4D Test
-    t = unmask_optimized(masked4D, mask)
+    t = unmask(masked4D, mask)
     assert_equal(t.ndim, 4)
     assert_array_equal(t, unmasked4D)
-    t = unmask_optimized([masked4D], mask)
+    t = unmask([masked4D], mask)
     assert_true(isinstance(t, types.ListType))
     assert_equal(t[0].ndim, 4)
     assert_array_equal(t[0], unmasked4D)
 
     # 3D Test
-    t = unmask_optimized(masked3D, mask)
+    t = unmask(masked3D, mask)
     assert_equal(t.ndim, 3)
     assert_array_equal(t, unmasked3D)
-    t = unmask_optimized([masked3D], mask)
+    t = unmask([masked3D], mask)
     assert_true(isinstance(t, types.ListType))
     assert_equal(t[0].ndim, 3)
     assert_array_equal(t[0], unmasked3D)
 
+    # 5D test
+    shape5D = (10, 20, 30, 40, 41)
+    data5D = generator.rand(*shape5D)
+    mask = generator.randint(2, size=shape5D[:-1]).astype(np.bool)
+
+    masked5D = data5D[mask, :].T
+    unmasked5D = data5D.copy()
+    unmasked5D[-mask, :] = 0
+
+    t = unmask(masked5D, mask)
+    assert_equal(t.ndim, len(shape5D))
+    assert_array_equal(t, unmasked5D)
+    t = unmask([masked5D], mask)
+    assert_true(isinstance(t, types.ListType))
+    assert_equal(t[0].ndim, len(shape5D))
+    assert_array_equal(t[0], unmasked5D)
+
     # Error test
     dummy = generator.rand(500)
-    assert_raises(ValueError, unmask_optimized, dummy, mask)
-    assert_raises(ValueError, unmask_optimized, [dummy], mask)
+    assert_raises(ValueError, unmask, dummy, mask)
+    assert_raises(ValueError, unmask, [dummy], mask)
 
 
 def test_intersect_masks():


### PR DESCRIPTION
I profiled the memory usage of unmask, and found that it was _really_ unefficient. The usage of numpy.concatenate at the end of the function requires almost three times the memory that will be required at the end of unmask().

I solved this problem by writing two functions for the special cases of the 3D and N-D arrays, which use much less memory (almost three times less) than the original unmask().

At the same time, **the signature of the function was modified**. The input array is now shaped like in scikit-learn, meaning than the first dimension is time and the second is features (if d is the input array, the value at for the n-th instant for the p-th feature is d[n, p]). It was the opposite by default. The "transpose" option has been removed as well, because it is though to be unclear and useless. Instead of writing something like:

```
data = unmask(timeseries, transpose=True)
```

write

```
data = unmask(timeseries.T).T
```

which is both shorter and clearer (transpose=True doesn't tell you which matrix is transposed, and when. You'll have to test or read the code to know).
