### PR TITLE
Add nilearn/data as a data dir in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ def configuration(parent_package='', top_path=None):
     config.add_subpackage('nilearn/_utils')
     config.add_subpackage('nilearn/_utils/fixes')
     config.add_subpackage("nilearn/plotting")
+    config.add_data_dir("nilearn/data")
     return config
 
 


### PR DESCRIPTION
Otherwise the MNI template is missing when installing nilearn with setup.py.
