### PR TITLE
Use filename variables in examples

### DIFF
--- a/examples/connectivity/plot_adhd_covariance.py
+++ b/examples/connectivity/plot_adhd_covariance.py
@@ -50,9 +50,9 @@ def plot_matrices(cov, prec, title):
 
 
 print("-- Fetching datasets ...")
-import nilearn.datasets
-atlas = nilearn.datasets.fetch_msdl_atlas()
-dataset = nilearn.datasets.fetch_adhd()
+from nilearn import datasets
+msdl_atlas_dataset = datasets.fetch_msdl_atlas()
+adhd_dataset = datasets.fetch_adhd()
 
 import nilearn.image
 import nilearn.input_data
@@ -64,21 +64,24 @@ mem = Memory(".")
 n_subjects = 10
 subjects = []
 
-for subject_n in range(n_subjects):
-    filename = dataset["func"][subject_n]
-    print("Processing file %s" % filename)
+func_filenames = adhd_dataset.func
+confound_filenames = adhd_dataset.confounds
+for func_filename, confound_filename in zip(func_filenames,
+                                            confound_filenames):
+    print("Processing file %s" % func_filename)
 
     print("-- Computing confounds ...")
-    confound_file = dataset["confounds"][subject_n]
-    hv_confounds = mem.cache(nilearn.image.high_variance_confounds)(filename)
+    hv_confounds = mem.cache(nilearn.image.high_variance_confounds)(
+        func_filename)
 
     print("-- Computing region signals ...")
     masker = nilearn.input_data.NiftiMapsMasker(
-        atlas["maps"], resampling_target="maps", detrend=True,
+        msdl_atlas_dataset.maps, resampling_target="maps", detrend=True,
         low_pass=None, high_pass=0.01, t_r=2.5, standardize=True,
         memory=mem, memory_level=1, verbose=1)
-    region_ts = masker.fit_transform(filename,
-                                     confounds=[hv_confounds, confound_file])
+    region_ts = masker.fit_transform(func_filename,
+                                     confounds=[hv_confounds,
+                                                confound_filename])
     subjects.append(region_ts)
 
 

--- a/examples/connectivity/plot_canica_resting_state.py
+++ b/examples/connectivity/plot_canica_resting_state.py
@@ -23,8 +23,8 @@ Pre-prints for both papers are available on hal
 ### Load ADHD rest dataset ####################################################
 from nilearn import datasets
 
-dataset = datasets.fetch_adhd()
-func_files = dataset.func # The list of 4D nifti files for each subject
+adhd_dataset = datasets.fetch_adhd()
+func_filenames = adhd_dataset.func  # list of 4D nifti files for each subject
 
 ### Apply CanICA ##############################################################
 from nilearn.decomposition.canica import CanICA
@@ -33,7 +33,7 @@ n_components = 20
 canica = CanICA(n_components=n_components, smoothing_fwhm=6.,
                 memory="nilearn_cache", memory_level=5,
                 threshold=3., verbose=10, random_state=0)
-canica.fit(func_files)
+canica.fit(func_filenames)
 
 # Retrieve the independent components in brain space
 components_img = canica.masker_.inverse_transform(canica.components_)
@@ -50,7 +50,7 @@ from nilearn.plotting import plot_stat_map
 for i in range(n_components):
     plot_stat_map(nibabel.Nifti1Image(components_img.get_data()[..., i],
                                       components_img.get_affine()),
-                  display_mode="z", title="IC %d"%i, cut_coords=1,
+                  display_mode="z", title="IC %d" % i, cut_coords=1,
                   colorbar=False)
 
 plt.show()

