### PR TITLE
Added missing 3d-image enforcements

### DIFF
--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -36,6 +36,7 @@ def filter_and_mask(imgs, mask_img_,
     if verbose > 0:
         class_name = enclosing_scope_name(stack_level=2)
 
+    mask_img_ = _utils.check_niimg(mask_img_, ensure_3d=True)
     imgs = _utils.check_niimgs(imgs, accept_3d=True)
 
     # Resampling: allows the user to change the affine, the shape or both

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -193,7 +193,7 @@ class MultiNiftiMasker(BaseMasker, CacheMixin):
                              ' requested (imgs != None) while a mask has'
                              ' been provided at masker creation. Given mask'
                              ' will be used.' % self.__class__.__name__)
-            self.mask_img_ = _utils.check_niimg(self.mask_img)
+            self.mask_img_ = _utils.check_niimg(self.mask_img, ensure_3d=True)
 
         # If resampling is requested, resample the mask as well.
         # Resampling: allows the user to change the affine, the shape or both.

--- a/nilearn/input_data/nifti_region.py
+++ b/nilearn/input_data/nifti_region.py
@@ -157,7 +157,7 @@ class NiftiLabelsMasker(BaseEstimator, TransformerMixin, CacheMixin):
             logger.log("loading data from %s" %
                        _utils._repr_niimgs(self.mask_img)[:200],
                        verbose=self.verbose)
-            self.mask_img_ = _utils.check_niimg(self.mask_img)
+            self.mask_img_ = _utils.check_niimg(self.mask_img, ensure_3d=True)
         else:
             self.mask_img_ = None
 
@@ -407,7 +407,7 @@ class NiftiMapsMasker(BaseEstimator, TransformerMixin, CacheMixin):
             logger.log("loading mask from %s" %
                        _utils._repr_niimgs(self.mask_img)[:200],
                        verbose=self.verbose)
-            self.mask_img_ = _utils.check_niimg(self.mask_img)
+            self.mask_img_ = _utils.check_niimg(self.mask_img, ensure_3d=True)
         else:
             self.mask_img_ = None
 

--- a/nilearn/input_data/tests/test_base_masker.py
+++ b/nilearn/input_data/tests/test_base_masker.py
@@ -3,7 +3,7 @@ Test the base_masker module
 """
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_raises
+from numpy.testing import assert_array_almost_equal
 import nibabel
 
 from ..base_masker import filter_and_mask

--- a/nilearn/input_data/tests/test_base_masker.py
+++ b/nilearn/input_data/tests/test_base_masker.py
@@ -3,12 +3,12 @@ Test the base_masker module
 """
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_raises
 import nibabel
 
 from ..base_masker import filter_and_mask
 from ... import image
-
+from ..._utils.testing import assert_raises_regexp
 
 def test_cropping_code_paths():
     # Will mask data with an identically sampled mask and
@@ -47,3 +47,12 @@ def test_cropping_code_paths():
                                 cropped_mask_img, parameters)
 
     assert_array_almost_equal(out_data_cropped, out_data_uncropped)
+
+
+def test_filter_and_mask():
+    data = np.zeros([20, 30, 40, 5])
+    mask = np.zeros([20, 30, 40, 2])
+    mask[10, 15, 20, :] = 1
+
+    assert_raises_regexp(TypeError, "A 3D image is expected", filter_and_mask,
+                         data, mask, {})

--- a/nilearn/input_data/tests/test_multi_nifti_masker.py
+++ b/nilearn/input_data/tests/test_multi_nifti_masker.py
@@ -94,6 +94,13 @@ def test_3d_images():
     # This is mostly a smoke test
     assert_equal(len(epis), 2)
 
+    # verify that 4D mask arguments are refused
+    mask_img_4d = Nifti1Image(np.ones((2, 2, 2, 2), dtype=np.int8),
+                              affine=np.diag((4, 4, 4, 1)))
+    masker2 = MultiNiftiMasker(mask_img=mask_img_4d)
+    testing.assert_raises_regexp(TypeError, "A 3D image is expected",
+                                 masker2.fit)
+
 
 def test_joblib_cache():
     if not LooseVersion(nibabel.__version__) > LooseVersion('1.1.0'):
