### PR TITLE
Fix cache mixin

### DIFF
--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -130,7 +130,7 @@ def cache(func, memory, func_memory_level=None, memory_level=None,
     if (func_memory_level is None
             or memory_level is None
             or memory is None
-            or func_memory_level < memory_level):
+            or memory_level < func_memory_level):
         memory = Memory(cachedir=None)
     else:
         if isinstance(memory, basestring):

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -9,7 +9,6 @@ import os
 import shutil
 from distutils.version import LooseVersion
 import json
-import numpy as np
 
 import nibabel
 from sklearn.externals.joblib import Memory
@@ -54,7 +53,7 @@ def _safe_cache(memory, func, **kwargs):
     if len(collisions) > 0:
         if nilearn.check_cache_version:
             warnings.warn("Incompatible cache in %s: "
-                          "old version of nibabel. Deleting "
+                          "different version of nibabel. Deleting "
                           "the cache. Put nilearn.check_cache_version "
                           "to false to avoid this behavior."
                           % cachedir)

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -161,7 +161,7 @@ class CacheMixin(object):
     parameter to self._cache(). See _cache() documentation for details.
     """
 
-    def _cache(self, func, memory_level=1, **kwargs):
+    def _cache(self, func, func_memory_level=1, **kwargs):
         """ Return a joblib.Memory object.
 
         The memory_level determines the level above which the wrapped
@@ -209,5 +209,5 @@ class CacheMixin(object):
                               "Setting memory_level to 1.")
                 self.memory_level = 1
 
