### PR TITLE
Add dependency checks to setup.py

### DIFF
--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -8,18 +8,19 @@ visualization tools.
 
 See http://nilearn.github.com for complete documentation.
 """
-import gzip
-
-from .version import check_module_dependencies
 
 #
-check_module_dependencies()
-del check_module_dependencies
+from .version import _check_module_dependencies
+_check_module_dependencies()
 
-# Monkey-patch gzip to have faster reads on large
-# gzip files
+
+# Monkey-patch gzip to have faster reads on large gzip files
+#   Note: import must occur AFTER dependency checks occur above.
+import gzip
+
 if hasattr(gzip.GzipFile, 'max_read_chunk'):
     gzip.GzipFile.max_read_chunk = 100 * 1024 * 1024  # 100Mb
+
 
 # Boolean controling whether the joblib caches should be
 # flushed if the version of certain modules changes (eg nibabel, as it

--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -8,67 +8,18 @@ visualization tools.
 
 See http://nilearn.github.com for complete documentation.
 """
+import gzip
 
-from version import __version__
+from .version import check_module_dependencies
 
+#
+check_module_dependencies()
+del check_module_dependencies
 
-def _import_module_with_version_check(module_name, minimum_version):
-    """Check that module is installed with a recent enough version
-    """
-    from distutils.version import LooseVersion
-
-    try:
-        module = __import__(module_name)
-    except ImportError as exc:
-        user_friendly_info = ('{} could not be found, '
-                              'please install it properly to use nilearn'
-                              ).format(module_name)
-        exc.args += (user_friendly_info,)
-        raise
-
-    module_version = module.__version__
-
-    version_too_old = (not LooseVersion(module_version) >=
-                       LooseVersion(minimum_version))
-
-    if version_too_old:
-        message = (
-            'A {module_name} version of at least {minimum_version} '
-            'is required to use nilearn. {module_version} was found. '
-            'Please upgrade {module_name}').format(
-                module_name=module_name,
-                minimum_version=minimum_version,
-                module_version=module_version)
-
-        raise ImportError(message)
-
-    return module
-
-
-def _check_dependencies():
-    _required_module_versions = [('numpy', '1.6.0'),
-                                 ('scipy', '0.9.0'),
-                                 ('sklearn', '0.10'),
-                                 ('nibabel', '1.1.0')]
-
-    for module_name, minimum_version in _required_module_versions:
-        _import_module_with_version_check(module_name, minimum_version)
-
-    try:
-        import gzip
-        if hasattr(gzip.GzipFile, 'max_read_chunk'):
-            # Monkey-patch gzip to have faster reads on large
-            # gzip files
-            gzip.GzipFile.max_read_chunk = 100 * 1024 * 1024  # 100Mb
-    except ImportError as exc:
-        exc.args += ('Python has been compiled without gzip, '
-                     'reading nii.gz files will be impossible.',)
-        raise
-
-_check_dependencies()
-
-del _import_module_with_version_check
-del _check_dependencies
+# Monkey-patch gzip to have faster reads on large
+# gzip files
+if hasattr(gzip.GzipFile, 'max_read_chunk'):
+    gzip.GzipFile.max_read_chunk = 100 * 1024 * 1024  # 100Mb
 
 # Boolean controling whether the joblib caches should be
 # flushed if the version of certain modules changes (eg nibabel, as it

--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -11,9 +11,6 @@ See http://nilearn.github.com for complete documentation.
 
 from .version import _check_module_dependencies, __version__
 
-
-# Each time nilearn is imported, check module dependencies
-#   so that a user gets a useful error message immediately.
 _check_module_dependencies()
 
 

