### PR TITLE
Fix a couple of RST links in the doc

### DIFF
--- a/doc/data_analysis/resting_state_networks.rst
+++ b/doc/data_analysis/resting_state_networks.rst
@@ -5,7 +5,7 @@ Extracting resting-state networks
 =========================================
 
 .. topic:: **Page summary**
-   
+
    This page demonstrates the use of multi-subject Independent Component
    Analysis (ICA) of resting-state fMRI data to extract brain networks in
    an data-driven way. Here we use the 'CanICA' approach, that implements
@@ -26,8 +26,8 @@ Retrieving example data
 ------------------------
 
 We will use sample data from the `ADHD 200 resting-state dataset
-<http://fcon_1000.projects.nitrc.org/indi/adhd200/>`, that has been
-preprocessed using `CPAC <http://fcp-indi.github.io/>`. We use nilearn
+<http://fcon_1000.projects.nitrc.org/indi/adhd200/>`_ has been
+preprocessed using `CPAC <http://fcp-indi.github.io/>`_. We use nilearn
 functions to fetch data from Internet and get the filenames (:ref:`more
 on data loading <loading_data>`):
 
@@ -45,7 +45,7 @@ To visualize the results, a mean EPI image is useful:
 .. literalinclude:: ../../plot_canica_resting_state.py
     :start-after: ### Compute a mean epi ########################################################
     :end-before: ### Apply CanICA ##############################################################
- 
+
 
 Applying CanICA
 ================


### PR DESCRIPTION
As the following snapshot from http://nilearn.github.io/data_analysis/resting_state_networks.html shows:

![rst-non-links](https://cloud.githubusercontent.com/assets/1680079/4118866/09c4c9ea-32a6-11e4-9f51-a34ab271a0bc.png)
