### PR TITLE
Fix colorbar positioning when using 'axes' argument

### DIFF
--- a/nilearn/plotting/slicers.py
+++ b/nilearn/plotting/slicers.py
@@ -407,15 +407,18 @@ class BaseSlicer(object):
         return ims
 
     def _colorbar_show(self, im):
-        adjusted_width = self._colorbar_width / len(self.axes)
-        adjusted_right_margin = 0.01 / len(self.axes)
+        x_adjusted_width = self._colorbar_width / len(self.axes)
+        x_adjusted_right_margin = 0.01 / len(self.axes)
         figure = self.frame_axes.figure
         _, y0, x1, y1 = self.rect
+        y_width = y1 - y0
+        y_margin = 0.05 * y_width
+
         self._colorbar_ax = figure.add_axes([
-            x1 - (adjusted_width + adjusted_right_margin),
-            y0 + 0.05,
-            adjusted_width - adjusted_right_margin,
-            y1 - 0.10])
+            x1 - (x_adjusted_width + x_adjusted_right_margin),
+            y0 + y_margin,
+            x_adjusted_width - x_adjusted_right_margin,
+            y_width - 2 * y_margin])
 
         ticks = np.linspace(im.norm.vmin, im.norm.vmax, 5)
         figure.colorbar(im, cax=self._colorbar_ax, ticks=ticks)


### PR DESCRIPTION
Fixes #299. The fourth argument of add_axes was using y1 instead of a width (credits go to @AlexandreAbraham for finding out the root cause of this).

I tweak the margin logic to make it scale invariant. Updated plots:

![plot_stat_map_with_multiple_axes](https://cloud.githubusercontent.com/assets/1680079/5262417/d9aeac72-7a25-11e4-895e-dc91f56b00e2.png)

![plot_stat_map_default](https://cloud.githubusercontent.com/assets/1680079/5262419/de330b30-7a25-11e4-92fe-d106f6d3ebf5.png)