--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -9,8 +9,11 @@ visualization tools.
 See http://nilearn.github.com for complete documentation.
 """
 
-#
-from .version import _check_module_dependencies
+from .version import _check_module_dependencies, __version__
+
+
+# Each time nilearn is imported, check module dependencies
+#   so that a user gets a useful error message immediately.
 _check_module_dependencies()
 
 

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -2,40 +2,33 @@
 """
 nilearn version, required package versions, and utilities for checking
 """
-# Author: Alexandre Abraham, Philippe Gervais, Ben Cipollini
+# Author: Loïc Estève, Ben Cipollini
 # License: simplified BSD
 
 __version__ = '0.1b1'
 
-# All metadata needed for required modules:
-#    * minver: minimum required version of the module
-#    * manual: whether the module must be installed manually
-# See more info in check_module_dependencies docstring.
-#
-# This is a list to preserve order, and to avoid the Python 2.7
-#   dependency of collections.OrderedDict
 _NILEARN_INSTALL_MSG = 'See %s for installation information.' % (
     'http://nilearn.github.io/introduction.html#installation')
+
+# This is a tuple to preserve order, so that dependencies are checked
+#   in some meaningful order (more => less 'core').  We avoid using
+#   collections.OrderedDict to preserve Python 2.6 compatibility.
 REQUIRED_MODULE_METADATA = (
     ('numpy', {
-        'minver': '1.6.0',
-        'manual_install': True,
+        'min_version': '1.6.0',
+        'required_at_installation': True,
         'install_info': _NILEARN_INSTALL_MSG}),
     ('scipy', {
-        'minver': '0.9.0',
-        'manual_install': True,
+        'min_version': '0.9.0',
+        'required_at_installation': True,
         'install_info': _NILEARN_INSTALL_MSG}),
     ('sklearn', {
-        'minver': '0.10',
-        'manual_install': True,
+        'min_version': '0.10',
+        'required_at_installation': True,
         'install_info': _NILEARN_INSTALL_MSG}),
     ('nibabel', {
-        'minver': '1.1.0',
-        'manual_install': False}),
-    ('gzip', {
-        'minver': '0.0.0',
-        'manual_install': True,
-        'install_info': 'Use a python version compiled with gzip.'}))
+        'min_version': '1.1.0',
+        'required_at_installation': False}),)
 
 
 def _import_module_with_version_check(
@@ -75,23 +68,25 @@ def _import_module_with_version_check(
     return module
 
 
-def _check_module_dependencies(preinstalled_modules_only=False):
+def _check_module_dependencies(is_nilearn_installing=False):
     """We want to check dependencies in the following scenarios:
 
         * When running installation, we want to:
-            + Fail if manually-installed packages are not installed
+            + Fail if any required package that needs manual installation
+              is not already installed.
             + Communicate packages to install automatically
 
         * When running code from the nilearn package,
             + Fail if any needed module is missing
     """
-    for (module_name, module_metadata) in REQUIRED_MODULE_METADATA:
-        if preinstalled_modules_only and not module_metadata['manual_install']:
-            # Skip check for auto-installed modules,
-            #   when preinstalled_modules_only is specified.
-            continue
 
-        _import_module_with_version_check(
-            module_name=module_name,
-            minimum_version=module_metadata['minver'],
-            install_info=module_metadata.get('install_info'))
+    for (module_name, module_metadata) in REQUIRED_MODULE_METADATA:
+        if not (is_nilearn_installing and
+                not module_metadata['required_at_installation']):
+            # Skip check only when installing and it's a module that
+            # will be auto-installed.
+            _import_module_with_version_check(
+                module_name=module_name,
+                minimum_version=module_metadata['min_version'],
+                install_info=module_metadata.get('install_info'))
+    

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -69,15 +69,17 @@ def _import_module_with_version_check(
 
 
 def _check_module_dependencies(is_nilearn_installing=False):
-    """We want to check dependencies in the following scenarios:
+    """Throw an exception if nilearn dependencies are not installed.
 
-        * When running installation, we want to:
-            + Fail if any required package that needs manual installation
-              is not already installed.
-            + Communicate packages to install automatically
+    Parameters
+    ----------
+    is_nilearn_installing: boolean
+        if True, only error on missing packages that cannot be auto-installed.
+        if False, error on any missing package.
 
-        * When running code from the nilearn package,
-            + Fail if any needed module is missing
+    Throws
+    -------
+    ImportError
     """
 
     for (module_name, module_metadata) in REQUIRED_MODULE_METADATA:

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -7,8 +7,36 @@ nilearn version, required package versions, and utilities for checking
 
 __version__ = '0.1b1'
 
