### PR TITLE
Fix warnings thrown during tests

### DIFF
--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -8,10 +8,11 @@ visualization tools.
 
 See http://nilearn.github.io for complete documentation.
 """
-
 import gzip
+from distutils.version import LooseVersion
 
-from .version import _check_module_dependencies, __version__
+from .version import _check_module_dependencies, get_min_version, __version__
+
 
 _check_module_dependencies()
 
@@ -25,3 +26,9 @@ if hasattr(gzip.GzipFile, 'max_read_chunk'):
 # structures
 # This  is used in nilearn._utils.cache_mixin
 check_cache_version = True
+
+# WardAgglomeration cannot be migrated to AgglomerativeClustering until
+#   our scikit-learn minv_version is 0.15.
+if LooseVersion(get_min_version('sklearn')) < LooseVersion('0.15'):
+    import warnings
+    warnings.filterwarnings('once', 'The Ward class is deprecated since 0.14 and will be removed in 0.17.')

--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -27,8 +27,16 @@ if hasattr(gzip.GzipFile, 'max_read_chunk'):
 # This  is used in nilearn._utils.cache_mixin
 check_cache_version = True
 
+# These are warnings that we may trigger, but that we can do nothing about.
+# Hide them from users; warnings should be triggered for things that they
+# can act on only!
+import warnings
+
+# We know this, no need to expose our users to it.
+warnings.filterwarnings('ignore', 'check_cv will return indices instead of boolean masks', DeprecationWarning)
+warnings.filterwarnings('ignore', 'The compiler package is deprecated and removed in Python 3.x.', DeprecationWarning)
+
 # WardAgglomeration cannot be migrated to AgglomerativeClustering until
 #   our scikit-learn minv_version is 0.15.
 if LooseVersion(get_min_version('sklearn')) < LooseVersion('0.15'):
-    import warnings
     warnings.filterwarnings('once', 'The Ward class is deprecated since 0.14 and will be removed in 0.17.')

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -78,7 +78,7 @@ def assert_warns_regex(warning_class, warning_regex,
         for w in ws:
             if isinstance(w.message, warning_class) and \
                 (warning_regex is None or
-                    re.compile(warning_regex).search(w.message[-1])):
+                    re.compile(warning_regex).search(w.message.args[-1])):
                 warning_found = True
 
         if not warning_found:

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -10,6 +10,7 @@ import re
 import sys
 import tempfile
 import warnings
+from nose.tools import assert_equal, assert_true
 from six import string_types
 from six.moves import urllib
 
@@ -50,15 +51,54 @@ except ImportError:
                 raise AssertionError("Should have raised %r" %
                                      expected_exception(expected_regexp))
 
+
+try:
+    from sklearn.utils.testing import clean_warning_registry
+except ImportError:
+    def clean_warning_registry():
+        """Safe way to reset warnings """
+        warnings.resetwarnings()
+        reg = "__warningregistry__"
+        for mod_name, mod in list(sys.modules.items()):
+            if 'six.moves' in mod_name:
+                continue
+            if hasattr(mod, reg):
+                getattr(mod, reg).clear()
+
+
 try:
     from sklearn.utils.testing import assert_warns
 except ImportError:
     # sklearn.utils.testing.assert_warns new in scikit-learn 0.14
     def assert_warns(warning_class, func, *args, **kw):
+        #clean_warning_registry()
         with warnings.catch_warnings(record=True):
-            warnings.simplefilter("ignore", warning_class)
+            warnings.simplefilter('always', warning_class)
             output = func(*args, **kw)
         return output
+
+
+def assert_warns_regex(expected_warning, expected_regexp,
+                       callable_obj, *args, **kwargs):
+    #clean_warning_registry()
+    with warnings.catch_warnings(record=True) as ws:
+        warnings.simplefilter('always')
+        outputs = callable_obj(*args, **kwargs)
+        warning_found = False
+        for w in ws:
+            if isinstance(w.message, expected_warning) and \
+                (not expected_regexp or
+                    re.compile(expected_regexp).search(w.message[-1])):
+                warning_found = True
+
+        if not warning_found:
+            assert_true(len(ws) > 0,
+                        "No warning detected; should have raised %r" %
+                        expected_warning(expected_regexp))
+            assert_true(False, "Failed.")
+    return outputs
+
+
 
 
 @contextlib.contextmanager

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -53,52 +53,40 @@ except ImportError:
 
 
 try:
-    from sklearn.utils.testing import clean_warning_registry
-except ImportError:
-    def clean_warning_registry():
-        """Safe way to reset warnings """
-        warnings.resetwarnings()
-        reg = "__warningregistry__"
-        for mod_name, mod in list(sys.modules.items()):
-            if 'six.moves' in mod_name:
-                continue
-            if hasattr(mod, reg):
-                getattr(mod, reg).clear()
-
-
-try:
     from sklearn.utils.testing import assert_warns
 except ImportError:
     # sklearn.utils.testing.assert_warns new in scikit-learn 0.14
-    def assert_warns(warning_class, func, *args, **kw):
-        #clean_warning_registry()
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter('always', warning_class)
-            output = func(*args, **kw)
-        return output
+    def assert_warns(warning_class, func, *args, **kwargs):
+        return assert_warns_regex(warning_class, None,
+                                  func, *args, **kwargs)
 
 
-def assert_warns_regex(expected_warning, expected_regexp,
+def assert_warns_regex(warning_class, warning_regex,
                        callable_obj, *args, **kwargs):
-    #clean_warning_registry()
+    """
+    This function expects a warning of type <warning_class>
+    to be raised when calling callable_obj with the provided
+    arguments, with the warning message text matching warning_regex.
+
+    The function returns the value of calling callable_obj
+    with the supplied parameters.
+    """
     with warnings.catch_warnings(record=True) as ws:
-        warnings.simplefilter('always')
-        outputs = callable_obj(*args, **kwargs)
+        warnings.simplefilter('always', warning_class)
+        output = callable_obj(*args, **kwargs)
         warning_found = False
         for w in ws:
-            if isinstance(w.message, expected_warning) and \
-                (not expected_regexp or
-                    re.compile(expected_regexp).search(w.message[-1])):
+            if isinstance(w.message, warning_class) and \
+                (warning_regex is None or
+                    re.compile(warning_regex).search(w.message[-1])):
                 warning_found = True
 
         if not warning_found:
             assert_true(len(ws) > 0,
                         "No warning detected; should have raised %r" %
-                        expected_warning(expected_regexp))
+                        warning_class(warning_regex))
             assert_true(False, "Failed.")
-    return outputs
-
-
+    return output
 
 
 @contextlib.contextmanager

--- a/nilearn/decoding/tests/test_searchlight.py
+++ b/nilearn/decoding/tests/test_searchlight.py
@@ -42,12 +42,7 @@ def test_searchlight():
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img,
                                  radius=0.5, n_jobs=n_jobs,
                                  scoring='accuracy', cv=cv)
-    with warnings.catch_warnings():
-        #  check_cv will return indices instead of boolean masks from 0.17
-        warnings.simplefilter('ignore', DeprecationWarning)
-        warnings.filterwarnings('ignore', 'Scikit-learn version is too old.',
-                                UserWarning)  # old versions of sklearn
-        sl.fit(data_img, cond)
+    sl.fit(data_img, cond)
     assert_equal(np.where(sl.scores_ == 1)[0].size, 1)
     assert_equal(sl.scores_[2, 2, 2], 1.)
 
@@ -55,10 +50,7 @@ def test_searchlight():
 
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img, radius=1,
                                  n_jobs=n_jobs, scoring='accuracy', cv=cv)
-    with warnings.catch_warnings(record=True):
-        #  check_cv will return indices instead of boolean masks from 0.17
-        warnings.simplefilter('ignore', DeprecationWarning)
-        sl.fit(data_img, cond)
+    sl.fit(data_img, cond)
     assert_equal(np.where(sl.scores_ == 1)[0].size, 7)
     assert_equal(sl.scores_[2, 2, 2], 1.)
     assert_equal(sl.scores_[1, 2, 2], 1.)
@@ -71,9 +63,6 @@ def test_searchlight():
     # Big radius : big ball selected
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img, radius=2,
                                  n_jobs=n_jobs, scoring='accuracy', cv=cv)
-    with warnings.catch_warnings(record=True):
-        #  check_cv will return indices instead of boolean masks from 0.17
-        warnings.simplefilter('ignore', DeprecationWarning)
-        sl.fit(data_img, cond)
+    sl.fit(data_img, cond)
     assert_equal(np.where(sl.scores_ == 1)[0].size, 33)
     assert_equal(sl.scores_[2, 2, 2], 1.)

--- a/nilearn/decoding/tests/test_searchlight.py
+++ b/nilearn/decoding/tests/test_searchlight.py
@@ -4,9 +4,12 @@ Test the searchlight module
 # Author: Alexandre Abraham
 # License: simplified BSD
 
-from nose.tools import assert_equal
 import numpy as np
+import warnings
+from nose.tools import assert_equal
+
 import nibabel
+
 from nilearn.decoding import searchlight
 
 
@@ -39,7 +42,12 @@ def test_searchlight():
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img,
                                  radius=0.5, n_jobs=n_jobs,
                                  scoring='accuracy', cv=cv)
-    sl.fit(data_img, cond)
+    with warnings.catch_warnings():
+        #  check_cv will return indices instead of boolean masks from 0.17
+        warnings.simplefilter('ignore', DeprecationWarning)
+        warnings.filterwarnings('ignore', 'Scikit-learn version is too old.',
+                                UserWarning)  # old versions of sklearn
+        sl.fit(data_img, cond)
     assert_equal(np.where(sl.scores_ == 1)[0].size, 1)
     assert_equal(sl.scores_[2, 2, 2], 1.)
 
@@ -47,7 +55,10 @@ def test_searchlight():
 
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img, radius=1,
                                  n_jobs=n_jobs, scoring='accuracy', cv=cv)
-    sl.fit(data_img, cond)
+    with warnings.catch_warnings(record=True):
+        #  check_cv will return indices instead of boolean masks from 0.17
+        warnings.simplefilter('ignore', DeprecationWarning)
+        sl.fit(data_img, cond)
     assert_equal(np.where(sl.scores_ == 1)[0].size, 7)
     assert_equal(sl.scores_[2, 2, 2], 1.)
     assert_equal(sl.scores_[1, 2, 2], 1.)
@@ -60,6 +71,9 @@ def test_searchlight():
     # Big radius : big ball selected
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img, radius=2,
                                  n_jobs=n_jobs, scoring='accuracy', cv=cv)
-    sl.fit(data_img, cond)
+    with warnings.catch_warnings(record=True):
+        #  check_cv will return indices instead of boolean masks from 0.17
+        warnings.simplefilter('ignore', DeprecationWarning)
+        sl.fit(data_img, cond)
     assert_equal(np.where(sl.scores_ == 1)[0].size, 33)
     assert_equal(sl.scores_[2, 2, 2], 1.)

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -14,9 +14,10 @@ from sklearn.utils.extmath import randomized_svd
 
 from ..input_data import NiftiMasker, MultiNiftiMasker, NiftiMapsMasker
 from ..input_data.base_masker import filter_and_mask
-from .._utils.class_inspect import get_params
-from .._utils.cache_mixin import cache
 from .._utils import as_ndarray
+from .._utils.cache_mixin import cache
+from .._utils.class_inspect import get_params
+
 
 def session_pca(imgs, mask_img, parameters,
                 n_components=20,

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -252,9 +252,22 @@ class MultiPCA(BaseEstimator, TransformerMixin):
                 if our_param is None:
                     # Default value
                     continue
-                if getattr(self.masker_, param_name) is not None:
-                    warnings.warn('Parameter %s of the masker overriden'
-                                  % param_name)
+                their_param = getattr(self.masker_, param_name)
+                if their_param is not None and their_param != our_param:
+                    # Special case of memory, which must be compared
+                    #   by cachedir.
+                    emit_warning = True
+                    if param_name == 'memory':
+                        if our_param.cachedir is None:
+                            continue
+                        else:
+                            emit_warning = (their_param.cachedir !=
+                                            our_param.cache_dir)
+                    if emit_warning:
+                        warnings.warn("Parameter %s of the masker overriden "
+                                      "(%s != %s)" % (param_name,
+                                                      str(their_param)[:20],
+                                                      str(our_param)[:20]))
                 setattr(self.masker_, param_name, our_param)
 
         # Masker warns if it has a mask_img and is passed

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -1,5 +1,6 @@
 """Test CanICA"""
 
+import warnings
 from nose.tools import assert_equal, assert_raises
 
 import nibabel
@@ -47,9 +48,12 @@ def test_canica_square_img():
     mask_img = nibabel.Nifti1Image(np.ones(shape, dtype=np.int8), affine)
 
     # We do a large number of inits to be sure to find the good match
-    canica = CanICA(n_components=4, random_state=rng, mask=mask_img,
-                    smoothing_fwhm=0., n_init=50)
-    canica.fit(data)
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', 'FastICA did not converge.',
+                                UserWarning)  # OK even if not converging.
+        canica = CanICA(n_components=4, random_state=rng, mask=mask_img,
+                        smoothing_fwhm=0., n_init=50)
+        canica.fit(data)
     maps = canica.masker_.inverse_transform(canica.components_).get_data()
     maps = np.rollaxis(maps, 3, 0)
 

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -1,10 +1,10 @@
 """Test CanICA"""
 
-import numpy as np
-from numpy.testing import assert_array_almost_equal
-from nose.tools import assert_true, assert_raises
+from nose.tools import assert_equal, assert_raises
 
 import nibabel
+import numpy as np
+from numpy.testing import assert_array_almost_equal
 
 from nilearn.decomposition.canica import CanICA
 
@@ -60,7 +60,7 @@ def test_canica_square_img():
     # K should be a permutation matrix, hence its coefficients 
     # should all be close to 0 1 or -1
     K_abs = np.abs(K)
-    assert_true(np.sum(K_abs > .9) == 4)
+    assert_equal(np.sum(K_abs > .9), 4)
     K_abs[K_abs > .9] -= 1
     assert_array_almost_equal(K_abs, 0, 1)
 

--- a/nilearn/decomposition/tests/test_multi_pca.py
+++ b/nilearn/decomposition/tests/test_multi_pca.py
@@ -41,8 +41,10 @@ def test_multi_pca():
     # Smoke test that multi_pca also works with single subject data
     multi_pca.fit(data[0])
 
-    # Check that asking for too little components raises a ValueError
-    multi_pca = MultiPCA()
+    # Check that asking for too little components raises a ValueError.
+    # pass an explicit mask, to avoid an additional error from computing
+    # a mask on dummy data.
+    multi_pca = MultiPCA(mask=mask_img)
     assert_raises(ValueError, multi_pca.fit, data[:2])
 
     # Smoke test the use of a masker and without CCA

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -78,7 +78,7 @@ def _extrapolate_out_mask(data, mask, iterations=1):
     masked_data[1:-1, 1:-1, 1:-1] = data.copy()
     masked_data[np.logical_not(larger_mask)] = np.nan
     outer_shell = larger_mask.copy()
-    outer_shell[1:-1, 1:-1, 1:-1] = new_mask - mask
+    outer_shell[1:-1, 1:-1, 1:-1] = np.logical_xor(new_mask, mask)
     outer_shell_x, outer_shell_y, outer_shell_z = np.where(outer_shell)
     extrapolation = list()
     for i, j, k in [(0, 1, 0), (0, -1, 0), (1, 0, 0), (-1, 0, 0),

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -140,7 +140,7 @@ def test_permuted_ols_check_h0_noeffect_labelswap(random_state=0):
     target_var = rng.randn(n_samples, 1)
     tested_var = np.arange(n_samples).reshape((-1, 1))
     tested_var_not_centered = tested_var.copy()
-    tested_var -= tested_var.mean(0)  # centered
+    tested_var = tested_var.astype(np.float64) - tested_var.mean(0)  # centered
     # permuted OLS
     # We check that h0 is close to the theoretical distribution, which is
     # known for this simple design (= t(n_samples - dof)).

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -5,6 +5,7 @@ Tests for the permuted_ols function.
 # Author: Virgile Fritsch, <virgile.fritsch@inria.fr>, Feb. 2014
 import nose
 import numpy as np
+import warnings
 from scipy import stats
 from sklearn.utils import check_random_state
 
@@ -517,9 +518,13 @@ def test_sided_test2(random_state=0):
     tested_var = np.arange(0, 20, 2)
     # permuted OLS
     # one-sided
-    neg_log_pvals_onesided, _, _ = permuted_ols(
-        tested_var, target_var, model_intercept=False,
-        two_sided_test=False, n_perm=100, random_state=random_state)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        neg_log_pvals_onesided, _, _ = permuted_ols(
+            tested_var, target_var, model_intercept=False,
+            two_sided_test=False, n_perm=100,
+            random_state=random_state)
+
     # one-sided (other side)
     neg_log_pvals_onesided2, _, _ = permuted_ols(
         tested_var, -target_var, model_intercept=False,

--- a/nilearn/plotting/edge_detect.py
+++ b/nilearn/plotting/edge_detect.py
@@ -65,7 +65,7 @@ def _edge_detect(image, high_threshold=.75, low_threshold=.4):
     np.seterr(**np_err)
     # Where the noise variance is 0, Wiener can create nans
     img[np.isnan(img)] = image[np.isnan(img)]
-    img /= img.max()
+    img /= (img.max() or 1.)  # avoid divide-by-zero warnings
     grad_x = ndimage.sobel(img, mode='constant', axis=0)
     grad_y = ndimage.sobel(img, mode='constant', axis=1)
     grad_mag = np.sqrt(grad_x**2 + grad_y**2)
@@ -78,7 +78,7 @@ def _edge_detect(image, high_threshold=.75, low_threshold=.4):
     for angle in np.arange(0, 2, .25):
         thinner = thinner | (
                 (grad_mag > .85*ndimage.maximum_filter(grad_mag,
-                                    footprint=_orientation_kernel(angle))) 
+                                    footprint=_orientation_kernel(angle)))
                 & (((grad_angle - angle) % 2) < .75)
                )
     # Remove the edges next to the side of the image: they are not reliable

--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -237,4 +237,4 @@ def find_cut_slices(img, direction='z', n_cuts=12, spacing='auto'):
     cut_coords = coord_transform(**kwargs)[axis]
     # We need to atleast_1d to make sure that when n_cuts is 1 we do
     # get an iterable
-    return np.atleast_1d(cut_coords)
+    return np.atleast_1d(cut_coords).astype(int)

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -22,12 +22,14 @@ except ImportError:
 
 import nibabel
 
+from nilearn._utils.testing import assert_warns_regex
 from nilearn.image.resampling import coord_transform
 
 from nilearn.plotting.img_plotting import (MNI152TEMPLATE, plot_anat, plot_img,
                                            plot_roi, plot_stat_map, plot_epi,
                                            plot_glass_brain, plot_connectome)
 from nilearn._utils.testing import assert_raises_regex
+
 
 mni_affine = np.array([[  -2.,    0.,    0.,   90.],
                        [   0.,    2.,    0., -126.],
@@ -210,7 +212,12 @@ def test_plot_empty_slice():
     pl.switch_backend('template')
     data = np.zeros((20, 20, 20))
     img = nibabel.Nifti1Image(data, mni_affine)
-    plot_img(img, display_mode='y', threshold=1)
+
+    plot_anat(img)
+    slicer = assert_warns_regex(UserWarning, 'empty mask',
+                                plot_img, img, display_mode='y', threshold=1)
+    slicer.close()
+    pl.close('all')
 
 
 def test_plot_img_invalid():

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -214,8 +214,7 @@ def test_plot_empty_slice():
     img = nibabel.Nifti1Image(data, mni_affine)
 
     plot_anat(img)
-    slicer = assert_warns_regex(UserWarning, 'empty mask',
-                                plot_img, img, display_mode='y', threshold=1)
+    slicer = plot_img(img, display_mode='y', threshold=1)
     slicer.close()
     pl.close('all')
 

--- a/nilearn/tests/test_cache_mixin.py
+++ b/nilearn/tests/test_cache_mixin.py
@@ -13,6 +13,7 @@ from sklearn.externals.joblib import Memory
 
 import nilearn
 from nilearn._utils import cache_mixin
+from nilearn._utils.testing import assert_warns_regex
 
 
 def f(x):
@@ -56,7 +57,8 @@ def test__safe_cache_flush():
 
         # First turn off version checking
         nilearn.check_cache_version = False
-        cache_mixin._safe_cache(mem, f)
+        assert_warns_regex(UserWarning, 'Incompatible cache',
+                           cache_mixin._safe_cache, mem, f)
         assert_true(os.path.exists(nibabel_dir))
 
         # Second turn on version checking
@@ -65,7 +67,8 @@ def test__safe_cache_flush():
         cache_mixin.__cache_checked = {}
         with open(version_file, 'w') as f:
             json.dump({"nibabel": [0, 0]}, f)
-        cache_mixin._safe_cache(mem, f)
+        assert_warns_regex(UserWarning, 'Incompatible cache',
+                           cache_mixin._safe_cache, mem, f)
         assert_true(os.path.exists(version_file))
         assert_false(os.path.exists(nibabel_dir))
     finally:

--- a/nilearn/tests/test_datasets.py
+++ b/nilearn/tests/test_datasets.py
@@ -23,7 +23,8 @@ from nose.tools import (assert_true, assert_false, assert_equal, assert_raises,
 
 from nilearn import datasets
 from nilearn._utils.testing import (mock_request, wrap_chunk_read_,
-                                    FetchFilesMock, assert_raises_regex)
+                                    FetchFilesMock, assert_raises_regex,
+                                    assert_warns_regex)
 
 
 currdir = os.path.dirname(os.path.abspath(__file__))
@@ -257,9 +258,10 @@ def test_fail_fetch_haxby_simple():
             (os.path.join(path, 'bald.nii.gz'), local_url, opts)
     ]
 
-    assert_raises(IOError, datasets._fetch_files,
-            os.path.join(tmpdir, 'haxby2001_simple'), files,
-            verbose=0)
+    assert_warns_regex(UserWarning, 'An error occured while fetching',
+                       assert_raises, IOError, datasets._fetch_files,
+                       os.path.join(tmpdir, 'haxby2001_simple'), files,
+                       verbose=0)
     dummy = open(os.path.join(datasetdir, 'attributes.txt'), 'r')
     stuff = dummy.read(5)
     dummy.close()

--- a/nilearn/tests/test_group_sparse_covariance.py
+++ b/nilearn/tests/test_group_sparse_covariance.py
@@ -2,7 +2,8 @@ from nose.tools import assert_equal, assert_true, assert_raises
 
 import numpy as np
 
-from nilearn._utils.testing import generate_group_sparse_gaussian_graphs
+from nilearn._utils.testing import (generate_group_sparse_gaussian_graphs,
+                                    assert_warns_regex)
 from nilearn.group_sparse_covariance import (group_sparse_covariance,
                                              group_sparse_scores,
                                              GroupSparseCovariance,

--- a/nilearn/tests/test_group_sparse_covariance.py
+++ b/nilearn/tests/test_group_sparse_covariance.py
@@ -1,11 +1,12 @@
 from nose.tools import assert_equal, assert_true, assert_raises
 
 import numpy as np
+
 from nilearn._utils.testing import generate_group_sparse_gaussian_graphs
 from nilearn.group_sparse_covariance import (group_sparse_covariance,
-                                       group_sparse_scores,
-                                       GroupSparseCovariance,
-                                       GroupSparseCovarianceCV)
+                                             group_sparse_scores,
+                                             GroupSparseCovariance,
+                                             GroupSparseCovarianceCV)
 
 
 def test_group_sparse_covariance():
@@ -20,10 +21,17 @@ def test_group_sparse_covariance():
     alpha = 0.1
 
     # These executions must hit the tolerance limit
-    emp_covs, omega = group_sparse_covariance(signals, alpha, max_iter=20,
-                                              tol=1e-2, debug=True, verbose=0)
-    emp_covs, omega2 = group_sparse_covariance(signals, alpha, max_iter=20,
-                                               tol=1e-2, debug=True, verbose=0)
+    emp_covs, omega = assert_warns_regex(UserWarning,
+                                         'input signals do not all have unit variance',
+                                         group_sparse_covariance,
+                                         signals, alpha, max_iter=20,
+                                         tol=1e-2, debug=True, verbose=0)
+
+    emp_covs2, omega2 = assert_warns_regex(UserWarning,
+                                           'input signals do not all have unit variance',
+                                           group_sparse_covariance,
+                                           signals, alpha, max_iter=20,
+                                           tol=1e-2, debug=True, verbose=0)
 
     np.testing.assert_almost_equal(omega, omega2, decimal=4)
 
@@ -40,8 +48,12 @@ def test_group_sparse_covariance():
 
     # Use a probe to test for number of iterations and decreasing objective.
     probe = Probe()
-    emp_covs, omega = group_sparse_covariance(
-        signals, alpha, max_iter=4, tol=None, verbose=0, probe_function=probe)
+    emp_covs, omega = assert_warns_regex(UserWarning,
+                                         'input signals do not all have unit variance',
+                                         group_sparse_covariance,
+                                         signals, alpha, max_iter=4,
+                                         tol=None, verbose=0,
+                                         probe_function=probe)
     objective = probe.objective
     # check number of iterations
     assert_equal(len(objective), 4)
@@ -60,11 +72,15 @@ def test_group_sparse_covariance():
     # Check consistency between classes
     gsc1 = GroupSparseCovarianceCV(alphas=4, tol=1e-1, max_iter=20, verbose=0,
                                    early_stopping=True)
-    gsc1.fit(signals)
+    assert_warns_regex(UserWarning,
+                       'input signals do not all have unit variance',
+                       gsc1.fit, signals)
 
     gsc2 = GroupSparseCovariance(alpha=gsc1.alpha_, tol=1e-1, max_iter=20,
                                  verbose=0)
-    gsc2.fit(signals)
+    assert_warns_regex(UserWarning,
+                       'input signals do not all have unit variance',
+                       gsc2.fit, signals)
 
     np.testing.assert_almost_equal(gsc1.precisions_, gsc2.precisions_,
                                    decimal=4)

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -165,10 +165,10 @@ def test_unmask():
 
     masked4D = data4D[mask, :].T
     unmasked4D = data4D.copy()
-    unmasked4D[-mask, :] = 0
+    unmasked4D[np.logical_not(mask), :] = 0
     masked3D = data3D[mask]
     unmasked3D = data3D.copy()
-    unmasked3D[-mask] = 0
+    unmasked3D[np.logical_not(mask)] = 0
 
     # 4D Test, test value ordering at the same time.
     t = unmask(masked4D, mask_img, order="C").get_data()
@@ -209,7 +209,7 @@ def test_unmask():
 
     masked5D = data5D[mask, :].T
     unmasked5D = data5D.copy()
-    unmasked5D[-mask, :] = 0
+    unmasked5D[np.logical_not(mask), :] = 0
 
     t = unmask(masked5D, mask_img).get_data()
     assert_equal(t.ndim, len(shape5D))

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -3,7 +3,6 @@ Test the mask-extracting utilities.
 """
 import types
 import distutils.version
