### PR TITLE
Ignore all current example file-based outputs.

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,3 @@
+*.nii
+*.nii.gz
+*.png


### PR DESCRIPTION
See issue #343 for details.

**Limitations:**
Since the outputs use relative paths, this will only work if you run the examples from anywhere within the `examples` subdirectory.  If, for example, you run this from the base directory (`nilearn`, you'll still see these files show up.

If desired, I could change the examples to output to the same directory that the example file resides in, rather than the current working directory.