+# All metadata needed for required modules:
+#    * minver: minimum required version of the module
+#    * manual: whether the module must be installed manually
+# See more info in check_module_dependencies docstring.
+#
+# This is a list to preserve order, and to avoid the Python 2.7
+#   dependency of collections.OrderedDict
+REQUIRED_MODULE_METADATA = (
+    ('numpy', {
+        'minver': '1.6.0',
+        'manual_install': True,
+        'install_info': 'Install via your OS package manager (Linux) or Anaconda (OSX, Windows).'}),
+    ('scipy', {
+        'minver': '0.9.0',
+        'manual_install': True,
+        'install_info': 'Install via your OS package manager (Linux) or Anaconda (OSX, Windows).'}),
+    ('sklearn', {
+        'minver': '0.10',
+        'manual_install': True,
+        'install_info': 'Install via your OS package manager (Linux) or Anaconda (OSX, Windows).'}),
+    ('nibabel', {
+        'minver': '1.1.0',
+        'manual_install': False}),
+    ('gzip', {
+        'minver': '0.0.0',
+        'manual_install': True,
+        'install_info': 'Use a python version compiled with gzip.'}))
 
-def _import_module_with_version_check(module_name, minimum_version):
+
+def _import_module_with_version_check(module_name, minimum_version, install_info=None):
     """Check that module is installed with a recent enough version
     """
     from distutils.version import LooseVersion
@@ -16,9 +44,9 @@ def _import_module_with_version_check(module_name, minimum_version):
     try:
         module = __import__(module_name)
     except ImportError as exc:
-        user_friendly_info = ('{} could not be found, '
-                              'please install it properly to use nilearn'
-                              ).format(module_name)
+        user_friendly_info = ('Module "{}" could not be found.  {}').format(
+            module_name,
+            install_info or 'Please install it properly to use nilearn.')
         exc.args += (user_friendly_info,)
         raise
 
@@ -41,21 +69,7 @@ def _import_module_with_version_check(module_name, minimum_version):
 
     return module
 
-def get_required_module_metadata():
-    """Return all metadata needed for required modules:
-        * minver: minimum required version of the module
-        * manual: whether the module must be installed manually.
-
-    See more info in check_module_dependencies docstring.
-    """
-    return {
-        'numpy': {'minver': '1.6.0', 'manual_install': True},
-        'scipy': {'minver': '0.9.0', 'manual_install': True},
-        'sklearn': {'minver': '0.10', 'manual_install': True},
-        'nibabel': {'minver': '1.1.0', 'manual_install': False},
-        'gzip': {'minver': '0.0.0', 'manual_install': True}}
-
-def check_module_dependencies(manual_install_only=False):
+def _check_module_dependencies(manual_install_only=False):
     """We want to check dependencies in the following scenarios:
 
         * When running installation, we want to:
@@ -65,10 +79,13 @@ def check_module_dependencies(manual_install_only=False):
         * When running code from the nilearn package,
             + Fail if any needed module is missing
     """
-    for module_name, module_metadata in get_required_module_metadata().iteritems():
-        if module_metadata['manual_install'] and manual_install_only:
+    for (module_name, module_metadata) in REQUIRED_MODULE_METADATA:
+        if manual_install_only and not module_metadata['manual_install']:
             # Skip check for manual install, when manual_install_only is specified.
             continue
 
-        _import_module_with_version_check(module_name, module_metadata['minver'])
+        _import_module_with_version_check(
+            module_name=module_name,
+            minimum_version=module_metadata['minver'],
+            install_info=module_metadata.get('install_info'))
 

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -18,15 +18,15 @@ REQUIRED_MODULE_METADATA = (
     ('numpy', {
         'minver': '1.6.0',
         'manual_install': True,
-        'install_info': 'Install via your OS package manager (Linux) or Anaconda (OSX, Windows).'}),
+        'install_info': 'See http://nilearn.github.io/introduction.html#installation for installation information.'}),
     ('scipy', {
         'minver': '0.9.0',
         'manual_install': True,
-        'install_info': 'Install via your OS package manager (Linux) or Anaconda (OSX, Windows).'}),
+        'install_info': 'See http://nilearn.github.io/introduction.html#installation for installation information'}),
     ('sklearn', {
         'minver': '0.10',
         'manual_install': True,
-        'install_info': 'Install via your OS package manager (Linux) or Anaconda (OSX, Windows).'}),
+        'install_info': 'See http://nilearn.github.io/introduction.html#installation for installation information'}),
     ('nibabel', {
         'minver': '1.1.0',
         'manual_install': False}),