-import warnings
 import numpy as np
 
 from numpy.testing import assert_array_equal
@@ -16,7 +15,8 @@ from nilearn import masking
 from nilearn.masking import (compute_epi_mask, compute_multi_epi_mask,
                              compute_background_mask, unmask, _unmask_3d,
                              _unmask_4d, intersect_masks, MaskWarning)
-from nilearn._utils.testing import (write_tmp_imgs, assert_raises_regex)
+from nilearn._utils.testing import (write_tmp_imgs, assert_raises_regex,
+                                    assert_warns_regex)
 
 np_version = (np.version.full_version if hasattr(np.version, 'full_version')
               else np.version.short_version)
@@ -60,10 +60,9 @@ def test_compute_epi_mask():
     mean_image[0, 0, 0] = 1.2
     mean_image[0, 0, 2] = 1.1
     mean_image = Nifti1Image(mean_image, np.eye(4))
-    with warnings.catch_warnings(record=True) as w:
-        compute_epi_mask(mean_image, exclude_zeros=True)
-    assert_equal(len(w), 1)
-    assert_true(isinstance(w[0].message, masking.MaskWarning))
+
+    assert_warns_regex(masking.MaskWarning, 'Computed an empty mask',
+                       compute_epi_mask, mean_image, exclude_zeros=True)
 
 
 def test_compute_background_mask():
