### PR TITLE
Enable Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,20 @@
 language: python
 
-python:
-    - "2.7"
-
 virtualenv:
   system_site_packages: true
 
 env:
-  - NEURODEBIAN=0
-  - NEURODEBIAN=1
+  matrix:
+    - DISTRIB="ubuntu" PYTHON_VERSION="2.7"
+      COVERAGE="false"
+    - DISTRIB="neurodebian" PYTHON_VERSION="2.7"
+      COVERAGE="false"
+    - DISTRIB="conda" PYTHON_VERSION="2.6"
+      NUMPY_VERSION="1.9.0" SCIPY_VERSION="0.14.0"
+      MATPLOTLIB_VERSION="1.4" SKLEARN_VERSION="0.15.2"
 
-before_install:
-    - wget -O- http://neuro.debian.net/lists/precise.us-nh.libre | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
-    - sudo apt-key adv --recv-keys --keyserver pgp.mit.edu 2649A5A9
-    - if [ $NEURODEBIAN -eq 1 ]; then sudo apt-get update -qq; fi
-    - sudo apt-get install -qq python-scipy python-nose python-nibabel python-sklearn
-
-install:
-    - python setup.py install
+install: 
+    source continuous_integration/install.sh
 
 script:
     - make clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ virtualenv:
 env:
   matrix:
     - DISTRIB="ubuntu" PYTHON_VERSION="2.7"
-      COVERAGE="false"
     - DISTRIB="neurodebian" PYTHON_VERSION="2.7"
-      COVERAGE="false"
     - DISTRIB="conda" PYTHON_VERSION="2.6"
       NUMPY_VERSION="1.9.0" SCIPY_VERSION="0.14.0"
       MATPLOTLIB_VERSION="1.4" SKLEARN_VERSION="0.15.2"

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -58,9 +58,11 @@ else
     exit 1
 fi
 
-python --version
-python -c "import numpy; print('numpy %s' % numpy.__version__)"
-python -c "import scipy; print('scipy %s' % scipy.__version__)"
-python -c "import sklearn; print ('sklearn %s' % sklearn.__version__)"
-
 python setup.py install
