### PR TITLE
Travis should cd outside current working directory before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,7 @@ before_script:
 
 script:
     - python continuous_integration/show-python-packages-versions.py
-    - make test-code
+    # We want to back out of the current working directory to make
+    # sure we are using nilearn installed in site-packages rather
+    # than the one from the current working directory
+    - cd && make -C $OLDPWD test-code && cd -


### PR DESCRIPTION
This is to ensure that we use nilearn installed in site-packages via python setup.py install rather than the one from the current directory.  Amongst other things it will detect problems in setup.py, for example missing entries in package_data.

Putting that in .travis.yml seemed like the most sensible thing to do. Let me know if you see a better way.