### PR TITLE
Remove explicit mention of NiftiMasker from BaseMasker

### DIFF
--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -153,8 +153,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
             raise ValueError('It seems that %s has not been fit. '
                              'You must call fit() before calling transform().'
                              % self.__class__.__name__)
-        from .nifti_masker import NiftiMasker
-        params = get_params(NiftiMasker, self)
+        params = get_params(self.__class__, self)
         # Remove the mask-computing params: they are not useful and will
         # just invalid the cache for no good reason
         for name in ('mask_img', 'mask_args'):
@@ -196,8 +195,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
             raise ValueError('It seems that %s has not been fit. '
                              'You must call fit() before calling transform().'
                              % self.__class__.__name__)
-        from .nifti_masker import NiftiMasker
-        params = get_params(NiftiMasker, self)
+        params = get_params(self.__class__, self)
 
         reference_affine = None
         if self.target_affine is None:


### PR DESCRIPTION
This seems rather hacky for a few different reasons mainly generic OOP ones where the base class knows about a derived class, hard-coded class name, circular import. 

The tests pass but maybe I am missing something subtle so I figured I would ask: is there any reason not to use `self.__class__` rather than `NiftiMasker`?