+
+# Report versions after install, as some of these packages may depend 
+# on the install script.
+python --version
+for pkg in 'numpy' 'scipy' 'sklearn' 'matplotlib' 'nibabel'; do
+    python -c "import $pkg; print('$pkg %s' % $pkg.__version__)"
+done

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# This script is meant to be called by the "install" step defined in
+# .travis.yml. See http://docs.travis-ci.com/ for more details.
+# The behavior of the script is controlled by environment variabled defined
+# in the .travis.yml in the top level folder of the project.
+#
+# This script is adapted from a similar script from the scikit-learn repository.
+#
+# License: 3-clause BSD
+
+set -e
+
+# Fix the compilers to workaround avoid having the Python 3.4 build
+# lookup for g++44 unexpectedly.
+export CC=gcc
+export CXX=g++
+
+if [[ "$DISTRIB" == "ubuntu" ]]; then
+    # Use standard ubuntu packages in their default version
+    sudo apt-get install -qq python-scipy python-nose python-pip python-sklearn
+
+elif [[ "$DISTRIB" == "neurodebian" ]]; then
+    wget -O- http://neuro.debian.net/lists/precise.us-nh.libre | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
+    sudo apt-key adv --recv-keys --keyserver pgp.mit.edu 2649A5A9
+    sudo apt-get update -qq
+    sudo apt-get install -qq python-scipy python-nose python-nibabel python-sklearn
+
+elif [[ "$DISTRIB" == "conda" ]]; then
+    # Deactivate the travis-provided virtual environment and setup a
+    # conda-based environment instead
+    deactivate
+
+    # Use the miniconda installer for faster download / install of conda
+    # itself
+    wget http://repo.continuum.io/miniconda/Miniconda-3.6.0-Linux-x86_64.sh \
+        -O miniconda.sh
+    chmod +x miniconda.sh && ./miniconda.sh -b
+    export PATH=/home/travis/miniconda/bin:$PATH
+    conda update --yes conda
+
+    # Configure the conda environment and put it in the path using the
+    # provided versions
+    conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
+        numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
+        matplotlib=$MATPLOTLIB_VERSION scikit-learn=$SKLEARN_VERSION
+    source activate testenv
+
+    if [[ "$INSTALL_MKL" == "true" ]]; then
+        # Make sure that MKL is used
+        conda install --yes mkl
+    else
+        # Make sure that MKL is not used
+        conda remove --yes --features mkl || echo "MKL not installed"
+    fi
+
+else
+    echo "Unrecognized distribution ($DISTRIB); cannot setup travis environment."
+    exit 1
+fi
+
+python --version
+python -c "import numpy; print('numpy %s' % numpy.__version__)"
+python -c "import scipy; print('scipy %s' % scipy.__version__)"
+python -c "import sklearn; print ('sklearn %s' % sklearn.__version__)"
+
+python setup.py install

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -265,7 +265,7 @@ def concat_niimgs(niimgs, dtype=np.float32, accept_4d=False,
         else:
             nii_str = "image #" + str(index)
         if verbose > 0:
-            print "Concatenating {}/{}: {}".format(index + 1, sum(lengths),
+            print "Concatenating {0}/{1}: {2}".format(index + 1, sum(lengths),
                                                    nii_str)
 
         if index == 0:  # we have already loaded the first one

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -266,7 +266,7 @@ def concat_niimgs(niimgs, dtype=np.float32, accept_4d=False,
             nii_str = "image #" + str(index)
         if verbose > 0:
             print "Concatenating {0}/{1}: {2}".format(index + 1, sum(lengths),
-                                                   nii_str)
+                                                      nii_str)
 
         if index == 0:  # we have already loaded the first one
             cur_4d_index += size

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -238,7 +238,7 @@ def _get_dataset_dir(dataset_name, data_dir=None, verbose=0):
                 return path
             except Exception as exc:
                 short_error_message = getattr(exc, 'strerror', str(exc))
-                errors.append('\n -{} ({})'.format(path, short_error_message))
+                errors.append('\n -{0} ({1})'.format(path, short_error_message))
 
     raise OSError('Nilearn tried to store the dataset in the following '
             'directories, but:' + ''.join(errors))

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -349,7 +349,7 @@ def resample_img(img, target_affine=None, target_shape=None,
         interpolation_order = 0
     else:
         message = ("interpolation must be either 'continuous' "
-                   "or 'nearest' but it was set to '{}'").format(interpolation)
+                   "or 'nearest' but it was set to '{0}'").format(interpolation)
         raise ValueError(message)
 
     if isinstance(img, basestring):

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -137,7 +137,7 @@ def test_resampling_error_checks():
 
     # Invalid interpolation
     interpolation = 'an_invalid_interpolation'
-    pattern = "interpolation must be either.+{}".format(interpolation)
+    pattern = "interpolation must be either.+{0}".format(interpolation)
     testing.assert_raises_regexp(ValueError, pattern,
                                  resample_img, img, target_shape=target_shape,
                                  target_affine=affine,
@@ -434,7 +434,7 @@ def test_reorder_img():
 
     # Make sure invalid resample argument is included in the error message
     interpolation = 'an_invalid_interpolation'
-    pattern = "interpolation must be either.+{}".format(interpolation)
+    pattern = "interpolation must be either.+{0}".format(interpolation)
     testing.assert_raises_regexp(ValueError, pattern,
                                  reorder_img, ref_img,
                                  resample=interpolation)

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -983,8 +983,8 @@ def get_create_display_fun(display_mode, class_dict):
     try:
         return class_dict[display_mode].init_with_figure
     except KeyError:
-        message = ('{} is not a valid display_mode. '
-                   'Valid options are {}').format(
+        message = ('{0} is not a valid display_mode. '
+                   'Valid options are {1}').format(
                        display_mode, sorted(class_dict.keys()))
         raise ValueError(message)
 

--- a/nilearn/plotting/glass_brain.py
+++ b/nilearn/plotting/glass_brain.py
@@ -96,20 +96,20 @@ def _get_json_and_transform(direction):
 
     dirname = os.path.dirname(os.path.abspath(__file__))
     dirname = os.path.join(dirname, 'glass_brain_files')
-    direction_to_filename = {
-        direction: os.path.join(
+    direction_to_filename = dict([
+        (_direction, os.path.join(
             dirname,
-            'brain_schematics_{0}.json'.format(view_name))
-        for direction, view_name in direction_to_view_name.iteritems()}
+            'brain_schematics_{0}.json'.format(view_name)))
+        for _direction, view_name in direction_to_view_name.iteritems()])
 
-    direction_to_transforms = {
-        direction: transforms.Affine2D.from_values(*params)
-        for direction, params in direction_to_transform_params.iteritems()}
+    direction_to_transforms = dict([
+        (_direction, transforms.Affine2D.from_values(*params))
+        for _direction, params in direction_to_transform_params.iteritems()])
 
-    direction_to_json_and_transform = {
-        direction: (direction_to_filename[direction],
-                    direction_to_transforms[direction])
-        for direction in direction_to_filename}
+    direction_to_json_and_transform = dict([
+        (_direction, (direction_to_filename[_direction],
+                      direction_to_transforms[_direction]))
+        for _direction in direction_to_filename])
 
     filename_and_transform = direction_to_json_and_transform.get(direction)
 

--- a/nilearn/plotting/glass_brain.py
+++ b/nilearn/plotting/glass_brain.py
@@ -14,7 +14,7 @@ from matplotlib import transforms
 def _codes_bezier(pts):
     bezier_num = len(pts)
     # Next two lines are meant to handle both Bezier 3 and 4
-    path_attr = 'CURVE{}'.format(bezier_num)
+    path_attr = 'CURVE{0}'.format(bezier_num)
     codes = [getattr(Path, path_attr)] * (bezier_num - 1)
     return [Path.MOVETO] + codes
 
@@ -99,7 +99,7 @@ def _get_json_and_transform(direction):
     direction_to_filename = {
         direction: os.path.join(
             dirname,
-            'brain_schematics_{}.json'.format(view_name))
+            'brain_schematics_{0}.json'.format(view_name))
         for direction, view_name in direction_to_view_name.iteritems()}
 
     direction_to_transforms = {
@@ -114,8 +114,8 @@ def _get_json_and_transform(direction):
     filename_and_transform = direction_to_json_and_transform.get(direction)
 
     if filename_and_transform is None:
-        message = ("No glass brain view associated with direction '{}'. "
-                   "Possible directions are {}").format(
+        message = ("No glass brain view associated with direction '{0}'. "
+                   "Possible directions are {1}").format(
                        direction,
                        direction_to_json_and_transform.keys())
         raise ValueError(message)

--- a/nilearn/plotting/glass_brain_files/svg_to_json_converter.py
+++ b/nilearn/plotting/glass_brain_files/svg_to_json_converter.py
@@ -32,7 +32,7 @@ class SVGToJSONConverter(object):
             my_type = 'segment'
             pts = [p.coord() for p in (obj.start, obj.end)]
         else:
-            msg = '{} is not a supported class'.format(obj.__class__)
+            msg = '{0} is not a supported class'.format(obj.__class__)
             raise TypeError(msg)
 
         # svg has its origin in the top left whereas

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -108,7 +108,7 @@ def test_plot_img_empty():
 def test_plot_img_invalid():
     # Check that we get a meaningful error message when we give a wrong
     # display_mode argument
-    assert_raises(plot_anat, display_mode='zzz')
+    assert_raises(Exception, plot_anat, display_mode='zzz')
 
 
 def test_plot_img_with_auto_cut_coords():

--- a/nilearn/tests/test_datasets.py
+++ b/nilearn/tests/test_datasets.py
@@ -4,6 +4,7 @@ Test the datasets module
 # Author: Alexandre Abraham
 # License: simplified BSD
 
+import contextlib
 import os
 import shutil
 from tempfile import mkdtemp, mkstemp
@@ -618,7 +619,7 @@ def test_uncompress():
     # Create a zipfile
     dtemp = mkdtemp()
     ztemp = os.path.join(dtemp, 'test.zip')
-    with zipfile.ZipFile(ztemp, 'w') as testzip:
+    with contextlib.closing(zipfile.ZipFile(ztemp, 'w')) as testzip:
         testzip.write(temp)
     datasets._uncompress_file(ztemp)
     assert(os.path.exists(os.path.join(dtemp, temp)))
@@ -626,7 +627,7 @@ def test_uncompress():
 
     dtemp = mkdtemp()
     ztemp = os.path.join(dtemp, 'test.tar')
-    with tarfile.open(ztemp, 'w') as tar:
+    with contextlib.closing(tarfile.open(ztemp, 'w')) as tar:
         tar.add(temp)
     datasets._uncompress_file(ztemp)
     assert(os.path.exists(os.path.join(dtemp, temp)))

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from numpy.testing import assert_array_equal
 from nose.tools import assert_true, assert_false, assert_equal, \
-    assert_raises, assert_is_instance
+    assert_raises
 
 from nibabel import Nifti1Image
 
@@ -64,7 +64,7 @@ def test_compute_epi_mask():
     with warnings.catch_warnings(True) as w:
         compute_epi_mask(mean_image, exclude_zeros=True)
     assert_equal(len(w), 1)
-    assert_is_instance(w[0].message, masking.MaskWarning)
+    assert_true(isinstance(w[0].message, masking.MaskWarning))
 
 
 def test_compute_background_mask():
@@ -90,7 +90,7 @@ def test_compute_background_mask():
     with warnings.catch_warnings(True) as w:
         compute_background_mask(mean_image)
     assert_equal(len(w), 1)
-    assert_is_instance(w[0].message, masking.MaskWarning)
+    assert_true(isinstance(w[0].message, masking.MaskWarning))
 
 
 def test_apply_mask():

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -42,7 +42,7 @@ def _import_module_with_version_check(
     try:
         module = __import__(module_name)
     except ImportError as exc:
-        user_friendly_info = ('Module "{}" could not be found.  {}').format(
+        user_friendly_info = ('Module "{0}" could not be found.  {1}').format(
             module_name,
             install_info or 'Please install it properly to use nilearn.')
         exc.args += (user_friendly_info,)
@@ -91,4 +91,3 @@ def _check_module_dependencies(is_nilearn_installing=False):
                 module_name=module_name,
                 minimum_version=module_metadata['min_version'],
                 install_info=module_metadata.get('install_info'))
-    


### PR DESCRIPTION
This partially addresses #357.

There are a few issues preventing the setup script, code, and tests from running in Python 2.6:
* Trailing whitespace in `version.py` led to a setup syntax error.
* `"format_str{}".format(str)` is illegal in Python 2.6; use `"format_str{0}".format(str)`
* Dictionary comprehensions are NYI in Python 2.6; use `dict([list_comprehension])`
* Many `assert_X` functions are unavailable in Python 2.6; convert the few we were using to `assert_true`
* Context managers for `ZipFile`, `TarFile` don't exist in Python 2.6; wrap with `contextlib`
* Context manager for `nose.assert_raises` doesn't exist in Python 2.6; use our custom `assert_raises_regexp`, which was more appropriate anyway (since we wanted to check the error message of the error anyway).

I've also changed the `.travis.yml` file to contain a flow like `scikit-learn`.  The following three scenarios are now enabled:
* Python 2.6 under Anaconda install
* Python 2.7 using system packages
* Python 2.7 under neurodebian.

Tests for all three scenarios are working (or were working; seems the PGP key for neurodebian is choking at this moment, out of the blue)...