@@ -73,7 +73,7 @@ def _check_module_dependencies(manual_install_only=False):
     """We want to check dependencies in the following scenarios:
 
         * When running installation, we want to:
-            + Fail if manually-installed packages are not intalled
+            + Fail if manually-installed packages are not installed
             + Communicate packages to install automatically
 
         * When running code from the nilearn package,

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -14,19 +14,21 @@ __version__ = '0.1b1'
 #
 # This is a list to preserve order, and to avoid the Python 2.7
 #   dependency of collections.OrderedDict
+_NILEARN_INSTALL_MSG = 'See %s for installation information.' % (
+    'http://nilearn.github.io/introduction.html#installation')
 REQUIRED_MODULE_METADATA = (
     ('numpy', {
         'minver': '1.6.0',
         'manual_install': True,
-        'install_info': 'See http://nilearn.github.io/introduction.html#installation for installation information.'}),
+        'install_info': _NILEARN_INSTALL_MSG}),
     ('scipy', {
         'minver': '0.9.0',
         'manual_install': True,
-        'install_info': 'See http://nilearn.github.io/introduction.html#installation for installation information'}),
+        'install_info': _NILEARN_INSTALL_MSG}),
     ('sklearn', {
         'minver': '0.10',
         'manual_install': True,
-        'install_info': 'See http://nilearn.github.io/introduction.html#installation for installation information'}),
+        'install_info': _NILEARN_INSTALL_MSG}),
     ('nibabel', {
         'minver': '1.1.0',
         'manual_install': False}),
@@ -36,7 +38,10 @@ REQUIRED_MODULE_METADATA = (
         'install_info': 'Use a python version compiled with gzip.'}))
 
 
-def _import_module_with_version_check(module_name, minimum_version, install_info=None):
+def _import_module_with_version_check(
+        module_name,
+        minimum_version,
+        install_info=None):
     """Check that module is installed with a recent enough version
     """
     from distutils.version import LooseVersion
@@ -69,7 +74,8 @@ def _import_module_with_version_check(module_name, minimum_version, install_info
 
     return module
 
-def _check_module_dependencies(manual_install_only=False):
+
+def _check_module_dependencies(preinstalled_modules_only=False):
     """We want to check dependencies in the following scenarios:
 
         * When running installation, we want to:
