### PR TITLE
[WIP] Adding Python 3.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ env:
     - DISTRIB="conda" PYTHON_VERSION="2.6"
       NUMPY_VERSION="1.9.1" SCIPY_VERSION="0.15.1"
       MATPLOTLIB_VERSION="1.4.2" SKLEARN_VERSION="0.15.2"
+    - DISTRIB="conda" PYTHON_VERSION="3.4"
+      NUMPY_VERSION="1.9.1" SCIPY_VERSION="0.15.1"
+      MATPLOTLIB_VERSION="1.4.2" SKLEARN_VERSION="0.15.2"
 
 install: 
     - source continuous_integration/install.sh

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 # caution: testing won't work on windows, see README
 
+export PYTHONWARNINGS=error::UserWarning::0  # treat user warnings as errors
 PYTHON ?= python
 CYTHON ?= cython
 NOSETESTS ?= nosetests

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,7 @@ The required dependencies to use the software are:
 * SciPy >= 0.7
 * Scikit-learn >= 0.12.1
 * Nibabel >= 1.1.0.
+* Six
 This configuration almost matches the Ubuntu 10.04 LTS release from
 April 2010, except for scikit-learn, which must be installed separately.
 

--- a/doc/building_blocks/decoding_simulated.rst
+++ b/doc/building_blocks/decoding_simulated.rst
@@ -91,7 +91,7 @@ models, a `coef_` attribute that stores the coefficients **w** estimated.
 
 .. literalinclude:: ../../examples/decoding/plot_simulated_data.py
     :start-after: # Run the estimators
-    :end-before:     print title
+    :end-before:     print (title)
 
 .. |estimator1| image:: ../auto_examples/decoding/images/plot_simulated_data_2.png
     :target: ../auto_examples/decoding/plot_simulated_data.html

--- a/doc/building_blocks/manipulating_mr_images.rst
+++ b/doc/building_blocks/manipulating_mr_images.rst
@@ -167,11 +167,12 @@ can be loaded with `numpy.genfromtxt` but you may have to specify some options
 For the Haxby datasets, we can load the categories of the images
 presented to the subject::
 
+    >>> from six import string_types
     >>> from nilearn import datasets
     >>> haxby_files = datasets.fetch_haxby(n_subjects=1)
     >>> import numpy as np
     >>> labels = np.genfromtxt(haxby_files.session_target[0], skip_header=1,
-    ...                        usecols=[0], dtype=basestring)
+    ...                        usecols=[0], dtype=string_types)
     >>> print (np.unique(labels))
     ['bottle' 'cat' 'chair' 'face' 'house' 'rest' 'scissors' 'scrambledpix'
      'shoe']

--- a/doc/building_blocks/manipulating_mr_images.rst
+++ b/doc/building_blocks/manipulating_mr_images.rst
@@ -36,7 +36,7 @@ datasets and atlases. Dataset fetching functions can be imported from
 They return a structure that contains the different file names::
 
     >>> # The different files