@@ -101,11 +108,11 @@ def test_joblib_cache():
         raise SkipTest
     from sklearn.externals.joblib import hash
     # Dummy mask
-    data = np.zeros((40, 40, 40, 2))
-    data[20, 20, 20] = 1
-    data_img = Nifti1Image(data, np.eye(4))
+    mask = np.zeros((40, 40, 40))
+    mask[20, 20, 20] = 1
+    mask_img = Nifti1Image(mask, np.eye(4))
 
-    with testing.write_tmp_imgs(data_img, create_files=True)\
+    with testing.write_tmp_imgs(mask_img, create_files=True)\
                 as filename:
         masker = MultiNiftiMasker(mask_img=filename)
         masker.fit()

--- a/nilearn/input_data/tests/test_nifti_region.py
+++ b/nilearn/input_data/tests/test_nifti_region.py
@@ -43,6 +43,14 @@ def test_nifti_labels_masker():
     labels11_img = testing.generate_labeled_regions(shape1, affine=affine1,
                                                     n_regions=n_regions)
 
+    mask_img_4d = nibabel.Nifti1Image(np.ones((2, 2, 2, 2), dtype=np.int8),
+                                      affine=np.diag((4, 4, 4, 1)))
+
+    # verify that 4D mask arguments are refused
+    masker = NiftiLabelsMasker(labels11_img, mask_img=mask_img_4d)
+    testing.assert_raises_regexp(TypeError, "A 3D image is expected",
+                                 masker.fit)
+
     # check exception when transform() called without prior fit()
     masker11 = NiftiLabelsMasker(labels11_img, resampling_target=None)
     testing.assert_raises_regexp(
@@ -287,6 +295,14 @@ def test_nifti_maps_masker_2():
 
     maps33_img, _ = \
                   testing.generate_maps(shape3, n_regions, affine=affine)
+
+    mask_img_4d = nibabel.Nifti1Image(np.ones((2, 2, 2, 2), dtype=np.int8),
+                                      affine=np.diag((4, 4, 4, 1)))
+
+    # verify that 4D mask arguments are refused
+    masker = NiftiMapsMasker(maps33_img, mask_img=mask_img_4d)
+    testing.assert_raises_regexp(TypeError, "A 3D image is expected",
+                                 masker.fit)
 
     # Test error checking
     assert_raises(ValueError, NiftiMapsMasker, maps33_img,

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -39,7 +39,8 @@ def _load_mask_img(mask_img, allow_empty=False):
     mask: numpy.ndarray
         boolean version of the mask
     '''
-    mask_img = _utils.check_niimg(mask_img)
+    # 3D image for mask_img not enforced here on purpose
+    mask_img = _utils.check_niimg(mask_img, ensure_3d=False)
     mask = mask_img.get_data()
     values = np.unique(mask)
 
@@ -575,7 +576,7 @@ def _apply_mask_fmri(imgs, mask_img, dtype='f',
     values (this is checked for in apply_mask, not in this function).
     """
 
-    mask_img = _utils.check_niimg(mask_img)
+    mask_img = _utils.check_niimg(mask_img, ensure_3d=True)
     mask_affine = mask_img.get_affine()
     mask_data = _utils.as_ndarray(mask_img.get_data(),
                                   dtype=np.bool)

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -87,6 +87,7 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
         colorbar=colorbar)
 
     if bg_img is not None:
+        bg_img = _utils.check_niimg(bg_img, ensure_3d=True)
         display.add_overlay(bg_img,
                            vmin=bg_vmin, vmax=bg_vmax,
                            cmap=pl.cm.gray, interpolation=interpolation)

--- a/nilearn/region.py
+++ b/nilearn/region.py
@@ -66,7 +66,7 @@ def img_to_signals_labels(imgs, labels_img, mask_img=None,
     nilearn.region.img_to_signals_maps
     """
 
-    labels_img = _utils.check_niimg(labels_img)
+    labels_img = _utils.check_niimg(labels_img, ensure_3d=True)
 
     # TODO: Make a special case for list of strings (load one image at a
     # time).
@@ -81,7 +81,7 @@ def img_to_signals_labels(imgs, labels_img, mask_img=None,
         raise ValueError("labels_img and imgs affines must be identical")
 
     if mask_img is not None:
-        mask_img = _utils.check_niimg(mask_img)
+        mask_img = _utils.check_niimg(mask_img, ensure_3d=True)
         if _utils._get_shape(mask_img) != target_shape:
             raise ValueError("mask_img and imgs shapes must be identical.")
         if abs(mask_img.get_affine() - target_affine).max() > 1e-9:
@@ -152,14 +152,14 @@ def signals_to_img_labels(signals, labels_img, mask_img=None,
     nilearn.region.signals_to_img_maps
     """
 
-    labels_img = _utils.check_niimg(labels_img)
+    labels_img = _utils.check_niimg(labels_img, ensure_3d=True)
 
     signals = np.asarray(signals)
     target_affine = labels_img.get_affine()
     target_shape = _utils._get_shape(labels_img)[:3]
 
     if mask_img is not None:
-        mask_img = _utils.check_niimg(mask_img)
+        mask_img = _utils.check_niimg(mask_img, ensure_3d=True)
         if _utils._get_shape(mask_img) != target_shape:
             raise ValueError("mask_img and labels_img shapes "
                              "must be identical.")
@@ -251,7 +251,7 @@ def img_to_signals_maps(imgs, maps_img, mask_img=None):
     maps_data = maps_img.get_data()
 
     if mask_img is not None:
-        mask_img = _utils.check_niimg(mask_img)
+        mask_img = _utils.check_niimg(mask_img, ensure_3d=True)
         if _utils._get_shape(mask_img) != shape:
             raise ValueError("mask_img and imgs shapes must be identical.")
         if abs(mask_img.get_affine() - affine).max() > 1e-9:

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -137,8 +137,9 @@ def test_apply_mask():
                          masking.apply_mask, data_img, mask_img_4d)
 
     # Check data shape and affine
-    assert_raises(TypeError, masking.apply_mask,
-                  data_img, Nifti1Image(mask[20, ...], affine))
+    assert_raises_regexp(TypeError, "A 3D image is expected",
+                         masking.apply_mask, data_img,
+                         Nifti1Image(mask[20, ...], affine))
     assert_raises(ValueError, masking.apply_mask,
                   data_img, Nifti1Image(mask, affine / 2.))
     # Check that full masking raises error

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -14,9 +14,10 @@ from nibabel import Nifti1Image
 
 from .. import masking
 from ..masking import compute_epi_mask, compute_multi_epi_mask, \
-    compute_background_mask, unmask, intersect_masks, MaskWarning
+    compute_background_mask, unmask, intersect_masks, MaskWarning, \
+    _load_mask_img
 
-from .._utils.testing import write_tmp_imgs
+from .._utils.testing import write_tmp_imgs, assert_raises_regexp
 
 np_version = (np.version.full_version if hasattr(np.version, 'full_version')
               else np.version.short_version)
@@ -130,8 +131,13 @@ def test_apply_mask():
     series = masking.apply_mask(data_img, mask_img, smoothing_fwhm=9)
     assert_true(np.all(np.isfinite(series)))
 
+    # veriy that 4D masks are rejected
+    mask_img_4d = Nifti1Image(np.ones((40, 40, 40, 2)), np.eye(4))
+    assert_raises_regexp(TypeError, "A 3D image is expected",
+                         masking.apply_mask, data_img, mask_img_4d)
+
     # Check data shape and affine
-    assert_raises(ValueError, masking.apply_mask,
+    assert_raises(TypeError, masking.apply_mask,
                   data_img, Nifti1Image(mask[20, ...], affine))
     assert_raises(ValueError, masking.apply_mask,
                   data_img, Nifti1Image(mask, affine / 2.))


### PR DESCRIPTION
Some functions with mask arguments did not complain about iterables of niimg-like objects.

attempts to address #302 