### PR TITLE
Add missing reorder_img import

### DIFF
--- a/nilearn/image/__init__.py
+++ b/nilearn/image/__init__.py
@@ -2,10 +2,11 @@
 Mathematical operations working on niimgs like -a (3+n)-D block of data,
 and an affine.
 """
-from .resampling import resample_img
+from .resampling import resample_img, reorder_img
 from .image import high_variance_confounds, smooth_img, crop_img, \
-            mean_img
+    mean_img
 
-__all__ = ['resample_img', 'high_variance_confounds', 'smooth_img',
-           'crop_img', 'mean_img', 'reorder_img']
+__all__ = ['resample_img', 'reorder_img',
+           'high_variance_confounds', 'smooth_img',
+           'crop_img', 'mean_img']
 


### PR DESCRIPTION
This was causing 

``` python
from nilearn.image import *
```

 to fail with:
`AttributeError: 'module' object has no attribute 'reorder_img'`