-        return cache(func, self.memory, func_memory_level=memory_level,
+        return cache(func, self.memory, func_memory_level=func_memory_level,
                      memory_level=self.memory_level, **kwargs)

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -9,6 +9,7 @@ import os
 import shutil
 from distutils.version import LooseVersion
 import json
+import numpy as np
 
 import nibabel
 from sklearn.externals.joblib import Memory
@@ -127,7 +128,10 @@ def cache(func, memory, func_memory_level=None, memory_level=None,
         returned.
     """
 
-    if func_memory_level < memory_level or memory is None:
+    if (func_memory_level is None
+            or memory_level is None
+            or memory is None
+            or func_memory_level < memory_level):
         memory = Memory(cachedir=None)
     else:
         if isinstance(memory, basestring):

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -127,14 +127,16 @@ def cache(func, memory, func_memory_level=None, memory_level=None,
         returned.
     """
 
+    verbose = kwargs.get('verbose', 0)
+
     if (func_memory_level is None
             or memory_level is None
             or memory is None
             or memory_level < func_memory_level):
-        memory = Memory(cachedir=None)
+        memory = Memory(cachedir=None, verbose=verbose)
     else:
         if isinstance(memory, basestring):
-            memory = Memory(cachedir=memory)
+            memory = Memory(cachedir=memory, verbose=verbose)
         if not isinstance(memory, memory_classes):
             raise TypeError("'memory' argument must be a string or a "
                             "joblib.Memory object. "

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -188,7 +188,7 @@ def _to_4d(data):
 
 def concat_niimgs(niimgs, dtype=np.float32, accept_4d=False,
                   auto_resample=False, verbose=0,
-                  memory=Memory(cachedir=None), ref_memory_level=0):
+                  memory=Memory(cachedir=None), memory_level=0):
     """Concatenate a list of 3D/4D niimgs of varying lengths.
 
     The niimgs list can contain niftis/paths to images of varying dimensions
@@ -289,8 +289,8 @@ def concat_niimgs(niimgs, dtype=np.float32, accept_4d=False,
                 print "...resampled to first nifti!"
             
             from .. import image  # we avoid a circular import
-            niimg = cache(image.resample_img, memory, ref_memory_level,
-                          memory_level=2)(
+            niimg = cache(image.resample_img, memory, func_memory_level=2,
+                          memory_level=memory_level)(
                               niimg,
                               target_affine=target_affine,
                               target_shape=target_item_shape)

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -23,7 +23,7 @@ from .._utils import as_ndarray
 def session_pca(imgs, mask_img, parameters,
                 n_components=20,
                 confounds=None,
-                ref_memory_level=0,
+                func_memory_level=0,
                 memory=Memory(cachedir=None),
                 verbose=0,
                 copy=True):
@@ -67,11 +67,11 @@ def session_pca(imgs, mask_img, parameters,
     """
 
     data, affine = cache(
-        filter_and_mask, memory=memory, ref_memory_level=ref_memory_level,
+        filter_and_mask, memory, func_memory_level=func_memory_level,
         memory_level=2,
         ignore=['verbose', 'memory', 'ref_memory_level', 'copy'])(
             imgs, mask_img, parameters,
-            ref_memory_level=ref_memory_level,
+            func_memory_level=func_memory_level,
             memory=memory,
             verbose=verbose,
             confounds=confounds,
@@ -297,8 +297,8 @@ class MultiPCA(BaseEstimator, TransformerMixin):
                 data[index * self.n_components:
                      (index + 1) * self.n_components] = subject_pca
             data, variance, _ = cache(randomized_svd,
-                                memory=self.memory,
-                                ref_memory_level=3,
+                                self.memory,
+                                func_memory_level=3,
                                 memory_level=self.memory_level)(
                         data.T, n_components=self.n_components)
             # as_ndarray is to get rid of memmapping

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -23,7 +23,7 @@ from .._utils import as_ndarray
 def session_pca(imgs, mask_img, parameters,
                 n_components=20,
                 confounds=None,
-                func_memory_level=0,
+                memory_level=0,
                 memory=Memory(cachedir=None),
                 verbose=0,
                 copy=True):
@@ -52,7 +52,7 @@ def session_pca(imgs, mask_img, parameters,
     n_components: integer, optional
         Number of components to be extracted by the PCA
 
-    ref_memory_level: integer, optional
+    memory_level: integer, optional
         Integer indicating the level of memorization. The higher, the more
         function calls are cached.
 
@@ -67,11 +67,11 @@ def session_pca(imgs, mask_img, parameters,
     """
 
     data, affine = cache(
-        filter_and_mask, memory, func_memory_level=func_memory_level,
-        memory_level=2,
-        ignore=['verbose', 'memory', 'ref_memory_level', 'copy'])(
+        filter_and_mask, memory, memory_level=memory_level,
+        func_memory_level=2,
+        ignore=['verbose', 'memory', 'memory_level', 'copy'])(
             imgs, mask_img, parameters,
-            func_memory_level=func_memory_level,
+            memory_level=memory_level,
             memory=memory,
             verbose=verbose,
             confounds=confounds,
@@ -274,7 +274,7 @@ class MultiPCA(BaseEstimator, TransformerMixin):
                 parameters,
                 n_components=self.n_components,
                 memory=self.memory,
-                ref_memory_level=self.memory_level,
+                memory_level=self.memory_level,
                 confounds=confound,
                 verbose=self.verbose
             )

--- a/nilearn/group_sparse_covariance.py
+++ b/nilearn/group_sparse_covariance.py
@@ -542,7 +542,7 @@ class GroupSparseCovariance(BaseEstimator, CacheMixin):
 
         logger.log("Computing precision matrices", verbose=self.verbose)
         ret = self._cache(
-            _group_sparse_covariance, memory_level=1)(
+            _group_sparse_covariance, func_memory_level=1)(
                 self.covariances_, n_samples, self.alpha,
                 tol=self.tol, max_iter=self.max_iter,
                 verbose=max(0, self.verbose - 1), debug=False)

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -22,7 +22,7 @@ from .._utils.class_inspect import enclosing_scope_name, get_params
 
 def filter_and_mask(imgs, mask_img_,
                     parameters,
-                    ref_memory_level=0,
+                    memory_level=0,
                     memory=Memory(cachedir=None),
                     verbose=0,
                     confounds=None,
@@ -54,8 +54,8 @@ def filter_and_mask(imgs, mask_img_,
         # now we can crop
         mask_img_ = image.crop_img(mask_img_, copy=False)
 
-        imgs = cache(image.resample_img, memory, ref_memory_level,
-                    memory_level=2, ignore=['copy'])(
+        imgs = cache(image.resample_img, memory, memory_level=memory_level,
+                     func_memory_level=2, ignore=['copy'])(
                         imgs,
                         target_affine=mask_img_.get_affine(),
                         target_shape=mask_img_.shape,
@@ -88,8 +88,9 @@ def filter_and_mask(imgs, mask_img_,
                 and parameters['low_pass'] is not None):
             clean_memory_level = 4
 
-        data = cache(signal.clean, memory, ref_memory_level,
-                     memory_level=clean_memory_level)(
+        data = cache(signal.clean, memory,
+                     func_memory_level=clean_memory_level,
+                     memory_level=memory_level)(
                         data,
                         confounds=confounds, low_pass=parameters['low_pass'],
                         high_pass=parameters['high_pass'],
@@ -106,7 +107,8 @@ def filter_and_mask(imgs, mask_img_,
             if confounds is not None:
                 confounds = confounds[sessions == s]
             data[sessions == s, :] = \
-                cache(signal.clean, memory, ref_memory_level, memory_level=2)(
+                cache(signal.clean, memory, func_memory_level=2,
+                      memory_level=memory_level)(
                         data[sessions == s, :],
                         confounds=confounds,
                         low_pass=parameters['low_pass'],
@@ -165,13 +167,13 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
             params.pop(name, None)
         data, _ = self._cache(filter_and_mask, memory_level=1,
                            ignore=['verbose', 'memory', 'copy'])(
-                              imgs, self.mask_img_,
-                              params,
-                              ref_memory_level=self.memory_level,
-                              memory=self.memory,
-                              verbose=self.verbose,
-                              confounds=confounds,
-                              copy=copy
+                                imgs, self.mask_img_,
+                                params,
+                                memory_level=self.memory_level,
+                                memory=self.memory,
+                                verbose=self.verbose,
+                                confounds=confounds,
+                                copy=copy
                             )
         return data
 
@@ -216,14 +218,14 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         if confounds is None:
             confounds = itertools.repeat(None, len(imgs_list))
         data = Parallel(n_jobs=n_jobs)(delayed(func)(
-                              imgs, self.mask_img_,
-                              params,
-                              ref_memory_level=self.memory_level,
-                              memory=self.memory,
-                              verbose=self.verbose,
-                              confounds=confounds,
-                              reference_affine=reference_affine,
-                              copy=copy)
+                                imgs, self.mask_img_,
+                                params,
+                                memory_level=self.memory_level,
+                                memory=self.memory,
+                                verbose=self.verbose,
+                                confounds=confounds,
+                                reference_affine=reference_affine,
+                                copy=copy)
                           for imgs, confounds in zip(imgs_list, confounds))
         return zip(*data)[0]
 

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -165,7 +165,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         # just invalid the cache for no good reason
         for name in ('mask_img', 'mask_args'):
             params.pop(name, None)
-        data, _ = self._cache(filter_and_mask, memory_level=1,
+        data, _ = self._cache(filter_and_mask, func_memory_level=1,
                            ignore=['verbose', 'memory', 'copy'])(
                                 imgs, self.mask_img_,
                                 params,
@@ -213,7 +213,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
             reference_affine = _utils.check_niimgs(imgs_list[0],
                                                    accept_3d=True).get_affine()
 
-        func = self._cache(_safe_filter_and_mask, memory_level=1,
+        func = self._cache(_safe_filter_and_mask, func_memory_level=1,
                            ignore=['verbose', 'memory', 'copy'])
         if confounds is None:
             confounds = itertools.repeat(None, len(imgs_list))
@@ -272,7 +272,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
                 return self.fit(**fit_params).transform(X, confounds=confounds)
 
     def inverse_transform(self, X):
-        img = self._cache(masking.unmask, memory_level=1,
+        img = self._cache(masking.unmask, func_memory_level=1,
             )(X, self.mask_img_)
         # Be robust again memmapping that will create read-only arrays in
         # internal structures of the header: remove the memmaped array

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -129,7 +129,7 @@ def filter_and_mask(imgs, mask_img_,
 
 def _safe_filter_and_mask(imgs, mask_img_,
                          parameters,
-                         ref_memory_level=0,
+                         memory_level=0,
                          memory=Memory(cachedir=None),
                          verbose=0,
                          confounds=None,
@@ -147,7 +147,7 @@ def _safe_filter_and_mask(imgs, mask_img_,
         parameters = parameters.copy()
         parameters['target_affine'] = reference_affine
 
-    return filter_and_mask(imgs, mask_img_, parameters, ref_memory_level,
+    return filter_and_mask(imgs, mask_img_, parameters, memory_level,
             memory, verbose, confounds, copy)
 
 

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -178,7 +178,7 @@ class MultiNiftiMasker(BaseMasker, CacheMixin):
 
             self.mask_img_ = self._cache(
                         compute_mask,
-                        memory_level=1,
+                        func_memory_level=1,
                         ignore=['n_jobs', 'verbose', 'memory'])(
                             imgs,
                             target_affine=self.target_affine,
@@ -200,7 +200,7 @@ class MultiNiftiMasker(BaseMasker, CacheMixin):
         if self.verbose > 0:
             print "[%s.transform] Resampling mask" % self.__class__.__name__
         self.mask_img_ = self._cache(image.resample_img,
-                                    memory_level=1)(
+                                    func_memory_level=1)(
             self.mask_img_,
             target_affine=self.target_affine,
             target_shape=self.target_shape,

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -163,7 +163,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
                 print "[%s.fit] Computing the mask" % self.__class__.__name__
             imgs = _utils.check_niimgs(imgs, accept_3d=True)
             self.mask_img_ = self._cache(compute_mask,
-                              memory_level=1,
+                              func_memory_level=1,
                               ignore=['verbose'])(
                 imgs,
                 verbose=max(0, self.verbose - 1),
@@ -176,7 +176,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
         # Resampling: allows the user to change the affine, the shape or both
         if self.verbose > 0:
             print "[%s.fit] Resampling mask" % self.__class__.__name__
-        self.mask_img_ = self._cache(image.resample_img, memory_level=1)(
+        self.mask_img_ = self._cache(image.resample_img, func_memory_level=1)(
             self.mask_img_,
             target_affine=self.target_affine,
             target_shape=self.target_shape,

--- a/nilearn/input_data/nifti_region.py
+++ b/nilearn/input_data/nifti_region.py
@@ -234,24 +234,24 @@ class NiftiLabelsMasker(BaseEstimator, TransformerMixin, CacheMixin):
 
         if self.resampling_target == "labels":
             logger.log("resampling images", verbose=self.verbose)
-            imgs = self._cache(image.resample_img, memory_level=1)(
+            imgs = self._cache(image.resample_img, func_memory_level=1)(
                 imgs, interpolation="continuous",
                 target_shape=_utils._get_shape(self.labels_img_),
                 target_affine=self.labels_img_.get_affine())
 
         if self.smoothing_fwhm is not None:
             logger.log("smoothing images", verbose=self.verbose)
-            imgs = self._cache(image.smooth_img, memory_level=1)(
+            imgs = self._cache(image.smooth_img, func_memory_level=1)(
                 imgs, fwhm=self.smoothing_fwhm)
 
         logger.log("extracting region signals", verbose=self.verbose)
         region_signals, self.labels_ = self._cache(
-            region.img_to_signals_labels, memory_level=1)(
+            region.img_to_signals_labels, func_memory_level=1)(
                 imgs, self.labels_img_,
                 background_label=self.background_label)
 
         logger.log("cleaning extracted signals", verbose=self.verbose)
-        region_signals = self._cache(signal.clean, memory_level=1
+        region_signals = self._cache(signal.clean, func_memory_level=1
                                      )(region_signals,
                                        detrend=self.detrend,
                                        standardize=self.standardize,
@@ -491,32 +491,32 @@ class NiftiMapsMasker(BaseEstimator, TransformerMixin, CacheMixin):
 
         if self.resampling_target == "mask":
             logger.log("resampling images to fit mask", verbose=self.verbose)
-            imgs = self._cache(image.resample_img, memory_level=1)(
+            imgs = self._cache(image.resample_img, func_memory_level=1)(
                 imgs, interpolation="continuous",
                 target_shape=_utils._get_shape(self.mask_img_),
                 target_affine=self.mask_img_.get_affine())
 
         if self.resampling_target == "maps":
             logger.log("resampling images to fit maps", verbose=self.verbose)
-            imgs = self._cache(image.resample_img, memory_level=1)(
+            imgs = self._cache(image.resample_img, func_memory_level=1)(
                 imgs, interpolation="continuous",
                 target_shape=_utils._get_shape(self.maps_img_)[:3],
                 target_affine=self.maps_img_.get_affine())
 
         if self.smoothing_fwhm is not None:
             logger.log("smoothing images", verbose=self.verbose)
-            imgs = self._cache(image.smooth_img, memory_level=1)(
+            imgs = self._cache(image.smooth_img, func_memory_level=1)(
                 imgs, fwhm=self.smoothing_fwhm)
 
         logger.log("extracting region signals", verbose=self.verbose)
         region_signals, self.labels_ = self._cache(
-            region.img_to_signals_maps, memory_level=1)(
+            region.img_to_signals_maps, func_memory_level=1)(
                 imgs,
                 self.maps_img_,
                 mask_img=self.mask_img_)
 
         logger.log("cleaning extracted signals", verbose=self.verbose)
-        region_signals = self._cache(signal.clean, memory_level=1
+        region_signals = self._cache(signal.clean, func_memory_level=1
                                      )(region_signals,
                                        detrend=self.detrend,
                                        standardize=self.standardize,

--- a/nilearn/tests/test_cache_mixin.py
+++ b/nilearn/tests/test_cache_mixin.py
@@ -77,7 +77,7 @@ def test__safe_cache_flush():
 def test_cache_memory_level():
     temp_dir = tempfile.mkdtemp()
     job_glob = os.path.join(temp_dir, 'joblib', '*')
-    mem = Memory(cachedir=temp_dir)
+    mem = Memory(cachedir=temp_dir, verbose=0)
     cache_mixin.cache(f, mem)(2)
     assert_true(len(glob.glob(job_glob)) == 0)
     cache_mixin.cache(f, mem, func_memory_level=2, memory_level=1)(2)

--- a/nilearn/tests/test_cache_mixin.py
+++ b/nilearn/tests/test_cache_mixin.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tempfile
 import json
+import glob
 
 from nose.tools import assert_false, assert_true
 
@@ -13,9 +14,11 @@ from sklearn.externals.joblib import Memory
 import nilearn
 from .._utils import cache_mixin
 
+
 def f(x):
     # A simple test function
     return x
+
 
 def test__safe_cache_dir_creation():
     # Test the _safe_cache function that is supposed to flush the
@@ -70,3 +73,14 @@ def test__safe_cache_flush():
         #if os.path.exists(temp_dir):
         #    shutil.rmtree(temp_dir)
 
+
+def test_cache_memory_level():
+    temp_dir = tempfile.mkdtemp()
+    job_glob = os.path.join(temp_dir, 'joblib', '*')
+    mem = Memory(cachedir=temp_dir)
+    cache_mixin.cache(f, mem)(2)
+    assert_true(len(glob.glob(job_glob)) == 0)
+    cache_mixin.cache(f, mem, func_memory_level=2, memory_level=1)(2)
+    assert_true(len(glob.glob(job_glob)) == 0)
+    cache_mixin.cache(f, mem, func_memory_level=2, memory_level=3)(2)
+    assert_true(len(glob.glob(job_glob)) == 2)


### PR DESCRIPTION
Addresses #385.

Fix semantic problems in cache_mixin that led to misuse of the functions. Shorten the code.

Roadmap:
- [X] In `_utils/cache_mixin.py`, put all the code into the function `cache` (remove duplicate). The code in `CacheMixin` should be a wrapper around `cache`
- [X] Rename `ref_memory_level` to `func_memory_level` to avoid ambiguity.
- [X] Put `None` as default for both parameters
- [x] Check all occurences of caching in the code
- [X] Add a test on memory level