### PR TITLE
Preprocessed ABIDE fetching function

### DIFF
--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -2258,7 +2258,7 @@ def load_mni152_template():
 
 def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
                     strategy='nofilt_noglobal', derivatives=['func_preproc'],
-                    quality_checked=True, verbose=0, **kwargs):
+                    quality_checked=True, url=None, verbose=0, **kwargs):
     """ Fetch ABIDE dataset
 
     Fetch the Autism Brain Imaging Data Exchange (ABIDE) dataset wrt criteria
@@ -2336,7 +2336,9 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
     """
     # General file: phenotypic information
     data_dir = _get_dataset_dir('ABIDE_pcp', data_dir=data_dir)
-    url = 'https://s3.amazonaws.com/fcp-indi/data/Projects/ABIDE_Initiative'
+    if url is None:
+        url = ('https://s3.amazonaws.com/fcp-indi/data/Projects/'
+               'ABIDE_Initiative')
 
     if quality_checked:
         kwargs['qc_rater_1'] = 'OK'


### PR DESCRIPTION
This PR introduces a function to fetch the ABIDE dataset preprocessed by the preprocessed connectome project (PCP). This function proposes several options, such as restriction to the subjects for which the quality check is OK, along with the selection of the preprocessing pipeline.

Note: I haven't tested the downloading function for all available preprocessing pipeline because of the size of the datasets. There is no example using this dataset in the PR.

@ccraddock @GaelVaroquaux 
