### PR TITLE
Fixed a bug in signals.clean()

### DIFF
--- a/nisl/signals.py
+++ b/nisl/signals.py
@@ -298,7 +298,7 @@ def clean(signals, detrend=True, standardize=True, confounds=None,
                     confounds = np.genfromtxt(filename, skiprows=1)
         # Restrict the signal to the orthogonal of the confounds
         confounds = np.atleast_2d(confounds)
-        confounds = _standardize(confounds, normalize=True)
+        confounds = _standardize(confounds, normalize=True, detrend=detrend)
         Q = qr_economic(confounds)[0]
         signals -= np.dot(Q, np.dot(Q.T, signals))
 

--- a/nisl/tests/test_signals.py
+++ b/nisl/tests/test_signals.py
@@ -208,6 +208,23 @@ def test_clean_confounds():
                                       detrend=True, standardize=True)
     assert(abs(np.dot(confounds.T, cleaned_signals)).max() < 20. * eps)
 
+    # Test detrending. No trend should exist in the output.
+    # Use confounds with a trend.
+    temp = confounds.T
+    temp += np.arange(confounds.shape[0])
+
+    cleaned_signals = nisignals.clean(signals + noises, confounds=confounds,
+                                      detrend=False)
+    coeffs = np.polyfit(np.arange(cleaned_signals.shape[0]),
+                        cleaned_signals, 1)
+    assert_true((abs(coeffs) > 1e-3).any())   # trend remains
+
+    cleaned_signals = nisignals.clean(signals + noises, confounds=confounds,
+                                      detrend=True)
+    coeffs = np.polyfit(np.arange(cleaned_signals.shape[0]),
+                        cleaned_signals, 1)
+    assert_true((abs(coeffs) < 5. * eps).all())  # trend removed
+
     # TODO: Test with confounds read from a file
 
 


### PR DESCRIPTION
The "detrend" boolean argument in clean() is an easy way to add a trend as another confound to remove. Thus, it must be exactly equivalent to adding a trend in the "confounds" array. This was not the case before this commit. 

The fix was easy: it was just a matter of detrending the confounds as well as the signals.

A similar concern could exist with filtering: if a low-pass or high-pass filter is specified, the output result must not contain unfiltered frequencies, even if some confounds do contain those frequencies. This is not the case with the present implementation, because filtering is performed after everything else.
