### PR TITLE
[MRG] Resample_img segmentation fault

### DIFF
--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -237,6 +237,12 @@ def _resample_one_img(data, A, A_inv, b, target_shape,
         data = _extrapolate_out_mask(data, np.logical_not(not_finite),
                                      iterations=2)[0]
 
+    # See https://github.com/nilearn/nilearn/issues/346 Copying the
+    # array makes it C continuous and as such the int32 index in the C
+    # code is a lot less likely to overflow
+    if (LooseVersion(scipy.__version__) < LooseVersion('0.14.1')):
+        data = data.copy()
+
     # The resampling itself
     ndimage.affine_transform(data, A,
                              offset=np.dot(A_inv, b),

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -507,3 +507,18 @@ def test_coord_transform_trivial():
     np.testing.assert_array_equal(z+1, z_)
 
 
+def test_resample_img_segmentation_fault():
+    # see https://github.com/nilearn/nilearn/issues/346
+    shape_in = (64, 64, 64)
+    aff_in = np.diag([2., 2., 2., 1.])
+    aff_out = np.diag([3., 3., 3., 1.])
+    # fourth_dim = 1024 works fine but for 1025 creates a segmentation
+    # fault with scipy < 0.14.1
+    fourth_dim = 1025
+    data = np.ones(shape_in + (fourth_dim, ), dtype=np.float64)
+
+    img_in = Nifti1Image(data, aff_in)
+
+    resample_img(img_in,
+                 target_affine=aff_out,
+                 interpolation='nearest')


### PR DESCRIPTION
Copying the data makes the array C contiguous and the int32 index a lot less likely to overflow
in the scipy C code. Add test.

Full disclosure: I haven't investigated the penalty performance of copying the data for big images. I tried to put together a heuristic a little while ago to decide whether the array was big enough to trigger this segmentation fault but I didn't have time to investigate fully.

Fixes #346.