@@ -80,12 +86,12 @@ def _check_module_dependencies(manual_install_only=False):
             + Fail if any needed module is missing
     """
     for (module_name, module_metadata) in REQUIRED_MODULE_METADATA:
-        if manual_install_only and not module_metadata['manual_install']:
-            # Skip check for manual install, when manual_install_only is specified.
+        if preinstalled_modules_only and not module_metadata['manual_install']:
+            # Skip check for auto-installed modules,
+            #   when preinstalled_modules_only is specified.
             continue
 
         _import_module_with_version_check(
             module_name=module_name,
             minimum_version=module_metadata['minver'],
             install_info=module_metadata.get('install_info'))
-

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -1,1 +1,74 @@
+# *- encoding: utf-8 -*-
+"""
+nilearn version, required package versions, and utilities for checking
+"""
+# Author: Alexandre Abraham, Philippe Gervais, Ben Cipollini
+# License: simplified BSD
+
 __version__ = '0.1b1'
+
+
+def _import_module_with_version_check(module_name, minimum_version):
+    """Check that module is installed with a recent enough version
+    """
+    from distutils.version import LooseVersion
+
+    try:
+        module = __import__(module_name)
+    except ImportError as exc:
+        user_friendly_info = ('{} could not be found, '
+                              'please install it properly to use nilearn'
+                              ).format(module_name)
+        exc.args += (user_friendly_info,)
+        raise
+
+    # Avoid choking on modules with no __version__ attribute
+    module_version = getattr(module, '__version__', '0.0.0')
+
+    version_too_old = (not LooseVersion(module_version) >=
+                       LooseVersion(minimum_version))
+
+    if version_too_old:
+        message = (
+            'A {module_name} version of at least {minimum_version} '
+            'is required to use nilearn. {module_version} was found. '
+            'Please upgrade {module_name}').format(
+                module_name=module_name,
+                minimum_version=minimum_version,
+                module_version=module_version)
+
+        raise ImportError(message)
+
+    return module
+
+def get_required_module_metadata():
+    """Return all metadata needed for required modules:
+        * minver: minimum required version of the module
+        * manual: whether the module must be installed manually.
+
+    See more info in check_module_dependencies docstring.
+    """
+    return {
+        'numpy': {'minver': '1.6.0', 'manual_install': True},
+        'scipy': {'minver': '0.9.0', 'manual_install': True},
+        'sklearn': {'minver': '0.10', 'manual_install': True},
+        'nibabel': {'minver': '1.1.0', 'manual_install': False},
+        'gzip': {'minver': '0.0.0', 'manual_install': True}}
+
+def check_module_dependencies(manual_install_only=False):
+    """We want to check dependencies in the following scenarios:
+
+        * When running installation, we want to:
+            + Fail if manually-installed packages are not intalled
+            + Communicate packages to install automatically
+
+        * When running code from the nilearn package,
+            + Fail if any needed module is missing
+    """
+    for module_name, module_metadata in get_required_module_metadata().iteritems():
+        if module_metadata['manual_install'] and manual_install_only:
+            # Skip check for manual install, when manual_install_only is specified.
+            continue
+
+        _import_module_with_version_check(module_name, module_metadata['minver'])
+

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,7 @@ from setuptools import setup, find_packages
 
 
 # Make sources available using relative paths from this file's directory.
-#  dirname can return '', so use 'or' below to avoid chdir on empty
-#  while being succinct.
-os.chdir(os.path.dirname(__file__) or os.getcwd())
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
 
 def load_version():
@@ -24,7 +22,8 @@ def load_version():
     # load all vars into globals, otherwise
     #   the later function call using global vars doesn't work.
     globals_dict = {}
-    execfile(os.path.join('nilearn', 'version.py'), globals_dict)
+    with open(os.path.join('nilearn', 'version.py')) as fp:
+        exec(fp.read(), globals_dict)
 
     return globals_dict
 
@@ -46,7 +45,7 @@ VERSION = _VERSION_GLOBALS['__version__']
 
 if __name__ == "__main__":
     if is_installing():
-        eval('_check_module_dependencies(manual_install_only=True)', _VERSION_GLOBALS)
+        _VERSION_GLOBALS['_check_module_dependencies'](manual_install_only=True)#eval('_check_module_dependencies(manual_install_only=True)', _VERSION_GLOBALS)
 
     old_path = os.getcwd()
     local_path = os.path.dirname(os.path.abspath(sys.argv[0]))

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ def load_version():
 
 
 def is_installing():
-    return len(sys.argv) > 1 and sys.argv[1] == 'install'
+    # Allow command-lines such as "python setup.py build install"
+    return len(sys.argv) > 1 and 'install' in sys.argv
 
 
 _VERSION_GLOBALS = load_version()

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,11 @@ import os
 
 from setuptools import setup, find_packages
 
+# Make the current nilearn sources importable.
+__curdir__ = os.path.dirname(__file__)
+sys.path.insert(1, __curdir__)
+
+from nilearn import version
 
 def get_version():
     """Returns the version found in nilearn/version.py
