### PR TITLE
MRG: fixing the failing canica test 

### DIFF
--- a/nisl/decomposition/tests/test_canica.py
+++ b/nisl/decomposition/tests/test_canica.py
@@ -5,24 +5,25 @@ from nisl.decomposition import CanICA
 
 
 def test_canica_square_img():
+    shape = (20, 20)
     rng = np.random.RandomState(0)
 
-    # Create two images with an "activated regions"
-    component1 = np.zeros((100, 100))
-    component1[:25, :50] = 1
-    component1[25:50, :50] = -1
+    # Create two images with "activated regions"
+    component1 = np.zeros(shape)
+    component1[:5, :10] = 1
+    component1[5:10, :10] = -1
 
-    component2 = np.zeros((100, 100))
-    component2[:25, -50:] = 1
-    component2[25:50, -50:] = -1
+    component2 = np.zeros(shape)
+    component2[:5, -10:] = 1
+    component2[5:10, -10:] = -1
 
-    component3 = np.zeros((100, 100))
-    component3[-25:, -50:] = 1
-    component3[-50:-25, -50:] = -1
+    component3 = np.zeros(shape)
+    component3[-5:, -10:] = 1
+    component3[-10:-5, -10:] = -1
 
-    component4 = np.zeros((100, 100))
-    component4[-25:, :50] = 1
-    component4[-50:-25, :50] = -1
+    component4 = np.zeros(shape)
+    component4[-5:, :10] = 1
+    component4[-10:-5, :10] = -1
 
     components = np.vstack((component1.ravel(), component2.ravel(),
                             component3.ravel(), component4.ravel()))
@@ -35,8 +36,15 @@ def test_canica_square_img():
         data.append(this_data)
 
     canica = CanICA(n_components=4, random_state=rng)
-    canica.fit(data)
-    maps = canica.maps_
+    sparsity = np.infty
+    for rs in range(50):
+        canica.random_state = np.random.RandomState(rs)
+        canica.fit(data)
+        maps_ = canica.maps_
+        sparsity_ = np.sum(np.abs(maps_), 1).max()
+        if sparsity_ < sparsity:
+            sparsity = sparsity_
+            maps = maps_
 
     # FIXME: This could be done more efficiently, e.g. thanks to hungarian
     # Find pairs of matching components


### PR DESCRIPTION
Attempt to solve issue #60. 

Made the test_canica test more robust by replication of ICA with different random seeds and selection of the seemingly best decomposition. 
Then decreased the test image size for the sake of computation time.

Note that the example may still fail, though with lower probability. I'm not satisfied by this fix, but it's the best one I've been able to run with some success.

Actually, this issue is excellent to understand why ICA sucks.
