### PR TITLE
Clearer import errors when dependencies are not installed

### DIFF
--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -60,9 +60,10 @@ def _check_dependencies():
             # Monkey-patch gzip to have faster reads on large
             # gzip files
             gzip.GzipFile.max_read_chunk = 100 * 1024 * 1024  # 100Mb
-    except ImportError:
-        raise ImportError('Python has been compiled without gzip,'
-                          ' reading nii.gz files will be impossible.')
+    except ImportError as exc:
+        exc.args += ('Python has been compiled without gzip, '
+                     'reading nii.gz files will be impossible.',)
+        raise
 
 _check_dependencies()
 


### PR DESCRIPTION
At the moment you get an error message printed at the top  and a stacktrace with a slightly confusing UnboundLocalError. Maybe a personal bias, but when I got the error initially, I completely missed the former and only saw the latter.

Before the change:

```
nibabel could not be found, please install it properly to use nilearn.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "nilearn/__init__.py", line 71, in <module>
    _check_dependencies()
  File "nilearn/__init__.py", line 64, in _check_dependencies
    if not LooseVersion(nibabel.__version__) >= LooseVersion('1.1.0'):
UnboundLocalError: local variable 'nibabel' referenced before assignment
```

After the change:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "nilearn/__init__.py", line 71, in <module>
    _check_dependencies()
  File "nilearn/__init__.py", line 51, in _check_dependencies
    raise ImportError('nibabel could not be found,'
ImportError: nibabel could not be found, please install it properly to use nilearn.
```

Not sure how likely it is that python has been built without gzip and whether in this (rare?) case we just want a warning saying that reading nii.gz files will not be supported rather than an exception .