-    >>> print (haxby_files.keys())
+    >>> print (list(haxby_files.keys()))
     ['mask_house_little', 'anat', 'mask_house', 'mask_face', 'func', 'session_target', 'mask_vt', 'mask_face_little']
     >>> #  Path to first functional file
     >>> print (haxby_files.func[0] # doctest: +ELLIPSIS)

--- a/doc/building_blocks/manipulating_mr_images.rst
+++ b/doc/building_blocks/manipulating_mr_images.rst
@@ -36,10 +36,10 @@ datasets and atlases. Dataset fetching functions can be imported from
 They return a structure that contains the different file names::
 
     >>> # The different files
-    >>> print haxby_files.keys()
+    >>> print (haxby_files.keys())
     ['mask_house_little', 'anat', 'mask_house', 'mask_face', 'func', 'session_target', 'mask_vt', 'mask_face_little']
     >>> #  Path to first functional file
-    >>> print haxby_files.func[0] # doctest: +ELLIPSIS
+    >>> print (haxby_files.func[0] # doctest: +ELLIPSIS)
     /.../nilearn_data/haxby2001/subj1/bold.nii.gz
 
 |
@@ -172,7 +172,7 @@ presented to the subject::
     >>> import numpy as np
     >>> labels = np.genfromtxt(haxby_files.session_target[0], skip_header=1,
     ...                        usecols=[0], dtype=basestring)
-    >>> print np.unique(labels)
+    >>> print (np.unique(labels))
     ['bottle' 'cat' 'chair' 'face' 'house' 'rest' 'scissors' 'scrambledpix'
      'shoe']
 

--- a/doc/building_blocks/pipeline_introduction.rst
+++ b/doc/building_blocks/pipeline_introduction.rst
@@ -39,7 +39,7 @@ example, we can download the data from the
 
 `dataset.func` contains filenames referring to dataset files on the disk::
 
-  >>> dataset.keys()
+  >>> list(dataset.keys())
   ['mask_house_little', 'anat', 'mask_house', 'mask_face', 'func', 'session_target', 'mask_vt', 'mask_face_little']
   >>> dataset.func # doctest: +ELLIPSIS
   ['.../haxby2001/subj1/bold.nii.gz']

--- a/doc/data_analysis/decoding.rst
+++ b/doc/data_analysis/decoding.rst
@@ -85,7 +85,7 @@ First, load the data using nilearn's data downloading function,
 The ``haxby_dataset`` object has several entries that contain paths to the files
 downloaded on the disk::
 
-    >>> print haxby_dataset # doctest: +SKIP
+    >>> print (haxby_dataset)  # doctest: +SKIP
     {'anat': ['/home/varoquau/dev/nilearn/nilearn_data/haxby2001/subj1/anat.nii.gz'],
     'func': ['/home/varoquau/dev/nilearn/nilearn_data/haxby2001/subj1/bold.nii.gz'],
     'mask_face': ['/home/varoquau/dev/nilearn/nilearn_data/haxby2001/subj1/mask8b_face_vt.nii.gz'],
@@ -237,7 +237,7 @@ under Windows)::
 **Prediction accuracy**: We can take a look at the results of the
 *cross_val_score* function::
 
-  >>> print cv_scores # doctest: +SKIP
+  >>> print (cv_scores) # doctest: +SKIP
   [0.72727272727272729, 0.46511627906976744, 0.72093023255813948, 0.58139534883720934, 0.7441860465116279]
 
 This is simply the prediction score for each fold, i.e. the fraction of
@@ -267,7 +267,7 @@ to use the session label, present in the behavioral data file, and
     >>> session_label = session_label[condition_mask] # doctest: +SKIP
     >>> cv = LeaveOneLabelOut(labels=session_label) # doctest: +SKIP
     >>> cv_scores = cross_val_score(svc, fmri_masked, target, cv=cv)
-    >>> print cv_scores
+    >>> print (cv_scores)
     [ 1.          0.61111111  0.94444444  0.88888889  0.88888889  0.94444444
       0.72222222  0.94444444  0.5         0.72222222  0.5         0.55555556]
 
@@ -467,9 +467,9 @@ and recompute the cross-validation score::
 
     >>> cv_scores = cross_val_score(anova_lda, X, y, cv=cv, verbose=1)
     >>> classification_accuracy = np.mean(cv_scores)
-    >>> print "Classification accuracy: %f" % classification_accuracy, \
-    ...     " / Chance level: %f" % (1. / n_conditions) # doctest: +SKIP
-    Classification accuracy: 1.000000   / Chance level: 0.500000
+    >>> print ("Classification accuracy: %.4f / Chance Level: %.4f" % \
+    ...    (classification_accuracy, 1. / n_conditions)) # doctest: +SKIP
+    Classification accuracy: 1.0000 / Chance level: 0.5000
 
 
 Changing the feature selection

--- a/doc/issues.txt
+++ b/doc/issues.txt
@@ -1,0 +1,18 @@
+Create RSA code
+
+
+Refactor datasets
+	* Separate base functions from fetch methods (code and tests)
+	* Make easily extensible (create a basic template)
+
+Create examples cache
+	* Make CacheMixin (or Memory) read from environment variables (if memory not specified)
+
+Silent datasets download
+    * 
+
+Single-location Memory
+    * 
+
+Python 3.x
+    * Many more warnings in decoding/plot_haxby_full_analysis.py for 3.4 vs. 2.6

--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -963,10 +963,10 @@ def embed_code_links(app, exception):
                                 for name, link in str_repl.iteritems():
                                     line = line.replace(name, link)
                                 fid.write(line.encode('utf-8'))
-    except urllib2.HTTPError, e:
+    except urllib2.HTTPError as e:
         print ("The following HTTP Error has occurred:\n")
         print e.code
-    except urllib2.URLError, e:
+    except urllib2.URLError as e:
         print ("\n...\n"
                "Warning: Embedding the documentation hyperlinks requires "
                "internet access.\nPlease check your network connection.\n"

--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -8,6 +8,7 @@ example files.
 Files that generate images should start with 'plot'
 
 """
+from six import string_types
 from time import time
 import os
 import re
@@ -710,7 +711,7 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, plot_gallery):
                 for var_name, var in my_globals.iteritems():
                     if not hasattr(var, '__module__'):
                         continue
-                    if not isinstance(var.__module__, basestring):
+                    if not isinstance(var.__module__, string_types):
                         continue
                     if var.__module__.split('.')[0] not in DOCMODULES:
                         continue
@@ -754,7 +755,7 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, plot_gallery):
                                 continue
                             if not hasattr(this_fun, '__module__'):
                                 continue
-                            if not isinstance(this_fun.__module__, basestring):
+                            if not isinstance(this_fun.__module__, string_types):
                                 continue
                             if (this_fun.__module__.split('.')[0]
                                     not in DOCMODULES):

--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -21,6 +21,7 @@ from six import string_types
 from six.moves import cPickle, urllib
 from six.moves.StringIO import StringIO
 from time import time
+
 try:
     from PIL import Image
 except:
@@ -227,11 +228,11 @@ class SphinxDocLinkResolver(object):
         if full_name in self._searchindex['objects']:
             value = self._searchindex['objects'][full_name]
             if isinstance(value, dict):
-                value = value[value.keys()[0]]
+                value = value[list(value.keys())[0]]
             fname_idx = value[0]
         elif cobj['module_short'] in self._searchindex['objects']:
             value = self._searchindex['objects'][cobj['module_short']]
-            if cobj['name'] in value.keys():
+            if cobj['name'] in list(value.keys()):
                 fname_idx = value[cobj['name']][0]
 
         if fname_idx is not None:
@@ -706,7 +707,7 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, plot_gallery):
 
                 # get variables so we can later add links to the documentation
                 example_code_obj = {}
-                for var_name, var in my_globals.iteritems():
+                for var_name, var in my_globals.items():
                     if not hasattr(var, '__module__'):
                         continue
                     if not isinstance(var.__module__, string_types):
@@ -938,7 +939,7 @@ def embed_code_links(app, exception):
                     fid.close()
                     str_repl = {}
                     # generate replacement strings with the links
-                    for name, cobj in example_code_obj.iteritems():
+                    for name, cobj in example_code_obj.items():
                         this_module = cobj['module'].split('.')[0]
 
                         if this_module not in doc_resolvers:
@@ -959,7 +960,7 @@ def embed_code_links(app, exception):
                         with open(full_fname, 'wb') as fid:
                             for line in lines_in:
                                 line = line.decode('utf-8')
-                                for name, link in str_repl.iteritems():
+                                for name, link in str_repl.items():
                                     line = line.replace(name, link)
                                 fid.write(line.encode('utf-8'))
     except urllib.error.HTTPError as e:

--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -8,20 +8,19 @@ example files.
 Files that generate images should start with 'plot'
 
 """
-from six import string_types
-from time import time
 import os
 import re
 import shutil
 import traceback
 import glob
 import sys
-import cPickle
 import gzip
 import posixpath
 import subprocess
-from StringIO import StringIO
-from six.moves import urllib
+from six import string_types
+from six.moves import cPickle, urllib
+from six.moves.StringIO import StringIO
+from time import time
 try:
     from PIL import Image
 except:

--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -16,13 +16,12 @@ import shutil
 import traceback
 import glob
 import sys
-from StringIO import StringIO
 import cPickle
-import urllib2
 import gzip
 import posixpath
 import subprocess
-
+from StringIO import StringIO
+from six.moves import urllib
 try:
     from PIL import Image
 except:
@@ -61,7 +60,7 @@ class Tee(object):
 def _get_data(url):
     """Helper function to get data over http or from a local file"""
     if url.startswith('http://'):
-        resp = urllib2.urlopen(url)
+        resp = urllib.request.urlopen(url)
         encoding = resp.headers.dict.get('content-encoding', 'plain')
         data = resp.read()
         if encoding == 'plain':
@@ -964,10 +963,10 @@ def embed_code_links(app, exception):
                                 for name, link in str_repl.iteritems():
                                     line = line.replace(name, link)
                                 fid.write(line.encode('utf-8'))
-    except urllib2.HTTPError as e:
+    except urllib.error.HTTPError as e:
         print ("The following HTTP Error has occurred:\n")
         print (e.code)
-    except urllib2.URLError as e:
+    except urllib.error.URLError as e:
         print ("\n...\n"
                "Warning: Embedding the documentation hyperlinks requires "
                "internet access.\nPlease check your network connection.\n"

--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -345,7 +345,7 @@ plot_rst_template = """
 # an html div tag that our CSS uses to turn the lists into horizontal
 # lists.
 HLIST_HEADER = """
-.. rst-class:: horizontal
+.. rst-cglass:: horizontal
 
 """
 
@@ -513,11 +513,11 @@ def generate_dir_rst(dir, fhindex, example_dir, root_dir, plot_gallery):
         target_dir = root_dir
         src_dir = example_dir
     if not os.path.exists(os.path.join(src_dir, 'README.txt')):
-        print 80 * '_'
+        print (80 * '_')
         print ('Example directory %s does not have a README.txt file' %
-               src_dir)
-        print 'Skipping this directory'
-        print 80 * '_'
+              src_dir)
+        print ('Skipping this directory')
+        print (80 * '_')
         return
     fhindex.write("""
 
@@ -686,7 +686,7 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, plot_gallery):
         if not os.path.exists(first_image_file) or \
            os.stat(first_image_file).st_mtime <= os.stat(src_file).st_mtime:
             # We need to execute the code
-            print 'plotting %s' % fname
+            print ('plotting %s' % fname)
             t0 = time()
             import matplotlib.pyplot as plt
             plt.close('all')
@@ -823,15 +823,15 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, plot_gallery):
                     fig.savefig(image_path % fig_num, **kwargs)
                     figure_list.append(image_fname % fig_num)
             except:
-                print 80 * '_'
-                print '%s is not compiling:' % fname
+                print (80 * '_')
+                print ('%s is not compiling:' % fname)
                 traceback.print_exc()
-                print 80 * '_'
+                print (80 * '_')
             finally:
                 os.chdir(cwd)
                 sys.stdout = orig_stdout
 
-            print " - time elapsed : %.2g sec" % time_elapsed
+            print (" - time elapsed : %.2g sec" % time_elapsed)
         else:
             figure_list = [f[len(image_dir):]
                             for f in glob.glob(image_path % '[1-9]')]
@@ -893,7 +893,7 @@ def embed_code_links(app, exception):
     try:
         if exception is not None:
             return
-        print 'Embedding documentation hyperlinks in examples..'
+        print ('Embedding documentation hyperlinks in examples..')
 
         # Add resolvers for the packages for which we want to show links
         doc_resolvers = {}
@@ -926,7 +926,7 @@ def embed_code_links(app, exception):
 
         for dirpath, _, filenames in os.walk(html_example_dir):
             for fname in filenames:
-                print '\tprocessing: %s' % fname
+                print ('\tprocessing: %s' % fname)
                 full_fname = os.path.join(html_example_dir, dirpath, fname)
                 subpath = dirpath[len(html_example_dir) + 1:]
                 pickle_fname = os.path.join(example_dir, subpath,
@@ -965,14 +965,14 @@ def embed_code_links(app, exception):
                                 fid.write(line.encode('utf-8'))
     except urllib2.HTTPError as e:
         print ("The following HTTP Error has occurred:\n")
-        print e.code
+        print (e.code)
     except urllib2.URLError as e:
         print ("\n...\n"
                "Warning: Embedding the documentation hyperlinks requires "
                "internet access.\nPlease check your network connection.\n"
                "Unable to continue embedding due to a URL Error: \n")
-        print e.args
-    print '[done]'
+        print (e.args)
+    print ('[done]')
 
 
 def setup(app):

--- a/doc/sphinxext/numpy_ext/docscrape.py
+++ b/doc/sphinxext/numpy_ext/docscrape.py
@@ -376,7 +376,7 @@ class NumpyDocString(object):
         idx = self['index']
         out = []
         out += ['.. index:: %s' % idx.get('default', '')]
-        for section, references in idx.iteritems():
+        for section, references in idx.items():
             if section == 'default':
                 continue
             out += ['   :%s: %s' % (section, ', '.join(references))]

--- a/doc/sphinxext/numpy_ext/docscrape.py
+++ b/doc/sphinxext/numpy_ext/docscrape.py
@@ -6,7 +6,7 @@ import inspect
 import textwrap
 import re
 import pydoc
-from StringIO import StringIO
+from six.moves.StringIO import StringIO
 from warnings import warn
 
 

--- a/doc/sphinxext/numpy_ext/docscrape.py
+++ b/doc/sphinxext/numpy_ext/docscrape.py
@@ -435,7 +435,7 @@ class FunctionDoc(NumpyDocString):
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*', '\*')
                 signature = '%s%s' % (func_name, argspec)
-            except TypeError, e:
+            except TypeError as e:
                 signature = '%s()' % func_name
             self['Signature'] = signature
 

--- a/doc/sphinxext/numpy_ext/docscrape.py
+++ b/doc/sphinxext/numpy_ext/docscrape.py
@@ -458,7 +458,7 @@ class FunctionDoc(NumpyDocString):
 
         if self._role:
             if not roles.has_key(self._role):
-                print "Warning: invalid role %s" % self._role
+                print ("Warning: invalid role %s" % self._role)
             out += '.. %s:: %s\n    \n\n' % (roles.get(self._role, ''),
                                              func_name)
 

--- a/doc/sphinxext/numpy_ext/docscrape_sphinx.py
+++ b/doc/sphinxext/numpy_ext/docscrape_sphinx.py
@@ -137,7 +137,7 @@ class SphinxDocString(NumpyDocString):
             return out
 
         out += ['.. index:: %s' % idx.get('default', '')]
-        for section, references in idx.iteritems():
+        for section, references in idx.items():
             if section == 'default':
                 continue
             elif section == 'refguide':

--- a/doc/sphinxext/numpy_ext_old/docscrape.py
+++ b/doc/sphinxext/numpy_ext_old/docscrape.py
@@ -6,7 +6,7 @@ import inspect
 import textwrap
 import re
 import pydoc
-from StringIO import StringIO
+from six.moves.StringIO import StringIO
 from warnings import warn
 
 

--- a/doc/sphinxext/numpy_ext_old/docscrape.py
+++ b/doc/sphinxext/numpy_ext_old/docscrape.py
@@ -419,7 +419,7 @@ class FunctionDoc(NumpyDocString):
         self._role = role  # e.g. "func" or "meth"
         try:
             NumpyDocString.__init__(self, inspect.getdoc(func) or '')
-        except ValueError, e:
+        except ValueError as e:
             print '*' * 78
             print "ERROR: '%s' while parsing `%s`" % (e, self._f)
             print '*' * 78
@@ -435,7 +435,7 @@ class FunctionDoc(NumpyDocString):
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*', '\*')
                 signature = '%s%s' % (func_name, argspec)
-            except TypeError, e:
+            except TypeError as e:
                 signature = '%s()' % func_name
             self['Signature'] = signature
 

--- a/doc/sphinxext/numpy_ext_old/docscrape.py
+++ b/doc/sphinxext/numpy_ext_old/docscrape.py
@@ -420,12 +420,12 @@ class FunctionDoc(NumpyDocString):
         try:
             NumpyDocString.__init__(self, inspect.getdoc(func) or '')
         except ValueError as e:
-            print '*' * 78
-            print "ERROR: '%s' while parsing `%s`" % (e, self._f)
-            print '*' * 78
-            #print "Docstring follows:"
-            #print doclines
-            #print '='*78
+            print ('*' * 78)
+            print ("ERROR: '%s' while parsing `%s`" % (e, self._f))
+            print ('*' * 78)
+            #print ("Docstring follows:")
+            #print (doclines)
+            #print ('='*78)
 
         if not self['Signature']:
             func, func_name = self.get_func()
@@ -458,7 +458,7 @@ class FunctionDoc(NumpyDocString):
 
         if self._role:
             if not roles.has_key(self._role):
-                print "Warning: invalid role %s" % self._role
+                print ("Warning: invalid role %s" % self._role)
             out += '.. %s:: %s\n    \n\n' % (roles.get(self._role, ''),
                                              func_name)
 
@@ -491,7 +491,7 @@ class ClassDoc(NumpyDocString):
         out += "\n\n"
 
         #for m in self.methods:
-        #    print "Parsing `%s`" % m
+        #    print ("Parsing `%s`" % m)
         #    out += str(self._func_doc(getattr(self._cls,m), 'meth')) + '\n\n'
         #    out += '.. index::\n   single: %s; %s\n\n' % (self._name, m)
 

--- a/doc/sphinxext/numpy_ext_old/docscrape.py
+++ b/doc/sphinxext/numpy_ext_old/docscrape.py
@@ -375,7 +375,7 @@ class NumpyDocString(object):
         idx = self['index']
         out = []
         out += ['.. index:: %s' % idx.get('default', '')]
-        for section, references in idx.iteritems():
+        for section, references in idx.items():
             if section == 'default':
                 continue
             out += ['   :%s: %s' % (section, ', '.join(references))]

--- a/doc/sphinxext/numpy_ext_old/docscrape_sphinx.py
+++ b/doc/sphinxext/numpy_ext_old/docscrape_sphinx.py
@@ -80,7 +80,7 @@ class SphinxDocString(NumpyDocString):
             return out
 
         out += ['.. index:: %s' % idx.get('default', '')]
-        for section, references in idx.iteritems():
+        for section, references in idx.items():
             if section == 'default':
                 continue
             elif section == 'refguide':

--- a/doc/sphinxext/numpy_ext_old/numpydoc.py
+++ b/doc/sphinxext/numpy_ext_old/numpydoc.py
@@ -49,7 +49,7 @@ def mangle_docstrings(app, what, name, obj, options, lines,
             try:
                 references.append(int(l[len('.. ['):l.index(']')]))
             except ValueError:
-                print "WARNING: invalid reference in %s docstring" % name
+                print ("WARNING: invalid reference in %s docstring" % name)
 
     # Start renaming from the biggest number, otherwise we may
     # overwrite references.
@@ -110,7 +110,7 @@ def monkeypatch_sphinx_ext_autodoc():
     if sphinx.ext.autodoc.format_signature is our_format_signature:
         return
 
-    print "[numpydoc] Monkeypatching sphinx.ext.autodoc ..."
+    print ("[numpydoc] Monkeypatching sphinx.ext.autodoc ...")
     _original_format_signature = sphinx.ext.autodoc.format_signature
     sphinx.ext.autodoc.format_signature = our_format_signature
 

--- a/examples/connectivity/plot_adhd_covariance.py
+++ b/examples/connectivity/plot_adhd_covariance.py
@@ -28,7 +28,7 @@ def plot_matrices(cov, prec, title):
 
     # Put zeros on the diagonal, for graph clarity.
     size = prec.shape[0]
-    prec[range(size), range(size)] = 0
+    prec[list(range(size)), list(range(size))] = 0
     span = max(abs(prec.min()), abs(prec.max()))
 
     # Display covariance matrix

--- a/examples/connectivity/plot_rest_clustering.py
+++ b/examples/connectivity/plot_rest_clustering.py
@@ -47,7 +47,7 @@ start = time.time()
 ward = WardAgglomeration(n_clusters=1000, connectivity=connectivity,
                          memory='nilearn_cache')
 ward.fit(fmri_masked)
-print "Ward agglomeration 1000 clusters: %.2fs" % (time.time() - start)
+print ("Ward agglomeration 1000 clusters: %.2fs" % (time.time() - start))
 
 # Compute the ward with more clusters, should be faster as we are using
 # the caching mechanism
@@ -55,7 +55,7 @@ start = time.time()
 ward = WardAgglomeration(n_clusters=2000, connectivity=connectivity,
                          memory='nilearn_cache')
 ward.fit(fmri_masked)
-print "Ward agglomeration 2000 clusters: %.2fs" % (time.time() - start)
+print ("Ward agglomeration 2000 clusters: %.2fs" % (time.time() - start))
 
 ### Show result ###############################################################
 

--- a/examples/decoding/plot_haxby_anova_svm.py
+++ b/examples/decoding/plot_haxby_anova_svm.py
@@ -111,9 +111,9 @@ for train, test in cv:
 classification_accuracy = np.mean(cv_scores)
 
 ### Printing the results
-print "=== ANOVA ==="
-print "Classification accuracy: %f" % classification_accuracy, \
-    " / Chance level: %f" % (1. / n_conditions)
-# Classification accuracy: 0.986111  / Chance level: 0.500000
+print ("=== ANOVA ===")
+print ("Classification accuracy: %.4f / Chance level: %f" % \
+    (classification_accuracy, 1. / n_conditions))
+# Classification accuracy: 0.9861 / Chance level: 0.5000
 
 plt.show()

--- a/examples/decoding/plot_haxby_different_estimators.py
+++ b/examples/decoding/plot_haxby_different_estimators.py
@@ -84,7 +84,7 @@ classifiers_scores = {}
 
 for classifier_name, classifier in sorted(classifiers.items()):
     classifiers_scores[classifier_name] = {}
-    print 70 * '_'
+    print (70 * '_')
 
     for category in categories:
         classification_target = stimuli[resting_state == False] == category
@@ -95,11 +95,11 @@ for classifier_name, classifier in sorted(classifiers.items()):
             classification_target,
             cv=cv, scoring="f1")
 
-        print "%10s: %14s -- scores: %1.2f +- %1.2f, time %.2fs" % (
+        print ("%10s: %14s -- scores: %1.2f +- %1.2f, time %.2fs" % (
             classifier_name, category,
             classifiers_scores[classifier_name][category].mean(),
             classifiers_scores[classifier_name][category].std(),
-            time.time() - t0)
+            time.time() - t0))
 
 ###############################################################################
 # make a rudimentary diagram

--- a/examples/decoding/plot_haxby_full_analysis.py
+++ b/examples/decoding/plot_haxby_full_analysis.py
@@ -53,7 +53,7 @@ mask_scores = {}
 mask_chance_scores = {}
 
 for mask_name in mask_names:
-    print "Working on mask %s" % mask_name
+    print ("Working on mask %s" % mask_name)
     # For decoding, standardizing is often very important
     mask_filename = haxby_dataset[mask_name][0]
     masker = NiftiMasker(mask_img=mask_filename, standardize=True)
@@ -64,7 +64,7 @@ for mask_name in mask_names:
     mask_chance_scores[mask_name] = {}
 
     for category in categories:
-        print "Processing %s %s" % (mask_name, category)
+        print ("Processing %s %s" % (mask_name, category))
         classification_target = stimuli[resting_state == False] == category
         mask_scores[mask_name][category] = cross_val_score(
             classifier,
@@ -78,9 +78,9 @@ for mask_name in mask_names:
             classification_target,
             cv=cv, scoring="f1")
 
-        print "Scores: %1.2f +- %1.2f" % (
+        print ("Scores: %1.2f +- %1.2f" % (
             mask_scores[mask_name][category].mean(),
-            mask_scores[mask_name][category].std())
+            mask_scores[mask_name][category].std()))
 
 # make a rudimentary diagram
 import matplotlib.pyplot as plt

--- a/examples/decoding/plot_haxby_grid_search.py
+++ b/examples/decoding/plot_haxby_grid_search.py
@@ -100,12 +100,12 @@ for k in k_range:
     feature_selection.k = k
     cv_scores.append(np.mean(
         cross_val_score(anova_svc, X[session < 10], y[session < 10])))
-    print "CV score", cv_scores[-1]
+    print ("CV score: %.4f" % cv_scores[-1])
 
     anova_svc.fit(X[session < 10], y[session < 10])
     y_pred = anova_svc.predict(X[session == 10])
     scores_validation.append(np.mean(y_pred == y[session == 10]))
-    print "score validation", scores_validation[-1]
+    print ("score validation: %.4f" % scores_validation[-1])
 
 
 from matplotlib import pyplot as plt

--- a/examples/decoding/plot_haxby_multiclass.py
+++ b/examples/decoding/plot_haxby_multiclass.py
@@ -65,9 +65,9 @@ cv_scores_ovo = cross_val_score(svc_ovo, X, y, cv=5, verbose=1)
 
 cv_scores_ova = cross_val_score(svc_ova, X, y, cv=5, verbose=1)
 
-print 79 * "_"
-print 'OvO', cv_scores_ovo.mean()
-print 'OvA', cv_scores_ova.mean()
+print (79 * "_")
+print ('OvO', cv_scores_ovo.mean())
+print ('OvA', cv_scores_ova.mean())
 
 plt.figure(figsize=(4, 3))
 plt.boxplot([cv_scores_ova, cv_scores_ovo])

--- a/examples/decoding/plot_miyawaki_reconstruction.py
+++ b/examples/decoding/plot_miyawaki_reconstruction.py
@@ -214,16 +214,16 @@ sys.stderr.write(" Done (%.2fs).\n" % (time.time() - t0))
 from sklearn.metrics import (accuracy_score, precision_score, recall_score,
                              f1_score)
 
-print "Scores"
-print "------"
-print "  - Accuracy (percent): %f" % np.mean([
-    accuracy_score(y_test[:, i], y_pred[:, i] > .5) for i in range(100)])
-print "  - Precision: %f" % np.mean([
-    precision_score(y_test[:, i], y_pred[:, i] > .5) for i in range(100)])
-print "  - Recall: %f" % np.mean([
-    recall_score(y_test[:, i], y_pred[:, i] > .5) for i in range(100)])
-print "  - F1-score: %f" % np.mean([
-    f1_score(y_test[:, i], y_pred[:, i] > .5) for i in range(100)])
+print ("Scores")
+print ("------")
+print ("  - Accuracy (percent): %f" % np.mean([
+    accuracy_score(y_test[:, i], y_pred[:, i] > .5) for i in range(100)]))
+print ("  - Precision: %f" % np.mean([
+    precision_score(y_test[:, i], y_pred[:, i] > .5) for i in range(100)]))
+print ("  - Recall: %f" % np.mean([
+    recall_score(y_test[:, i], y_pred[:, i] > .5) for i in range(100)]))
+print ("  - F1-score: %f" % np.mean([
+    f1_score(y_test[:, i], y_pred[:, i] > .5) for i in range(100)]))
 
 # Generate six images from reconstruction
 

--- a/examples/decoding/plot_oasis_vbm.py
+++ b/examples/decoding/plot_oasis_vbm.py
@@ -106,7 +106,7 @@ from nilearn.image.resampling import coord_transform
 affine = weight_img.get_affine()
 _, _, k_slice = coord_transform(0, 0, z_slice,
                                 linalg.inv(affine))
-k_slice = round(k_slice)
+k_slice = np.round(k_slice)
 
 fig = plt.figure(figsize=(5.5, 7.5), facecolor='k')
 weight_slice_data = weight_img.get_data()[..., k_slice, 0]

--- a/examples/decoding/plot_oasis_vbm.py
+++ b/examples/decoding/plot_oasis_vbm.py
@@ -64,10 +64,10 @@ gm_maps_masked[:, gm_maps_masked.var(0) < 0.01] = 0.
 new_images = nifti_masker.inverse_transform(gm_maps_masked)
 gm_maps_masked = nifti_masker.fit_transform(new_images)
 n_samples, n_features = gm_maps_masked.shape
-print n_samples, "subjects, ", n_features, "features"
+print ("%d samples, %d features" % (n_subjects, n_features))
 
 ### Prediction with SVR #######################################################
-print "ANOVA + SVR"
+print ("ANOVA + SVR")
 ### Define the prediction function to be used.
 # Here we use a Support Vector Classification, with a linear kernel
 from sklearn.svm import SVR
@@ -123,12 +123,12 @@ cv_scores = cross_val_score(anova_svr, gm_maps_masked, age)
 
 ### Return the corresponding mean prediction accuracy
 prediction_accuracy = np.mean(cv_scores)
-print "=== ANOVA ==="
-print "Prediction accuracy: %f" % prediction_accuracy
-print
+print ("=== ANOVA ===")
+print ("Prediction accuracy: %f" % prediction_accuracy)
+print ("")
 
 ### Inference with massively univariate model #################################
-print "Massively univariate model"
+print ("Massively univariate model")
 
 ### Statistical inference
 from nilearn.mass_univariate import permuted_ols
@@ -156,6 +156,6 @@ display.title(title, y=1.2)
 signed_neg_log_pvals_slice_data = \
     signed_neg_log_pvals_unmasked.get_data()[..., k_slice, 0]
 n_detections = (np.abs(signed_neg_log_pvals_slice_data) > threshold).sum()
-print '\n%d detections' % n_detections
+print ('\n%d detections' % n_detections)
 
 plt.show()

--- a/examples/decoding/plot_simulated_data.py
+++ b/examples/decoding/plot_simulated_data.py
@@ -77,7 +77,7 @@ def plot_slices(data, title=None):
     plt.figure(figsize=(5.5, 2.2))
     vmax = np.abs(data).max()
     for i in (0, 6, 11):
-        plt.subplot(1, 3, i / 5 + 1)
+        plt.subplot(1, 3, i // 5 + 1)
         plt.imshow(data[:, :, i], vmin=-vmax, vmax=vmax,
                   interpolation="nearest", cmap=plt.cm.RdBu_r)
         plt.xticks(())

--- a/examples/decoding/plot_simulated_data.py
+++ b/examples/decoding/plot_simulated_data.py
@@ -10,7 +10,7 @@ values.
 
 # Licence : BSD
 
-print __doc__
+print (__doc__)
 
 from time import time
 
@@ -150,7 +150,7 @@ for name, classifier in classifiers:
     # plot the results
     plot_slices(coefs, title=title)
 
-    print title
+    print (title)
 
 f_values, p_values = f_regression(X_train, y_train)
 p_values = np.reshape(p_values, (size, size, size))

--- a/examples/manipulating_visualizing/plot_affine_transformation.py
+++ b/examples/manipulating_visualizing/plot_affine_transformation.py
@@ -69,7 +69,7 @@ source_affine = np.eye(4)
 source_affine[:2, 3] = np.array([96, 64])
 
 # Rotate it slightly
-angle = np.pi / 180 * 15
+angle = np.pi / 180. * 15
 rotation_matrix = np.array([[np.cos(angle), -np.sin(angle)],
                             [np.sin(angle), np.cos(angle)]])
 source_affine[:2, :2] = rotation_matrix * 2.0  # 2.0mm voxel size

--- a/examples/manipulating_visualizing/plot_haxby_masks.py
+++ b/examples/manipulating_visualizing/plot_haxby_masks.py
@@ -4,6 +4,7 @@ Plot Haxby masks
 
 Small script to plot the masks of the Haxby dataset.
 """
+import numpy as np
 from scipy import linalg
 import matplotlib.pyplot as plt
 
@@ -20,7 +21,7 @@ from nilearn.image.resampling import coord_transform
 affine = mean_img.get_affine()
 _, _, k_slice = coord_transform(0, 0, z_slice,
                                 linalg.inv(affine))
-k_slice = round(k_slice)
+k_slice = np.round(k_slice)
 
 fig = plt.figure(figsize=(4, 5.4), facecolor='k')
 

--- a/examples/manipulating_visualizing/plot_haxby_mass_univariate.py
+++ b/examples/manipulating_visualizing/plot_haxby_mass_univariate.py
@@ -113,7 +113,7 @@ from nilearn.image.resampling import coord_transform
 affine = signed_neg_log_pvals_unmasked.get_affine()
 _, _, k_slice = coord_transform(0, 0, z_slice,
                                 linalg.inv(affine))
-k_slice = round(k_slice)
+k_slice = np.round(k_slice)
 
 threshold = -np.log10(0.1)  # 10% corrected
 

--- a/examples/manipulating_visualizing/plot_localizer_mass_univariate_methods.py
+++ b/examples/manipulating_visualizing/plot_localizer_mass_univariate_methods.py
@@ -71,7 +71,7 @@ from nilearn.image.resampling import coord_transform
 affine = neg_log_pvals_anova_unmasked.get_affine()
 _, _, k_slice = coord_transform(0, 0, z_slice,
                                 linalg.inv(affine))
-k_slice = round(k_slice)
+k_slice = np.round(k_slice)
 
 threshold = - np.log10(0.1)  # 10% corrected
 vmax = min(np.amax(neg_log_pvals_permuted_ols),

--- a/examples/manipulating_visualizing/plot_mask_computation.py
+++ b/examples/manipulating_visualizing/plot_mask_computation.py
@@ -89,10 +89,10 @@ detrended = NiftiMasker(mask_strategy='epi', detrend=True)
 trended_data = trended.fit_transform(nyu_img)
 detrended_data = detrended.fit_transform(nyu_img)
 
-print "Trended: mean %.2f, std %.2f" % \
-    (np.mean(trended_data), np.std(trended_data))
-print "Detrended: mean %.2f, std %.2f" % \
-    (np.mean(detrended_data), np.std(detrended_data))
+print ("Trended: mean %.2f, std %.2f" %
+       (np.mean(trended_data), np.std(trended_data)))
+print ("Detrended: mean %.2f, std %.2f" %
+       (np.mean(detrended_data), np.std(detrended_data)))
 
 
 plt.show()

--- a/examples/manipulating_visualizing/plot_roi_extraction.py
+++ b/examples/manipulating_visualizing/plot_roi_extraction.py
@@ -21,10 +21,11 @@ import nibabel
 haxby_dataset = datasets.fetch_haxby(n_subjects=1)
 
 # Second, load the labels
+from six import string_types
 import numpy as np
 
 haxby_labels = np.genfromtxt(haxby_dataset.session_target[0], skip_header=1,
-                             usecols=[0], dtype=basestring)
+                             usecols=[0], dtype=string_types)
 
 ### Visualization function ####################################################
 

--- a/examples/plot_haxby_simple.py
+++ b/examples/plot_haxby_simple.py
@@ -66,7 +66,7 @@ for train, test in cv:
     cv_scores.append(np.sum(prediction == target[test])
                      / float(np.size(target[test])))
 
-print cv_scores
+print (cv_scores)
 
 ### Unmasking #################################################################
 

--- a/examples/plot_haxby_simple.py
+++ b/examples/plot_haxby_simple.py
@@ -23,8 +23,8 @@ labels = np.recfromcsv(haxby_dataset.session_target[0], delimiter=" ")
 _, target = np.unique(labels['labels'], return_inverse=True)
 
 ### Keep only data corresponding to faces or cats #############################
-condition_mask = np.logical_or(labels['labels'] == 'face',
-                               labels['labels'] == 'cat')
+condition_mask = np.logical_or(labels['labels'] == b'face',
+                               labels['labels'] == b'cat')
 target = target[condition_mask]
 
 

--- a/examples/plot_localizer_simple_analysis.py
+++ b/examples/plot_localizer_simple_analysis.py
@@ -53,7 +53,8 @@ from nilearn.image.resampling import coord_transform
 affine = neg_log_pvals_anova_unmasked.get_affine()
 _, _, k_slice = coord_transform(0, 0, z_slice,
                                 linalg.inv(affine))
-k_slice = round(k_slice)
+
+k_slice = np.round(k_slice)
 threshold = - np.log10(0.1)  # 10% corrected
 
 # Plot Anova p-values

--- a/examples/plot_nilearn_101.py
+++ b/examples/plot_nilearn_101.py
@@ -20,7 +20,7 @@ anat_img = nibabel.load(anat_filename)
 
 # Accessing image data and affine #############################################
 anat_data = anat_img.get_data()
-print ('anat_data has shape: %s' % anat_data.shape)
+print ('anat_data has shape: %s' % str(anat_data.shape))
 anat_affine = anat_img.get_affine()
 print ('anat_affine:\n%s' % anat_affine)
 

--- a/examples/plot_nilearn_101.py
+++ b/examples/plot_nilearn_101.py
@@ -12,7 +12,7 @@ from nilearn import data
 # This is just a Nifti file that is shipped with nilearn
 anat_filename = os.path.join(os.path.dirname(data.__file__),
                              'avg152T1_brain.nii.gz')
-print 'anat_filename: ', anat_filename
+print ('anat_filename: %s' % anat_filename)
 
 # Using nibabel.load to load existing Nifti image #############################
 import nibabel
@@ -20,9 +20,9 @@ anat_img = nibabel.load(anat_filename)
 
 # Accessing image data and affine #############################################
 anat_data = anat_img.get_data()
-print 'anat_data has shape:', anat_data.shape
+print ('anat_data has shape: %s' % anat_data.shape)
 anat_affine = anat_img.get_affine()
-print 'anat_affine:\n', anat_affine
+print ('anat_affine:\n%s' % anat_affine)
 
 # Using image in nilearn functions ############################################
 from nilearn import image

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -4,11 +4,12 @@ Mixin for cache with joblib
 # Author: Gael Varoquaux, Alexandre Abraham, Philippe Gervais
 # License: simplified BSD
 
+import json
 import warnings
 import os
 import shutil
 from distutils.version import LooseVersion
-import json
+from six import string_types
 
 import nibabel
 from sklearn.externals.joblib import Memory
@@ -135,7 +136,7 @@ def cache(func, memory, func_memory_level=None, memory_level=None,
             or memory_level < func_memory_level):
         memory = Memory(cachedir=None, verbose=verbose)
     else:
-        if isinstance(memory, basestring):
+        if isinstance(memory, string_types):
             memory = Memory(cachedir=memory, verbose=verbose)
         if not isinstance(memory, memory_classes):
             raise TypeError("'memory' argument must be a string or a "
@@ -146,7 +147,7 @@ def cache(func, memory, func_memory_level=None, memory_level=None,
                           "but no Memory object or path has been provided"
                           " (parameter memory). Caching deactivated for "
                           "function %s." %
-                          (memory_level, func.func_name),
+                          (memory_level, func.__name__),
                           stacklevel=2)
     return _safe_cache(memory, func, **kwargs)
 
@@ -198,13 +199,13 @@ class CacheMixin(object):
             self.memory_level = 0
         if not hasattr(self, "memory"):
             self.memory = Memory(cachedir=None, verbose=verbose)
-        if isinstance(self.memory, basestring):
+        if isinstance(self.memory, string_types):
             self.memory = Memory(cachedir=self.memory, verbose=verbose)
 
         # If cache level is 0 but a memory object has been provided, set
         # memory_level to 1 with a warning.
         if self.memory_level == 0:
-            if (isinstance(self.memory, basestring)
+            if (isinstance(self.memory, string_types)
                     or self.memory.cachedir is not None):
                 warnings.warn("memory_level is currently set to 0 but "
                               "a Memory object has been provided. "

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -12,7 +12,8 @@ from six import string_types
 
 import nibabel
 from sklearn.externals.joblib import Memory
-from cache_mixin import cache
+from .cache_mixin import cache
+
 
 def is_img(obj):
     """ Check for get_data and get_affine method in an object

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -34,7 +34,8 @@ def is_img(obj):
     try:
         get_data = getattr(obj, "get_data")
         get_affine = getattr(obj, "get_affine")
-        return callable(get_data) and callable(get_affine)
+        return isinstance(get_data, collections.Callable) and \
+               isinstance(get_affine, collections.Callable)
     except AttributeError:
         return False
 
@@ -143,7 +144,7 @@ def check_niimg(niimg, ensure_3d=False):
 
     Its application is idempotent.
     """
-    if hasattr(niimg, "__iter__"):
+    if hasattr(niimg, "__iter__") and not isinstance(niimg, string_types):
         if ensure_3d:
             raise TypeError("A 3D image is expected, but an iterable was"
                 " given: %s" % short_repr(niimg))

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -7,11 +7,10 @@ Conversion utilities.
 import collections
 import copy
 import gc
-
 import numpy as np
+from six import string_types
 
 import nibabel
-
 from sklearn.externals.joblib import Memory
 from cache_mixin import cache
 
@@ -52,7 +51,7 @@ def _get_shape(img):
 def _repr_niimgs(niimgs):
     """ Pretty printing of niimg or niimgs.
     """
-    if isinstance(niimgs, basestring):
+    if isinstance(niimgs, string_types):
         return niimgs
     if isinstance(niimgs, collections.Iterable):
         return '[%s]' % ', '.join(_repr_niimgs(niimg) for niimg in niimgs)
@@ -152,7 +151,7 @@ def check_niimg(niimg, ensure_3d=False):
                             'image or a list of images' % niimg)
         return concat_niimgs(niimg)
 
-    if isinstance(niimg, basestring):
+    if isinstance(niimg, string_types):
         # data is a filename, we load it
         niimg = nibabel.load(niimg)
     elif not is_img(niimg):
@@ -242,7 +241,7 @@ def concat_niimgs(niimgs, dtype=np.float32, accept_4d=False,
             lengths.append(1)
         else:
             if not accept_4d:
-                if (isinstance(niimg, basestring)):
+                if (isinstance(niimg, string_types)):
                     i_error = "Image " + niimg
                 else:
                     i_error = "Image #" + str(index)
@@ -260,7 +259,7 @@ def concat_niimgs(niimgs, dtype=np.float32, accept_4d=False,
     cur_4d_index = 0
     for index, (iter_niimg, size) in enumerate(zip(niimgs, lengths)):
         # talk to user
-        if (isinstance(iter_niimg, basestring)):
+        if (isinstance(iter_niimg, string_types)):
             nii_str = "image " + iter_niimg
         else:
             nii_str = "image #" + str(index)
@@ -341,7 +340,7 @@ def check_niimgs(niimgs, accept_3d=False, return_iterator=False):
     # dimensionality and make a consistent error message.
     depth = 0
     first_img = niimgs
-    if accept_3d and (isinstance(first_img, basestring)
+    if accept_3d and (isinstance(first_img, string_types)
                       or not isinstance(first_img, collections.Iterable)):
         niimg = check_niimg(niimgs)
         if len(_get_shape(niimg)) == 3:
@@ -352,7 +351,7 @@ def check_niimgs(niimgs, accept_3d=False, return_iterator=False):
     # Use hasattr() instead of isinstance to workaround a Python 2.6/2.7 bug
     # See http://bugs.python.org/issue7624
     while hasattr(first_img, "__iter__") \
-            and not isinstance(first_img, basestring):
+            and not isinstance(first_img, string_types):
         if hasattr(first_img, '__len__') and len(first_img) == 0:
             raise TypeError('An empty object - %r - was passed instead of an '
                             'image or a list of images' % niimgs)

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -265,8 +265,8 @@ def concat_niimgs(niimgs, dtype=np.float32, accept_4d=False,
         else:
             nii_str = "image #" + str(index)
         if verbose > 0:
-            print "Concatenating {0}/{1}: {2}".format(index + 1, sum(lengths),
-                                                      nii_str)
+            print ("Concatenating {0}/{1}: {2}".format(index + 1, sum(lengths),
+                                                   nii_str))
 
         if index == 0:  # we have already loaded the first one
             cur_4d_index += size
@@ -286,7 +286,7 @@ def concat_niimgs(niimgs, dtype=np.float32, accept_4d=False,
                                     target_affine,
                                     niimg.get_affine()))
             if verbose > 0:
-                print "...resampled to first nifti!"
+                print ("...resampled to first nifti!")
             
             from .. import image  # we avoid a circular import
             niimg = cache(image.resample_img, memory, func_memory_level=2,

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -230,7 +230,7 @@ def concat_niimgs(niimgs, dtype=np.float32, accept_4d=False,
     """
 
     # get properties from first image
-    first_niimg = check_niimg(iter(niimgs).next())
+    first_niimg = check_niimg(next(iter(niimgs)))
     target_affine = first_niimg.get_affine()
     first_data = first_niimg.get_data()
     target_item_shape = first_niimg.shape[:3]  # skip 4th/time dimension
@@ -357,7 +357,7 @@ def check_niimgs(niimgs, accept_3d=False, return_iterator=False):
         if hasattr(first_img, '__len__') and len(first_img) == 0:
             raise TypeError('An empty object - %r - was passed instead of an '
                             'image or a list of images' % niimgs)
-        first_img = iter(first_img).next()
+        first_img = next(iter(first_img))
         depth += 1
 
     # First image is supposed to be a path or a Nifti-like element

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -10,6 +10,7 @@ import contextlib
 import warnings
 import inspect
 import re
+from nose.tools import assert_equal, assert_true
 
 import numpy as np
 import scipy.signal
@@ -45,15 +46,54 @@ except ImportError:
             raise AssertionError("Should have raised %r" %
                                  expected_exception(expected_regexp))
 
+
+try:
+    from sklearn.utils.testing import clean_warning_registry
+except ImportError:
+    def clean_warning_registry():
+        """Safe way to reset warnings """
+        warnings.resetwarnings()
+        reg = "__warningregistry__"
+        for mod_name, mod in list(sys.modules.items()):
+            if 'six.moves' in mod_name:
+                continue
+            if hasattr(mod, reg):
+                getattr(mod, reg).clear()
+
+
 try:
     from sklearn.utils.testing import assert_warns
 except ImportError:
     # sklearn.utils.testing.assert_warns new in scikit-learn 0.14
     def assert_warns(warning_class, func, *args, **kw):
+        #clean_warning_registry()
         with warnings.catch_warnings(record=True):
-            warnings.simplefilter("ignore", warning_class)
+            warnings.simplefilter('always', warning_class)
             output = func(*args, **kw)
         return output
+
+
+def assert_warns_regex(expected_warning, expected_regexp,
+                       callable_obj, *args, **kwargs):
+    #clean_warning_registry()
+    with warnings.catch_warnings(record=True) as ws:
+        warnings.simplefilter('always')
+        outputs = callable_obj(*args, **kwargs)
+        warning_found = False
+        for w in ws:
+            if isinstance(w.message, expected_warning) and \
+                (not expected_regexp or
+                    re.compile(expected_regexp).search(w.message[-1])):
+                warning_found = True
+
+        if not warning_found:
+            assert_true(len(ws) > 0,
+                        "No warning detected; should have raised %r" %
+                        expected_warning(expected_regexp))
+            assert_true(False, "Failed.")
+    return outputs
+
+
 
 
 @contextlib.contextmanager

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -7,17 +7,14 @@ import inspect
 import nose
 import os
 import sys
-import urllib2
 import contextlib
 import warnings
 import inspect
 import re
-<<<<<<< HEAD
 from nose.tools import assert_true
-=======
 from past.builtins import xrange
->>>>>>> Import xrange from past, for python2/3 support.
 from six import string_types
+from six.moves import urllib
 
 import numpy as np
 import scipy.signal
@@ -149,30 +146,21 @@ def write_tmp_imgs(*imgs, **kwargs):
             yield imgs
 
 
-class mock_urllib2(object):
-
-    urlparse = urllib2.urlparse
-
+class mock_request(object):
     def __init__(self):
-        """Object that mocks the urllib2 module to store downloaded filenames.
+        """Object that mocks the urllib (future) module to store downloaded filenames.
 
         `urls` is the list of the files whose download has been
         requested.
         """
         self.urls = set()
 
-    class HTTPError(urllib2.URLError):
-        code = 404
-
-    class URLError(urllib2.URLError):
-        pass
-
     def urlopen(self, url):
         self.urls.add(url)
         # If the file is local, we try to open it
         if url.startswith('file://'):
             try:
-                return urllib2.urlopen(url)
+                return urllib.request.urlopen(url)
             except:
                 pass
         return url
@@ -195,7 +183,7 @@ def wrap_chunk_read_(_chunk_read_):
 def mock_chunk_read_raise_error_(response, local_file, initial_size=0,
                                  chunk_size=8192, report_hook=None,
                                  verbose=0):
-    raise urllib2.HTTPError("url", 418, "I'm a teapot", None, None)
+    raise urllib.errors.HTTPError("url", 418, "I'm a teapot", None, None)
 
 
 class FetchFilesMock (object):

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -217,10 +217,10 @@ class FetchFilesMock (object):
                 # np.savetxt(fname, array, delimiter=',', fmt="%s",
                 #            header=','.join(array.dtype.names))
                 # We need to add the header ourselves
-                with open(fname, 'w') as f:
+                with open(fname, 'wb') as f:
                     header = '# {0}\n'.format(','.join(array.dtype.names))
                     f.write(header)
-                    np.savetxt(f, array, delimiter=',', fmt="%s")
+                    np.savetxt(f, array, delimiter=',', fmt='%s')
 
         return filenames
 

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -219,7 +219,7 @@ class FetchFilesMock (object):
                 # We need to add the header ourselves
                 with open(fname, 'wb') as f:
                     header = '# {0}\n'.format(','.join(array.dtype.names))
-                    f.write(header)
+                    f.write(header.encode())
                     np.savetxt(f, array, delimiter=',', fmt='%s')
 
         return filenames

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -12,7 +12,11 @@ import contextlib
 import warnings
 import inspect
 import re
+<<<<<<< HEAD
 from nose.tools import assert_true
+=======
+from past.builtins import xrange
+>>>>>>> Import xrange from past, for python2/3 support.
 from six import string_types
 
 import numpy as np

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -266,8 +266,8 @@ def generate_regions_ts(n_features, n_regions,
     boundaries.sort()
 
     regions = np.zeros((n_regions, n_features), order="C")
-    overlap_end = int((overlap + 1) / 2)
-    overlap_start = int(overlap / 2)
+    overlap_end = int((overlap + 1) / 2.)
+    overlap_start = int(overlap / 2.)
     for n in xrange(len(boundaries) - 1):
         start = int(max(0, boundaries[n] - overlap_start))
         end = int(min(n_features, boundaries[n + 1] + overlap_end))
@@ -422,14 +422,14 @@ def generate_fake_fmri(shape=(10, 11, 12), length=17, kind="noise",
     full_shape = shape + (length, )
     fmri = np.zeros(full_shape)
     # Fill central voxels timeseries with random signals
-    width = [s / 2 for s in shape]
-    shift = [s / 4 for s in shape]
+    width = [s // 2 for s in shape]
+    shift = [s // 4 for s in shape]
 
     if kind == "noise":
         signals = rand_gen.randint(256, size=(width + [length]))
     elif kind == "step":
         signals = np.ones(width + [length])
-        signals[..., :length / 2] = 0.5
+        signals[..., :length // 2] = 0.5
     else:
         raise ValueError("Unhandled value for parameter 'kind'")
 

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -3,6 +3,8 @@
 # Author: Alexandre Abrahame, Philippe Gervais
 # License: simplified BSD
 import functools
+import inspect
+import nose
 import os
 import sys
 import urllib2
@@ -613,12 +615,31 @@ def generate_group_sparse_gaussian_graphs(
     return signals, precisions, topology
 
 
-def skip_if_running_nose(msg=None):
+def skip_if(skip, skip_msg=None):
     """ Raise a SkipTest if we appear to be running the nose test loader.
 
     Parameters
     ==========
-    msg: string, optional
+    skip: bool
+        Whether the test should be skipped
+
+    skip_msg: string, optional
+        The message issued when SkipTest is raised
+    """
+    def wrap(f):
+        if skip:
+            raise nose.SkipTest(skip_msg)
+        else:
+            return f
+    return wrap
+
+
+def skip_if_running_nose(skip_msg=None):
+    """ Raise a SkipTest if we appear to be running the nose test loader.
+
+    Parameters
+    ==========
+    skip_msg: string, optional
         The message issued when SkipTest is raised
     """
     if not 'nose' in sys.modules:
@@ -635,8 +656,8 @@ def skip_if_running_nose(msg=None):
         loader_file_name = loader_file_name[:-1]
     for _, file_name, _, _, _, _ in stack:
         if file_name == loader_file_name:
-            if msg is not None:
-                raise nose.SkipTest(msg)
+            if skip_msg is not None:
+                raise nose.SkipTest(skip_msg)
             else:
                 raise nose.SkipTest
 

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -261,7 +261,7 @@ def generate_regions_ts(n_features, n_regions,
     # Start at 1 to avoid getting an empty region
     boundaries = np.zeros(n_regions + 1)
     boundaries[-1] = n_features
-    boundaries[1:-1] = rand_gen.permutation(range(1, n_features)
+    boundaries[1:-1] = rand_gen.permutation(list(range(1, n_features))
                                             )[:n_regions - 1]
     boundaries.sort()
 

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -12,7 +12,8 @@ import contextlib
 import warnings
 import inspect
 import re
-from nose.tools import assert_equal, assert_true
+from nose.tools import assert_true
+from six import string_types
 
 import numpy as np
 import scipy.signal
@@ -179,7 +180,7 @@ class mock_urllib2(object):
 def wrap_chunk_read_(_chunk_read_):
     def mock_chunk_read_(response, local_file, initial_size=0, chunk_size=8192,
                          report_hook=None, verbose=0):
-        if not isinstance(response, basestring):
+        if not isinstance(response, string_types):
             return _chunk_read_(response, local_file,
                     initial_size=initial_size, chunk_size=chunk_size,
                     report_hook=report_hook, verbose=verbose)

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -77,7 +77,7 @@ def assert_warns_regex(warning_class, warning_regex,
         for w in ws:
             if isinstance(w.message, warning_class) and \
                 (warning_regex is None or
-                    re.compile(warning_regex).search(w.message[-1])):
+                    re.compile(warning_regex).search(w.message.args[-1])):
                 warning_found = True
 
         if not warning_found:

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -29,11 +29,11 @@ from .. import masking
 from . import logger
 
 try:
-    from nose.tools import assert_raises_regexp
+    from nose.tools import assert_raises_regex
 except ImportError:
     # for Py 2.6
-    def assert_raises_regexp(expected_exception, expected_regexp,
-                            callable_obj=None, *args, **kwargs):
+    def assert_raises_regex(expected_exception, expected_regexp,
+                             callable_obj=None, *args, **kwargs):
         """Helper function to check for message patterns in exceptions"""
 
         not_raised = False

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -23,7 +23,16 @@ import collections
 
 import numpy as np
 from scipy import ndimage
-from sklearn.datasets.base import Bunch
+
+# scikit-learn has a bug where recursive imports cause an ImportError.
+# numpy/scipy also have a poor interaction, raising visible warnings
+# without user intervention, triggered here.
+# This code simply quiets them both.
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore', ImportError)
+    if hasattr(np, 'VisibleDeprecationWarning'):
+        warnings.simplefilter('ignore', np.VisibleDeprecationWarning)
+    from sklearn.datasets.base import Bunch
 
 import nibabel
 

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -2479,11 +2479,11 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
                'ABIDE_Initiative')
 
     if quality_checked:
-        kwargs['qc_rater_1'] = 'OK'
-        kwargs['qc_anat_rater_2'] = ['OK', 'maybe']
-        kwargs['qc_func_rater_2'] = ['OK', 'maybe']
-        kwargs['qc_anat_rater_3'] = 'OK'
-        kwargs['qc_func_rater_3'] = 'OK'
+        kwargs['qc_rater_1'] = b'OK'
+        kwargs['qc_anat_rater_2'] = [b'OK', b'maybe']
+        kwargs['qc_func_rater_2'] = [b'OK', b'maybe']
+        kwargs['qc_anat_rater_3'] = b'OK'
+        kwargs['qc_func_rater_3'] = b'OK'
 
     # Fetch the phenotypic file and load it
     csv = 'Phenotypic_V1_0b_preprocessed1.csv'

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -15,12 +15,9 @@ import time
 import hashlib
 import fnmatch
 import warnings
-import cPickle as pickle
-import cStringIO as StringIO
 import re
-from matplotlib import mlab
 from six import string_types
-from six.moves import urllib
+from six.moves import cPickle, StringIO, urllib
 
 import numpy as np
 from scipy import ndimage
@@ -2502,7 +2499,7 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
         pheno.append(re.sub(r',(?=[^"]*"(?:[^"]*"[^"]*")*[^"]*$)', ";", line))
     pheno_f.close()
     pheno = '\n'.join(pheno)
-    pheno = StringIO.StringIO(pheno)
+    pheno = StringIO(pheno)
     # We enforce empty comments because it is 'sharp' by default
     pheno = np.recfromcsv(pheno, comments=[], case_sensitive=True)
 

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -164,7 +164,7 @@ def _chunk_read_(response, local_file, chunk_size=8192, report_hook=None,
         total_size = response.info().getheader('Content-Length').strip()
     try:
         total_size = int(total_size) + initial_size
-    except Exception, e:
+    except Exception as e:
         if verbose > 1:
             print "Warning: total size could not be determined."
             if verbose > 2:
@@ -502,14 +502,17 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
         dt = time.time() - t0
         if verbose > 0:
             print '...done. (%i seconds, %i min)' % (dt, dt / 60)
+    except urllib2.HTTPError as e:
     except urllib2.HTTPError, e:
+        print 'Error while fetching file %s.' \
+            ' Dataset fetching aborted.' % file_name
         if verbose > 0:
             print 'Error while fetching file %s.' \
                 ' Dataset fetching aborted.' % file_name
         if verbose > 1:
             print "HTTP Error:", e, url
         raise
-    except urllib2.URLError, e:
+    except urllib2.URLError as e:
         if verbose > 0:
             print 'Error while fetching file %s.' \
                 ' Dataset fetching aborted.' % file_name

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -45,27 +45,27 @@ def _format_time(t):
 def _md5_sum_file(path):
     """ Calculates the MD5 sum of a file.
     """
-    f = open(path, 'rb')
-    m = hashlib.md5()
-    while True:
-        data = f.read(8192)
-        if not data:
-            break
-        m.update(data)
+    with open(path, 'rb') as f:
+        m = hashlib.md5()
+        while True:
+            data = f.read(8192)
+            if not data:
+                break
+            m.update(data)
     return m.hexdigest()
 
 
 def _read_md5_sum_file(path):
     """ Reads a MD5 checksum file and returns hashes as a dictionary.
     """
-    f = open(path, "r")
-    hashes = {}
-    while True:
-        line = f.readline()
-        if not line:
-            break
-        h, name = line.rstrip().split('  ', 1)
-        hashes[name] = h
+    with open(path, "r") as f:
+        hashes = {}
+        while True:
+            line = f.readline()
+            if not line:
+                break
+            h, name = line.rstrip().split('  ', 1)
+            hashes[name] = h
     return hashes
 
 
@@ -293,9 +293,8 @@ def _uncompress_file(file_, delete_archive=True, verbose=1):
     # We first try to see if it is a zip file
     try:
         filename, ext = os.path.splitext(file_)
-        fd = open(file_, "rb")
-        header = fd.read(4)
-        fd.close()
+        with open(file_, "rb") as fd:
+            header = fd.read(4)
         processed = False
         if zipfile.is_zipfile(file_):
             z = zipfile.ZipFile(file_)
@@ -318,9 +317,8 @@ def _uncompress_file(file_, delete_archive=True, verbose=1):
             filename, ext = os.path.splitext(file_)
             processed = True
         if tarfile.is_tarfile(file_):
-            tar = tarfile.open(file_, "r")
-            tar.extractall(path=data_dir)
-            tar.close()
+            with tarfile.open(file_, "r") as tar:
+                tar.extractall(path=data_dir)
             processed = True
         if not processed:
             raise IOError(
@@ -2492,12 +2490,13 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
     # field. This can be
     # done simply with pandas but we don't want such dependency ATM
     # pheno = pandas.read_csv(path_csv).to_records()
-    pheno_f = open(path_csv, 'r')
-    pheno = ['i' + pheno_f.readline()]
-    # This regexp replaces commas between double quotes
-    for line in pheno_f:
-        pheno.append(re.sub(r',(?=[^"]*"(?:[^"]*"[^"]*")*[^"]*$)', ";", line))
-    pheno_f.close()
+    with open(path_csv, 'r') as pheno_f:
+        pheno = ['i' + pheno_f.readline()]
+        
+        # This regexp replaces commas between double quotes
+        for line in pheno_f:
+            pheno.append(re.sub(r',(?=[^"]*"(?:[^"]*"[^"]*")*[^"]*$)', ";", line))
+
     pheno = '\n'.join(pheno)
     pheno = StringIO(pheno)
     # We enforce empty comments because it is 'sharp' by default

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -5,6 +5,7 @@ Utilities to download NeuroImaging datasets
 # Author: Alexandre Abraham, Philippe Gervais
 # License: simplified BSD
 
+import contextlib
 import collections
 import os
 import tarfile
@@ -317,7 +318,7 @@ def _uncompress_file(file_, delete_archive=True, verbose=1):
             filename, ext = os.path.splitext(file_)
             processed = True
         if tarfile.is_tarfile(file_):
-            with tarfile.open(file_, "r") as tar:
+            with contextlib.closing(tarfile.open(file_, "r")) as tar:
                 tar.extractall(path=data_dir)
             processed = True
         if not processed:

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -301,7 +301,7 @@ def _uncompress_file(file_, delete_archive=True, verbose=1):
             z.extractall(data_dir)
             z.close()
             processed = True
-        elif ext == '.gz' or header.startswith('\x1f\x8b'):
+        elif ext == '.gz' or header.startswith(b'\x1f\x8b'):
             import gzip
             gz = gzip.open(file_)
             if ext == '.tgz':

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -5,6 +5,7 @@ Utilities to download NeuroImaging datasets
 # Author: Alexandre Abraham, Philippe Gervais
 # License: simplified BSD
 
+import collections
 import os
 import urllib
 import urllib2
@@ -19,7 +20,8 @@ import warnings
 import cPickle as pickle
 import cStringIO as StringIO
 import re
-import collections
+from matplotlib import mlab
+from six import string_types
 
 import numpy as np
 from scipy import ndimage
@@ -361,7 +363,7 @@ def _filter_column(array, col, criteria):
     except:
         raise KeyError('Filtering criterion %s does not exist' % col)
 
-    if not isinstance(criteria, basestring) and \
+    if not isinstance(criteria, string_types) and \
             not isinstance(criteria, tuple) and \
             isinstance(criteria, collections.Iterable):
         filter = np.zeros(array.shape[0], dtype=np.bool)
@@ -1909,7 +1911,7 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
         BMC neuroscience 8.1 (2007): 91.
 
     """
-    if isinstance(contrasts, basestring):
+    if isinstance(contrasts, string_types):
         raise ValueError('Constrasts should be a list of string, a single '
                          'string was given: "%s"' % contrasts)
     if n_subjects is None:

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -7,8 +7,6 @@ Utilities to download NeuroImaging datasets
 
 import collections
 import os
-import urllib
-import urllib2
 import tarfile
 import zipfile
 import sys
@@ -22,6 +20,7 @@ import cStringIO as StringIO
 import re
 from matplotlib import mlab
 from six import string_types
+from six.moves import urllib
 
 import numpy as np
 from scipy import ndimage
@@ -73,7 +72,7 @@ def _read_md5_sum_file(path):
     return hashes
 
 
-class ResumeURLOpener(urllib.FancyURLopener):
+class ResumeURLOpener(urllib.request.FancyURLopener):
     """Create sub-class in order to overide error 206.  This error means a
        partial file is being sent, which is fine in this case.
        Do nothing with this error.
@@ -135,7 +134,7 @@ def _chunk_read_(response, local_file, chunk_size=8192, report_hook=None,
 
     Parameters
     ----------
-    response: urllib.addinfourl
+    response: urllib.response.addinfourl
         Response to the download request in order to get file size
 
     local_file: file
@@ -163,7 +162,7 @@ def _chunk_read_(response, local_file, chunk_size=8192, report_hook=None,
 
     """
     if total_size is None:
-        total_size = response.info().getheader('Content-Length').strip()
+        total_size = response.info().get('Content-Length').strip()
     try:
         total_size = int(total_size) + initial_size
     except Exception as e:
@@ -455,7 +454,7 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
         os.makedirs(data_dir)
 
     # Determine filename using URL
-    parse = urllib2.urlparse.urlparse(url)
+    parse = urllib.parse.urlparse(url)
     file_name = os.path.basename(parse.path)
 
     temp_file_name = file_name + ".part"
@@ -475,7 +474,7 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
     try:
         # Download data
         if verbose > 0:
-            displayed_url = urllib.splitquery(url)[0] if verbose == 1 else url
+            displayed_url = urllib.parse.splitquery(url)[0] if verbose == 1 else url
             print ('Downloading data from %s ...' % displayed_url)
         if resume and os.path.exists(temp_full_name):
             url_opener = ResumeURLOpener()
@@ -485,7 +484,7 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
             url_opener.addheader("Range", "bytes=%s-" % (local_file_size))
             try:
                 data = url_opener.open(url)
-            except urllib2.HTTPError:
+            except urllib.error.HTTPError:
                 # There is a problem that may be due to resuming. Switch back
                 # to complete download method
                 return _fetch_file(url, data_dir, resume=False,
@@ -493,7 +492,7 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
             local_file = open(temp_full_name, "ab")
             initial_size = local_file_size
         else:
-            data = urllib2.urlopen(url)
+            data = urllib.request.urlopen(url)
             local_file = open(temp_full_name, "wb")
         _chunk_read_(data, local_file, report_hook=(verbose > 0),
                      initial_size=initial_size, verbose=verbose)
@@ -504,14 +503,14 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
         dt = time.time() - t0
         if verbose > 0:
             print ('...done. (%i seconds, %i min)' % (dt, dt / 60))
-    except urllib2.HTTPError as e:
+    except urllib.error.HTTPError as e:
         if verbose > 0:
             print ('Error while fetching file %s. Dataset fetching aborted.' %
                    (file_name))
         if verbose > 1:
             print ("HTTP Error: %s, %s" % (e, url))
         raise
-    except urllib2.URLError as e:
+    except urllib.error.URLError as e:
         if verbose > 0:
             print ('Error while fetching file %s. Dataset fetching aborted.' %
                    (file_name))
@@ -605,7 +604,7 @@ def _fetch_files(data_dir, files, resume=True, mock=False, verbose=1):
     #   files that must be downloaded will be in this directory. If a corrupted
     #   file is found, or a file is missing, this working directory will be
     #   deleted.
-    files_pickle = pickle.dumps(files)
+    files_pickle = cPickle.dumps(files)
     files_md5 = hashlib.md5(files_pickle).hexdigest()
     temp_dir = os.path.join(data_dir, files_md5)
 
@@ -1977,7 +1976,7 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
             "visual click vs visual sentences",
         "button press vs calculation and sentence listening/reading":
             "auditory&visual motor vs cognitive processing"}
-    allowed_contrasts = contrast_name_wrapper.values()
+    allowed_contrasts = list(contrast_name_wrapper.values())
     # convert contrast names
     contrasts_wrapped = []
     # get a unique ID for each contrast. It is used to give a unique name to
@@ -2016,7 +2015,7 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
 
     urls = ["%sbrainomics_data_%d.zip?rql=%s&vid=data-zip"
             % (root_url, i,
-               urllib.quote(base_query % {"types": rql_types,
+               urllib.parse.quote(base_query % {"types": rql_types,
                                           "label": c},
                             safe=',()'))
             for c, i in zip(contrasts_wrapped, contrasts_indices)]
@@ -2034,7 +2033,7 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
     if get_masks:
         urls.append("%sbrainomics_data_masks.zip?rql=%s&vid=data-zip"
                     % (root_url,
-                       urllib.quote(base_query % {"types": '"boolean mask"',
+                       urllib.parse.quote(base_query % {"types": '"boolean mask"',
                                                   "label": "mask"},
                                     safe=',()')))
         for subject_id in subject_ids:
@@ -2046,7 +2045,7 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
     if get_anats:
         urls.append("%sbrainomics_data_anats.zip?rql=%s&vid=data-zip"
                     % (root_url,
-                       urllib.quote(base_query % {"types": '"normalized T1"',
+                       urllib.parse.quote(base_query % {"types": '"normalized T1"',
                                                   "label": "anatomy"},
                                     safe=',()')))
         for subject_id in subject_ids:
@@ -2058,10 +2057,10 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
     # Fetch subject characteristics (separated in two files)
     if url is None:
         url_csv = ("%sdataset/cubicwebexport.csv?rql=%s&vid=csvexport"
-                   % (root_url, urllib.quote("Any X WHERE X is Subject")))
+                   % (root_url, urllib.parse.quote("Any X WHERE X is Subject")))
         url_csv2 = ("%sdataset/cubicwebexport2.csv?rql=%s&vid=csvexport"
                     % (root_url,
-                       urllib.quote("Any X,XI,XD WHERE X is QuestionnaireRun, "
+                       urllib.parse.quote("Any X,XI,XD WHERE X is QuestionnaireRun, "
                                     "X identifier XI, X datetime "
                                     "XD", safe=',')
                        ))

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -497,7 +497,7 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
         shutil.move(temp_full_name, full_name)
         dt = time.time() - t0
         if verbose > 0:
-            print ('...done. (%i seconds, %i min)' % (dt, dt / 60))
+            print ('...done. (%i seconds, %i min)' % (dt, dt // 60))
     except urllib.error.HTTPError as e:
         if verbose > 0:
             print ('Error while fetching file %s. Dataset fetching aborted.' %
@@ -1617,9 +1617,9 @@ def fetch_harvard_oxford(atlas_name, data_dir=None, symmetric_split=False,
 
     labels = np.unique(atlas)
     slices = ndimage.find_objects(atlas)
-    middle_ind = (atlas.shape[0] - 1) / 2
+    middle_ind = (atlas.shape[0] - 1) // 2
     crosses_middle = [s.start < middle_ind and s.stop > middle_ind
-             for s, _, _ in slices]
+                      for s, _, _ in slices]
 
     # Split every zone crossing the median plane into two parts.
     # Assumes that the background label is zero.

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -17,8 +17,9 @@ import hashlib
 import fnmatch
 import warnings
 import re
+from io import BytesIO
 from six import string_types
-from six.moves import cPickle, StringIO, urllib
+from six.moves import cPickle, urllib
 
 import numpy as np
 from scipy import ndimage
@@ -358,13 +359,15 @@ def _filter_column(array, col, criteria):
     except:
         raise KeyError('Filtering criterion %s does not exist' % col)
 
-    if not isinstance(criteria, string_types) and \
-            not isinstance(criteria, tuple) and \
-            isinstance(criteria, collections.Iterable):
+    if (not isinstance(criteria, string_types) and
+        not isinstance(criteria, bytes) and
+        not isinstance(criteria, tuple) and
+            isinstance(criteria, collections.Iterable)):
+
         filter = np.zeros(array.shape[0], dtype=np.bool)
         for criterion in criteria:
             filter = np.logical_or(filter,
-                        _filter_column(array, col, criterion))
+                                   _filter_column(array, col, criterion))
         return filter
 
     if isinstance(criteria, tuple):
@@ -2459,7 +2462,8 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
 
     # Parameter check
     for derivative in derivatives:
-        if not derivative in ['alff', 'degree_binarize', 'degree_weighted',
+        if derivative not in [
+                'alff', 'degree_binarize', 'degree_weighted',
                 'dual_regression', 'eigenvector_binarize',
                 'eigenvector_weighted', 'falff', 'func_mask', 'func_mean',
                 'func_preproc', 'lfcd', 'reho', 'rois_aal', 'rois_cc200',
@@ -2493,21 +2497,22 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
     # pheno = pandas.read_csv(path_csv).to_records()
     with open(path_csv, 'r') as pheno_f:
         pheno = ['i' + pheno_f.readline()]
-        
+
         # This regexp replaces commas between double quotes
         for line in pheno_f:
             pheno.append(re.sub(r',(?=[^"]*"(?:[^"]*"[^"]*")*[^"]*$)', ";", line))
 
-    pheno = '\n'.join(pheno)
-    pheno = StringIO(pheno)
+    # bytes (encode()) needed for python 2/3 compat with numpy
+    pheno = '\n'.join(pheno).encode()
+    pheno = BytesIO(pheno)
     # We enforce empty comments because it is 'sharp' by default
-    pheno = np.recfromcsv(pheno, comments=[], case_sensitive=True)
+    pheno = np.recfromcsv(pheno, comments='xyzpdq', case_sensitive=True)
 
     # First, filter subjects with no filename
-    pheno = pheno[pheno['FILE_ID'] != 'no_filename']
+    pheno = pheno[pheno['FILE_ID'] != b'no_filename']
     # Apply user defined filters
-    filter = _filter_columns(pheno, kwargs)
-    pheno = pheno[filter]
+    user_filter = _filter_columns(pheno, kwargs)
+    pheno = pheno[user_filter]
 
     # Go into specific data folder and url
     data_dir = os.path.join(data_dir, pipeline, strategy)
@@ -2515,7 +2520,7 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
 
     # Get the files
     results = {}
-    file_ids = pheno['FILE_ID']
+    file_ids = [file_id.decode() for file_id in pheno['FILE_ID']]
     if n_subjects is not None:
         file_ids = file_ids[:n_subjects]
         pheno = pheno[:n_subjects]
@@ -2532,5 +2537,4 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
         if ext == '.1D':
             files = [np.loadtxt(f) for f in files]
         results[derivative] = files
-
     return Bunch(**results)

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -862,7 +862,7 @@ def fetch_yeo_2011_atlas(data_dir=None, url=None, resume=True, verbose=1):
             as rst_file:
         fdescr = rst_file.read()
 
-    params = dict([('description', fdescr)] + zip(keys, sub_files))
+    params = dict([('description', fdescr)] + list(zip(keys, sub_files)))
     return Bunch(**params)
 
 

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -166,9 +166,9 @@ def _chunk_read_(response, local_file, chunk_size=8192, report_hook=None,
         total_size = int(total_size) + initial_size
     except Exception as e:
         if verbose > 1:
-            print "Warning: total size could not be determined."
+            print ("Warning: total size could not be determined.")
             if verbose > 2:
-                print "Full stack trace: %s" % e
+                print ("Full stack trace: %s" % e)
         total_size = None
     bytes_so_far = initial_size
 
@@ -241,14 +241,14 @@ def _get_dataset_dir(dataset_name, data_dir=None, lookup_defaults=False,
         paths.append(os.path.expanduser('~/nilearn_data'))
 
     if verbose > 2:
-        print 'Dataset search paths:', paths
+        print ('Dataset search paths: %s' % paths)
 
     # Check if the dataset exists somewhere
     for path in paths:
         path = os.path.join(path, dataset_name)
         if os.path.exists(path) and os.path.isdir(path):
             if verbose > 1:
-                print 'Dataset found in', path
+                print ('Dataset found in %s' % path)
             return path
 
     # If not, create a folder in the first writeable directory
@@ -259,7 +259,7 @@ def _get_dataset_dir(dataset_name, data_dir=None, lookup_defaults=False,
             try:
                 os.makedirs(path)
                 if verbose > 0:
-                    print 'Dataset created in', path
+                    print ('Dataset created in %s' % path)
                 return path
             except Exception as exc:
                 short_error_message = getattr(exc, 'strerror', str(exc))
@@ -290,7 +290,7 @@ def _uncompress_file(file_, delete_archive=True, verbose=1):
     This handles zip, tar, gzip and bzip files only.
     """
     if verbose > 0:
-        print 'extracting data from %s...' % file_
+        print ('Extracting data from %s...' % file_)
     data_dir = os.path.dirname(file_)
     # We first try to see if it is a zip file
     try:
@@ -330,10 +330,10 @@ def _uncompress_file(file_, delete_archive=True, verbose=1):
         if delete_archive:
             os.remove(file_)
         if verbose > 0:
-            print '   ...done.'
+            print ('   ...done.')
     except Exception as e:
         if verbose > 0:
-            print 'Error uncompressing file: %s' % e
+            print ('Error uncompressing file: %s' % e)
         raise
 
 
@@ -474,7 +474,7 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
         # Download data
         if verbose > 0:
             displayed_url = urllib.splitquery(url)[0] if verbose == 1 else url
-            print 'Dowloading data from %s ...' % displayed_url
+            print ('Downloading data from %s ...' % displayed_url)
         if resume and os.path.exists(temp_full_name):
             url_opener = ResumeURLOpener()
             # Download has been interrupted, we try to resume it.
@@ -501,23 +501,20 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
         shutil.move(temp_full_name, full_name)
         dt = time.time() - t0
         if verbose > 0:
-            print '...done. (%i seconds, %i min)' % (dt, dt / 60)
+            print ('...done. (%i seconds, %i min)' % (dt, dt / 60))
     except urllib2.HTTPError as e:
-    except urllib2.HTTPError, e:
-        print 'Error while fetching file %s.' \
-            ' Dataset fetching aborted.' % file_name
         if verbose > 0:
-            print 'Error while fetching file %s.' \
-                ' Dataset fetching aborted.' % file_name
+            print ('Error while fetching file %s. Dataset fetching aborted.' %
+                   (file_name))
         if verbose > 1:
-            print "HTTP Error:", e, url
+            print ("HTTP Error: %s, %s" % (e, url))
         raise
     except urllib2.URLError as e:
         if verbose > 0:
-            print 'Error while fetching file %s.' \
-                ' Dataset fetching aborted.' % file_name
+            print ('Error while fetching file %s. Dataset fetching aborted.' %
+                   (file_name))
         if verbose > 1:
-            print "URL Error:", e, url
+            print ("URL Error: %s, %s" % (e, url))
         raise
     finally:
         if local_file is not None:

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -1910,8 +1910,8 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
 
     """
     if isinstance(contrasts, string_types):
-        raise ValueError('Constrasts should be a list of string, a single '
-                         'string was given: "%s"' % contrasts)
+        raise ValueError('Constrasts should be a list of strings, but'
+                         'a single string was given: "%s"' % contrasts)
     if n_subjects is None:
         n_subjects = 94  # 94 subjects available
     if (n_subjects > 94) or (n_subjects < 1):
@@ -2336,13 +2336,13 @@ def fetch_oasis_vbm(n_subjects=None, dartel_version=True,
 
     # Keep CSV information only for selected subjects
     csv_data = np.recfromcsv(ext_vars_file)
-    actual_subjects_ids = ["OAS1"
-                           + str.split(os.path.basename(x), "OAS1")[1][:9]
+    # Comparisons to recfromcsv data must be bytes.
+    actual_subjects_ids = [("OAS1" +
+                            str.split(os.path.basename(x),
+                                      "OAS1")[1][:9]).encode()
                            for x in gm_maps]
-    subject_mask = np.zeros(csv_data.size, dtype=bool)
-    for i, subject_id in enumerate(csv_data['id']):
-        if subject_id in actual_subjects_ids:
-            subject_mask[i] = True
+    subject_mask = np.asarray([subject_id in actual_subjects_ids
+                               for subject_id in csv_data['id']])
     csv_data = csv_data[subject_mask]
 
     return Bunch(

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -177,7 +177,7 @@ def _group_iter_search_light(list_rows, estimator, X, y,
                 else:
                     crlf = "\n"
                 percent = float(i) / len(list_rows)
-                percent = round(percent * 100, 2)
+                percent = np.round(percent * 100, 2)
                 dt = time.time() - t0
                 # We use a max to avoid a division by zero
                 remaining = (100. - percent) / max(0.01, percent) * dt

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -14,6 +14,7 @@ import time
 import sys
 import warnings
 from distutils.version import LooseVersion
+from six import string_types
 
 import numpy as np
 
@@ -314,7 +315,7 @@ class SearchLight(BaseEstimator):
                                     mask_affine))
 
         estimator = self.estimator
-        if isinstance(estimator, basestring):
+        if isinstance(estimator, string_types):
             estimator = ESTIMATOR_CATALOG[estimator]()
 
         scores = search_light(X, y, estimator, A,

--- a/nilearn/decoding/tests/test_searchlight.py
+++ b/nilearn/decoding/tests/test_searchlight.py
@@ -40,8 +40,9 @@ def test_searchlight():
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img,
                                  radius=0.5, n_jobs=n_jobs,
                                  scoring='accuracy', cv=cv)
-    with warnings.catch_warnings(record=True):
+    with warnings.catch_warnings():
         warnings.simplefilter('ignore', DeprecationWarning)
+        warnings.simplefilter('ignore', UserWarning)  # old versions of sklearn
         sl.fit(data_img, cond)
     assert_equal(np.where(sl.scores_ == 1)[0].size, 1)
     assert_equal(sl.scores_[2, 2, 2], 1.)

--- a/nilearn/decoding/tests/test_searchlight.py
+++ b/nilearn/decoding/tests/test_searchlight.py
@@ -44,8 +44,10 @@ def test_searchlight():
                                  radius=0.5, n_jobs=n_jobs,
                                  scoring='accuracy', cv=cv)
     with warnings.catch_warnings():
+        #  check_cv will return indices instead of boolean masks from 0.17
         warnings.simplefilter('ignore', DeprecationWarning)
-        #warnings.simplefilter('ignore', UserWarning)  # old versions of sklearn
+        warnings.filterwarnings('ignore', 'Scikit-learn version is too old.',
+                                UserWarning)  # old versions of sklearn
         sl.fit(data_img, cond)
     assert_equal(np.where(sl.scores_ == 1)[0].size, 1)
     assert_equal(sl.scores_[2, 2, 2], 1.)
@@ -55,6 +57,7 @@ def test_searchlight():
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img, radius=1,
                                  n_jobs=n_jobs, scoring='accuracy', cv=cv)
     with warnings.catch_warnings(record=True):
+        #  check_cv will return indices instead of boolean masks from 0.17
         warnings.simplefilter('ignore', DeprecationWarning)
         sl.fit(data_img, cond)
     assert_equal(np.where(sl.scores_ == 1)[0].size, 7)
@@ -70,6 +73,7 @@ def test_searchlight():
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img, radius=2,
                                  n_jobs=n_jobs, scoring='accuracy', cv=cv)
     with warnings.catch_warnings(record=True):
+        #  check_cv will return indices instead of boolean masks from 0.17
         warnings.simplefilter('ignore', DeprecationWarning)
         sl.fit(data_img, cond)
     assert_equal(np.where(sl.scores_ == 1)[0].size, 33)

--- a/nilearn/decoding/tests/test_searchlight.py
+++ b/nilearn/decoding/tests/test_searchlight.py
@@ -32,7 +32,10 @@ def test_searchlight():
     # Define cross validation
     from sklearn.cross_validation import check_cv
     # avoid using KFold for compatibility with sklearn 0.10-0.13
-    cv = check_cv(4, cond)
+    with warnings.catch_warnings():
+        #  check_cv will return indices instead of boolean masks from 0.17
+        warnings.simplefilter('ignore', DeprecationWarning)
+        cv = check_cv(4, cond)
     n_jobs = 1
 
     # Run Searchlight with different radii
@@ -42,7 +45,7 @@ def test_searchlight():
                                  scoring='accuracy', cv=cv)
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', DeprecationWarning)
-        warnings.simplefilter('ignore', UserWarning)  # old versions of sklearn
+        #warnings.simplefilter('ignore', UserWarning)  # old versions of sklearn
         sl.fit(data_img, cond)
     assert_equal(np.where(sl.scores_ == 1)[0].size, 1)
     assert_equal(sl.scores_[2, 2, 2], 1.)

--- a/nilearn/decoding/tests/test_searchlight.py
+++ b/nilearn/decoding/tests/test_searchlight.py
@@ -22,7 +22,7 @@ def test_searchlight():
     mask = np.ones((5, 5, 5), np.bool)
     mask_img = nibabel.Nifti1Image(mask.astype(np.int), np.eye(4))
     # Create a condition array
-    cond = np.arange(frames, dtype=int) > frames / 2
+    cond = np.arange(frames, dtype=int) > frames / 2.
 
     # Create an activation pixel.
     data[2, 2, 2, :] = 0

--- a/nilearn/decoding/tests/test_searchlight.py
+++ b/nilearn/decoding/tests/test_searchlight.py
@@ -3,10 +3,12 @@ Test the searchlight module
 """
 # Author: Alexandre Abraham
 # License: simplified BSD
+import warnings
 
 from nose.tools import assert_equal
 import numpy as np
 import nibabel
+
 from .. import searchlight
 
 
@@ -27,7 +29,6 @@ def test_searchlight():
     data[2, 2, 2][cond.astype(np.bool)] = 2
     data_img = nibabel.Nifti1Image(data, np.eye(4))
 
-
     # Define cross validation
     from sklearn.cross_validation import check_cv
     # avoid using KFold for compatibility with sklearn 0.10-0.13
@@ -39,7 +40,9 @@ def test_searchlight():
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img,
                                  radius=0.5, n_jobs=n_jobs,
                                  scoring='accuracy', cv=cv)
-    sl.fit(data_img, cond)
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter('ignore', DeprecationWarning)
+        sl.fit(data_img, cond)
     assert_equal(np.where(sl.scores_ == 1)[0].size, 1)
     assert_equal(sl.scores_[2, 2, 2], 1.)
 
@@ -47,7 +50,9 @@ def test_searchlight():
 
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img, radius=1,
                                  n_jobs=n_jobs, scoring='accuracy', cv=cv)
-    sl.fit(data_img, cond)
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter('ignore', DeprecationWarning)
+        sl.fit(data_img, cond)
     assert_equal(np.where(sl.scores_ == 1)[0].size, 7)
     assert_equal(sl.scores_[2, 2, 2], 1.)
     assert_equal(sl.scores_[1, 2, 2], 1.)
@@ -60,6 +65,8 @@ def test_searchlight():
     # Big radius : big ball selected
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img, radius=2,
                                  n_jobs=n_jobs, scoring='accuracy', cv=cv)
-    sl.fit(data_img, cond)
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter('ignore', DeprecationWarning)
+        sl.fit(data_img, cond)
     assert_equal(np.where(sl.scores_ == 1)[0].size, 33)
     assert_equal(sl.scores_[2, 2, 2], 1.)

--- a/nilearn/decomposition/__init__.py
+++ b/nilearn/decomposition/__init__.py
@@ -2,4 +2,6 @@
 The :mod:`nilearn.decomposition` module includes a subject level
 variant of the ICA called Canonnical ICA.
 """
-from canica import CanICA
+from .canica import CanICA
+
+__all__ = ['CanICA']

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -1,16 +1,14 @@
 """
 PCA dimension reduction on multiple subjects
 """
-import warnings
 import itertools
-
-from scipy import linalg
 import numpy as np
+import warnings
+from scipy import linalg
+from six import string_types
 
 import nibabel
-
 from sklearn.base import BaseEstimator, TransformerMixin, clone
-
 from sklearn.externals.joblib import Parallel, delayed, Memory
 from sklearn.utils.extmath import randomized_svd
 
@@ -213,7 +211,7 @@ class MultiPCA(BaseEstimator, TransformerMixin):
             the affine is considered the same for all.
         """
         # Hack to support single-subject data:
-        if isinstance(imgs, (basestring, nibabel.Nifti1Image)):
+        if isinstance(imgs, (string_types, nibabel.Nifti1Image)):
             imgs = [imgs]
             # This is a very incomplete hack, as it won't work right for
             # single-subject list of 3D filenames

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -17,8 +17,8 @@ from sklearn.utils.extmath import randomized_svd
 from ..input_data import NiftiMasker, MultiNiftiMasker, NiftiMapsMasker
 from ..input_data.base_masker import filter_and_mask
 from .._utils import as_ndarray
-from .._utils.class_inspect import get_params
 from .._utils.cache_mixin import cache
+from .._utils.class_inspect import get_params
 
 
 def session_pca(imgs, mask_img, parameters,

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -253,7 +253,10 @@ class MultiPCA(BaseEstimator, TransformerMixin):
                     warnings.warn('Parameter %s of the masker overriden'
                                   % param_name)
                 setattr(self.masker_, param_name, our_param)
-        self.masker_.fit(imgs)
+        if self.masker_.mask_img:
+            self.masker_.fit()
+        else:
+            self.masker_.fit(imgs)
         self.mask_img_ = self.masker_.mask_img_
 
         parameters = get_params(MultiNiftiMasker, self)

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -75,7 +75,7 @@ def session_pca(imgs, mask_img, parameters,
             verbose=verbose,
             confounds=confounds,
             copy=copy)
-    if n_components <= data.shape[0] / 4:
+    if n_components <= data.shape[0] // 4:
         U, S, _ = randomized_svd(data.T, n_components)
     else:
         U, S, _ = linalg.svd(data.T, full_matrices=False)

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -2,7 +2,7 @@
 import nibabel
 import numpy as np
 from numpy.testing import assert_array_almost_equal
-from nose.tools import assert_true
+from nose.tools import assert_equal
 from nilearn.decomposition.canica import CanICA
 
 
@@ -58,7 +58,7 @@ def test_canica_square_img():
     # K should be a permutation matrix, hence its coefficients
     # should all be close to 0 1 or -1
     K_abs = np.abs(K)
-    assert_true(np.sum(K_abs > .9) == 4)
+    assert_equal(np.sum(K_abs > .9), 4)
     K_abs[K_abs > .9] -= 1
     assert_array_almost_equal(K_abs, 0, 1)
 

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -41,6 +41,7 @@ def test_canica_square_img():
         this_data = np.rollaxis(this_data, 0, 4)
         data.append(nibabel.Nifti1Image(this_data, affine))
 
+    # Pass an explicit mask, as computing a mask on our fake data will fail
     mask_img = nibabel.Nifti1Image(np.ones(shape, dtype=np.int8), affine)
 
     # We do a large number of inits to be sure to find the good match
@@ -54,7 +55,7 @@ def test_canica_square_img():
     # Find pairs of matching components
     # compute the cross-correlation matrix between components
     K = np.corrcoef(components, maps.reshape(4, 400))[4:, :4]
-    # K should be a permutation matrix, hence its coefficients 
+    # K should be a permutation matrix, hence its coefficients
     # should all be close to 0 1 or -1
     K_abs = np.abs(K)
     assert_true(np.sum(K_abs > .9) == 4)

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -1,11 +1,16 @@
 """Test CanICA"""
+import os
+
 import nibabel
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 from nose.tools import assert_equal
+
 from nilearn.decomposition.canica import CanICA
+from nilearn._utils.testing import skip_if
 
 
+@skip_if(os.environ.get('DISTRIB') == 'neurodebian')
 def test_canica_square_img():
     shape = (20, 20, 1)
     affine = np.eye(4)

--- a/nilearn/decomposition/tests/test_multi_pca.py
+++ b/nilearn/decomposition/tests/test_multi_pca.py
@@ -40,8 +40,10 @@ def test_multi_pca():
     # Smoke test that multi_pca also works with single subject data
     multi_pca.fit(data[0])
 
-    # Check that asking for too little components raises a ValueError
-    multi_pca = MultiPCA()
+    # Check that asking for too little components raises a ValueError.
+    # pass an explicit mask, to avoid an additional error from computing
+    # a mask on dummy data.
+    multi_pca = MultiPCA(mask=mask_img)  
     nose.tools.assert_raises(ValueError, multi_pca.fit, data[:2])
 
     # Smoke test the use of a masker and without CCA

--- a/nilearn/group_sparse_covariance.py
+++ b/nilearn/group_sparse_covariance.py
@@ -9,6 +9,7 @@ import warnings
 import collections
 import operator
 import itertools
+from past.builtins import xrange
 
 import numpy as np
 import scipy.linalg

--- a/nilearn/group_sparse_covariance.py
+++ b/nilearn/group_sparse_covariance.py
@@ -1021,14 +1021,14 @@ class GroupSparseCovarianceCV(BaseEstimator, CacheMixin):
             #   of alpha.
             # - precisions_list: corresponding precisions matrices, for each
             #   value of alpha.
-            precisions_list, scores = zip(*this_path)
+            precisions_list, scores = list(zip(*this_path))
             # now scores[i][j] is the score for the i-th folding, j-th value of
             # alpha (analoguous for precisions_list)
-            precisions_list = zip(*precisions_list)
+            precisions_list = list(zip(*precisions_list))
             scores = [np.mean(sc) for sc in zip(*scores)]
             # scores[i] is the mean score obtained for the i-th value of alpha.
 
-            path.extend(zip(alphas, scores, precisions_list))
+            path.extend(list(zip(alphas, scores, precisions_list)))
             path = sorted(path, key=operator.itemgetter(0), reverse=True)
 
             # Find the maximum score (avoid using the built-in 'max' function

--- a/nilearn/group_sparse_covariance.py
+++ b/nilearn/group_sparse_covariance.py
@@ -995,10 +995,10 @@ class GroupSparseCovarianceCV(BaseEstimator, CacheMixin):
             train_test_subjs = []
             for train_test in zip(*cv):
                 assert(len(train_test) == n_subjects)
-                train_test_subjs.append(zip(*[(subject[train, :],
-                                               subject[test, :])
-                                            for subject, (train, test)
-                                            in zip(subjects, train_test)]))
+                train_test_subjs.append(list(zip(*[(subject[train, :],
+                                                    subject[test, :])
+                                             for subject, (train, test)
+                                             in zip(subjects, train_test)])))
             if self.early_stopping:
                 probes = [EarlyStopProbe(test_subjs, verbose=self.verbose)
                           for _, test_subjs in train_test_subjs]
@@ -1014,7 +1014,7 @@ class GroupSparseCovarianceCV(BaseEstimator, CacheMixin):
                     precisions_init=None if self.early_stopping else prec_init,
                     probe_function=probe)
                 for (train_subjs, test_subjs), prec_init, probe
-                in list(zip(train_test_subjs, covs_init, probes)))
+                in zip(train_test_subjs, covs_init, probes))
 
             # this_path[i] is a tuple (precisions_list, scores)
             # - scores: scores obtained with the i-th folding, for each value

--- a/nilearn/group_sparse_covariance.py
+++ b/nilearn/group_sparse_covariance.py
@@ -1014,7 +1014,7 @@ class GroupSparseCovarianceCV(BaseEstimator, CacheMixin):
                     precisions_init=None if self.early_stopping else prec_init,
                     probe_function=probe)
                 for (train_subjs, test_subjs), prec_init, probe
-                in zip(train_test_subjs, covs_init, probes))
+                in list(zip(train_test_subjs, covs_init, probes)))
 
             # this_path[i] is a tuple (precisions_list, scores)
             # - scores: scores obtained with the i-th folding, for each value

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -7,6 +7,7 @@ See also nilearn.signal.
 # License: simplified BSD
 
 import collections
+from six import string_types
 
 import numpy as np
 from scipy import ndimage
@@ -240,7 +241,7 @@ def smooth_img(imgs, fwhm):
     # Use hasattr() instead of isinstance to workaround a Python 2.6/2.7 bug
     # See http://bugs.python.org/issue7624
     if hasattr(imgs, "__iter__") \
-       and not isinstance(imgs, basestring):
+       and not isinstance(imgs, string_types):
         single_img = False
     else:
         single_img = True
@@ -428,7 +429,7 @@ def mean_img(imgs, target_affine=None, target_shape=None,
         mean image
 
     """
-    if (isinstance(imgs, basestring) or
+    if (isinstance(imgs, string_types) or
         not isinstance(imgs, collections.Iterable)):
         imgs = [imgs, ]
         total_n_imgs = 1

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -6,6 +6,7 @@ Utilities to resample a Nifti Image
 
 import warnings
 from distutils.version import LooseVersion
+from six import string_types
 
 import numpy as np
 import scipy
@@ -362,7 +363,7 @@ def resample_img(img, target_affine=None, target_shape=None,
                    "or 'nearest' but it was set to '{0}'").format(interpolation)
         raise ValueError(message)
 
-    if isinstance(img, basestring):
+    if isinstance(img, string_types):
         # Avoid a useless copy
         input_img_is_string = True
     else:

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -155,7 +155,7 @@ def get_bounds(shape, affine):
                     [0,    bdim, cdim, 1],
                     [adim, bdim, cdim, 1]]).T
     box = np.dot(affine, box)[:3]
-    return zip(box.min(axis=-1), box.max(axis=-1))
+    return list(zip(box.min(axis=-1), box.max(axis=-1)))
 
 
 def get_mask_bounds(img):

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -279,7 +279,7 @@ def test_concat_imgs():
 
 def test_index_img():
     img_3d = nibabel.Nifti1Image(np.ones((3, 4, 5)), np.eye(4))
-    testing.assert_raises_regexp(TypeError, '4D Nifti image',
+    testing.assert_raises_regex(TypeError, '4D Nifti image',
                                  image.index_img, img_3d, 0)
 
     affine = np.array([[1., 2., 3., 4.],
@@ -303,7 +303,7 @@ def test_index_img():
     for i in [fourth_dim_size, - fourth_dim_size - 1,
               [0, fourth_dim_size],
               np.repeat(True, fourth_dim_size + 1)]:
-        testing.assert_raises_regexp(
+        testing.assert_raises_regex(
             IndexError,
             'out of bounds|invalid index|out of range',
             image.index_img, img_4d, i)
@@ -311,7 +311,7 @@ def test_index_img():
 
 def test_iter_img():
     img_3d = nibabel.Nifti1Image(np.ones((3, 4, 5)), np.eye(4))
-    testing.assert_raises_regexp(TypeError, '4D Nifti image',
+    testing.assert_raises_regex(TypeError, '4D Nifti image',
                                  image.iter_img, img_3d)
 
     affine = np.array([[1., 2., 3., 4.],

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -289,7 +289,7 @@ def test_index_img():
     img_4d, _ = testing.generate_fake_fmri(affine=affine)
 
     fourth_dim_size = niimg_conversions._get_shape(img_4d)[3]
-    tested_indices = (range(fourth_dim_size) +
+    tested_indices = (list(range(fourth_dim_size)) +
                       [slice(2, 8, 2), [1, 2, 3, 2], [],
                        (np.arange(fourth_dim_size) % 3) == 1])
     for i in tested_indices:

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -243,13 +243,13 @@ def test_raises_bbox_error_if_data_outside_box():
     img = Nifti1Image(data, affine)
 
     # some axis flipping affines
-    axis_flips = np.array(map(np.diag,
+    axis_flips = np.array(list(map(np.diag,
                               [[-1, 1, 1, 1],
                                [1, -1, 1, 1],
                                [1, 1, -1, 1],
                                [-1, -1, 1, 1],
                                [-1, 1, -1, 1],
-                               [1, -1, -1, 1]]))
+                               [1, -1, -1, 1]])))
 
     # some in plane 90 degree rotations base on these
     # (by permuting two lines)

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -44,7 +44,7 @@ def pad(array, *args):
                          len(args))
 
     all_paddings = np.zeros([array.ndim, 2], dtype=np.int64)
-    all_paddings[:len(args) / 2] = np.array(args).reshape(-1, 2)
+    all_paddings[:len(args) // 2] = np.array(args).reshape(-1, 2)
 
     lower_paddings, upper_paddings = all_paddings.T
     new_shape = np.array(array.shape) + upper_paddings + lower_paddings
@@ -105,7 +105,7 @@ def test_resampling_with_affine():
     """
     prng = np.random.RandomState(10)
     data = prng.randint(4, size=(1, 4, 4))
-    for angle in (0, np.pi, np.pi / 2, np.pi / 4, np.pi / 3):
+    for angle in (0, np.pi, np.pi / 2., np.pi / 4., np.pi / 3.):
         rot = rotation(0, angle)
         rot_img = resample_img(Nifti1Image(data, np.eye(4)),
                                target_affine=rot,
@@ -471,7 +471,7 @@ def test_reorder_img_non_native_endianness():
 
         affine = np.eye(4)
 
-        theta = math.pi / 6
+        theta = math.pi / 6.
         c = math.cos(theta)
         s = math.sin(theta)
 

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -138,7 +138,7 @@ def test_resampling_error_checks():
     # Invalid interpolation
     interpolation = 'an_invalid_interpolation'
     pattern = "interpolation must be either.+{0}".format(interpolation)
-    testing.assert_raises_regexp(ValueError, pattern,
+    testing.assert_raises_regex(ValueError, pattern,
                                  resample_img, img, target_shape=target_shape,
                                  target_affine=affine,
                                  interpolation="an_invalid_interpolation")
@@ -225,7 +225,7 @@ def test_raises_upon_3x3_affine_and_no_shape():
     message = ("Given target shape without anchor "
                "vector: Affine shape should be \(4, 4\) and "
                "not \(3, 3\)")
-    testing.assert_raises_regexp(
+    testing.assert_raises_regex(
         exception, message,
         resample_img, img, target_affine=np.eye(3) * 2,
         target_shape=(10, 10, 10))
@@ -272,7 +272,7 @@ def test_raises_bbox_error_if_data_outside_box():
                    "by the target affine does "
                    "not contain any of the data")
 
-        testing.assert_raises_regexp(
+        testing.assert_raises_regex(
             exception, message,
             resample_img, img, target_affine=new_affine)
 
@@ -417,7 +417,7 @@ def test_reorder_img():
     # exception
     affine[1, 0] = 0.1
     ref_img = Nifti1Image(data, affine)
-    testing.assert_raises_regexp(ValueError, 'Cannot reorder the axes',
+    testing.assert_raises_regex(ValueError, 'Cannot reorder the axes',
                                  reorder_img, ref_img)
 
     # Test that no exception is raised when resample='continuous'
@@ -435,7 +435,7 @@ def test_reorder_img():
     # Make sure invalid resample argument is included in the error message
     interpolation = 'an_invalid_interpolation'
     pattern = "interpolation must be either.+{0}".format(interpolation)
-    testing.assert_raises_regexp(ValueError, pattern,
+    testing.assert_raises_regex(ValueError, pattern,
                                  reorder_img, ref_img,
                                  resample=interpolation)
 

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -8,6 +8,7 @@ import warnings
 
 import numpy as np
 import itertools
+from six import string_types
 
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.externals.joblib import Memory, Parallel, delayed
@@ -30,7 +31,7 @@ def filter_and_mask(imgs, mask_img_,
     # If we have a string (filename), we won't need to copy, as
     # there will be no side effect
 
-    if isinstance(imgs, basestring):
+    if isinstance(imgs, string_types):
         copy = False
 
     if verbose > 0:

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -228,7 +228,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
                                 reference_affine=reference_affine,
                                 copy=copy)
                           for imgs, confounds in zip(imgs_list, confounds))
-        return zip(*data)[0]
+        return list(zip(*data))[0]
 
     def fit_transform(self, X, y=None, confounds=None, **fit_params):
         """Fit to data, then transform it

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -146,13 +146,13 @@ class MultiNiftiMasker(BaseMasker, CacheMixin):
 
         # Load data (if filenames are given, load them)
         if self.verbose > 0:
-            print "[%s.fit] Loading data from %s" % (
+            print ("[%s.fit] Loading data from %s" % (
                 self.__class__.__name__,
-                _utils._repr_niimgs(imgs)[:200])
+                _utils._repr_niimgs(imgs)[:200]))
         # Compute the mask if not given by the user
         if self.mask_img is None:
             if self.verbose > 0:
-                print "[%s.fit] Computing mask" % self.__class__.__name__
+                print ("[%s.fit] Computing mask" % self.__class__.__name__)
             data = []
             if not isinstance(imgs, collections.Iterable) \
                     or isinstance(imgs, basestring):
@@ -198,7 +198,7 @@ class MultiNiftiMasker(BaseMasker, CacheMixin):
         # If resampling is requested, resample the mask as well.
         # Resampling: allows the user to change the affine, the shape or both.
         if self.verbose > 0:
-            print "[%s.transform] Resampling mask" % self.__class__.__name__
+            print ("[%s.transform] Resampling mask" % self.__class__.__name__)
         self.mask_img_ = self._cache(image.resample_img,
                                     func_memory_level=1)(
             self.mask_img_,

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -6,6 +6,7 @@ Transformer used to apply basic transformations on multi subject MRI data.
 
 import warnings
 import collections
+from six import string_types
 
 from sklearn.externals.joblib import Memory
 
@@ -155,7 +156,7 @@ class MultiNiftiMasker(BaseMasker, CacheMixin):
                 print ("[%s.fit] Computing mask" % self.__class__.__name__)
             data = []
             if not isinstance(imgs, collections.Iterable) \
-                    or isinstance(imgs, basestring):
+                    or isinstance(imgs, string_types):
                 raise ValueError("[%s.fit] For multiple processing, you should"
                                  " provide a list of data "
                                  "(e.g. Nifti1Image objects or filenames)."
@@ -232,6 +233,6 @@ class MultiNiftiMasker(BaseMasker, CacheMixin):
             preprocessed images
         """
         if not hasattr(imgs, '__iter__')\
-                    or isinstance(imgs, basestring):
+                    or isinstance(imgs, string_types):
                 return self.transform_single_imgs(imgs)
         return self.transform_imgs(imgs, confounds, n_jobs=self.n_jobs)

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -187,7 +187,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
             self.affine_ = self.mask_img_.get_affine()
         # Load data in memory
         self.mask_img_.get_data()
-        if self.verbose > 10:
+        if self.verbose > 0:
             print "[%s.fit] Finished fit" % self.__class__.__name__
         return self
 

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -144,9 +144,9 @@ class NiftiMasker(BaseMasker, CacheMixin):
 
         # Load data (if filenames are given, load them)
         if self.verbose > 0:
-            print "[%s.fit] Loading data from %s" % (
+            print ("[%s.fit] Loading data from %s" % (
                             self.__class__.__name__,
-                            _utils._repr_niimgs(imgs)[:200])
+                            _utils._repr_niimgs(imgs)[:200]))
 
         # Compute the mask if not given by the user
         if self.mask_img is None:
@@ -160,7 +160,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
                 raise ValueError("Unknown value of mask_strategy '%s'. "
                     "Acceptable values are 'background' and 'epi'.")
             if self.verbose > 0:
-                print "[%s.fit] Computing the mask" % self.__class__.__name__
+                print ("[%s.fit] Computing the mask" % self.__class__.__name__)
             imgs = _utils.check_niimgs(imgs, accept_3d=True)
             self.mask_img_ = self._cache(compute_mask,
                               func_memory_level=1,
@@ -175,7 +175,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
         # If resampling is requested, resample also the mask
         # Resampling: allows the user to change the affine, the shape or both
         if self.verbose > 0:
-            print "[%s.fit] Resampling mask" % self.__class__.__name__
+            print ("[%s.fit] Resampling mask" % self.__class__.__name__)
         self.mask_img_ = self._cache(image.resample_img, func_memory_level=1)(
             self.mask_img_,
             target_affine=self.target_affine,
@@ -188,7 +188,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
         # Load data in memory
         self.mask_img_.get_data()
         if self.verbose > 0:
-            print "[%s.fit] Finished fit" % self.__class__.__name__
+            print ("[%s.fit] Finished fit" % self.__class__.__name__)
         return self
 
     def transform(self, imgs, confounds=None):

--- a/nilearn/input_data/nifti_region.py
+++ b/nilearn/input_data/nifti_region.py
@@ -35,7 +35,7 @@ def _compose_err_msg(msg, **kwargs):
         msg, with "key: value" appended. Only string values are appended.
     """
     updated_msg = msg
-    for k, v in kwargs.iteritems():
+    for k, v in kwargs.items():
         if isinstance(v, string_types):
             updated_msg += "\n" + k + ": " + v
 

--- a/nilearn/input_data/nifti_region.py
+++ b/nilearn/input_data/nifti_region.py
@@ -3,6 +3,7 @@ Transformer for computing ROI signals.
 """
 
 import numpy as np
+from six import string_types
 
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.externals.joblib import Memory
@@ -35,7 +36,7 @@ def _compose_err_msg(msg, **kwargs):
     """
     updated_msg = msg
     for k, v in kwargs.iteritems():
-        if isinstance(v, basestring):
+        if isinstance(v, string_types):
             updated_msg += "\n" + k + ": " + v
 
     return updated_msg

--- a/nilearn/input_data/tests/__init__.py
+++ b/nilearn/input_data/tests/__init__.py
@@ -1,4 +1,4 @@
 # For nosetests to be able to execute only one test.
-import test_nifti_masker
-import test_multi_nifti_masker
-import test_nifti_region
+from . import test_nifti_masker
+from . import test_multi_nifti_masker
+from . import test_nifti_region

--- a/nilearn/input_data/tests/test_base_masker.py
+++ b/nilearn/input_data/tests/test_base_masker.py
@@ -8,7 +8,7 @@ import nibabel
 
 from ..base_masker import filter_and_mask
 from ... import image
-from ..._utils.testing import assert_raises_regexp
+from ..._utils.testing import assert_raises_regex
 
 def test_cropping_code_paths():
     # Will mask data with an identically sampled mask and
@@ -54,5 +54,5 @@ def test_filter_and_mask():
     mask = np.zeros([20, 30, 40, 2])
     mask[10, 15, 20, :] = 1
 
-    assert_raises_regexp(TypeError, "A 3D image is expected", filter_and_mask,
+    assert_raises_regex(TypeError, "A 3D image is expected", filter_and_mask,
                          data, mask, {})

--- a/nilearn/input_data/tests/test_multi_nifti_masker.py
+++ b/nilearn/input_data/tests/test_multi_nifti_masker.py
@@ -14,7 +14,7 @@ import nibabel
 from distutils.version import LooseVersion
 
 from ..multi_nifti_masker import MultiNiftiMasker
-from ..._utils.testing import assert_raises_regexp, assert_warns_regex, \
+from ..._utils.testing import assert_raises_regex, assert_warns_regex, \
     write_tmp_imgs
 
 
@@ -103,7 +103,7 @@ def test_3d_images():
     mask_img_4d = Nifti1Image(np.ones((2, 2, 2, 2), dtype=np.int8),
                               affine=np.diag((4, 4, 4, 1)))
     masker2 = MultiNiftiMasker(mask_img=mask_img_4d)
-    assert_raises_regexp(TypeError, "A 3D image is expected",
+    assert_raises_regex(TypeError, "A 3D image is expected",
                          masker2.fit)
 
 

--- a/nilearn/input_data/tests/test_nifti_region.py
+++ b/nilearn/input_data/tests/test_nifti_region.py
@@ -48,12 +48,12 @@ def test_nifti_labels_masker():
 
     # verify that 4D mask arguments are refused
     masker = NiftiLabelsMasker(labels11_img, mask_img=mask_img_4d)
-    testing.assert_raises_regexp(TypeError, "A 3D image is expected",
+    testing.assert_raises_regex(TypeError, "A 3D image is expected",
                                  masker.fit)
 
     # check exception when transform() called without prior fit()
     masker11 = NiftiLabelsMasker(labels11_img, resampling_target=None)
-    testing.assert_raises_regexp(
+    testing.assert_raises_regex(
         ValueError,
         'has not been fitted. ', masker11.transform, fmri11_img)
 
@@ -91,7 +91,7 @@ def test_nifti_labels_masker():
     signals11 = masker11.fit_transform(fmri11_img)
     assert_equal(signals11.shape, (length, n_regions))
 
-    testing.assert_raises_regexp(
+    testing.assert_raises_regex(
         ValueError, 'has not been fitted. ',
         NiftiLabelsMasker(labels11_img).inverse_transform, signals11)
 
@@ -231,7 +231,7 @@ def test_nifti_maps_masker():
     masker11 = NiftiMapsMasker(labels11_img, mask_img=mask11_img,
                                resampling_target=None)
 
-    testing.assert_raises_regexp(
+    testing.assert_raises_regex(
         ValueError, 'has not been fitted. ',
         masker11.transform, fmri11_img)
     signals11 = masker11.fit().transform(fmri11_img)
@@ -266,7 +266,7 @@ def test_nifti_maps_masker():
     signals11 = masker11.fit_transform(fmri11_img)
     assert_equal(signals11.shape, (length, n_regions))
 
-    testing.assert_raises_regexp(
+    testing.assert_raises_regex(
         ValueError, 'has not been fitted. ',
         NiftiMapsMasker(labels11_img).inverse_transform, signals11)
 
@@ -301,7 +301,7 @@ def test_nifti_maps_masker_2():
 
     # verify that 4D mask arguments are refused
     masker = NiftiMapsMasker(maps33_img, mask_img=mask_img_4d)
-    testing.assert_raises_regexp(TypeError, "A 3D image is expected",
+    testing.assert_raises_regex(TypeError, "A 3D image is expected",
                                  masker.fit)
 
     # Test error checking

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -249,7 +249,7 @@ def compute_epi_mask(epi_img, lower_cutoff=0.2, upper_cutoff=0.85,
         The brain mask (3D image)
     """
     if verbose > 0:
-        print "EPI mask computation"
+        print ("EPI mask computation")
 
     epi_img = _utils.check_niimgs(epi_img, accept_3d=True)
 
@@ -415,7 +415,7 @@ def compute_background_mask(data_imgs, border_size=2,
         The brain mask (3D image)
     """
     if verbose > 0:
-        print "Background mask computation"
+        print ("Background mask computation")
 
     data_imgs = _utils.check_niimgs(data_imgs, accept_3d=True)
 

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -74,7 +74,7 @@ def _extrapolate_out_mask(data, mask, iterations=1):
     masked_data[1:-1, 1:-1, 1:-1] = data.copy()
     masked_data[np.logical_not(larger_mask)] = np.nan
     outer_shell = larger_mask.copy()
-    outer_shell[1:-1, 1:-1, 1:-1] = new_mask - mask
+    outer_shell[1:-1, 1:-1, 1:-1] = np.logical_xor(new_mask, mask)
     outer_shell_x, outer_shell_y, outer_shell_z = np.where(outer_shell)
     extrapolation = list()
     for i, j, k in [(0, 1, 0), (0, -1, 0), (1, 0, 0), (-1, 0, 0),

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -20,9 +20,6 @@ class MaskWarning(UserWarning):
     "A class to always raise warnings"
 
 
-warnings.simplefilter("always", MaskWarning)
-
-
 def _load_mask_img(mask_img, allow_empty=False):
     ''' Check that a mask is valid, ie with two values including 0 and load it.
 

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -5,6 +5,8 @@ Massively Univariate Linear Model estimated with OLS and permutation test.
 # Author: Benoit Da Mota, <benoit.da_mota@inria.fr>, sept. 2011
 #         Virgile Fritsch, <virgile.fritsch@inria.fr>, jan. 2014
 import warnings
+from past.builtins import xrange
+
 import numpy as np
 from scipy import linalg
 from sklearn.utils import check_random_state

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -5,6 +5,7 @@ Tests for the permuted_ols function.
 # Author: Virgile Fritsch, <virgile.fritsch@inria.fr>, Feb. 2014
 import nose
 import numpy as np
+import warnings
 from scipy import stats
 from sklearn.utils import check_random_state
 
@@ -517,9 +518,13 @@ def test_sided_test2(random_state=0):
     tested_var = np.arange(0, 20, 2)
     # permuted OLS
     # one-sided
-    neg_log_pvals_onesided, _, _ = permuted_ols(
-        tested_var, target_var, model_intercept=False,
-        two_sided_test=False, n_perm=100, random_state=random_state)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        neg_log_pvals_onesided, _, _ = permuted_ols(
+            tested_var, target_var, model_intercept=False,
+            two_sided_test=False, n_perm=100,
+            random_state=random_state)
+
     # one-sided (other side)
     neg_log_pvals_onesided2, _, _ = permuted_ols(
         tested_var, -target_var, model_intercept=False,

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -12,8 +12,8 @@ from sklearn.utils import check_random_state
 from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
                            assert_array_less, assert_equal)
 
-from nilearn.mass_univariate import permuted_ols
-from nilearn.mass_univariate.permuted_least_squares import (
+from ...mass_univariate import permuted_ols
+from ...mass_univariate.permuted_least_squares import (
     _t_score_with_covars_and_normalized_design, orthonormalize_matrix)
 
 

--- a/nilearn/plotting/cm.py
+++ b/nilearn/plotting/cm.py
@@ -5,13 +5,14 @@ Matplotlib colormaps useful for neuroimaging.
 """
 import numpy as _np
 
-from nilearn._utils.testing import skip_if_running_nose
+from .._utils.testing import skip_if_running_nose
 
 try:
     from matplotlib import cm as _cm
     from matplotlib import colors as _colors
 except ImportError:
     skip_if_running_nose('Could not import matplotlib')
+
 
 ################################################################################
 # Custom colormaps for two-tailed symmetric statistics

--- a/nilearn/plotting/cm.py
+++ b/nilearn/plotting/cm.py
@@ -154,7 +154,7 @@ if hasattr(_cm, 'afmhot'): # or afmhot
 # Build colormaps and their reverse.
 _cmap_d = dict()
 
-for _cmapname in _cmaps_data.keys():
+for _cmapname in list(_cmaps_data.keys()):
     _cmapname_r = _cmapname + '_r'
     _cmapspec = _cmaps_data[_cmapname]
     _cmaps_data[_cmapname_r] = _cm.revcmap(_cmapspec)

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -4,9 +4,8 @@ The Slicer classes.
 The main purpose of these classes is to have auto adjust of axes size to
 the data with different layout of cuts.
 """
-
-import operator
-
+import collections
+import numbers
 import numpy as np
 
 import nibabel
@@ -22,12 +21,12 @@ except ImportError:
 
 
 # Local imports
+from . import glass_brain
 from .find_cuts import find_xyz_cut_coords, find_cut_slices
 from .edge_detect import _edge_map
-from ..image.resampling import get_bounds, reorder_img, coord_transform,\
-            get_mask_bounds
+from ..image.resampling import get_bounds, reorder_img, coord_transform, \
+                               get_mask_bounds
 
-from . import glass_brain
 
 ################################################################################
 # class BaseAxes
@@ -307,7 +306,7 @@ class BaseSlicer(object):
             axes = [0., 0., 1., 1.]
             if leave_space:
                 axes = [0.3, 0, .7, 1.]
-        if operator.isSequenceType(axes):
+        if isinstance(axes, collections.Sequence):
             axes = figure.add_axes(axes)
         # People forget to turn their axis off, or to set the zorder, and
         # then they cannot see their slicer
@@ -803,8 +802,8 @@ class BaseStackedSlicer(BaseSlicer):
             lower, upper = bounds['xyz'.index(cls._direction)]
             cut_coords = np.linspace(lower, upper, cut_coords).tolist()
         else:
-            if (not operator.isSequenceType(cut_coords) and
-                    operator.isNumberType(cut_coords)):
+            if (not isinstance(cut_coords, collections.Sequence) and
+                    isinstance(cut_coords, numbers.Number)):
                 cut_coords = find_cut_slices(img,
                                              direction=cls._direction,
                                              n_cuts=cut_coords)

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -445,7 +445,7 @@ class BaseSlicer(object):
                                     affine))
 
         data_2d_list = []
-        for display_ax in self.axes.itervalues():
+        for display_ax in self.axes.values():
             try:
                 data_2d = display_ax.transform_to_2d(data, affine)
             except IndexError:
@@ -543,7 +543,7 @@ class BaseSlicer(object):
         data_bounds = get_bounds(data.shape, img.get_affine())
 
         # For each ax, cut the data and plot it
-        for display_ax in self.axes.itervalues():
+        for display_ax in self.axes.values():
             try:
                 data_2d = display_ax.transform_to_2d(data, affine)
                 edge_mask = _edge_map(data_2d)
@@ -697,7 +697,7 @@ class OrthoSlicer(BaseSlicer):
             ticks_margin = adjusted_width * self._colorbar_labels_margin
             x1 = x1 - (adjusted_width + ticks_margin)
 
-        for display_ax in display_ax_dict.itervalues():
+        for display_ax in display_ax_dict.values():
             bounds = display_ax.get_object_bounds()
             if not bounds:
                 # This happens if the call to _map_show was not
@@ -708,7 +708,7 @@ class OrthoSlicer(BaseSlicer):
             xmin, xmax, ymin, ymax = bounds
             width_dict[display_ax.ax] = (xmax - xmin)
         total_width = float(sum(width_dict.values()))
-        for ax, width in width_dict.iteritems():
+        for ax, width in width_dict.items():
             width_dict[ax] = width/total_width*(x1 -x0)
         x_ax = display_ax_dict.get('x', dummy_ax)
         y_ax = display_ax_dict.get('y', dummy_ax)
@@ -853,7 +853,7 @@ class BaseStackedSlicer(BaseSlicer):
             ticks_margin = adjusted_width*self._colorbar_labels_margin
             x1 = x1 - (adjusted_width+ticks_margin)
 
-        for display_ax in display_ax_dict.itervalues():
+        for display_ax in display_ax_dict.values():
             bounds = display_ax.get_object_bounds()
             if not bounds:
                 # This happens if the call to _map_show was not
@@ -864,7 +864,7 @@ class BaseStackedSlicer(BaseSlicer):
             xmin, xmax, ymin, ymax = bounds
             width_dict[display_ax.ax] = (xmax - xmin)
         total_width = float(sum(width_dict.values()))
-        for ax, width in width_dict.iteritems():
+        for ax, width in width_dict.items():
             width_dict[ax] = width/total_width*(x1 -x0)
         left_dict = dict()
         left = float(x0)

--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -234,4 +234,4 @@ def find_cut_slices(img, direction='z', n_cuts=12, spacing='auto'):
     cut_coords = coord_transform(**kwargs)[axis]
     # We need to atleast_1d to make sure that when n_cuts is 1 we do
     # get an iterable
-    return np.atleast_1d(cut_coords)
+    return np.atleast_1d(cut_coords).astype(int)

--- a/nilearn/plotting/glass_brain.py
+++ b/nilearn/plotting/glass_brain.py
@@ -100,11 +100,11 @@ def _get_json_and_transform(direction):
         (_direction, os.path.join(
             dirname,
             'brain_schematics_{0}.json'.format(view_name)))
-        for _direction, view_name in direction_to_view_name.iteritems()])
+        for _direction, view_name in direction_to_view_name.items()])
 
     direction_to_transforms = dict([
         (_direction, transforms.Affine2D.from_values(*params))
-        for _direction, params in direction_to_transform_params.iteritems()])
+        for _direction, params in direction_to_transform_params.items()])
 
     direction_to_json_and_transform = dict([
         (_direction, (direction_to_filename[_direction],
@@ -117,7 +117,7 @@ def _get_json_and_transform(direction):
         message = ("No glass brain view associated with direction '{0}'. "
                    "Possible directions are {1}").format(
                        direction,
-                       direction_to_json_and_transform.keys())
+                       list(direction_to_json_and_transform.keys()))
         raise ValueError(message)
 
     return filename_and_transform

--- a/nilearn/plotting/glass_brain_files/plot_align_svg.py
+++ b/nilearn/plotting/glass_brain_files/plot_align_svg.py
@@ -25,7 +25,7 @@ display = img_plotting.plot_glass_brain(bg_img, threshold=0,
 # e.g. parieto-occipital sulcus
 
 def add_brain_schematics(display):
-    for axes in display.axes.itervalues():
+    for axes in display.axes.values():
         kwargs = {'alpha': 0.5, 'linewidth': 1, 'edgecolor': 'orange'}
         object_bounds = glass_brain.plot_brain_schematics(axes.ax,
                                                           axes.direction,

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -8,8 +8,8 @@ Only matplotlib is required.
 # License: BSD
 
 # Standard library imports
-import operator
 import functools
+import numbers
 
 # Standard scientific libraries imports (more specific imports are
 # delayed, so that the part module can be used without them).
@@ -270,11 +270,11 @@ def _load_anat(anat_img=MNI152TEMPLATE, dim=False, black_bg='auto'):
             vmean = .5 * (vmin + vmax)
             ptp = .5 * (vmax - vmin)
             if black_bg:
-                if not operator.isNumberType(dim):
+                if not isinstance(dim, numbers.Number):
                     dim = .8
                 vmax = vmean + (1 + dim) * ptp
             else:
-                if not operator.isNumberType(dim):
+                if not isinstance(dim, numbers.Number):
                     dim = .6
                 vmin = vmean - (1 + dim) * ptp
     if black_bg == 'auto':

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -40,7 +40,8 @@ def test_stacked_slicer():
     slicer = XSlicer.init_with_figure(img=img, cut_coords=3)
     slicer.add_overlay(img, cmap=pl.cm.gray)
     # Forcing a layout here, to test the locator code
-    slicer.savefig(tempfile.TemporaryFile())
+    with tempfile.TemporaryFile() as fp:
+        slicer.savefig(fp)
     slicer.close()
 
 
@@ -53,5 +54,6 @@ def test_demo_ortho_projector():
     img = load_mni152_template()
     oprojector = OrthoProjector.init_with_figure(img=img)
     oprojector.add_overlay(img, cmap=pl.cm.gray)
-    oprojector.savefig(tempfile.TemporaryFile())
+    with tempfile.TemporaryFile() as fp:
+        oprojector.savefig(fp)
     oprojector.close()

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -18,9 +18,11 @@ except ImportError:
 
 import nibabel
 
+from ..._utils.testing import assert_warns_regex
 from ...image.resampling import coord_transform
 from ..img_plotting import MNI152TEMPLATE, plot_anat, plot_img, plot_roi,\
     plot_stat_map, plot_epi, plot_glass_brain
+
 
 mni_affine = np.array([[  -2.,    0.,    0.,   90.],
                         [   0.,    2.,    0., -126.],
@@ -100,7 +102,8 @@ def test_plot_img_empty():
     data = np.zeros((20, 20, 20))
     img = nibabel.Nifti1Image(data, mni_affine)
     plot_anat(img)
-    slicer = plot_img(img, display_mode='y', threshold=1)
+    slicer = assert_warns_regex(UserWarning, 'empty mask',
+                                plot_img, img, display_mode='y', threshold=1)
     slicer.close()
     pl.close('all')
 

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -54,7 +54,8 @@ def test_demo_plot_roi():
     # Test the black background code path
     demo_plot_roi(black_bg=True)
 
-    out = demo_plot_roi(output_file=tempfile.TemporaryFile(suffix='.png'))
+    with tempfile.TemporaryFile(suffix='.png') as fp:
+        out = demo_plot_roi(output_file=fp)
     assert_true(out is None)
 
 
@@ -69,16 +70,19 @@ def test_plot_functions():
     ortho_slicer = plot_anat(img, dim=True)
     # Test saving with empty plot
     z_slicer = plot_anat(anat_img=False, display_mode='z')
-    ortho_slicer.savefig(tempfile.TemporaryFile())
+    with tempfile.TemporaryFile() as fp:
+        ortho_slicer.savefig(fp)
     z_slicer = plot_anat(display_mode='z')
-    ortho_slicer.savefig(tempfile.TemporaryFile())
+    with tempfile.TemporaryFile() as fp:
+        ortho_slicer.savefig(fp)
     z_slicer.add_edges(img, color='c')
 
     for func in [plot_anat, plot_img, plot_stat_map,
                  plot_epi, plot_glass_brain]:
         ortho_slicer = func(img, cut_coords=(80, -120, -60))
         # Saving forces a draw, and thus smoke-tests the axes locators
-        ortho_slicer.savefig(tempfile.TemporaryFile())
+        with tempfile.TemporaryFile() as fp:
+            ortho_slicer.savefig(fp)
         ortho_slicer.add_edges(img, color='c')
 
         # Smoke test coordinate finder, with and without mask
@@ -87,7 +91,8 @@ def test_plot_functions():
         func(masked_img, display_mode='x')
         func(img, display_mode='y')
 
-        out = func(img, output_file=tempfile.TemporaryFile(suffix='.png'))
+        with tempfile.TemporaryFile(suffix='.png') as fp:
+            out = func(img, output_file=fp)
         assert_true(out is None)
     pl.close('all')
 

--- a/nilearn/region.py
+++ b/nilearn/region.py
@@ -6,6 +6,7 @@ or as weights in one image per region (maps).
 """
 # Author: Philippe Gervais
 # License: simplified BSD
+from past.builtins import xrange
 
 import numpy as np
 from scipy import linalg, ndimage

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -8,6 +8,7 @@ features
 # License: simplified BSD
 
 import distutils.version
+from six import string_types
 
 import numpy as np
 from scipy import signal, stats, linalg
@@ -360,7 +361,7 @@ def clean(signals, detrend=True, standardize=True, confounds=None,
     """
 
     if not isinstance(confounds,
-                      (list, tuple, basestring, np.ndarray, type(None))):
+                      (list, tuple, string_types, np.ndarray, type(None))):
         raise TypeError("confounds keyword has an unhandled type: %s"
                         % confounds.__class__)
 
@@ -380,7 +381,7 @@ def clean(signals, detrend=True, standardize=True, confounds=None,
         # Read confounds
         all_confounds = []
         for confound in confounds:
-            if isinstance(confound, basestring):
+            if isinstance(confound, string_types):
                 filename = confound
                 confound = np.genfromtxt(filename)
                 if np.isnan(confound.flat[0]):

--- a/nilearn/tests/test_cache_mixin.py
+++ b/nilearn/tests/test_cache_mixin.py
@@ -13,6 +13,8 @@ from sklearn.externals.joblib import Memory
 
 import nilearn
 from .._utils import cache_mixin
+from .._utils.testing import assert_warns_regex
+
 
 
 def f(x):
@@ -56,7 +58,8 @@ def test__safe_cache_flush():
 
         # First turn off version checking
         nilearn.check_cache_version = False
-        cache_mixin._safe_cache(mem, f)
+        assert_warns_regex(UserWarning, 'Incompatible cache',
+                           cache_mixin._safe_cache, mem, f)
         assert_true(os.path.exists(nibabel_dir))
 
         # Second turn on version checking
@@ -65,7 +68,8 @@ def test__safe_cache_flush():
         cache_mixin.__cache_checked = {}
         with open(version_file, 'w') as f:
             json.dump({"nibabel": [0, 0]}, f)
-        cache_mixin._safe_cache(mem, f)
+        assert_warns_regex(UserWarning, 'Incompatible cache',
+                           cache_mixin._safe_cache, mem, f)
         assert_true(os.path.exists(version_file))
         assert_false(os.path.exists(nibabel_dir))
     finally:

--- a/nilearn/tests/test_cache_mixin.py
+++ b/nilearn/tests/test_cache_mixin.py
@@ -16,7 +16,6 @@ from .._utils import cache_mixin
 from .._utils.testing import assert_warns_regex
 
 
-
 def f(x):
     # A simple test function
     return x

--- a/nilearn/tests/test_datasets.py
+++ b/nilearn/tests/test_datasets.py
@@ -18,7 +18,7 @@ from nose.tools import assert_true, assert_false, assert_equal, assert_raises
 
 from .. import datasets
 from .._utils.testing import mock_urllib2, wrap_chunk_read_,\
-    FetchFilesMock, assert_raises_regexp
+    FetchFilesMock, assert_raises_regexp, assert_warns_regex
 
 
 currdir = os.path.dirname(os.path.abspath(__file__))
@@ -233,9 +233,10 @@ def test_fail_fetch_haxby_simple():
             (os.path.join(path, 'bald.nii.gz'), local_url, opts)
     ]
 
-    assert_raises(IOError, datasets._fetch_files,
-            os.path.join(tmpdir, 'haxby2001_simple'), files,
-            verbose=0)
+    assert_warns_regex(UserWarning, 'An error occured while fetching',
+                       assert_raises, IOError, datasets._fetch_files,
+                       os.path.join(tmpdir, 'haxby2001_simple'), files,
+                       verbose=0)
     dummy = open(os.path.join(datasetdir, 'attributes.txt'), 'r')
     stuff = dummy.read(5)
     dummy.close()

--- a/nilearn/tests/test_datasets.py
+++ b/nilearn/tests/test_datasets.py
@@ -7,11 +7,12 @@ Test the datasets module
 import contextlib
 import os
 import shutil
-from tempfile import mkdtemp, mkstemp
 import numpy as np
 import zipfile
 import tarfile
 import gzip
+from six import string_types
+from tempfile import mkdtemp, mkstemp
 
 from nose import with_setup
 from nose.tools import assert_true, assert_false, assert_equal, assert_raises
@@ -362,7 +363,7 @@ def test_miyawaki2008():
     dataset = datasets.fetch_miyawaki2008(data_dir=tmpdir, verbose=0)
     assert_equal(len(dataset.func), 32)
     assert_equal(len(dataset.label), 32)
-    assert_true(isinstance(dataset.mask, basestring))
+    assert_true(isinstance(dataset.mask, string_types))
     assert_equal(len(dataset.mask_roi), 38)
     assert_equal(len(url_mock.urls), 1)
 
@@ -371,8 +372,8 @@ def test_miyawaki2008():
 @with_setup(setup_tmpdata, teardown_tmpdata)
 def test_fetch_msdl_atlas():
     dataset = datasets.fetch_msdl_atlas(data_dir=tmpdir, verbose=0)
-    assert_true(isinstance(dataset.labels, basestring))
-    assert_true(isinstance(dataset.maps, basestring))
+    assert_true(isinstance(dataset.labels, string_types))
+    assert_true(isinstance(dataset.maps, string_types))
     assert_equal(len(url_mock.urls), 1)
 
 
@@ -380,16 +381,16 @@ def test_fetch_msdl_atlas():
 @with_setup(setup_tmpdata, teardown_tmpdata)
 def test_fetch_icbm152_2009():
     dataset = datasets.fetch_icbm152_2009(data_dir=tmpdir, verbose=0)
-    assert_true(isinstance(dataset.csf, basestring))
-    assert_true(isinstance(dataset.eye_mask, basestring))
-    assert_true(isinstance(dataset.face_mask, basestring))
-    assert_true(isinstance(dataset.gm, basestring))
-    assert_true(isinstance(dataset.mask, basestring))
-    assert_true(isinstance(dataset.pd, basestring))
-    assert_true(isinstance(dataset.t1, basestring))
-    assert_true(isinstance(dataset.t2, basestring))
-    assert_true(isinstance(dataset.t2_relax, basestring))
-    assert_true(isinstance(dataset.wm, basestring))
+    assert_true(isinstance(dataset.csf, string_types))
+    assert_true(isinstance(dataset.eye_mask, string_types))
+    assert_true(isinstance(dataset.face_mask, string_types))
+    assert_true(isinstance(dataset.gm, string_types))
+    assert_true(isinstance(dataset.mask, string_types))
+    assert_true(isinstance(dataset.pd, string_types))
+    assert_true(isinstance(dataset.t1, string_types))
+    assert_true(isinstance(dataset.t2, string_types))
+    assert_true(isinstance(dataset.t2_relax, string_types))
+    assert_true(isinstance(dataset.wm, string_types))
     assert_equal(len(url_mock.urls), 1)
 
 
@@ -397,13 +398,13 @@ def test_fetch_icbm152_2009():
 @with_setup(setup_tmpdata, teardown_tmpdata)
 def test_fetch_yeo_2011_atlas():
     dataset = datasets.fetch_yeo_2011_atlas(data_dir=tmpdir, verbose=0)
-    assert_true(isinstance(dataset.anat, basestring))
-    assert_true(isinstance(dataset.colors_17, basestring))
-    assert_true(isinstance(dataset.colors_7, basestring))
-    assert_true(isinstance(dataset.thick_17, basestring))
-    assert_true(isinstance(dataset.thick_7, basestring))
-    assert_true(isinstance(dataset.thin_17, basestring))
-    assert_true(isinstance(dataset.thin_7, basestring))
+    assert_true(isinstance(dataset.anat, string_types))
+    assert_true(isinstance(dataset.colors_17, string_types))
+    assert_true(isinstance(dataset.colors_7, string_types))
+    assert_true(isinstance(dataset.thick_17, string_types))
+    assert_true(isinstance(dataset.thick_7, string_types))
+    assert_true(isinstance(dataset.thin_17, string_types))
+    assert_true(isinstance(dataset.thin_7, string_types))
     assert_equal(len(url_mock.urls), 1)
 
 
@@ -426,7 +427,7 @@ def test_fetch_localizer_contrasts():
     assert_true(dataset.tmaps is None)
     assert_true(dataset.masks is None)
     assert_true(isinstance(dataset.ext_vars, np.recarray))
-    assert_true(isinstance(dataset.cmaps[0], basestring))
+    assert_true(isinstance(dataset.cmaps[0], string_types))
     assert_equal(dataset.ext_vars.size, 94)
     assert_equal(len(dataset.cmaps), 94)
 
@@ -439,7 +440,7 @@ def test_fetch_localizer_contrasts():
     assert_true(dataset.anats is None)
     assert_true(dataset.tmaps is None)
     assert_true(dataset.masks is None)
-    assert_true(isinstance(dataset.cmaps[0], basestring))
+    assert_true(isinstance(dataset.cmaps[0], string_types))
     assert_true(isinstance(dataset.ext_vars, np.recarray))
     assert_equal(len(dataset.cmaps), 20)
     assert_equal(dataset.ext_vars.size, 20)
@@ -453,7 +454,7 @@ def test_fetch_localizer_contrasts():
     assert_true(dataset.tmaps is None)
     assert_true(dataset.masks is None)
     assert_true(isinstance(dataset.ext_vars, np.recarray))
-    assert_true(isinstance(dataset.cmaps[0], basestring))
+    assert_true(isinstance(dataset.cmaps[0], string_types))
     assert_equal(len(dataset.cmaps), 20 * 2)  # two contrasts are fetched
     assert_equal(dataset.ext_vars.size, 20)
 
@@ -466,8 +467,8 @@ def test_fetch_localizer_contrasts():
     assert_true(dataset.masks is None)
     assert_true(dataset.tmaps is None)
     assert_true(isinstance(dataset.ext_vars, np.recarray))
-    assert_true(isinstance(dataset.anats[0], basestring))
-    assert_true(isinstance(dataset.cmaps[0], basestring))
+    assert_true(isinstance(dataset.anats[0], string_types))
+    assert_true(isinstance(dataset.cmaps[0], string_types))
     assert_equal(dataset.ext_vars.size, 94)
     assert_equal(len(dataset.anats), 94)
     assert_equal(len(dataset.cmaps), 94)
@@ -481,8 +482,8 @@ def test_fetch_localizer_contrasts():
     assert_true(dataset.anats is None)
     assert_true(dataset.tmaps is None)
     assert_true(isinstance(dataset.ext_vars, np.recarray))
-    assert_true(isinstance(dataset.cmaps[0], basestring))
-    assert_true(isinstance(dataset.masks[0], basestring))
+    assert_true(isinstance(dataset.cmaps[0], string_types))
+    assert_true(isinstance(dataset.masks[0], string_types))
     assert_equal(dataset.ext_vars.size, 94)
     assert_equal(len(dataset.cmaps), 94)
     assert_equal(len(dataset.masks), 94)
@@ -496,8 +497,8 @@ def test_fetch_localizer_contrasts():
     assert_true(dataset.anats is None)
     assert_true(dataset.masks is None)
     assert_true(isinstance(dataset.ext_vars, np.recarray))
-    assert_true(isinstance(dataset.cmaps[0], basestring))
-    assert_true(isinstance(dataset.tmaps[0], basestring))
+    assert_true(isinstance(dataset.cmaps[0], string_types))
+    assert_true(isinstance(dataset.tmaps[0], string_types))
     assert_equal(dataset.ext_vars.size, 94)
     assert_equal(len(dataset.cmaps), 94)
     assert_equal(len(dataset.tmaps), 94)
@@ -512,10 +513,10 @@ def test_fetch_localizer_contrasts():
                                                  verbose=0)
 
     assert_true(isinstance(dataset.ext_vars, np.recarray))
-    assert_true(isinstance(dataset.anats[0], basestring))
-    assert_true(isinstance(dataset.cmaps[0], basestring))
-    assert_true(isinstance(dataset.masks[0], basestring))
-    assert_true(isinstance(dataset.tmaps[0], basestring))
+    assert_true(isinstance(dataset.anats[0], string_types))
+    assert_true(isinstance(dataset.cmaps[0], string_types))
+    assert_true(isinstance(dataset.masks[0], string_types))
+    assert_true(isinstance(dataset.tmaps[0], string_types))
     assert_equal(dataset.ext_vars.size, 94)
     assert_equal(len(dataset.anats), 94)
     assert_equal(len(dataset.cmaps), 94)
@@ -538,7 +539,7 @@ def test_fetch_localizer_calculation_task():
                                                         url=local_url,
                                                         verbose=0)
     assert_true(isinstance(dataset.ext_vars, np.recarray))
-    assert_true(isinstance(dataset.cmaps[0], basestring))
+    assert_true(isinstance(dataset.cmaps[0], string_types))
     assert_equal(dataset.ext_vars.size, 94)
     assert_equal(len(dataset.cmaps), 94)
 
@@ -548,7 +549,7 @@ def test_fetch_localizer_calculation_task():
                                                         url=local_url,
                                                         verbose=0)
     assert_true(isinstance(dataset.ext_vars, np.recarray))
-    assert_true(isinstance(dataset.cmaps[0], basestring))
+    assert_true(isinstance(dataset.cmaps[0], string_types))
     assert_equal(dataset.ext_vars.size, 20)
     assert_equal(len(dataset.cmaps), 20)
 
@@ -566,20 +567,20 @@ def test_fetch_oasis_vbm():
                                        verbose=0)
     assert_equal(len(dataset.gray_matter_maps), 403)
     assert_equal(len(dataset.white_matter_maps), 403)
-    assert_true(isinstance(dataset.gray_matter_maps[0], basestring))
-    assert_true(isinstance(dataset.white_matter_maps[0], basestring))
+    assert_true(isinstance(dataset.gray_matter_maps[0], string_types))
+    assert_true(isinstance(dataset.white_matter_maps[0], string_types))
     assert_true(isinstance(dataset.ext_vars, np.recarray))
-    assert_true(isinstance(dataset.data_usage_agreement, basestring))
+    assert_true(isinstance(dataset.data_usage_agreement, string_types))
     assert_equal(len(url_mock.urls), 3)
 
     dataset = datasets.fetch_oasis_vbm(data_dir=tmpdir, url=local_url,
                                        dartel_version=False, verbose=0)
     assert_equal(len(dataset.gray_matter_maps), 415)
     assert_equal(len(dataset.white_matter_maps), 415)
-    assert_true(isinstance(dataset.gray_matter_maps[0], basestring))
-    assert_true(isinstance(dataset.white_matter_maps[0], basestring))
+    assert_true(isinstance(dataset.gray_matter_maps[0], string_types))
+    assert_true(isinstance(dataset.white_matter_maps[0], string_types))
     assert_true(isinstance(dataset.ext_vars, np.recarray))
-    assert_true(isinstance(dataset.data_usage_agreement, basestring))
+    assert_true(isinstance(dataset.data_usage_agreement, string_types))
     assert_equal(len(url_mock.urls), 4)
 
 

--- a/nilearn/tests/test_datasets.py
+++ b/nilearn/tests/test_datasets.py
@@ -19,7 +19,7 @@ from nose.tools import assert_true, assert_false, assert_equal, assert_raises
 
 from .. import datasets
 from .._utils.testing import mock_request, wrap_chunk_read_,\
-    FetchFilesMock, assert_raises_regexp, assert_warns_regex
+    FetchFilesMock, assert_raises_regex, assert_warns_regex
 
 currdir = os.path.dirname(os.path.abspath(__file__))
 datadir = os.path.join(currdir, 'data')
@@ -91,7 +91,7 @@ def test_get_dataset_dir():
     no_write = os.path.join(tmpdir, 'no_write')
     os.makedirs(no_write)
     os.chmod(no_write, 0o400)
-    assert_raises_regexp(OSError, 'Permission denied',
+    assert_raises_regex(OSError, 'Permission denied',
                          datasets._get_dataset_dir, 'test', no_write,
                          verbose=0)
 
@@ -99,7 +99,7 @@ def test_get_dataset_dir():
     test_file = os.path.join(tmpdir, 'some_file')
     with open(test_file, 'w') as out:
         out.write('abcfeg')
-    assert_raises_regexp(OSError, 'Not a directory',
+    assert_raises_regex(OSError, 'Not a directory',
                          datasets._get_dataset_dir, 'test', test_file,
                          verbose=0)
 

--- a/nilearn/tests/test_datasets.py
+++ b/nilearn/tests/test_datasets.py
@@ -336,18 +336,23 @@ def test_fetch_nyu_rest():
 def test_fetch_adhd():
     local_url = "file://" + datadir
 
-    sub1 = ['3902469', '7774305', '3699991']
-    sub2 = ['2014113', '4275075', '1019436', '3154996', '3884955', '0027034',
-            '4134561', '0027018', '6115230', '0027037', '8409791', '0027011']
-    sub3 = ['3007585', '8697774', '9750701', '0010064', '0021019', '0010042',
-            '0010128', '2497695', '4164316', '1552181', '4046678', '0023012']
-    sub4 = ['1679142', '1206380', '0023008', '4016887', '1418396', '2950754',
-            '3994098', '3520880', '1517058', '9744150', '1562298', '3205761',
-            '3624598']
+    sub1 = [3902469, 7774305, 3699991]
+    sub2 = [2014113, 4275075, 1019436,
+            3154996, 3884955,   27034,
+            4134561,   27018, 6115230,
+              27037, 8409791,   27011]
+    sub3 = [3007585, 8697774, 9750701,
+              10064,   21019,   10042,
+              10128, 2497695, 4164316,
+            1552181, 4046678,   23012]
+    sub4 = [1679142, 1206380,   23008,
+            4016887, 1418396, 2950754,
+            3994098, 3520880, 1517058,
+            9744150, 1562298, 3205761, 3624598]
     subs = np.asarray(sub1 + sub2 + sub3 + sub4)
-    subs = subs.view(dtype=[('Subject', 'S7')])
+    subs = subs.view(dtype=[('Subject', '<i8')])
     file_mock.add_csv('ADHD200_40subs_motion_parameters_and_phenotypics.csv',
-            subs)
+                      subs)
 
     adhd = datasets.fetch_adhd(data_dir=tmpdir, url=local_url,
                                n_subjects=12, verbose=0)
@@ -411,7 +416,7 @@ def test_fetch_yeo_2011_atlas():
 @with_setup(setup_tmpdata, teardown_tmpdata)
 def test_fetch_localizer_contrasts():
     local_url = "file://" + datadir
-    ids = np.asarray(['S%2d' % i for i in range(94)])
+    ids = np.asarray([('S%2d' % i).encode() for i in range(94)])
     ids = ids.view(dtype=[('subject_id', 'S3')])
     file_mock.add_csv('cubicwebexport.csv', ids)
     file_mock.add_csv('cubicwebexport2.csv', ids)
@@ -594,11 +599,11 @@ def test_load_mni152_template():
 @with_setup(setup_tmpdata, teardown_tmpdata)
 def test_fetch_abide_pcp():
     local_url = "file://" + datadir
-    ids = ['50%03d' % i for i in range(800)]
+    ids = [('50%03d' % i).encode() for i in range(800)]
     filenames = ['no_filename'] * 800
     filenames[::2] = ['filename'] * 400
     pheno = np.asarray(list(zip(ids, filenames)), dtype=[('subject_id', int),
-                                                         ('FILE_ID', 'S11')])
+                                                         ('FILE_ID', 'U11')])
     # pheno = pheno.T.view()
     file_mock.add_csv('Phenotypic_V1_0b_preprocessed1.csv', pheno)
 
@@ -625,19 +630,19 @@ def test_filter_columns():
 
     value1 = value1 % 2
     values = np.asarray(list(zip(value1, value2)),
-                        dtype=[('INT', int), ('STR', 'S1')])
+                        dtype=[('INT', int), ('STR', b'S1')])
 
     # No filter
     f = datasets._filter_columns(values, [])
     assert_equal(np.sum(f), 500)
 
-    f = datasets._filter_columns(values, {'STR': 'b'})
+    f = datasets._filter_columns(values, {'STR': b'b'})
     assert_equal(np.sum(f), 167)
 
-    f = datasets._filter_columns(values, {'INT': 1, 'STR': 'b'})
+    f = datasets._filter_columns(values, {'INT': 1, 'STR': b'b'})
     assert_equal(np.sum(f), 84)
 
-    f = datasets._filter_columns(values, {'INT': 1, 'STR': 'b'},
+    f = datasets._filter_columns(values, {'INT': 1, 'STR': b'b'},
             combination='or')
     assert_equal(np.sum(f), 333)
 

--- a/nilearn/tests/test_datasets.py
+++ b/nilearn/tests/test_datasets.py
@@ -597,9 +597,9 @@ def test_fetch_abide_pcp():
     ids = ['50%03d' % i for i in range(800)]
     filenames = ['no_filename'] * 800
     filenames[::2] = ['filename'] * 400
-    pheno = np.asarray(zip(ids, filenames), dtype=[('subject_id', int),
-                                                   ('FILE_ID', 'S11')])
-    #pheno = pheno.T.view()
+    pheno = np.asarray(list(zip(ids, filenames)), dtype=[('subject_id', int),
+                                                         ('FILE_ID', 'S11')])
+    # pheno = pheno.T.view()
     file_mock.add_csv('Phenotypic_V1_0b_preprocessed1.csv', pheno)
 
     # All subjects
@@ -614,7 +614,7 @@ def test_filter_columns():
     strings = np.asarray(['a', 'b', 'c'])
     value2 = strings[value1 % 3]
 
-    values = np.asarray(zip(value1, value2),
+    values = np.asarray(list(zip(value1, value2)),
                         dtype=[('INT', int), ('STR', 'S1')])
 
     f = datasets._filter_columns(values, {'INT': (23, 46)})
@@ -624,7 +624,7 @@ def test_filter_columns():
     assert_equal(np.sum(f), 15)
 
     value1 = value1 % 2
-    values = np.asarray(zip(value1, value2),
+    values = np.asarray(list(zip(value1, value2)),
                         dtype=[('INT', int), ('STR', 'S1')])
 
     # No filter

--- a/nilearn/tests/test_datasets.py
+++ b/nilearn/tests/test_datasets.py
@@ -54,7 +54,7 @@ def teardown_tmpdata():
 def test_md5_sum_file():
     # Create dummy temporary file
     out, f = mkstemp()
-    os.write(out, 'abcfeg')
+    os.write(out, b'abcfeg')
     os.close(out)
     assert_equal(datasets._md5_sum_file(f), '18f32295c556b2a1a3a8e68fe1ad40f7')
     os.remove(f)
@@ -107,8 +107,8 @@ def test_get_dataset_dir():
 def test_read_md5_sum_file():
     # Create dummy temporary file
     out, f = mkstemp()
-    os.write(out, '20861c8c3fe177da19a7e9539a5dbac  /tmp/test\n'
-              '70886dcabe7bf5c5a1c24ca24e4cbd94  test/some_image.nii')
+    os.write(out, b'20861c8c3fe177da19a7e9539a5dbac  /tmp/test\n'
+             b'70886dcabe7bf5c5a1c24ca24e4cbd94  test/some_image.nii')
     os.close(out)
     h = datasets._read_md5_sum_file(f)
     assert_true('/tmp/test' in h)

--- a/nilearn/tests/test_datasets.py
+++ b/nilearn/tests/test_datasets.py
@@ -91,7 +91,7 @@ def test_get_dataset_dir():
     # Verify exception is raised on read-only directories
     no_write = os.path.join(tmpdir, 'no_write')
     os.makedirs(no_write)
-    os.chmod(no_write, 0400)
+    os.chmod(no_write, 0o400)
     assert_raises_regexp(OSError, 'Permission denied',
                          datasets._get_dataset_dir, 'test', no_write,
                          verbose=0)

--- a/nilearn/tests/test_group_sparse_covariance.py
+++ b/nilearn/tests/test_group_sparse_covariance.py
@@ -1,7 +1,8 @@
 from nose.tools import assert_equal, assert_true, assert_raises
 
 import numpy as np
-from .._utils.testing import generate_group_sparse_gaussian_graphs
+from .._utils.testing import (generate_group_sparse_gaussian_graphs,
+                              assert_warns_regex)
 from ..group_sparse_covariance import (group_sparse_covariance,
                                        group_sparse_scores,
                                        GroupSparseCovariance,
@@ -20,10 +21,17 @@ def test_group_sparse_covariance():
     alpha = 0.1
 
     # These executions must hit the tolerance limit
-    emp_covs, omega = group_sparse_covariance(signals, alpha, max_iter=20,
-                                              tol=1e-2, debug=True, verbose=0)
-    emp_covs, omega2 = group_sparse_covariance(signals, alpha, max_iter=20,
-                                               tol=1e-2, debug=True, verbose=0)
+    emp_covs, omega = assert_warns_regex(UserWarning,
+                                         'input signals do not all have unit variance',
+                                         group_sparse_covariance,
+                                         signals, alpha, max_iter=20,
+                                         tol=1e-2, debug=True, verbose=0)
+
+    emp_covs2, omega2 = assert_warns_regex(UserWarning,
+                                           'input signals do not all have unit variance',
+                                           group_sparse_covariance,
+                                           signals, alpha, max_iter=20,
+                                           tol=1e-2, debug=True, verbose=0)
 
     np.testing.assert_almost_equal(omega, omega2, decimal=4)
 
@@ -40,8 +48,12 @@ def test_group_sparse_covariance():
 
     # Use a probe to test for number of iterations and decreasing objective.
     probe = Probe()
-    emp_covs, omega = group_sparse_covariance(
-        signals, alpha, max_iter=4, tol=None, verbose=0, probe_function=probe)
+    emp_covs, omega = assert_warns_regex(UserWarning,
+                                         'input signals do not all have unit variance',
+                                         group_sparse_covariance,
+                                         signals, alpha, max_iter=4,
+                                         tol=None, verbose=0,
+                                         probe_function=probe)
     objective = probe.objective
     # check number of iterations
     assert_equal(len(objective), 4)
@@ -60,11 +72,15 @@ def test_group_sparse_covariance():
     # Check consistency between classes
     gsc1 = GroupSparseCovarianceCV(alphas=4, tol=1e-1, max_iter=20, verbose=0,
                                    early_stopping=True)
-    gsc1.fit(signals)
+    assert_warns_regex(UserWarning,
+                       'input signals do not all have unit variance',
+                       gsc1.fit, signals)
 
     gsc2 = GroupSparseCovariance(alpha=gsc1.alpha_, tol=1e-1, max_iter=20,
                                  verbose=0)
-    gsc2.fit(signals)
+    assert_warns_regex(UserWarning,
+                       'input signals do not all have unit variance',
+                       gsc2.fit, signals)
 
     np.testing.assert_almost_equal(gsc1.precisions_, gsc2.precisions_,
                                    decimal=4)

--- a/nilearn/tests/test_logger.py
+++ b/nilearn/tests/test_logger.py
@@ -13,7 +13,7 @@ from nilearn._utils.logger import log
 @contextlib.contextmanager
 def capture_output():
     import sys
-    from cStringIO import StringIO
+    from six.moves import StringIO
     oldout, olderr = sys.stdout, sys.stderr
     try:
         out = [StringIO(), StringIO()]

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -15,10 +15,8 @@ from .. import masking
 from ..masking import compute_epi_mask, compute_multi_epi_mask, \
     compute_background_mask, unmask, intersect_masks, MaskWarning, \
     _load_mask_img
-
-from .._utils.testing import write_tmp_imgs, assert_raises_regexp, \
+from .._utils.testing import write_tmp_imgs, assert_raises_regex, \
     assert_warns_regex
-
 
 np_version = (np.version.full_version if hasattr(np.version, 'full_version')
               else np.version.short_version)
@@ -130,11 +128,11 @@ def test_apply_mask():
 
     # veriy that 4D masks are rejected
     mask_img_4d = Nifti1Image(np.ones((40, 40, 40, 2)), np.eye(4))
-    assert_raises_regexp(TypeError, "A 3D image is expected",
+    assert_raises_regex(TypeError, "A 3D image is expected",
                          masking.apply_mask, data_img, mask_img_4d)
 
     # Check data shape and affine
-    assert_raises_regexp(TypeError, "A 3D image is expected",
+    assert_raises_regex(TypeError, "A 3D image is expected",
                          masking.apply_mask, data_img,
                          Nifti1Image(mask[20, ...], affine))
     assert_raises(ValueError, masking.apply_mask,

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -166,10 +166,10 @@ def test_unmask():
 
     masked4D = data4D[mask, :].T
     unmasked4D = data4D.copy()
-    unmasked4D[-mask, :] = 0
+    unmasked4D[np.logical_not(mask), :] = 0
     masked3D = data3D[mask]
     unmasked3D = data3D.copy()
-    unmasked3D[-mask] = 0
+    unmasked3D[np.logical_not(mask)] = 0
 
     # 4D Test, test value ordering at the same time.
     t = unmask(masked4D, mask_img, order="C").get_data()
@@ -210,7 +210,7 @@ def test_unmask():
 
     masked5D = data5D[mask, :].T
     unmasked5D = data5D.copy()
-    unmasked5D[-mask, :] = 0
+    unmasked5D[np.logical_not(mask), :] = 0
 
     t = unmask(masked5D, mask_img).get_data()
     assert_equal(t.ndim, len(shape5D))

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -176,7 +176,7 @@ def test_unmask():
     assert_array_equal(t, unmasked4D)
     t = unmask([masked4D], mask_img, order="F")
     t = [t_.get_data() for t_ in t]
-    assert_true(isinstance(t, types.ListType))
+    assert_true(isinstance(t, list))
     assert_equal(t[0].ndim, 4)
     assert_false(t[0].flags["C_CONTIGUOUS"])
     assert_true(t[0].flags["F_CONTIGUOUS"])
@@ -192,7 +192,7 @@ def test_unmask():
             assert_array_equal(t, unmasked3D)
             t = unmask([masked3D], filename, order="F")
             t = [t_.get_data() for t_ in t]
-            assert_true(isinstance(t, types.ListType))
+            assert_true(isinstance(t, list))
             assert_equal(t[0].ndim, 3)
             assert_false(t[0].flags["C_CONTIGUOUS"])
             assert_true(t[0].flags["F_CONTIGUOUS"])
@@ -214,7 +214,7 @@ def test_unmask():
     assert_array_equal(t, unmasked5D)
     t = unmask([masked5D], mask_img)
     t = [t_.get_data() for t_ in t]
-    assert_true(isinstance(t, types.ListType))
+    assert_true(isinstance(t, list))
     assert_equal(t[0].ndim, len(shape5D))
     assert_array_equal(t[0], unmasked5D)
 

--- a/nilearn/tests/test_niimg_conversions.py
+++ b/nilearn/tests/test_niimg_conversions.py
@@ -9,7 +9,6 @@ name starts with an underscore
 
 import os
 import tempfile
-import itertools
 
 from nose.tools import assert_equal, assert_true
 
@@ -102,7 +101,7 @@ def test_check_niimgs():
                                             return_iterator=True)
     img_3d_iterator_2 = _utils.check_niimgs(img_3d_iterator_1,
                                             return_iterator=True)
-    for img_1, img_2 in itertools.izip(img_3d_iterator_1, img_3d_iterator_2):
+    for img_1, img_2 in zip(img_3d_iterator_1, img_3d_iterator_2):
         assert_true(img_1.get_data().shape == (10, 10, 10))
         assert_array_equal(img_1.get_data(), img_2.get_data())
         assert_array_equal(img_1.get_affine(), img_2.get_affine())
@@ -111,7 +110,7 @@ def test_check_niimgs():
                                             return_iterator=True)
     img_3d_iterator_2 = _utils.check_niimgs(img_4d_1,
                                             return_iterator=True)
-    for img_1, img_2 in itertools.izip(img_3d_iterator_1, img_3d_iterator_2):
+    for img_1, img_2 in zip(img_3d_iterator_1, img_3d_iterator_2):
         assert_true(img_1.get_data().shape == (10, 10, 10))
         assert_array_equal(img_1.get_data(), img_2.get_data())
         assert_array_equal(img_1.get_affine(), img_2.get_affine())

--- a/nilearn/tests/test_niimg_conversions.py
+++ b/nilearn/tests/test_niimg_conversions.py
@@ -20,7 +20,7 @@ from nibabel import Nifti1Image
 
 from nilearn import _utils
 from nilearn._utils import testing
-from nilearn._utils.testing import assert_raises_regexp
+from nilearn._utils.testing import assert_raises_regex
 
 
 class PhonyNiimage(object):
@@ -38,16 +38,16 @@ class PhonyNiimage(object):
 
 def test_check_niimg():
     # check error for non-forced but necessary resampling
-    assert_raises_regexp(TypeError, 'image',
+    assert_raises_regex(TypeError, 'image',
                          _utils.check_niimg, 0)
 
     # check error for non-forced but necessary resampling
-    assert_raises_regexp(TypeError, 'image',
+    assert_raises_regex(TypeError, 'image',
                          _utils.check_niimg, [])
 
     # Test ensure_3d
     # check error for non-forced but necessary resampling
-    assert_raises_regexp(TypeError, '3D',
+    assert_raises_regex(TypeError, '3D',
                          _utils.check_niimg, ['test.nii', ], ensure_3d=True)
 
     # Check that a filename does not raise an error
@@ -59,11 +59,11 @@ def test_check_niimg():
         _utils.check_niimg(filename)
 
     # Test ensure_3d with a in-memory object
-    assert_raises_regexp(TypeError, '3D',
+    assert_raises_regex(TypeError, '3D',
                          _utils.check_niimg, data, ensure_3d=True)
 
     # Test ensure_3d with a non 3D image
-    assert_raises_regexp(TypeError, '3D',
+    assert_raises_regex(TypeError, '3D',
                          _utils.check_niimg, data_img, ensure_3d=True)
 
     # Test ensure_3d with a 4D image with a length 1 4th dim
@@ -73,10 +73,10 @@ def test_check_niimg():
 
 
 def test_check_niimgs():
-    assert_raises_regexp(TypeError, 'image',
+    assert_raises_regex(TypeError, 'image',
                          _utils.check_niimgs, 0)
 
-    assert_raises_regexp(TypeError, 'image',
+    assert_raises_regex(TypeError, 'image',
                          _utils.check_niimgs, [])
 
     affine = np.eye(4)
@@ -116,7 +116,7 @@ def test_check_niimgs():
         assert_array_equal(img_1.get_affine(), img_2.get_affine())
 
     # This should raise an error: a 3D img is given and we want a 4D
-    assert_raises_regexp(TypeError, 'image',
+    assert_raises_regex(TypeError, 'image',
                          _utils.check_niimgs, img_3d)
     # This shouldn't raise an error
     _utils.check_niimgs(img_3d, accept_3d=True)
@@ -172,7 +172,7 @@ def test_concat_niimgs():
     concatenate_true = np.ones(shape + (3,))
 
     # Smoke-test the accept_4d
-    assert_raises_regexp(ValueError, 'image',
+    assert_raises_regex(ValueError, 'image',
                          _utils.concat_niimgs, [img1, img4d])
     concatenated = _utils.concat_niimgs([img1, img4d], accept_4d=True)
     np.testing.assert_equal(concatenated.get_data(), concatenate_true,
@@ -184,7 +184,7 @@ def test_concat_niimgs():
     assert_true(concatenated.shape == img1.shape + (3, ))
 
     # check error for non-forced but necessary resampling
-    assert_raises_regexp(ValueError, 'different from reference affine',
+    assert_raises_regex(ValueError, 'different from reference affine',
                          _utils.concat_niimgs, [img1, img2],
                          accept_4d=False)
 

--- a/nilearn/tests/test_region.py
+++ b/nilearn/tests/test_region.py
@@ -3,8 +3,8 @@ Test for "region" module.
 """
 # Author: Ph. Gervais
 # License: simplified BSD
-import warnings
 import numpy as np
+import warnings
 from nose.tools import assert_raises, assert_true
 
 import nibabel
@@ -307,10 +307,11 @@ def test_signal_extraction_with_maps_and_labels():
     mask_img = nibabel.Nifti1Image(mask_data.astype(np.int8),
                                    labels_img.get_affine())
     # Ignore a known warning about divide-by-zero on our dummy data.
-    labels_signals, labels_labels = \
-        assert_warns_regex(RuntimeWarning, '',
-                           region.img_to_signals_labels,
-                           fmri_img, labels_img, mask_img=mask_img)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        labels_signals, labels_labels =\
+                        region.img_to_signals_labels(fmri_img, labels_img,
+                                                     mask_img=mask_img)
     maps_signals, maps_labels = \
         region.img_to_signals_maps(fmri_img, maps_img,
                                    mask_img=mask_img)

--- a/nilearn/tests/test_region.py
+++ b/nilearn/tests/test_region.py
@@ -3,6 +3,7 @@ Test for "region" module.
 """
 # Author: Ph. Gervais
 # License: simplified BSD
+import warnings
 
 import numpy as np
 from nose.tools import assert_raises, assert_true
@@ -305,9 +306,12 @@ def test_signal_extraction_with_maps_and_labels():
     mask_data = (labels_data == 1) + (labels_data == 2) + (labels_data == 5)
     mask_img = nibabel.Nifti1Image(mask_data.astype(np.int8),
                                    labels_img.get_affine())
-    labels_signals, labels_labels =\
-                    region.img_to_signals_labels(fmri_img, labels_img,
-                                                 mask_img=mask_img)
+    # Ignore a known warning about divide-by-zero on our dummy data.
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        labels_signals, labels_labels =\
+                        region.img_to_signals_labels(fmri_img, labels_img,
+                                                     mask_img=mask_img)
     maps_signals, maps_labels = \
                   region.img_to_signals_maps(fmri_img, maps_img,
                                              mask_img=mask_img)
@@ -331,9 +335,11 @@ def test_signal_extraction_with_maps_and_labels():
     region1 = labels_data == 2
     indices = [ind[:1] for ind in np.where(region1)]
     fmri_img.get_data()[indices + [slice(None)]] = float('nan')
-    labels_signals, labels_labels =\
-                    region.img_to_signals_labels(fmri_img, labels_img,
-                                                 mask_img=mask_img)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)  # divide by zero
+        labels_signals, labels_labels =\
+                        region.img_to_signals_labels(fmri_img, labels_img,
+                                                     mask_img=mask_img)
     assert_true(np.all(np.isnan(labels_signals[:, labels_labels.index(2)])))
 
 

--- a/nilearn/tests/test_region.py
+++ b/nilearn/tests/test_region.py
@@ -126,13 +126,13 @@ def test_signals_extraction_with_labels():
     # and back
     signals_r, labels_r = region.img_to_signals_labels(data_img, labels_img)
     np.testing.assert_almost_equal(signals_r, signals)
-    assert_true(labels_r == range(1, 9))
+    assert_true(labels_r == list(range(1, 9)))
 
     with write_tmp_imgs(data_img) as fname_img:
         signals_r, labels_r = region.img_to_signals_labels(fname_img,
                                                            labels_img)
         np.testing.assert_almost_equal(signals_r, signals)
-        assert_true(labels_r == range(1, 9))
+        assert_true(labels_r == list(range(1, 9)))
 
     ## Same thing, with mask.
     assert_raises_regex(TypeError, "A 3D image is expected",
@@ -179,7 +179,7 @@ def test_signals_extraction_with_labels():
     signals_r, labels_r = region.img_to_signals_labels(data_img, labels_img,
                                            mask_img=mask_img)
     np.testing.assert_almost_equal(signals_r, signals)
-    assert_true(labels_r == range(1, 9))
+    assert_true(labels_r == list(range(1, 9)))
 
     # Test input validation
     data_img = nibabel.Nifti1Image(np.zeros((2, 3, 4, 5)), np.eye(4))
@@ -279,7 +279,7 @@ def test_signal_extraction_with_maps_and_labels():
     length = 8
 
     # Generate labels
-    labels = range(n_regions + 1)  # 0 is background
+    labels = list(range(n_regions + 1))  # 0 is background
     labels_img = generate_labeled_regions(shape, n_regions, labels=labels)
     labels_data = labels_img.get_data()
     # Convert to maps
@@ -318,7 +318,7 @@ def test_signal_extraction_with_maps_and_labels():
 
     np.testing.assert_almost_equal(maps_signals, labels_signals)
     assert_true(maps_signals.shape[1] == n_regions)
-    assert_true(maps_labels == range(len(maps_labels)))
+    assert_true(maps_labels == list(range(len(maps_labels))))
     assert_true(labels_signals.shape == (length, n_regions))
     assert_true(labels_labels == labels[1:])
 
@@ -389,7 +389,7 @@ def test__trim_maps():
     maps_i_correct[np.logical_not(mask_data), :] = 0
     np.testing.assert_almost_equal(maps_i_correct, maps_i)
     np.testing.assert_equal(mask_data, maps_i_mask)
-    np.testing.assert_equal(np.asarray(range(8)), maps_i_indices)
+    np.testing.assert_equal(np.asarray(list(range(8))), maps_i_indices)
 
     # mask intersecting half of the regions
     mask_data = np.zeros(shape, dtype=np.int8)
@@ -407,4 +407,4 @@ def test__trim_maps():
     mask_data[1, 1, 1] = 0  # for test to succeed
     np.testing.assert_equal(mask_data, maps_i_mask)
     mask_data[1, 1, 1] = 1  # reset, just in case.
-    np.testing.assert_equal(np.asarray(range(4)), maps_i_indices)
+    np.testing.assert_equal(np.asarray(list(range(4))), maps_i_indices)

--- a/nilearn/tests/test_region.py
+++ b/nilearn/tests/test_region.py
@@ -14,7 +14,7 @@ from .. import region
 from .._utils.testing import generate_timeseries, generate_regions_ts
 from .._utils.testing import generate_labeled_regions, generate_maps
 from .._utils.testing import generate_fake_fmri
-from .._utils.testing import write_tmp_imgs, assert_raises_regexp
+from .._utils.testing import write_tmp_imgs, assert_raises_regex
 from .._utils.testing import assert_warns_regex
 
 
@@ -111,7 +111,7 @@ def test_signals_extraction_with_labels():
     assert_true(np.all(data.std(axis=-1) > 0))
 
     # verify that 4D label images are refused
-    assert_raises_regexp(TypeError, "A 3D image is expected",
+    assert_raises_regex(TypeError, "A 3D image is expected",
                          region.img_to_signals_labels, data_img, labels_4d_img)
 
     # There must be non-zero data (safety net)
@@ -135,10 +135,10 @@ def test_signals_extraction_with_labels():
         assert_true(labels_r == range(1, 9))
 
     ## Same thing, with mask.
-    assert_raises_regexp(TypeError, "A 3D image is expected",
+    assert_raises_regex(TypeError, "A 3D image is expected",
                          region.img_to_signals_labels, data_img, labels_img,
                          mask_img=mask_4d_img)
-    assert_raises_regexp(TypeError, "A 3D image is expected",
+    assert_raises_regex(TypeError, "A 3D image is expected",
                          region.signals_to_img_labels, data_img, labels_img,
                          mask_img=mask_4d_img)
 
@@ -226,7 +226,7 @@ def test_signal_extraction_with_maps():
     img = nibabel.Nifti1Image(data, np.eye(4))
 
     # verify that 4d masks are refused
-    assert_raises_regexp(TypeError, "A 3D image is expected",
+    assert_raises_regex(TypeError, "A 3D image is expected",
                          region.img_to_signals_maps, img, maps_img,
                          mask_img=mask_4d_img)
 

--- a/nilearn/tests/test_region.py
+++ b/nilearn/tests/test_region.py
@@ -307,11 +307,10 @@ def test_signal_extraction_with_maps_and_labels():
     mask_img = nibabel.Nifti1Image(mask_data.astype(np.int8),
                                    labels_img.get_affine())
     # Ignore a known warning about divide-by-zero on our dummy data.
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', RuntimeWarning)
-        labels_signals, labels_labels =\
-                        region.img_to_signals_labels(fmri_img, labels_img,
-                                                     mask_img=mask_img)
+    labels_signals, labels_labels = \
+        assert_warns_regex(RuntimeWarning, '',
+                           region.img_to_signals_labels,
+                           fmri_img, labels_img, mask_img=mask_img)
     maps_signals, maps_labels = \
         region.img_to_signals_maps(fmri_img, maps_img,
                                    mask_img=mask_img)

--- a/nilearn/tests/test_region.py
+++ b/nilearn/tests/test_region.py
@@ -84,9 +84,9 @@ def test_signals_extraction_with_labels():
 
     # labels
     labels_data = np.zeros(shape, dtype=np.int)
-    h0 = shape[0] / 2
-    h1 = shape[1] / 2
-    h2 = shape[2] / 2
+    h0 = shape[0] // 2
+    h1 = shape[1] // 2
+    h2 = shape[2] // 2
     labels_data[:h0, :h1, :h2] = 1
     labels_data[:h0, :h1, h2:] = 2
     labels_data[:h0, h1:, :h2] = 3
@@ -364,9 +364,9 @@ def test__trim_maps():
 
     # maps
     maps_data = np.zeros(shape + (n_regions,), dtype=np.float32)
-    h0 = shape[0] / 2
-    h1 = shape[1] / 2
-    h2 = shape[2] / 2
+    h0 = shape[0] // 2
+    h1 = shape[1] // 2
+    h2 = shape[2] // 2
     maps_data[:h0, :h1, :h2, 0] = 1
     maps_data[:h0, :h1, h2:, 1] = 1.1
     maps_data[:h0, h1:, :h2, 2] = 1

--- a/nilearn/tests/test_region.py
+++ b/nilearn/tests/test_region.py
@@ -6,6 +6,7 @@ Test for "region" module.
 import numpy as np
 import warnings
 from nose.tools import assert_raises, assert_true
+from past.builtins import xrange
 
 import nibabel
 

--- a/nilearn/tests/test_region.py
+++ b/nilearn/tests/test_region.py
@@ -4,7 +4,6 @@ Test for "region" module.
 # Author: Ph. Gervais
 # License: simplified BSD
 import warnings
-
 import numpy as np
 from nose.tools import assert_raises, assert_true
 
@@ -15,6 +14,7 @@ from .._utils.testing import generate_timeseries, generate_regions_ts
 from .._utils.testing import generate_labeled_regions, generate_maps
 from .._utils.testing import generate_fake_fmri
 from .._utils.testing import write_tmp_imgs, assert_raises_regexp
+from .._utils.testing import assert_warns_regex
 
 
 def test_generate_regions_ts():
@@ -307,14 +307,13 @@ def test_signal_extraction_with_maps_and_labels():
     mask_img = nibabel.Nifti1Image(mask_data.astype(np.int8),
                                    labels_img.get_affine())
     # Ignore a known warning about divide-by-zero on our dummy data.
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', RuntimeWarning)
-        labels_signals, labels_labels =\
-                        region.img_to_signals_labels(fmri_img, labels_img,
-                                                     mask_img=mask_img)
+    labels_signals, labels_labels = \
+        assert_warns_regex(RuntimeWarning, '',
+                           region.img_to_signals_labels,
+                           fmri_img, labels_img, mask_img=mask_img)
     maps_signals, maps_labels = \
-                  region.img_to_signals_maps(fmri_img, maps_img,
-                                             mask_img=mask_img)
+        region.img_to_signals_maps(fmri_img, maps_img,
+                                   mask_img=mask_img)
 
     np.testing.assert_almost_equal(maps_signals, labels_signals)
     assert_true(maps_signals.shape[1] == n_regions)

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -3,7 +3,6 @@ Test the signals module
 """
 # Author: Gael Varoquaux, Alexandre Abraham
 # License: simplified BSD
-
 import os.path
 import warnings
 
@@ -335,7 +334,7 @@ def test_clean_confounds():
 def test_high_variance_confounds():
     # C and F order might take different paths in the function. Check that the
     # result is identical.
-    n_features = 1001
+    n_features = 1000
     length = 20
     n_confounds = 5
     seriesC, _, _ = generate_signals(n_features=n_features,

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -10,11 +10,12 @@ import warnings
 import numpy as np
 from nose.tools import assert_true, assert_false, assert_raises
 
+import scipy.signal
+
 # Use nisignal here to avoid name collisions (using nilearn.signal is
 # not possible)
 from .. import signal as nisignal
 from ..signal import clean
-import scipy.signal
 
 
 def generate_signals(n_features=17, n_confounds=5, length=41,
@@ -242,10 +243,12 @@ def test_clean_frequencies():
     sx = np.vstack((sx1, sx2)).T
     assert_true(clean(sx, standardize=False, high_pass=0.002, low_pass=None)
                 .max() > 0.1)
+
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', scipy.signal.filter_design.BadCoefficients)
         assert_true(clean(sx, standardize=False, high_pass=0.2, low_pass=None)
                     .max() < 0.01)
+
     assert_true(clean(sx, standardize=False, low_pass=0.01).max() > 0.9)
     assert_raises(ValueError, clean, sx, low_pass=0.4, high_pass=0.5)
 

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -5,6 +5,7 @@ Test the signals module
 # License: simplified BSD
 
 import os.path
+import warnings
 
 import numpy as np
 from nose.tools import assert_true, assert_false, assert_raises
@@ -241,8 +242,10 @@ def test_clean_frequencies():
     sx = np.vstack((sx1, sx2)).T
     assert_true(clean(sx, standardize=False, high_pass=0.002, low_pass=None)
                 .max() > 0.1)
-    assert_true(clean(sx, standardize=False, high_pass=0.2, low_pass=None)
-                .max() < 0.01)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', scipy.signal.filter_design.BadCoefficients)
+        assert_true(clean(sx, standardize=False, high_pass=0.2, low_pass=None)
+                    .max() < 0.01)
     assert_true(clean(sx, standardize=False, low_pass=0.01).max() > 0.9)
     assert_raises(ValueError, clean, sx, low_pass=0.4, high_pass=0.5)
 

--- a/nilearn/tests/test_testing.py
+++ b/nilearn/tests/test_testing.py
@@ -2,7 +2,7 @@ import itertools
 
 import numpy as np
 
-from nose.tools import assert_equals, assert_raises
+from nose.tools import assert_equal, assert_raises
 
 from .._utils.testing import generate_fake_fmri
 
@@ -33,11 +33,11 @@ def test_generate_fake_fmri():
                 block_type=btype,
                 rand_gen=rand_gen)
 
-        assert_equals(fmri.shape[:-1], shape)
-        assert_equals(fmri.shape[-1], length)
+        assert_equal(fmri.shape[:-1], shape)
+        assert_equal(fmri.shape[-1], length)
 
         if n_block is not None:
-            assert_equals(target.size, length)
+            assert_equal(target.size, length)
 
     assert_raises(ValueError, generate_fake_fmri, length=10, n_blocks=10,
                   block_size=None, rand_gen=rand_gen)

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -28,7 +28,10 @@ REQUIRED_MODULE_METADATA = (
         'install_info': _NILEARN_INSTALL_MSG}),
     ('nibabel', {
         'min_version': '1.1.0',
-        'required_at_installation': False}),)
+        'required_at_installation': False}),
+    ('six', {
+        'min_version': '0.0.0',
+        'required_at_installation': False}))
 
 
 def _import_module_with_version_check(

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -29,9 +29,12 @@ REQUIRED_MODULE_METADATA = (
     ('nibabel', {
         'min_version': '1.1.0',
         'required_at_installation': False}),
+    ('future', {
+        'min_version': '0.0.0',
+        'required_at_installation': False}),
     ('six', {
         'min_version': '0.0.0',
-        'required_at_installation': False}))
+        'required_at_installation': False}),)
 
 
 def _import_module_with_version_check(


### PR DESCRIPTION

This PR depends on two unmerged PRs (#369, #371), but I am opening this PR now for three reasons:

1. Supporting Python 2 and 3 takes creating and following compatibility conventions.  I wanted to list what I've discovered from the code so far, and open discussion to agreeing on such conventions.
2. To get any help (none needed, but appreciated) to solve remaining issues
3. To open early review to anybody who wishes to do so (see https://github.com/bcipolli/nilearn/compare/bcipolli:fix_warnings...python-3.x to view a set of commits specific to Python 2/3 support).
.


Open issues to solve (see https://travis-ci.org/bcipolli/nilearn/builds for latest branch builds / test errors):
* File-based string operations with numpy are really challenging in Python 3.x, because of changes in defaults (all strings are unicode).

Here's the current list of conventions I'm using so far:

**Python 2 conventions that are now Python 3 requirements**
* All `nilearn` imports should be relative (except, perhaps, in tests)
* Write `except Exception, e` as `except Exception as e`
* Write `isinstance(x, types.ListType)` as `isinstance(x, list)`
* Write `callable(x)` as `isinstance(x, collections.Callable)`
* Write `operator.isSequenceType(x)` as `isinstance(x, collections.Sequence)`
* Write `operator.isNumberType(x)` as `isinstance(x, collections.Number)`
* Write `nose.tools.assert_equals` as `nose.tools.assert_equal`
* Write `nilearn._utils.testing.assert_raises_regexp` as `nilearn._utils.testing.assert_raises_regex` (mirrors nose clarification)
* Write `<Iterable>.next()` as `next(<Iterable>)`
* Write `filename = os.tempnam()` as `(_, filename) = tempfile.mkstemp()`
* Write `not key in dict` as `key not in dict` (this actually warns in Python 3.x!)
* Make sure to use `with open('file') as f' syntax; any file pointers that are not used in a context manager nor explicitly closed throw warnings.

**Python 3 changes that require care to be backwards compatible**
* Non-unicode strings must be prefixed with `b`: `b'string'`(mostly an issue interacting with numpy, but also some low-level operations like gzip code)
* Write `print "%s" % (message,)` as `print("%s" % (message,))`
* Write integer division `3 / 2 == 1` as `3 // 2 == 1`
* Write `<dict>.iteritems()` as `<dict>.items()` (there is no iteritems in Python 3)
* Write `<dict>.itervalues()` as `<dict>.values()` (there is no itervalues in Python 3)
* Write `itertools.izip()` as `zip()` (there is no `izip` in Python 3)
* Write octal string `0100` `0o100`
* Write `round` as `np.round` (avoids a numpy issue in Python 3)

**Importing things from `six` instead of places you're used to**
* Write `basestring` as `six.string_types` (requires `import six`)
* Use the new urllib object structure instead of ulrllib/urllib2
    * import from `six.moves.urllib`.
    * there are no base-level functions/objects, all are present in subpackages
* Import  `StringIO` and `cPickle from `six.moves`

**Changes in how you design / write code**
* Think carefully about any use of `xrange`.  If you *require* an iterator, then you must import `past.builtins.xrange`.  Otherwise, just use `range` (which is a list in Python 2, and an interator in Python 3).
* Most things that used to generate lists now generate iterators; any time you need a list, make sure to wrap it in `list()`
    * **THIS WILL GET YOU!**
    * Includes:
        * `dict.keys()`, `dict.values()`
        * `zip`
        * `range`
        * `map`

