### PR TITLE
Use facecolor and edgecolor when saving figure in gen_rst

### DIFF
--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -804,8 +804,10 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, plot_gallery):
                     matplotlib._pylab_helpers.Gcf.get_all_fig_managers()):
                     # Set the fig_num figure as the current figure as we can't
                     # save a figure that's not the current figure.
-                    plt.figure(fig_num)
-                    plt.savefig(image_path % fig_num)
+                    fig = plt.figure(fig_num)
+                    fig.savefig(image_path % fig_num,
+                                facecolor=fig.get_facecolor(),
+                                edgecolor=fig.get_edgecolor())
                     figure_list.append(image_fname % fig_num)
             except:
                 print 80 * '_'


### PR DESCRIPTION
On a black background, the white colorbar ticks were not visible in the saved figure.
# Master

![without_facecolor](https://cloud.githubusercontent.com/assets/1680079/5246351/475fd64c-7968-11e4-8424-7c58517ba740.png)
# This PR

![with_facecolor](https://cloud.githubusercontent.com/assets/1680079/5246353/4b36e83c-7968-11e4-9073-e5fc65338db8.png)

Objections anyone? 
