### PR TITLE
nisl.image.smooth() addition

### DIFF
--- a/nisl/resampling.py
+++ b/nisl/resampling.py
@@ -125,6 +125,7 @@ def resample_img(niimg, target_affine=None, target_shape=None,
     affine = niimg.get_affine()
 
     if copy:
+        # FIXME: "import copy" overwrites input parameter "copy"!
         import copy
         data = copy.copy(data)
         affine = copy.copy(affine)

--- a/nisl/testing.py
+++ b/nisl/testing.py
@@ -291,7 +291,7 @@ def generate_labeled_regions_large(shape, n_regions, rand_gen=None,
 
 
 def generate_fake_fmri(shape=(10, 11, 12), length=17, kind="noise",
-                       affine=np.eye(4)):
+                       affine=np.eye(4), rand_gen = np.random.RandomState(0)):
     """Generate a signal which can be used for testing.
 
     The return value is a 4D array, representing 3D volumes along time.
@@ -326,7 +326,6 @@ def generate_fake_fmri(shape=(10, 11, 12), length=17, kind="noise",
     full_shape = shape + (length, )
     fmri = np.zeros(full_shape)
     # Fill central voxels timeseries with random signals
-    rand_gen = np.random.RandomState(0)
     width = [s / 2 for s in shape]
     shift = [s / 4 for s in shape]
 

--- a/nisl/tests/test_image.py
+++ b/nisl/tests/test_image.py
@@ -5,6 +5,7 @@ from nose.tools import assert_true
 
 from .. import image
 from .. import testing
+import nibabel
 
 
 def test_high_variance_confounds():
@@ -27,3 +28,31 @@ def test_high_variance_confounds():
     confounds2 = image.high_variance_confounds(img, percentile=10.,
                                                n_confounds=n_confounds)
     assert_true(confounds2.shape == (length, n_confounds))
+
+
+def test_smooth():
+    # This function only checks added functionalities compared
+    # to _smooth_array()
+    shapes = ((10, 11, 12), (13, 14, 15))
+    lengths = (17, 18)
+    smooth = (1., 2., 3.)
+
+    img1, mask1 = testing.generate_fake_fmri(shape=shapes[0],
+                                             length=lengths[0])
+    img2, mask2 = testing.generate_fake_fmri(shape=shapes[1],
+                                             length=lengths[1])
+
+    for create_files in (False, True):
+        with testing.write_tmp_imgs(img1, img2,
+                                    create_files=create_files) as imgs:
+            # List of images as input
+            out = image.smooth(imgs, smooth)
+            assert_true(isinstance(out, list))
+            assert_true(len(out) == 2)
+            for o, s, l in zip(out, shapes, lengths):
+                assert_true(o.shape == (s + (l,)))
+
+            # Single image as input
+            out = image.smooth(imgs[0], smooth)
+            assert_true(isinstance(out, nibabel.Nifti1Image))
+            assert_true(out.shape == (shapes[0] + (lengths[0],)))


### PR DESCRIPTION
This function can be used to smooth images (!). It takes niimgs as input, and can process single image or list of images.

The only question is about the naming scheme: I created in the previous branch a "image" package, to contain functions related to niimg processing, as opposed to "signals" which is related to timeseries processing. 

An alternate name would be smooth_img(), but as it is already in the "image" namespace, it seems redundant to me.
