### PR TITLE
Enable tab completion for exploring modules

### DIFF
--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -9,20 +9,27 @@ visualisation tools.
 See http://nilearn.github.com for complete documentation.
 """
 
-try:
-    import numpy
-except ImportError:
-    print 'Numpy could not be found, please install it properly to use nilearn.'
 
-try:
-    import scipy
-except ImportError:
-    print 'Scipy could not be found, please install it properly to use nilearn.'
+def _check_dependencies():
+    try:
+        import numpy
+    except ImportError:
+        print ('Numpy could not be found, '
+        'please install it properly to use nilearn.')
 
-try:
-    import sklearn
-except ImportError:
-    print ('Scikit-learn could not be found,'
-           ' please install it properly to use nilearn.')
+    try:
+        import scipy
+    except ImportError:
+        print ('Scipy could not be found, '
+               'please install it properly to use nilearn.')
+
+    try:
+        import sklearn
+    except ImportError:
+        print ('Scikit-learn could not be found, '
+           'please install it properly to use nilearn.')
 
 __version__ = 0.1
+_check_dependencies()
+
+import io


### PR DESCRIPTION
Addressing issue https://github.com/nilearn/nilearn/issues/127

scoped numpy, scipy and sklearn imports,

Then added import io, which leads to visibility of the other submodules as well