--- a/examples/connectivity/plot_ica_resting_state.py
+++ b/examples/connectivity/plot_ica_resting_state.py
@@ -5,14 +5,13 @@ Independent component analysis of resting-state fMRI
 An example applying ICA to resting-state data.
 """
 
-import numpy as np
-
 ### Load nyu_rest dataset #####################################################
 from nilearn import datasets
 # Here we use only 3 subjects to get faster-running code. For better
 # results, simply increase this number
-dataset = datasets.fetch_nyu_rest(n_subjects=1)
 # XXX: must get the code to run for more than 1 subject
+nyu_dataset = datasets.fetch_nyu_rest(n_subjects=1)
+func_filename = nyu_dataset.func[0]
 
 ### Preprocess ################################################################
 from nilearn.input_data import NiftiMasker
@@ -22,10 +21,10 @@ from nilearn.input_data import NiftiMasker
 # EPI images
 masker = NiftiMasker(smoothing_fwhm=8, memory='nilearn_cache', memory_level=1,
                      mask_strategy='epi', standardize=False)
-data_masked = masker.fit_transform(dataset.func[0])
+data_masked = masker.fit_transform(func_filename)
 
 # Concatenate all the subjects
-#fmri_data = np.concatenate(data_masked, axis=1)
+# fmri_data = np.concatenate(data_masked, axis=1)
 fmri_data = data_masked
 
 
@@ -55,12 +54,12 @@ from nilearn import image
 from nilearn.plotting import plot_stat_map
 
 # Use the mean as a background
-mean_img = image.mean_img(dataset.func[0])
+mean_img = image.mean_img(func_filename)
 
-plot_stat_map(nibabel.Nifti1Image(component_img.get_data()[:,:,:,5], 
+plot_stat_map(nibabel.Nifti1Image(component_img.get_data()[:, :, :, 5],
                                   component_img.get_affine()), mean_img)
 
-plot_stat_map(nibabel.Nifti1Image(component_img.get_data()[:,:,:,12], 
+plot_stat_map(nibabel.Nifti1Image(component_img.get_data()[:, :, :, 12],
                                   component_img.get_affine()), mean_img)
 
 plt.show()

--- a/examples/connectivity/plot_rest_clustering.py
+++ b/examples/connectivity/plot_rest_clustering.py
@@ -17,17 +17,19 @@ Pattern Recognition 2011.
 ### Load nyu_rest dataset #####################################################
 
 import numpy as np
-from nilearn import datasets, input_data
+from nilearn import datasets
+from nilearn import input_data
 from nilearn.plotting.img_plotting import plot_roi, plot_epi
-dataset = datasets.fetch_nyu_rest(n_subjects=1)
+nyu_dataset = datasets.fetch_nyu_rest(n_subjects=1)
 
 # This is resting-state data: the background has not been removed yet,
 # thus we need to use mask_strategy='epi' to compute the mask from the
 # EPI images
 nifti_masker = input_data.NiftiMasker(memory='nilearn_cache',
-                            mask_strategy='epi', memory_level=1,
-                            standardize=False)
-fmri_masked = nifti_masker.fit_transform(dataset.func[0])
+                                      mask_strategy='epi', memory_level=1,
+                                      standardize=False)
+func_filename = nyu_dataset.func[0]
+fmri_masked = nifti_masker.fit_transform(func_filename)
 mask = nifti_masker.mask_img_.get_data().astype(np.bool)
 
 ### Ward ######################################################################
@@ -64,7 +66,7 @@ labels_img = nifti_masker.inverse_transform(labels)
 
 from nilearn.image import mean_img
 import matplotlib.pyplot as plt
-mean_func_img = mean_img(dataset.func[0])
+mean_func_img = mean_img(func_filename)
 
 # common cut coordinates for all plots
 

--- a/examples/decoding/plot_haxby_full_analysis.py
+++ b/examples/decoding/plot_haxby_full_analysis.py
@@ -16,14 +16,14 @@ that have been defined via a standard GLM-based analysis.
 
 ### Fetch data using nilearn dataset fetcher ################################
 from nilearn import datasets
-data_files = datasets.fetch_haxby(n_subjects=1)
+haxby_dataset = datasets.fetch_haxby(n_subjects=1)
 
 # Load nilearn NiftiMasker, the practical masking and unmasking tool
 from nilearn.input_data import NiftiMasker
 
 # load labels
 import numpy as np
-labels = np.recfromcsv(data_files.session_target[0], delimiter=" ")
+labels = np.recfromcsv(haxby_dataset.session_target[0], delimiter=" ")
 stimuli = labels['labels']
 # identify resting state labels in order to be able to remove them
 resting_state = stimuli == "rest"
@@ -46,6 +46,7 @@ dummy_classifier = DummyClassifier()
 from sklearn.cross_validation import LeaveOneLabelOut, cross_val_score
 cv = LeaveOneLabelOut(session_labels)
 
+func_filename = haxby_dataset.func[0]
 mask_names = ['mask_vt', 'mask_face', 'mask_house']
 
 mask_scores = {}
@@ -54,9 +55,10 @@ mask_chance_scores = {}
 for mask_name in mask_names:
     print "Working on mask %s" % mask_name
     # For decoding, standardizing is often very important
-    masker = NiftiMasker(mask_img=data_files[mask_name][0], standardize=True)
+    mask_filename = haxby_dataset[mask_name][0]
+    masker = NiftiMasker(mask_img=mask_filename, standardize=True)
     masked_timecourses = masker.fit_transform(
-        data_files.func[0])[resting_state == False]
+        func_filename)[resting_state == False]
 
     mask_scores[mask_name] = {}
     mask_chance_scores[mask_name] = {}
@@ -89,12 +91,12 @@ plt.xticks(tick_position, categories, rotation=45)
 
 for color, mask_name in zip('rgb', mask_names):
     score_means = [mask_scores[mask_name][category].mean()
-                for category in categories]
+                   for category in categories]
     plt.bar(tick_position, score_means, label=mask_name,
             width=.25, color=color)
 
     score_chance = [mask_chance_scores[mask_name][category].mean()
-                for category in categories]
+                    for category in categories]
     plt.bar(tick_position, score_chance,
             width=.25, edgecolor='k', facecolor='none')
 
@@ -108,4 +110,3 @@ plt.tight_layout()
 
 
 plt.show()
-

--- a/examples/decoding/plot_haxby_grid_search.py
+++ b/examples/decoding/plot_haxby_grid_search.py
@@ -36,17 +36,12 @@ a separator.
 ### Load Haxby dataset ########################################################
 from nilearn import datasets
 import numpy as np
-dataset_files = datasets.fetch_haxby_simple()
+haxby_dataset = datasets.fetch_haxby_simple()
 
-y, session = np.loadtxt(dataset_files.session_target).astype("int").T
-conditions = np.recfromtxt(dataset_files.conditions_target)['f0']
-mask_file = dataset_files.mask
-# fmri_data.shape is (40, 64, 64, 1452)
-# and mask.shape is (40, 64, 64)
+y, session = np.loadtxt(haxby_dataset.session_target).astype("int").T
+conditions = np.recfromtxt(haxby_dataset.conditions_target)['f0']
 
 ### Preprocess data ###########################################################
-
-### Restrict to faces and houses ##############################################
 
 # Keep only data corresponding to shoes or bottles
 condition_mask = np.logical_or(conditions == 'shoe', conditions == 'bottle')
@@ -55,11 +50,14 @@ conditions = conditions[condition_mask]
 
 ### Loading step ##############################################################
 from nilearn.input_data import NiftiMasker
+
+mask_filename = haxby_dataset.mask
 # For decoding, standardizing is often very important
-nifti_masker = NiftiMasker(mask_img=mask_file, sessions=session, smoothing_fwhm=4,
-                           standardize=True, memory="nilearn_cache",
-                           memory_level=1)
-X = nifti_masker.fit_transform(dataset_files.func)
+nifti_masker = NiftiMasker(mask_img=mask_filename, sessions=session,
+                           smoothing_fwhm=4, standardize=True,
+                           memory="nilearn_cache", memory_level=1)
+func_filename = haxby_dataset.func
+X = nifti_masker.fit_transform(func_filename)
 # Restrict to non rest data
 X = X[condition_mask]
 session = session[condition_mask]
@@ -101,7 +99,7 @@ scores_validation = []
 for k in k_range:
     feature_selection.k = k
     cv_scores.append(np.mean(
-            cross_val_score(anova_svc, X[session < 10], y[session < 10])))
+        cross_val_score(anova_svc, X[session < 10], y[session < 10])))
     print "CV score", cv_scores[-1]
 
     anova_svc.fit(X[session < 10], y[session < 10])

--- a/examples/decoding/plot_haxby_multiclass.py
+++ b/examples/decoding/plot_haxby_multiclass.py
@@ -12,11 +12,12 @@ from matplotlib import pyplot as plt
 ### Load Haxby dataset ########################################################
 from nilearn import datasets
 import numpy as np
-dataset_files = datasets.fetch_haxby_simple()
+haxby_dataset = datasets.fetch_haxby_simple()
+func_filename = haxby_dataset.func
+mask_filename = haxby_dataset.mask
 
-# fmri_data and mask are copied to break any reference to the original object
-y, session = np.loadtxt(dataset_files.session_target).astype("int").T
-conditions = np.recfromtxt(dataset_files.conditions_target)['f0']
+y, session = np.loadtxt(haxby_dataset.session_target).astype("int").T
+conditions = np.recfromtxt(haxby_dataset.conditions_target)['f0']
 
 # Remove the rest condition, it is not very interesting
 non_rest = conditions != 'rest'
@@ -31,10 +32,10 @@ unique_conditions = unique_conditions[np.argsort(order)]
 ### Loading step ##############################################################
 from nilearn.input_data import NiftiMasker
 # For decoding, standardizing is often very important
-nifti_masker = NiftiMasker(mask_img=dataset_files.mask, standardize=True,
+nifti_masker = NiftiMasker(mask_img=mask_filename, standardize=True,
                            sessions=session, smoothing_fwhm=4,
                            memory="nilearn_cache", memory_level=1)
-X = nifti_masker.fit_transform(dataset_files.func)
+X = nifti_masker.fit_transform(func_filename)
 X = X[non_rest]
 session = session[non_rest]
 

--- a/examples/decoding/plot_haxby_searchlight.py
+++ b/examples/decoding/plot_haxby_searchlight.py
@@ -14,11 +14,12 @@ import numpy as np
 import nibabel
 from nilearn import datasets
 
-dataset_files = datasets.fetch_haxby_simple()
+haxby_dataset = datasets.fetch_haxby_simple()
 
-fmri_img = nibabel.load(dataset_files.func)
-y, session = np.loadtxt(dataset_files.session_target).astype("int").T
-conditions = np.recfromtxt(dataset_files.conditions_target)['f0']
+fmri_filename = haxby_dataset.func
+fmri_img = nibabel.load(fmri_filename)
+y, session = np.loadtxt(haxby_dataset.session_target).astype("int").T
+conditions = np.recfromtxt(haxby_dataset.conditions_target)['f0']
 
 ### Restrict to faces and houses ##############################################
 condition_mask = np.logical_or(conditions == 'face', conditions == 'house')
@@ -34,7 +35,7 @@ conditions = conditions[condition_mask]
 #   should be processed (we only keep the slice z = 26 and the back of the
 #   brain to speed up computation)
 
-mask_img = nibabel.load(dataset_files.mask)
+mask_img = nibabel.load(haxby_dataset.mask)
 
 # .astype() makes a copy.
 process_mask = mask_img.get_data().astype(np.int)
@@ -60,10 +61,11 @@ cv = KFold(y.size, n_folds=4)
 
 import nilearn.decoding
 # The radius is the one of the Searchlight sphere that will scan the volume
-searchlight = nilearn.decoding.SearchLight(mask_img,
-                                      process_mask_img=process_mask_img,
-                                      radius=5.6, n_jobs=n_jobs,
-                                      verbose=1, cv=cv)
+searchlight = nilearn.decoding.SearchLight(
+    mask_img,
+    process_mask_img=process_mask_img,
+    radius=5.6, n_jobs=n_jobs,
+    verbose=1, cv=cv)
 searchlight.fit(fmri_img, y)
 
 ### F-scores computation ######################################################

--- a/examples/decoding/plot_haxby_stimuli.py
+++ b/examples/decoding/plot_haxby_stimuli.py
@@ -10,10 +10,10 @@ Cortex" (Science 2001)
 from scipy.misc import imread
 import matplotlib.pyplot as plt
 
-from nilearn.datasets import fetch_haxby
+from nilearn import datasets
 
-stimulus_information = fetch_haxby(n_subjects=0,
-                                   fetch_stimuli=True).stimuli
+haxby_dataset = datasets.fetch_haxby(n_subjects=0, fetch_stimuli=True)
+stimulus_information = haxby_dataset.stimuli
 
 for stim_type in sorted(stimulus_information.keys()):
     if stim_type == "controls":
@@ -34,4 +34,3 @@ for stim_type in sorted(stimulus_information.keys()):
     plt.suptitle(stim_type)
 
 plt.show()
-

--- a/examples/manipulating_visualizing/plot_demo_plotting.py
+++ b/examples/manipulating_visualizing/plot_demo_plotting.py
@@ -6,75 +6,83 @@ Nilearn comes with a set of plotting function for Nifti-like images.
 
 """
 
