### PR TITLE
Change behavior of stack_level to stop at first calling object

### DIFF
--- a/nilearn/_utils/class_inspect.py
+++ b/nilearn/_utils/class_inspect.py
@@ -49,7 +49,7 @@ def get_params(cls, instance, ignore=None):
     return params
 
 
-def enclosing_scope_name(ensure_estimator=True, stack_level=2):
+def enclosing_scope_name(ensure_estimator=True, max_stack_level=2):
     """ Find the name of the enclosing scope for debug output purpose
 
     Use inspection to climb up the stack until the calling object. This is
@@ -60,15 +60,15 @@ def enclosing_scope_name(ensure_estimator=True, stack_level=2):
     ==========
     ensure_estimator: boolean, default: True
         If true, find the enclosing object deriving from 'BaseEstimator'
-    stack_level: integer, default 3
+    max_stack_level: integer, default 3
         If ensure_estimator is not True, stack_level quantifies the
-        number of frame we will go up. We stop at the first frame that holds
-        a `self` local.
+        number of frame we will go up at most. We stop at the first frame
+        that holds a `self` local.
     """
     try:
         frame = inspect.currentframe()
         if not ensure_estimator:
-            for _ in range(stack_level):
+            for _ in range(max_stack_level):
                 frame = frame.f_back
                 if 'self' in frame.f_locals:
                     break

--- a/nilearn/tests/test_class_inspect.py
+++ b/nilearn/tests/test_class_inspect.py
@@ -63,5 +63,5 @@ def test_enclosing_scope_name():
     assert_equal(name, 'C.get_scope_name')
     name = b.get_scope_name(stack=3, ensure_estimator=False)
     assert_equal(name, 'get_scope_name')
-    name = b.get_scope_name(ensure_estimator=False, stack_level=120)
+    name = b.get_scope_name(ensure_estimator=False, max_stack_level=120)
     assert_equal(name, 'C.get_scope_name')


### PR DESCRIPTION
In `_utils.class_inspect.get_scope_name`, the behavior of `stack_level` is not very handy. In fact, it specifies _exactly_ the number of frames to climb up. However, this number is contextual and can't be determined in advance. I suggest to just climb up the frames until we find a calling object.
