### PR TITLE
Verbosity=0 should mean silent

### DIFF
--- a/doc/data_analysis/decoding.rst
+++ b/doc/data_analysis/decoding.rst
@@ -494,7 +494,7 @@ and create a new pipeline::
 and recompute the cross-validation score::
 
     >>> cv_scores = cross_val_score(rfe_svc, X, y, cv=cv, n_jobs=-1,
-    ...     verbose=True) # doctest: +SKIP
+    ...     verbose=1) # doctest: +SKIP
 
 But, be aware that this can take A WHILE...
 

--- a/examples/connectivity/plot_connect_comparison.py
+++ b/examples/connectivity/plot_connect_comparison.py
@@ -48,7 +48,7 @@ for n in range(n_displayed):
 
 # Fit one graph lasso per subject
 from sklearn.covariance import GraphLassoCV
-gl = GraphLassoCV(verbose=True)
+gl = GraphLassoCV(verbose=1)
 
 for n, subject in enumerate(subjects[:n_displayed]):
     gl.fit(subject)

--- a/examples/decoding/plot_haxby_grid_search.py
+++ b/examples/decoding/plot_haxby_grid_search.py
@@ -123,7 +123,7 @@ from sklearn.grid_search import GridSearchCV
 
 # Note that GridSearchCV takes an n_jobs argument that can make it go
 # much faster