@@ -86,10 +85,9 @@ def test_compute_background_mask():
     # Check that we get a useful warning for empty masks
     mean_image = np.zeros((9, 9, 9))
     mean_image = Nifti1Image(mean_image, np.eye(4))
-    with warnings.catch_warnings(record=True) as w:
-        compute_background_mask(mean_image)
-    assert_equal(len(w), 1)
-    assert_true(isinstance(w[0].message, masking.MaskWarning))
+
+    assert_warns_regex(masking.MaskWarning, 'Computed an empty mask',
+                       compute_background_mask, mean_image)
 
 
 def test_apply_mask():
@@ -328,10 +326,9 @@ def test_compute_multi_epi_mask():
     mask_b[2:6, 2:6] = 1
     mask_b_img = Nifti1Image(mask_b.astype(int), np.eye(4) / 2.)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", MaskWarning)
-        assert_raises(ValueError, compute_multi_epi_mask,
-                      [mask_a_img, mask_b_img])
+    assert_warns_regex(MaskWarning, 'Computed an empty mask',
+                       assert_raises, ValueError,
+                       compute_multi_epi_mask, [mask_a_img, mask_b_img])
     mask_ab = np.zeros((4, 4, 1), dtype=np.bool)
     mask_ab[2, 2] = 1
     mask_ab_ = compute_multi_epi_mask([mask_a_img, mask_b_img], threshold=1.,

--- a/nilearn/tests/test_region.py
+++ b/nilearn/tests/test_region.py
@@ -11,6 +11,7 @@ from six.moves import xrange
 import nibabel
 
 from nilearn import region
+from nilearn._utils.testing import assert_warns
 from nilearn._utils.testing import generate_timeseries, generate_regions_ts
 from nilearn._utils.testing import generate_labeled_regions, generate_maps
 from nilearn._utils.testing import generate_fake_fmri
@@ -307,6 +308,7 @@ def test_signal_extraction_with_maps_and_labels():
     mask_data = (labels_data == 1) + (labels_data == 2) + (labels_data == 5)
     mask_img = nibabel.Nifti1Image(mask_data.astype(np.int8),
                                    labels_img.get_affine())
+
     # Ignore a known warning about divide-by-zero on our dummy data.
     labels_signals, labels_labels = \
         assert_warns(RuntimeWarning,

--- a/nilearn/tests/test_region.py
+++ b/nilearn/tests/test_region.py
@@ -4,7 +4,6 @@ Test for "region" module.
 # Author: Ph. Gervais
 # License: simplified BSD
 import warnings
-
 import numpy as np
 from nose.tools import assert_raises, assert_true
 from six.moves import xrange
@@ -16,6 +15,7 @@ from nilearn._utils.testing import generate_timeseries, generate_regions_ts
 from nilearn._utils.testing import generate_labeled_regions, generate_maps
 from nilearn._utils.testing import generate_fake_fmri
 from nilearn._utils.testing import write_tmp_imgs, assert_raises_regex
+from nilearn._utils.testing import assert_warns
 
 
 def test_generate_regions_ts():
@@ -308,15 +308,14 @@ def test_signal_extraction_with_maps_and_labels():
     mask_img = nibabel.Nifti1Image(mask_data.astype(np.int8),
                                    labels_img.get_affine())
     # Ignore a known warning about divide-by-zero on our dummy data.
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', RuntimeWarning)
-        labels_signals, labels_labels =\
-                        region.img_to_signals_labels(fmri_img, labels_img,
-                                                     mask_img=mask_img)
+    labels_signals, labels_labels = \
+        assert_warns(RuntimeWarning,
+                     region.img_to_signals_labels,
+                     fmri_img, labels_img, mask_img=mask_img)
 
     maps_signals, maps_labels = \
-                  region.img_to_signals_maps(fmri_img, maps_img,
-                                             mask_img=mask_img)
+        region.img_to_signals_maps(fmri_img, maps_img,
+                                   mask_img=mask_img)
 
     np.testing.assert_almost_equal(maps_signals, labels_signals)
     assert_true(maps_signals.shape[1] == n_regions)

--- a/nilearn/tests/test_region.py
+++ b/nilearn/tests/test_region.py
@@ -3,6 +3,7 @@ Test for "region" module.
 """
 # Author: Ph. Gervais
 # License: simplified BSD
+import warnings
 
 import numpy as np
 from nose.tools import assert_raises, assert_true
@@ -306,9 +307,12 @@ def test_signal_extraction_with_maps_and_labels():
     mask_data = (labels_data == 1) + (labels_data == 2) + (labels_data == 5)
     mask_img = nibabel.Nifti1Image(mask_data.astype(np.int8),
                                    labels_img.get_affine())
-    labels_signals, labels_labels =\
-                    region.img_to_signals_labels(fmri_img, labels_img,
-                                                 mask_img=mask_img)
+    # Ignore a known warning about divide-by-zero on our dummy data.
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        labels_signals, labels_labels =\
+                        region.img_to_signals_labels(fmri_img, labels_img,
+                                                     mask_img=mask_img)
 
     maps_signals, maps_labels = \
                   region.img_to_signals_maps(fmri_img, maps_img,
@@ -333,9 +337,11 @@ def test_signal_extraction_with_maps_and_labels():
     region1 = labels_data == 2
     indices = [ind[:1] for ind in np.where(region1)]
     fmri_img.get_data()[indices + [slice(None)]] = float('nan')
-    labels_signals, labels_labels =\
-                    region.img_to_signals_labels(fmri_img, labels_img,
-                                                 mask_img=mask_img)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)  # divide by zero
+        labels_signals, labels_labels =\
+                        region.img_to_signals_labels(fmri_img, labels_img,
+                                                     mask_img=mask_img)
     assert_true(np.all(np.isnan(labels_signals[:, labels_labels.index(2)])))
 
 

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -5,11 +5,11 @@ Test the signals module
 # License: simplified BSD
 
 import os.path
+import warnings
 
 import numpy as np
-from nose.tools import assert_true, assert_false, assert_raises
-
 import scipy.signal
+from nose.tools import assert_true, assert_false, assert_raises
 
 # Use nisignal here to avoid name collisions (using nilearn.signal is
 # not possible)
@@ -242,10 +242,14 @@ def test_clean_frequencies():
     sx = np.vstack((sx1, sx2)).T
     assert_true(clean(sx, standardize=False, high_pass=0.002, low_pass=None)
                 .max() > 0.1)
-    assert_true(clean(sx, standardize=False, high_pass=0.2, low_pass=None)
-                .max() < 0.01)
     assert_true(clean(sx, standardize=False, low_pass=0.01).max() > 0.9)
+
+    # Error cases
     assert_raises(ValueError, clean, sx, low_pass=0.4, high_pass=0.5)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", scipy.signal.filter_design.BadCoefficients)
+        assert_true(clean(sx, standardize=False, high_pass=0.2, low_pass=None)
+                    .max() < 0.01)
 
 
 def test_clean_confounds():

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -9,11 +9,12 @@ import os.path
 import numpy as np
 from nose.tools import assert_true, assert_false, assert_raises
 
+import scipy.signal
+
 # Use nisignal here to avoid name collisions (using nilearn.signal is
 # not possible)
 from nilearn import signal as nisignal
 from nilearn.signal import clean
-import scipy.signal
 
 
 def generate_signals(n_features=17, n_confounds=5, length=41,

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -50,6 +50,13 @@ REQUIRED_MODULE_METADATA = (
         'required_at_installation': False}))
 
 
+def get_min_version(module_name):
+    for name, metadata in REQUIRED_MODULE_METADATA:
+        if name == module_name:
+            return metadata['min_version']
+    return None
+
+
 def _import_module_with_version_check(
         module_name,
         minimum_version,


### PR DESCRIPTION
Here, I've made the tests run with `UserWarning` causing errors.  I've debugged each of the warnings to find the root cause, and made one of three changes in every case:
* Tweaked the test to ignore that warning, if it's out of our control.
* Tweaked the test to expect that warning, if the test is designed to cause the warning
* Made small changes to the `nilearn` code to compensate for external bugs (there were 1 or 2 instances of this)
* Changed the `nilearn` code because of what I believe was a bug.

I have already gone through the commits once to try and make them clear; I will go through again to try and label what type of change I believe each one represents.

This makes the test output completely clean--warnings are either known to be ignored, expected (and tested), or fixed.  I think this is the best way to proceed to identify changes in the behavior of `nilearn` moving forward.

![image](https://cloud.githubusercontent.com/assets/4072455/5962296/c27d2390-a797-11e4-96a2-7b41ef12548f.png)
