### PR TITLE
Use correct facecolor/edgecolor savefig arguments in gen_rst.py

### DIFF
--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -805,9 +805,15 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, plot_gallery):
                     # Set the fig_num figure as the current figure as we can't
                     # save a figure that's not the current figure.
                     fig = plt.figure(fig_num)
-                    fig.savefig(image_path % fig_num,
-                                facecolor=fig.get_facecolor(),
-                                edgecolor=fig.get_edgecolor())
+                    kwargs = {}
+                    to_rgba = matplotlib.colors.colorConverter.to_rgba
+                    for attr in ['facecolor', 'edgecolor']:
+                        fig_attr = getattr(fig, 'get_' + attr)()
+                        default_attr = matplotlib.rcParams['figure.' + attr]
+                        if to_rgba(fig_attr) != to_rgba(default_attr):
+                            kwargs[attr] = fig_attr
+
+                    fig.savefig(image_path % fig_num, **kwargs)
                     figure_list.append(image_fname % fig_num)
             except:
                 print 80 * '_'


### PR DESCRIPTION
Further tweak to #298. Only pass facecolor/edgecolor arguments to savefig when they are different
than rcParams['figure.facecolor']/rcParams['figure.edgecolor'].

This seems to work well with both default and black facecolor backgrounds.