@@ -17,14 +22,14 @@ def get_version():
     """
     locals_dict = {}
     globals_dict = {}
-    with open(os.path.join('nilearn', 'version.py')) as fp:
+    with open(os.path.join(__curdir__, 'nilearn', 'version.py')) as fp:
         exec(fp.read(), globals_dict, locals_dict)
 
     return locals_dict['__version__']
 
 DISTNAME = 'nilearn'
 DESCRIPTION = 'Statistical learning for neuroimaging in Python'
-LONG_DESCRIPTION = open('README.rst').read()
+LONG_DESCRIPTION = open(os.path.join(__curdir__, 'README.rst')).read()
 MAINTAINER = 'Gael Varoquaux'
 MAINTAINER_EMAIL = 'gael.varoquaux@normalesup.org'
 URL = 'http://nilearn.github.com'
@@ -33,10 +38,18 @@ DOWNLOAD_URL = 'http://nilearn.github.com'
 VERSION = get_version()
 
 if __name__ == "__main__":
+    version.check_module_dependencies(manual_install_only=True)
+
     old_path = os.getcwd()
     local_path = os.path.dirname(os.path.abspath(sys.argv[0]))
     os.chdir(local_path)
     sys.path.insert(0, local_path)
+
+    # Convert module metadata into list of {mod_name}>={minver}
+    #   as required by install_requires
+    formatted_dependencies = ['%s>=%s' % (mod, meta['minver'])
+        for mod, meta in version.get_required_module_metadata().iteritems()
+        if not meta['manual_install']]
 
     setup(name=DISTNAME,
           maintainer=MAINTAINER,
@@ -68,5 +81,5 @@ if __name__ == "__main__":
           package_data={'nilearn.data': ['*.nii.gz'],
                         'nilearn.plotting.glass_brain_files': ['*.json'],
                         'nilearn.tests.data': ['*']},
-          install_requires=['nibabel>=1.1.0'],
+          install_requires=formatted_dependencies,
     )

--- a/setup.py
+++ b/setup.py
@@ -7,38 +7,46 @@ import os
 
 from setuptools import setup, find_packages
 
-# Make the current nilearn sources importable.
-__curdir__ = os.path.dirname(__file__)
-sys.path.insert(1, __curdir__)
 
-from nilearn import version
+# Make sources available using relative paths from this file's directory.
+#  dirname can return '', so use 'or' below to avoid chdir on empty
+#  while being succinct.
+os.chdir(os.path.dirname(__file__) or os.getcwd())
 
-def get_version():
+
+def load_version():
     """Returns the version found in nilearn/version.py
 
     Importing nilearn is not an option because there may dependencies
     like nibabel which are not installed and setup.py is supposed to
     install them.
     """
-    locals_dict = {}
+    # load all vars into globals, otherwise
+    #   the later function call using global vars doesn't work.
     globals_dict = {}
-    with open(os.path.join(__curdir__, 'nilearn', 'version.py')) as fp:
-        exec(fp.read(), globals_dict, locals_dict)
+    execfile(os.path.join('nilearn', 'version.py'), globals_dict)
 
-    return locals_dict['__version__']
+    return globals_dict
 
+def is_installing():
+    return len(sys.argv) > 1 and sys.argv[1] == 'install'
+
+
+_VERSION_GLOBALS = load_version()
 DISTNAME = 'nilearn'
 DESCRIPTION = 'Statistical learning for neuroimaging in Python'
-LONG_DESCRIPTION = open(os.path.join(__curdir__, 'README.rst')).read()
+LONG_DESCRIPTION = open('README.rst').read()
 MAINTAINER = 'Gael Varoquaux'
 MAINTAINER_EMAIL = 'gael.varoquaux@normalesup.org'
 URL = 'http://nilearn.github.com'
 LICENSE = 'new BSD'
 DOWNLOAD_URL = 'http://nilearn.github.com'
-VERSION = get_version()
+VERSION = _VERSION_GLOBALS['__version__']
+
 
 if __name__ == "__main__":
-    version.check_module_dependencies(manual_install_only=True)
+    if is_installing():
+        eval('_check_module_dependencies(manual_install_only=True)', _VERSION_GLOBALS)
 
     old_path = os.getcwd()
     local_path = os.path.dirname(os.path.abspath(sys.argv[0]))
@@ -48,7 +56,7 @@ if __name__ == "__main__":
     # Convert module metadata into list of {mod_name}>={minver}
     #   as required by install_requires
     formatted_dependencies = ['%s>=%s' % (mod, meta['minver'])
-        for mod, meta in version.get_required_module_metadata().iteritems()
+        for mod, meta in _VERSION_GLOBALS['REQUIRED_MODULE_METADATA']
         if not meta['manual_install']]
 
     setup(name=DISTNAME,

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,6 @@ import os
 from setuptools import setup, find_packages
 
 
-# Make sources available using relative paths from this file's directory.
-os.chdir(os.path.dirname(os.path.abspath(__file__)))
-
-
 def load_version():
     """Returns the version found in nilearn/version.py
 
@@ -26,6 +22,7 @@ def load_version():
         exec(fp.read(), globals_dict)
 
     return globals_dict
+
 
 def is_installing():
     return len(sys.argv) > 1 and sys.argv[1] == 'install'
@@ -45,18 +42,19 @@ VERSION = _VERSION_GLOBALS['__version__']
 
 if __name__ == "__main__":
     if is_installing():
-        _VERSION_GLOBALS['_check_module_dependencies'](manual_install_only=True)#eval('_check_module_dependencies(manual_install_only=True)', _VERSION_GLOBALS)
+        module_check_fn = _VERSION_GLOBALS['_check_module_dependencies']
+        module_check_fn(preinstalled_modules_only=True)
 
-    old_path = os.getcwd()
+    # Make sources available using relative paths from this file's directory.
     local_path = os.path.dirname(os.path.abspath(sys.argv[0]))
     os.chdir(local_path)
