### PR TITLE
move word cloud up into logo-bar

### DIFF
--- a/doc/themes/nilearn/layout.html
+++ b/doc/themes/nilearn/layout.html
@@ -94,6 +94,32 @@
       <img src="{{ pathto('_static/' + logo, 1) }}" alt="NiLearn logo"  border="0" />
     </a>
   </div>
+  <!-- A tag cloud to make it easy for people to find what they are
+                         looking for -->
+ <div class="tags">
+  <ul>
+    <li>
+      <big><a href="{{pathto('auto_examples/plot_haxby_decoding')}}">SVM</a></big>
+    </li>
+    <li>
+      <small><a href="{{pathto('data_analysis/parcellating')}}">Ward
+          clustering</a></small>
+    </li>
+    <li>
+      <a href="{{pathto('building_blocks/haxby_searchlight')}}">Searchlight</a>
+    </li>
+    <li>
+      <big><a href="{{pathto('data_analysis/resting_state_networks')}}">ICA</a></big>
+    </li>
+    <li>
+      <a href="{{pathto('building_blocks/data_preparation')}}">Nifti IO</a>
+    </li>
+    <li>
+      <a href="{{pathto('modules/reference')}}#module-nilearn.datasets">Datasets</a>
+    </li>
+  </ul>
+ </div>
+
   <div class="banner">
     <h1>NiLearn:</h1>
     <h2>Machine learning for Neuro-Imaging in Python</h2>
@@ -122,31 +148,6 @@
 
 
 {%- if (pagename == 'index') %}
-<!-- A tag cloud to make it easy for people to find what they are
-                         looking for -->
- <div class="tags">
-  <ul>
-    <li>
-      <big><a href="{{pathto('auto_examples/plot_haxby_decoding')}}">SVM</a></big>
-    </li>
-    <li>
-      <small><a href="{{pathto('data_analysis/parcellating')}}">Ward
-          clustering</a></small>
-    </li>
-    <li>
-      <a href="{{pathto('building_blocks/haxby_searchlight')}}">Searchlight</a>
-    </li>
-    <li>
-      <big><a href="{{pathto('data_analysis/resting_state_networks')}}">ICA</a></big>
-    </li>
-    <li>
-      <a href="{{pathto('building_blocks/data_preparation')}}">Nifti IO</a>
-    </li>
-    <li>
-      <a href="{{pathto('modules/reference')}}#module-nilearn.datasets">Datasets</a>
-    </li>
-  </ul>
- </div>
 
 <h4> News </h4>
   <ul>

--- a/doc/themes/nilearn/static/nature.css_t
+++ b/doc/themes/nilearn/static/nature.css_t
@@ -907,10 +907,14 @@ table.field-list tr td.field-body p {
 /* ------- tag cloud on the front page -------------------- */
 
 div.tags {
+    display: block;
+    max-width: 15em;
+    max-height: 7em;
+    float: right;
     font-weight: bold;
     font-size: 95%;
     padding: 5px;
-    margin: 17px 7px 21px 7px;
+    margin: 22px 5px 0px 7px;
     background-color: #FFC588;
     border-radius: 15px;
     moz-border-radius: 15px;
@@ -936,6 +940,12 @@ div.tags a {
 
 div.tags a:hover {
     color: #000;
+}
+
+@media (max-width: 900px) {
+    div.tags {
+        display: none;
+    }
 }
 
 li.toctree-li {


### PR DESCRIPTION
Shifts the wordcloud up to the top by the banners

Online build [here](http://jaquesgrobler.github.io/online-nilearn-doc-build/)

Let me know what you think about it's position etc.
Also how it behaves regarding responsive design. All fine on my side