-grid = GridSearchCV(anova_svc, param_grid={'anova__k': k_range}, verbose=True)
+grid = GridSearchCV(anova_svc, param_grid={'anova__k': k_range}, verbose=1)
 nested_cv_scores = cross_val_score(grid, X, y)
 
 plt.axhline(np.mean(nested_cv_scores),

--- a/examples/decoding/plot_haxby_multiclass.py
+++ b/examples/decoding/plot_haxby_multiclass.py
@@ -61,9 +61,9 @@ svc_ova = OneVsRestClassifier(Pipeline([
 ### Cross-validation scores ###################################################
 from sklearn.cross_validation import cross_val_score
 
-cv_scores_ovo = cross_val_score(svc_ovo, X, y, cv=5, verbose=True)
+cv_scores_ovo = cross_val_score(svc_ovo, X, y, cv=5, verbose=1)
 
-cv_scores_ova = cross_val_score(svc_ova, X, y, cv=5, verbose=True)
+cv_scores_ova = cross_val_score(svc_ova, X, y, cv=5, verbose=1)
 
 print 79 * "_"
 print 'OvO', cv_scores_ovo.mean()

--- a/nilearn/_utils/extmath.py
+++ b/nilearn/_utils/extmath.py
@@ -47,7 +47,7 @@ def fast_abs_percentile(data, percentile=80):
     return data[index + 1]
 
 
-def is_spd(M, decimal=15):
+def is_spd(M, decimal=15, verbose=1):
     """Assert that input matrix is symmetric positive definite.
 
     M must be symmetric down to specified decimal places.
@@ -58,16 +58,20 @@ def is_spd(M, decimal=15):
     M: numpy.ndarray
         symmetric positive definite matrix.
 
+    verbose: int, optional
+        verbosity level (0 means no message)
+
     Returns
     =======
     answer: boolean
         True if matrix is symmetric positive definite, False otherwise.
     """
     if not np.allclose(M, M.T, atol=0, rtol=10 ** -decimal):
-        print("matrix not symmetric to %d decimals" % decimal)
+        if verbose > 0:
+            print("matrix not symmetric to %d decimals" % decimal)
         return False
     eigvalsh = np.linalg.eigvalsh(M)
     ispd = eigvalsh.min() > 0
-    if not ispd:
+    if not ispd and verbose > 0:
         print("matrix has a negative eigenvalue: %.3f" % eigvalsh.min())
     return ispd

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -211,7 +211,7 @@ def concat_niimgs(niimgs, dtype=np.float32, accept_4d=False,
         Converts all images to the space of the first one.
 
     verbose: int
-        Controls the amount of verbosity.
+        Controls the amount of verbosity (0 means no messages).
 
     memory : instance of joblib.Memory or string
         Used to cache the resampling process.

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -500,7 +500,7 @@ def generate_signals_from_precisions(precisions,
 
 def generate_group_sparse_gaussian_graphs(
         n_subjects=5, n_features=30, min_n_samples=30, max_n_samples=50,
-        density=0.1, random_state=0):
+        density=0.1, random_state=0, verbose=0):
     """Generate signals drawn from a sparse Gaussian graphical model.
 
     Parameters
@@ -521,6 +521,9 @@ def generate_group_sparse_gaussian_graphs(
 
     random_state : int or numpy.random.RandomState instance, optional
         random number generator, or seed.
+
+    verbose: int, optional
+        verbosity level (0 means no message).
 
     Returns
     =======
@@ -571,7 +574,8 @@ def generate_group_sparse_gaussian_graphs(
     topology = topology > 0
     assert(np.all(topology == topology.T))
     logger.log("Sparsity: {0:f}".format(
-        1. * topology.sum() / (topology.shape[0] ** 2)))
+        1. * topology.sum() / (topology.shape[0] ** 2)),
+        verbose=verbose)
 
     # Generate temporal signals
     signals = generate_signals_from_precisions(precisions,

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -2,6 +2,7 @@
 """
 # Author: Alexandre Abrahame, Philippe Gervais
 # License: simplified BSD
+import functools
 import os
 import sys
 import urllib2
@@ -53,8 +54,6 @@ except ImportError:
             warnings.simplefilter("ignore", warning_class)
             output = func(*args, **kw)
         return output
-
-original_fetch_files = datasets._fetch_files
 
 
 @contextlib.contextmanager
@@ -165,6 +164,7 @@ def mock_chunk_read_raise_error_(response, local_file, initial_size=0,
 
 
 class FetchFilesMock (object):
+    _mock_fetch_files = functools.partial(datasets._fetch_files, mock=True)
 
     def __init__(self):
         """Create a mock that can fill a CSV file if needed
@@ -180,8 +180,7 @@ class FetchFilesMock (object):
         For test purpose, instead of actually fetching the dataset, this
         function creates empty files and return their paths.
         """
-        kwargs['mock'] = True
-        filenames = original_fetch_files(*args, **kwargs)
+        filenames = self._mock_fetch_files(*args, **kwargs)
         # Fill CSV files with given content if needed
         for fname in filenames:
             basename = os.path.basename(fname)

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -2054,7 +2054,8 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
                  ext_vars=csv_data)
 
 
-def fetch_localizer_calculation_task(n_subjects=None, data_dir=None, url=None):
+def fetch_localizer_calculation_task(n_subjects=None, data_dir=None, url=None,
+                                     verbose=1):
     """Fetch calculation task contrast maps from the localizer.
 
     This function is only a caller for the fetch_localizer_contrasts in order
@@ -2075,6 +2076,9 @@ def fetch_localizer_calculation_task(n_subjects=None, data_dir=None, url=None):
         Override download URL. Used for test only (or if you setup a mirror of
         the data).
 
+    verbose: int, optional
+        verbosity level (0 means no message).
+
     Returns
     -------
     data: Bunch
@@ -2087,7 +2091,7 @@ def fetch_localizer_calculation_task(n_subjects=None, data_dir=None, url=None):
                                      n_subjects=n_subjects,
                                      get_tmaps=False, get_masks=False,
                                      get_anats=False, data_dir=data_dir,
-                                     url=url, resume=True, verbose=1)
+                                     url=url, resume=True, verbose=verbose)
     data.pop('tmaps')
     data.pop('masks')
     data.pop('anats')

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -476,7 +476,7 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
         else:
             data = urllib2.urlopen(url)
             local_file = open(temp_full_name, "wb")
-        _chunk_read_(data, local_file, report_hook=True,
+        _chunk_read_(data, local_file, report_hook=(verbose > 0),
                      initial_size=initial_size, verbose=verbose)
         # temp file must be closed prior to the move
         if not local_file.closed:

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -60,7 +60,7 @@ def session_pca(imgs, mask_img, parameters,
         Used to cache the function calls.
 
     verbose: integer, optional
-        Indicate the level of verbosity
+        Indicate the level of verbosity (0 means no messages).
 
     copy: boolean, optional
         Whether or not data should be copied

--- a/nilearn/group_sparse_covariance.py
+++ b/nilearn/group_sparse_covariance.py
@@ -545,7 +545,7 @@ class GroupSparseCovariance(BaseEstimator, CacheMixin):
             _group_sparse_covariance, memory_level=1)(
                 self.covariances_, n_samples, self.alpha,
                 tol=self.tol, max_iter=self.max_iter,
-                verbose=self.verbose - 1, debug=False)
+                verbose=max(0, self.verbose - 1), debug=False)
 
         self.precisions_ = ret
         return self

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -416,7 +416,7 @@ def mean_img(imgs, target_affine=None, target_shape=None,
 
     verbose: int, optional
         Controls the amount of verbosity: higher numbers give
-        more messages
+        more messages (0 means no messages).
 
     n_jobs: integer, optional
         The number of CPUs to use to do the computation. -1 means

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -391,7 +391,7 @@ def _compute_mean(imgs, target_affine=None,
 
 
 def mean_img(imgs, target_affine=None, target_shape=None,
-             verbose=False, n_jobs=1):
+             verbose=0, n_jobs=1):
     """ Compute the mean of the images (in the time dimension of 4th dimension)
 
     Note that if list of 4D images are given, the mean of each 4D image is

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -185,7 +185,7 @@ class MultiNiftiMasker(BaseMasker, CacheMixin):
                             target_shape=self.target_shape,
                             n_jobs=self.n_jobs,
                             memory=self.memory,
-                            verbose=(self.verbose - 1),
+                            verbose=max(0, self.verbose - 1),
                         **mask_args)
         else:
             if imgs is not None:

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -165,7 +165,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
                               memory_level=1,
                               ignore=['verbose'])(
                 imgs,
-                verbose=(self.verbose - 1),
+                verbose=max(0, self.verbose - 1),
                 **mask_args)
         else:
             self.mask_img_ = _utils.check_niimg(self.mask_img,

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -162,13 +162,13 @@ def intersect_masks(mask_imgs, threshold=0.5, connected=True):
     return Nifti1Image(grp_mask, ref_affine)
 
 
-def _post_process_mask(mask, affine, opening=2, connected=True, msg=""):
+def _post_process_mask(mask, affine, opening=2, connected=True, warning_msg=""):
     if opening:
         opening = int(opening)
         mask = ndimage.binary_erosion(mask, iterations=opening)
     mask_any = mask.any()
     if not mask_any:
-        warnings.warn("Computed an empty mask. %s" % msg,
+        warnings.warn("Computed an empty mask. %s" % warning_msg,
             MaskWarning, stacklevel=2)
     if connected and mask_any:
         mask = largest_connected_component(mask)
@@ -284,7 +284,7 @@ def compute_epi_mask(epi_img, lower_cutoff=0.2, upper_cutoff=0.85,
     mask = mean_epi >= threshold
 
     return _post_process_mask(mask, affine, opening=opening,
-        connected=connected, msg="Are you sure that input "
+        connected=connected, warning_msg="Are you sure that input "
             "data are EPI images not detrended. ")
 
 
@@ -442,7 +442,7 @@ def compute_background_mask(data_imgs, border_size=2,
         mask = data != background
 
     return _post_process_mask(mask, affine, opening=opening,
-        connected=connected, msg="Are you sure that input "
+        connected=connected, warning_msg="Are you sure that input "
             "images have a homogeneous background.")
 
 

--- a/nilearn/tests/test_datasets.py
+++ b/nilearn/tests/test_datasets.py
@@ -534,7 +534,8 @@ def test_fetch_localizer_calculation_task():
     # Disabled: cannot be tested without actually fetching covariates CSV file
     # All subjects
     dataset = datasets.fetch_localizer_calculation_task(data_dir=tmpdir,
-                                                        url=local_url)
+                                                        url=local_url,
+                                                        verbose=0)
     assert_true(isinstance(dataset.ext_vars, np.recarray))
     assert_true(isinstance(dataset.cmaps[0], basestring))
     assert_equal(dataset.ext_vars.size, 94)
@@ -543,7 +544,8 @@ def test_fetch_localizer_calculation_task():
     # 20 subjects
     dataset = datasets.fetch_localizer_calculation_task(n_subjects=20,
                                                         data_dir=tmpdir,
-                                                        url=local_url)
+                                                        url=local_url,
+                                                        verbose=0)
     assert_true(isinstance(dataset.ext_vars, np.recarray))
     assert_true(isinstance(dataset.cmaps[0], basestring))
     assert_equal(dataset.ext_vars.size, 20)

--- a/nilearn/tests/test_extmath.py
+++ b/nilearn/tests/test_extmath.py
@@ -17,36 +17,36 @@ def test_fast_abs_percentile():
 
 def test_is_spd_with_non_symmetrical_matrix():
     matrix = np.arange(4).reshape(4, 1)
-    assert not is_spd(matrix)
+    assert not is_spd(matrix, verbose=0)
 
     matrix = np.array([[1, 1e-3 + 9e-19],
                        [1e-3, 1]])
-    assert is_spd(matrix)
+    assert is_spd(matrix, verbose=0)
 
     matrix = np.array([[1, 1e-3 + 1e-18],
                        [1e-3, 1]])
-    assert not is_spd(matrix)
+    assert not is_spd(matrix, verbose=0)
 
     matrix = np.array([[1, 1e-3 + 9e-8],
                        [1e-3, 1]])
-    assert is_spd(matrix, decimal=4)
+    assert is_spd(matrix, decimal=4, verbose=0)
 
     matrix = np.array([[1, 1e-3 + 1e-7],
                        [1e-3, 1]])
-    assert not is_spd(matrix, decimal=4)
+    assert not is_spd(matrix, decimal=4, verbose=0)
 
 
 def test_is_spd_with_symmetrical_matrix():
     # matrix with negative eigenvalue
     matrix = np.array([[0, 1],
                        [1, 0]])
-    assert not is_spd(matrix)
+    assert not is_spd(matrix, verbose=0)
 
     # matrix with 0 eigenvalue
     matrix = np.arange(4).reshape(2, 2)
-    assert not is_spd(matrix)
+    assert not is_spd(matrix, verbose=0)
 
     # spd matrix
     matrix = np.array([[2, 1],
                        [1, 1]])
-    assert is_spd(matrix)
+    assert is_spd(matrix, verbose=0)

--- a/nilearn/tests/test_group_sparse_covariance.py
+++ b/nilearn/tests/test_group_sparse_covariance.py
@@ -21,7 +21,7 @@ def test_group_sparse_covariance():
 
     # These executions must hit the tolerance limit
     emp_covs, omega = group_sparse_covariance(signals, alpha, max_iter=20,
-                                              tol=1e-2, debug=True, verbose=10)
+                                              tol=1e-2, debug=True, verbose=0)
     emp_covs, omega2 = group_sparse_covariance(signals, alpha, max_iter=20,
                                                tol=1e-2, debug=True, verbose=0)
 

--- a/nilearn/tests/test_niimg_conversions.py
+++ b/nilearn/tests/test_niimg_conversions.py
@@ -177,7 +177,7 @@ def test_concat_niimgs():
                          _utils.concat_niimgs, [img1, img4d])
     concatenated = _utils.concat_niimgs([img1, img4d], accept_4d=True)
     np.testing.assert_equal(concatenated.get_data(), concatenate_true,
-                            verbose=False)
+                            verbose=0)
 
     # smoke-test auto_resample
     concatenated = _utils.concat_niimgs((img1, img1b, img1c), accept_4d=False,


### PR DESCRIPTION
Fix for #366

The `verbosity` parameter should control output from a function, with `0` meaning no output (and a non-zero default for functions that we want to output by default.  In some functions, current behavior was to always output. 

Here, I have fixed the above, tweaked docstrings, and changed places where `verbose` was passed as a boolean to be passed as an int.

I've also made changes to the testing code, to suppress output by forcing `verbose=0`.  With this, we can expect no output in tests--allowing browsing test results more cleanly and exposing more clearly unexpected prints and warnings.