-from nilearn import plotting, datasets, image
+from nilearn import datasets
+from nilearn import plotting, image
 
 
 ###############################################################################
 # Retrieve the data: haxby dataset to have EPI images and masks, and
 # localizer dataset to have contrast maps
 
-haxby = datasets.fetch_haxby(n_subjects=1)
+haxby_dataset = datasets.fetch_haxby(n_subjects=1)
+haxby_anat_filename = haxby_dataset.anat[0]
+haxby_mask_filename = haxby_dataset.mask_vt[0]
+haxby_func_filename = haxby_dataset.func[0]
 
-localizer = datasets.fetch_localizer_contrasts(["left vs right button press"],
-                                               n_subjects=4,
-                                               get_anats=True,
-                                               get_tmaps=True)
-
+localizer_dataset = datasets.fetch_localizer_contrasts(
+    ["left vs right button press"],
+    n_subjects=4,
+    get_anats=True,
+    get_tmaps=True)
+localizer_anat_filename = localizer_dataset.anats[3]
+localizer_cmap_filename = localizer_dataset.cmaps[3]
+localizer_tmap_filename = localizer_dataset.tmaps[3]
 
 ###############################################################################
 # demo the different plotting function
 
 # Plotting statistical maps
-plotting.plot_stat_map(localizer.cmaps[3], bg_img=localizer.anats[3],
+plotting.plot_stat_map(localizer_cmap_filename, bg_img=localizer_anat_filename,
                        threshold=3, title="plot_stat_map",
                        cut_coords=(36, -27, 66))
 
 # Plotting anatomical maps
-plotting.plot_anat(haxby.anat[0], title="plot_anat")
+plotting.plot_anat(haxby_anat_filename, title="plot_anat")
 
 # Plotting ROIs (here the mask)
-plotting.plot_roi(haxby.mask_vt[0], bg_img=haxby.anat[0], title="plot_roi")
+plotting.plot_roi(haxby_mask_filename, bg_img=haxby_anat_filename,
+                  title="plot_roi")
 
 # Plotting EPI haxby
-mean_haxby_img = image.mean_img(haxby.func[0])
+mean_haxby_img = image.mean_img(haxby_func_filename)
 plotting.plot_epi(mean_haxby_img, title="plot_epi")
 
 # Plotting glass brain
-plotting.plot_glass_brain(localizer.tmaps[3], title='plot_glass_brain',
+plotting.plot_glass_brain(localizer_tmap_filename, title='plot_glass_brain',
                           threshold=3)
 
-plotting.plot_glass_brain(localizer.tmaps[3], title='plot_glass_brain',
+plotting.plot_glass_brain(localizer_tmap_filename, title='plot_glass_brain',
                           black_bg=True, display_mode='xz', threshold=3)
 
 ###############################################################################
 # demo the different display_mode
 
-plotting.plot_stat_map(localizer.cmaps[3], display_mode='ortho',
+plotting.plot_stat_map(localizer_cmap_filename, display_mode='ortho',
                        cut_coords=(36, -27, 60),
                        title="display_mode='ortho', cut_coords=(36, -27, 60)")
 
-plotting.plot_stat_map(localizer.cmaps[3], display_mode='z', cut_coords=5,
+plotting.plot_stat_map(localizer_cmap_filename, display_mode='z', cut_coords=5,
                        title="display_mode='z', cut_coords=5")
 
-plotting.plot_stat_map(localizer.cmaps[3], display_mode='x', cut_coords=(-36, 36),
+plotting.plot_stat_map(localizer_cmap_filename, display_mode='x', cut_coords=(-36, 36),
                        title="display_mode='x', cut_coords=(-36, 36)")
 
-plotting.plot_stat_map(localizer.cmaps[3], display_mode='y', cut_coords=1,
+plotting.plot_stat_map(localizer_cmap_filename, display_mode='y', cut_coords=1,
                        title="display_mode='x', cut_coords=(-36, 36)")
 
-plotting.plot_stat_map(localizer.cmaps[3], display_mode='z',
+plotting.plot_stat_map(localizer_cmap_filename, display_mode='z',
                        cut_coords=1, colorbar=False,
                        title="display_mode='z', cut_coords=1, colorbar=False")
 
-plotting.plot_stat_map(localizer.cmaps[3], display_mode='xz',
+plotting.plot_stat_map(localizer_cmap_filename, display_mode='xz',
                        cut_coords=(36, 60),
                        title="display_mode='xz', cut_coords=(36, 60)")
 
-plotting.plot_stat_map(localizer.cmaps[3], display_mode='yx',
+plotting.plot_stat_map(localizer_cmap_filename, display_mode='yx',
                        cut_coords=(-27, 36),
                        title="display_mode='yx', cut_coords=(-27, 36)")
 
-plotting.plot_stat_map(localizer.cmaps[3], display_mode='yz',
+plotting.plot_stat_map(localizer_cmap_filename, display_mode='yz',
                        cut_coords=(-27, 60),
                        title="display_mode='yz', cut_coords=(-27, 60)")
 
@@ -83,12 +91,12 @@ plotting.plot_stat_map(localizer.cmaps[3], display_mode='yz',
 
 # Plot T1 outline on top of the mean EPI (useful for checking coregistration)
 my_plot = plotting.plot_anat(mean_haxby_img, title="add_edges")
-my_plot.add_edges(haxby.anat[0])
+my_plot.add_edges(haxby_anat_filename)
 
 # Plotting outline of the mask on top of the EPI
 my_plot = plotting.plot_anat(mean_haxby_img, title="add_contours",
-                             cut_coords=(28,-34,-22))
-my_plot.add_contours(haxby.mask_vt[0], levels=[0.5], colors='r')
+                             cut_coords=(28, -34, -22))
+my_plot.add_contours(haxby_mask_filename, levels=[0.5], colors='r')
 
 import pylab as pl
 pl.show()

--- a/examples/manipulating_visualizing/plot_haxby_masks.py
+++ b/examples/manipulating_visualizing/plot_haxby_masks.py
@@ -8,11 +8,12 @@ from scipy import linalg
 import matplotlib.pyplot as plt
 
 from nilearn import datasets
-data = datasets.fetch_haxby()
+haxby_dataset = datasets.fetch_haxby()
 
 # Build the mean image because we have no anatomic data
 from nilearn import image
-mean_img = image.mean_img(data.func[0])
+func_filename = haxby_dataset.func[0]
+mean_img = image.mean_img(func_filename)
 
 z_slice = -24
 from nilearn.image.resampling import coord_transform
@@ -26,11 +27,14 @@ fig = plt.figure(figsize=(4, 5.4), facecolor='k')
 from nilearn.plotting import plot_anat
 display = plot_anat(mean_img, display_mode='z', cut_coords=[z_slice],
                     figure=fig)
-display.add_contours(data.mask_vt[0], contours=1, antialiased=False,
+mask_vt_filename = haxby_dataset.mask_vt[0]
+mask_house_filename = haxby_dataset.mask_house[0]
+mask_face_filename = haxby_dataset.mask_face[0]
+display.add_contours(mask_vt_filename, contours=1, antialiased=False,
                      linewidths=4., levels=[0], colors=['red'])
-display.add_contours(data.mask_house[0], contours=1, antialiased=False,
+display.add_contours(mask_house_filename, contours=1, antialiased=False,
                      linewidths=4., levels=[0], colors=['blue'])
-display.add_contours(data.mask_face[0], contours=1, antialiased=False,
+display.add_contours(mask_face_filename, contours=1, antialiased=False,
                      linewidths=4., levels=[0], colors=['limegreen'])
 
 # We generate a legend using the trick described on

--- a/examples/manipulating_visualizing/plot_haxby_mass_univariate.py
+++ b/examples/manipulating_visualizing/plot_haxby_mass_univariate.py
@@ -30,25 +30,25 @@ References
 # Author: Virgile Fritsch, <virgile.fritsch@inria.fr>, Feb. 2014
 import numpy as np
 from scipy import linalg
-import nibabel
 from nilearn import datasets
 from nilearn.input_data import NiftiMasker
 from nilearn.mass_univariate import permuted_ols
 
 ### Load Haxby dataset ########################################################
-dataset_files = datasets.fetch_haxby_simple()
+haxby_dataset = datasets.fetch_haxby_simple()
 
 ### Mask data #################################################################
-mask_img = nibabel.load(dataset_files.mask)
+mask_filename = haxby_dataset.mask
 nifti_masker = NiftiMasker(
-    mask_img=dataset_files.mask,
+    mask_img=mask_filename,
     memory='nilearn_cache', memory_level=1)  # cache options
-fmri_masked = nifti_masker.fit_transform(dataset_files.func)
+func_filename = haxby_dataset.func
+fmri_masked = nifti_masker.fit_transform(func_filename)
 
 ### Restrict to faces and houses ##############################################
 conditions_encoded, sessions = np.loadtxt(
-    dataset_files.session_target).astype("int").T
-conditions = np.recfromtxt(dataset_files.conditions_target)['f0']
+    haxby_dataset.session_target).astype("int").T
+conditions = np.recfromtxt(haxby_dataset.conditions_target)['f0']
 condition_mask = np.logical_or(conditions == 'face', conditions == 'house')
 conditions_encoded = conditions_encoded[condition_mask]
 fmri_masked = fmri_masked[condition_mask]
@@ -105,7 +105,7 @@ from nilearn.plotting import plot_stat_map
 
 # Use the fmri mean image as a surrogate of anatomical data
 from nilearn import image
-mean_fmri_img = image.mean_img(dataset_files.func)
+mean_fmri_img = image.mean_img(func_filename)
 
 # Various plotting parameters
 z_slice = -17  # plotted slice

--- a/examples/manipulating_visualizing/plot_localizer_mass_univariate_methods.py
+++ b/examples/manipulating_visualizing/plot_localizer_mass_univariate_methods.py
@@ -26,13 +26,14 @@ from nilearn.mass_univariate import permuted_ols
 
 ### Load Localizer contrast ###################################################
 n_samples = 94
-dataset_files = datasets.fetch_localizer_contrasts(
+localizer_dataset = datasets.fetch_localizer_contrasts(
     ['left button press (auditory cue)'], n_subjects=n_samples)
-tested_var = dataset_files.ext_vars['pseudo']
+tested_var = localizer_dataset.ext_vars['pseudo']
 # Quality check / Remove subjects with bad tested variate
 mask_quality_check = np.where(tested_var != 'None')[0]
 n_samples = mask_quality_check.size
-contrast_maps = [dataset_files.cmaps[i] for i in mask_quality_check]
+contrast_map_filenames = [localizer_dataset.cmaps[i]
+                          for i in mask_quality_check]
 tested_var = tested_var[mask_quality_check].astype(float).reshape((-1, 1))
 print("Actual number of subjects after quality check: %d" % n_samples)
 
@@ -40,7 +41,7 @@ print("Actual number of subjects after quality check: %d" % n_samples)
 nifti_masker = NiftiMasker(
     smoothing_fwhm=5,
     memory='nilearn_cache', memory_level=1)  # cache options
-fmri_masked = nifti_masker.fit_transform(contrast_maps)
+fmri_masked = nifti_masker.fit_transform(contrast_map_filenames)
 
 ### Anova (parametric F-scores) ###############################################
 from nilearn._utils.fixes import f_regression

--- a/examples/manipulating_visualizing/plot_mask_computation.py
+++ b/examples/manipulating_visualizing/plot_mask_computation.py
@@ -30,17 +30,17 @@ import nilearn.image as image
 from nilearn.plotting.img_plotting import plot_roi
 
 # Load Miyawaki dataset
-miyawaki = datasets.fetch_miyawaki2008()
-miyawaki_img = nibabel.load(miyawaki.func[0])
+miyawaki_dataset = datasets.fetch_miyawaki2008()
+miyawaki_filename = miyawaki_dataset.func[0]
 
-miyawaki_mean_img = image.mean_img(miyawaki.func[0])
+miyawaki_mean_img = image.mean_img(miyawaki_filename)
 
 # This time, we can use the NiftiMasker without changing the default mask
 # strategy, as the data has already been masked, and thus lies on a
 # homogeneous background
 
 masker = NiftiMasker()
-masker.fit(miyawaki_img)
+masker.fit(miyawaki_filename)
 
 plot_roi(masker.mask_img_, miyawaki_mean_img,
          title="Mask from already masked data")
@@ -50,8 +50,9 @@ plot_roi(masker.mask_img_, miyawaki_mean_img,
 # From raw EPI data
 
 # Load NYU resting-state dataset
-nyu = datasets.fetch_nyu_rest(n_subjects=1)
-nyu_img = nibabel.load(nyu.func[0])
+nyu_dataset = datasets.fetch_nyu_rest(n_subjects=1)
+nyu_filename = nyu_dataset.func[0]
+nyu_img = nibabel.load(nyu_filename)
 # Restrict nyu to 100 frames to speed up computation
 nyu_func = nyu_img.get_data()[..., :100]
 

--- a/examples/manipulating_visualizing/plot_roi_extraction.py
+++ b/examples/manipulating_visualizing/plot_roi_extraction.py
@@ -11,18 +11,20 @@ obtained.
 coronal = -24
 sagittal = -33
 axial = -17
+cut_coords = (coronal, sagittal, axial)
 
 ### Load the data #############################################################
 
 # Fetch the data files from Internet
 from nilearn import datasets
 import nibabel
-haxby_files = datasets.fetch_haxby(n_subjects=1)
+haxby_dataset = datasets.fetch_haxby(n_subjects=1)
 
 # Second, load the labels
 import numpy as np
-haxby_labels = np.genfromtxt(haxby_files.session_target[0], skip_header=1,
-                          usecols=[0], dtype=basestring)
+
+haxby_labels = np.genfromtxt(haxby_dataset.session_target[0], skip_header=1,
+                             usecols=[0], dtype=basestring)
 
 ### Visualization function ####################################################
 
@@ -30,19 +32,18 @@ import matplotlib.pyplot as plt
 from nilearn.plotting import plot_epi, plot_stat_map, plot_roi
 from nilearn.input_data import NiftiLabelsMasker
 
-plt.close('all')
-
 ### Find voxels of interest ###################################################
 
 # Smooth the data
 from nilearn import image
-fmri_img = image.smooth_img(haxby_files.func[0], fwhm=6)
+fmri_filename = haxby_dataset.func[0]
+fmri_img = image.smooth_img(fmri_filename, fwhm=6)
 
 # Plot the mean image
 fig_id = plt.subplot(2, 1, 1)
 mean_img = image.mean_img(fmri_img)
-plot_epi(mean_img, title='Smoothed mean EPI', cut_coords=(coronal, sagittal,
-    axial), axes=fig_id)
+plot_epi(mean_img, title='Smoothed mean EPI', cut_coords=cut_coords,
+         axes=fig_id)
 
 # Run a T-test for face and houses
 from scipy import stats
@@ -57,7 +58,7 @@ log_p_values[np.isnan(log_p_values)] = 0.
 log_p_values[log_p_values > 10.] = 10.
 fig_id = plt.subplot(2, 1, 2)
 plot_stat_map(nibabel.Nifti1Image(log_p_values, fmri_img.get_affine()), mean_img,
-    title="p-values", cut_coords=(coronal, sagittal, axial), axes=fig_id)
+              title="p-values", cut_coords=cut_coords, axes=fig_id)
 plt.subplots_adjust(left=0, right=1, bottom=0, top=1, hspace=0)
 
 ### Build a mask ##############################################################
@@ -67,28 +68,29 @@ fig_id = plt.subplot(3, 1, 1)
 log_p_values[log_p_values < 5] = 0
 plot_stat_map(nibabel.Nifti1Image(log_p_values, fmri_img.get_affine()), mean_img,
               title='Thresholded p-values', annotate=False, colorbar=False,
-              cut_coords=(coronal, sagittal, axial), axes=fig_id)
+              cut_coords=cut_coords, axes=fig_id)
 
 # Binarization and intersection with VT mask
 # (intersection corresponds to an "AND conjunction")
 bin_p_values = (log_p_values != 0)
-vt = nibabel.load(haxby_files.mask_vt[0]).get_data().astype(bool)
+mask_vt_filename = haxby_dataset.mask_vt[0]
+vt = nibabel.load(mask_vt_filename).get_data().astype(bool)
 bin_p_values_and_vt = np.logical_and(bin_p_values, vt)
 
 fig_id = plt.subplot(3, 1, 2)
-plot_roi(nibabel.Nifti1Image(bin_p_values_and_vt.astype(np.int), 
-         fmri_img.get_affine()), 
+plot_roi(nibabel.Nifti1Image(bin_p_values_and_vt.astype(np.int),
+         fmri_img.get_affine()),
          mean_img, title='Intersection with ventral temporal mask',
-         cut_coords=(coronal, sagittal, axial), axes=fig_id)
+         cut_coords=cut_coords, axes=fig_id)
 
 # Dilation
 fig_id = plt.subplot(3, 1, 3)
 from scipy import ndimage
 dil_bin_p_values_and_vt = ndimage.binary_dilation(bin_p_values_and_vt)
 plot_roi(nibabel.Nifti1Image(dil_bin_p_values_and_vt.astype(np.int),
-    fmri_img.get_affine()),
-    mean_img, title='Dilated mask', cut_coords=(coronal, sagittal, axial),
-    axes=fig_id, annotate=False)
+                             fmri_img.get_affine()),
+         mean_img, title='Dilated mask', cut_coords=cut_coords,
+         axes=fig_id, annotate=False)
 plt.subplots_adjust(left=0, right=1, bottom=0, top=1, hspace=0)
 
 # Identification of connected components
@@ -98,27 +100,27 @@ first_roi_data = (labels == 1).astype(np.int)
 second_roi_data = (labels == 2).astype(np.int)
 fig_id = plt.subplot(2, 1, 1)
 plot_roi(nibabel.Nifti1Image(first_roi_data, fmri_img.get_affine()),
-    mean_img, title='Connected components: first ROI', axes=fig_id)
+         mean_img, title='Connected components: first ROI', axes=fig_id)
 fig_id = plt.subplot(2, 1, 2)
 plot_roi(nibabel.Nifti1Image(second_roi_data, fmri_img.get_affine()),
-    mean_img, title='Connected components: second ROI', axes=fig_id)
+         mean_img, title='Connected components: second ROI', axes=fig_id)
 plt.subplots_adjust(left=0, right=1, bottom=0, top=1, hspace=0)
 plot_roi(nibabel.Nifti1Image(first_roi_data, fmri_img.get_affine()),
-    mean_img, title='Connected components: first ROI_',
-    output_file='snapshot_first_ROI.png')
+         mean_img, title='Connected components: first ROI_',
+         output_file='snapshot_first_ROI.png')
 plot_roi(nibabel.Nifti1Image(second_roi_data, fmri_img.get_affine()),
-    mean_img, title='Connected components: second ROI',
-    output_file='snapshot_second_ROI.png')
+         mean_img, title='Connected components: second ROI',
+         output_file='snapshot_second_ROI.png')
 
 # use the new ROIs to extract data maps in both ROIs
 masker = NiftiLabelsMasker(
-            labels_img=nibabel.Nifti1Image(labels, fmri_img.get_affine()),
-            resampling_target=None,
-            standardize=False,
-            detrend=False)
+    labels_img=nibabel.Nifti1Image(labels, fmri_img.get_affine()),
+    resampling_target=None,
+    standardize=False,
+    detrend=False)
 masker.fit()
 condition_names = list(set(haxby_labels))
-n_cond_img = fmri_data[...,haxby_labels == 'house'].shape[-1]
+n_cond_img = fmri_data[..., haxby_labels == 'house'].shape[-1]
 n_conds = len(condition_names)
 X1, X2 = np.zeros((n_cond_img, n_conds)), np.zeros((n_cond_img, n_conds))
 for i, cond in enumerate(condition_names):
@@ -134,11 +136,11 @@ for i in np.arange(2):
     plt.subplot(1, 2, i + 1)
     plt.boxplot(X1 if i == 0 else X2)
     plt.xticks(np.arange(len(condition_names)) + 1, condition_names,
-        rotation=25)
+               rotation=25)
     plt.title('Boxplots of data in ROI%i per condition' % (i + 1))
 
 plt.show()
 
 # save the ROI 'atlas' to a single output nifti
 nibabel.save(nibabel.Nifti1Image(labels, fmri_img.get_affine()),
-    'mask_atlas.nii')
+             'mask_atlas.nii')

--- a/examples/manipulating_visualizing/plot_visualization.py
+++ b/examples/manipulating_visualizing/plot_visualization.py
@@ -11,14 +11,15 @@ from nilearn import datasets
 from nilearn.image.image import mean_img
 from nilearn.plotting.img_plotting import plot_epi, plot_roi
 
-haxby_files = datasets.fetch_haxby(n_subjects=1)
+haxby_dataset = datasets.fetch_haxby(n_subjects=1)
 
 ### Visualization #############################################################
 
 import matplotlib.pyplot as plt
 
 # Compute the mean EPI: we do the mean along the axis 3, which is time
-mean_haxby = mean_img(haxby_files.func)
+func_filename = haxby_dataset.func[0]
+mean_haxby = mean_img(func_filename)
 
 plot_epi(mean_haxby)
 
@@ -26,16 +27,16 @@ plot_epi(mean_haxby)
 
 # Simple computation of a mask from the fMRI data
 from nilearn.masking import compute_epi_mask
-mask_img = compute_epi_mask(haxby_files.func[0])
+mask_img = compute_epi_mask(func_filename)
 
 plot_roi(mask_img, mean_haxby)
 
 ### Applying the mask #########################################################
 
 from nilearn.masking import apply_mask
-masked_data = apply_mask(haxby_files.func[0], mask_img)
+masked_data = apply_mask(func_filename, mask_img)
 
-# masked_data shape is (timepoints, voxels). We can plot the first 150 
+# masked_data shape is (timepoints, voxels). We can plot the first 150
 # timepoints from two voxels
 
 plt.figure(figsize=(7, 5))
@@ -46,4 +47,3 @@ plt.xlim(0, 150)
 plt.subplots_adjust(bottom=.12, top=.95, right=.95, left=.12)
 
 plt.show()
-

--- a/examples/plot_localizer_simple_analysis.py
+++ b/examples/plot_localizer_simple_analysis.py
@@ -22,14 +22,16 @@ from nilearn.input_data import NiftiMasker
 
 ### Load Localizer contrast ###################################################
 n_samples = 20
-dataset_files = datasets.fetch_localizer_calculation_task(n_subjects=n_samples)
+localizer_dataset = datasets.fetch_localizer_calculation_task(
+    n_subjects=n_samples)
 tested_var = np.ones((n_samples, 1))
 
 ### Mask data #################################################################
 nifti_masker = NiftiMasker(
     smoothing_fwhm=5,
     memory='nilearn_cache', memory_level=1)  # cache options
-fmri_masked = nifti_masker.fit_transform(dataset_files.cmaps)
+cmap_filenames = localizer_dataset.cmaps
+fmri_masked = nifti_masker.fit_transform(cmap_filenames)
 
 ### Anova (parametric F-scores) ###############################################
 from nilearn._utils.fixes import f_regression

--- a/examples/plot_nifti_simple.py
+++ b/examples/plot_nifti_simple.py
@@ -10,7 +10,7 @@ The mask is computed and visualized.
 
 from nilearn import datasets
 from nilearn.input_data import NiftiMasker
-dataset = datasets.fetch_nyu_rest(n_subjects=1)
+nyu_dataset = datasets.fetch_nyu_rest(n_subjects=1)
 
 ### Compute the mask ##########################################################
 
@@ -18,7 +18,8 @@ dataset = datasets.fetch_nyu_rest(n_subjects=1)
 # rely on the 'background' masking strategy. We need to use the 'epi' one
 nifti_masker = NiftiMasker(standardize=False, mask_strategy='epi',
                            memory="nilearn_cache", memory_level=2)
-nifti_masker.fit(dataset.func[0])
+func_filename = nyu_dataset.func[0]
+nifti_masker.fit(func_filename)
 mask_img = nifti_masker.mask_img_
 
 ### Visualize the mask ########################################################
@@ -27,14 +28,14 @@ from nilearn.plotting import plot_roi
 from nilearn.image.image import mean_img
 
 # calculate mean image for the background
-mean_func_img = mean_img(dataset.func[0])
+mean_func_img = mean_img(func_filename)
 
 plot_roi(mask_img, mean_func_img, display_mode='y', cut_coords=4, title="Mask")
 
 
 ### Preprocess data ###########################################################
-nifti_masker.fit(dataset.func[0])
-fmri_masked = nifti_masker.transform(dataset.func[0])
+nifti_masker.fit(func_filename)
+fmri_masked = nifti_masker.transform(func_filename)
 
 ### Run an algorithm ##########################################################
 from sklearn.decomposition import FastICA
@@ -49,7 +50,7 @@ components = nifti_masker.inverse_transform(components_masked)
 import nibabel
 from nilearn.plotting import plot_stat_map
 
-plot_stat_map(nibabel.Nifti1Image(components.get_data()[:,:,:,0],
+plot_stat_map(nibabel.Nifti1Image(components.get_data()[:, :, :, 0],
                                   components.get_affine()), mean_func_img,
               display_mode='y', cut_coords=4, title="Component 0")
 


### PR DESCRIPTION
to make it more obvious that the *_img functions can take filenames as input. In general it is not very clear what kind of object bunch.cmaps[0] is.

Other minor fixes went in while I was at it, amongs these:
- use dataset consistently for the object return by fetch_*
- use from nilearn.datasets import fetch_... to avoid dataset (the object returned by the fetcher) being confused with datasets (the module)
- pep8 fixes here and there

Comments more than welcome!