-    sys.path.insert(0, local_path)
 
     # Convert module metadata into list of {mod_name}>={minver}
     #   as required by install_requires
-    formatted_dependencies = ['%s>=%s' % (mod, meta['minver'])
-        for mod, meta in _VERSION_GLOBALS['REQUIRED_MODULE_METADATA']
-        if not meta['manual_install']]
+    formatted_dependencies = \
+        ['%s>=%s' % (mod, meta['minver'])
+            for mod, meta in _VERSION_GLOBALS['REQUIRED_MODULE_METADATA']
+            if not meta['manual_install']]
 
     setup(name=DISTNAME,
           maintainer=MAINTAINER,
@@ -88,5 +86,4 @@ if __name__ == "__main__":
           package_data={'nilearn.data': ['*.nii.gz'],
                         'nilearn.plotting.glass_brain_files': ['*.json'],
                         'nilearn.tests.data': ['*']},
-          install_requires=formatted_dependencies,
-    )
+          install_requires=formatted_dependencies,)

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ from setuptools import setup, find_packages
 
 
 def load_version():
-    """Returns the version found in nilearn/version.py
+    """Executes nilearn/version.py in a globals dictionary and return it.
 
-    Importing nilearn is not an option because there may dependencies
-    like nibabel which are not installed and setup.py is supposed to
-    install them.
+    Note: importing nilearn is not an option because there may be
+    dependencies like nibabel which are not installed and
+    setup.py is supposed to install them.
     """
     # load all vars into globals, otherwise
     #   the later function call using global vars doesn't work.
@@ -26,8 +26,11 @@ def load_version():
 
 def is_installing():
     # Allow command-lines such as "python setup.py build install"
-    return len(sys.argv) > 1 and 'install' in sys.argv
+    return 'install' in sys.argv
 
+
+# Make sources available using relative paths from this file's directory.
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
 _VERSION_GLOBALS = load_version()
 DISTNAME = 'nilearn'
@@ -44,18 +47,12 @@ VERSION = _VERSION_GLOBALS['__version__']
 if __name__ == "__main__":
     if is_installing():
         module_check_fn = _VERSION_GLOBALS['_check_module_dependencies']
-        module_check_fn(preinstalled_modules_only=True)
+        module_check_fn(is_nilearn_installing=True)
 
-    # Make sources available using relative paths from this file's directory.
-    local_path = os.path.dirname(os.path.abspath(sys.argv[0]))
-    os.chdir(local_path)
-
-    # Convert module metadata into list of {mod_name}>={minver}
-    #   as required by install_requires
-    formatted_dependencies = \
-        ['%s>=%s' % (mod, meta['minver'])
+    install_requires = \
+        ['%s>=%s' % (mod, meta['min_version'])
             for mod, meta in _VERSION_GLOBALS['REQUIRED_MODULE_METADATA']
-            if not meta['manual_install']]
+            if not meta['required_at_installation']]
 
     setup(name=DISTNAME,
           maintainer=MAINTAINER,
@@ -87,4 +84,4 @@ if __name__ == "__main__":
           package_data={'nilearn.data': ['*.nii.gz'],
                         'nilearn.plotting.glass_brain_files': ['*.json'],
                         'nilearn.tests.data': ['*']},
-          install_requires=formatted_dependencies,)
+          install_requires=install_requires,)


### PR DESCRIPTION
(edited to add link to original issue: fix #328)

**Summary:**
Previously, dependency checks were defined inside `__init__.py`.  I've:
* Moved the dependency check code to `version.py`
* Called the code from `__init__.py` and `setup.py`

This required some additional tweaks:
* Add metadata about which modules must be installed manually.
* Do slightly different dependency checks pre-setup (when we only need to check modules requiring manual installation) and post-setup (where we should check all modules).

There were a few other tiny tweaks I made, that I'll document inline.

 **Testing:**
* I tested that `nilearn` installs properly when all dependencies are installed
* I tested that `nilearn` fails with an error message if one of the `manual_only` modules is not installed (in my case, `sklearn`)
![screen shot 2015-01-08 at 10 57 52 pm](https://cloud.githubusercontent.com/assets/4072455/5676439/ad3396e4-978a-11e4-8694-4613882b8bd9.png)

**Notes:**
* The error message for modules requiring manual installation are very generic; further installation info could be stuffed into the `required_module` metadata, to produce better error messages.  Let me know if you'd like me to do that (I think it would be good...)