### PR TITLE
image.iter_img with a str argument was broken

### DIFF
--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -387,10 +387,10 @@ def check_niimgs(niimgs, accept_3d=False, return_iterator=False):
     # Now, we load data as we know its format
     if dim == 4:
         if return_iterator:
-            result = (_index_niimgs(niimgs, i)
-                      for i in range(_get_shape(niimgs)[3]))
+            result = (_index_niimgs(first_img, i)
+                      for i in range(shape[3]))
         else:
-            result = check_niimg(niimgs)
+            result = first_img
     else:
         if return_iterator:
             result = (check_niimg(img) for img in niimgs)

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -327,6 +327,14 @@ def test_iter_img():
         assert_array_equal(img.get_affine(),
                            img_4d.get_affine())
 
+    with testing.write_tmp_imgs(img_4d) as img_4d_filename:
+        for i, img in enumerate(image.iter_img(img_4d_filename)):
+            expected_data_3d = img_4d.get_data()[..., i]
+            assert_array_equal(img.get_data(),
+                               expected_data_3d)
+            assert_array_equal(img.get_affine(),
+                               img_4d.get_affine())
+
     img_3d_list = list(image.iter_img(img_4d))
     for i, img in enumerate(image.iter_img(img_3d_list)):
         expected_data_3d = img_4d.get_data()[..., i]
@@ -334,3 +342,11 @@ def test_iter_img():
                            expected_data_3d)
         assert_array_equal(img.get_affine(),
                            img_4d.get_affine())
+
+    with testing.write_tmp_imgs(*img_3d_list) as img_3d_filenames:
+        for i, img in enumerate(image.iter_img(img_3d_filenames)):
+            expected_data_3d = img_4d.get_data()[..., i]
+            assert_array_equal(img.get_data(),
+                               expected_data_3d)
+            assert_array_equal(img.get_affine(),
+                               img_4d.get_affine())


### PR DESCRIPTION
```python

import numpy as np

import nibabel as nib

from nilearn import image

data = np.ones((11, 12, 13, 14))
img = nib.Nifti1Image(data, np.eye(4))

filename = 'test.nii'
img.to_filename(filename)

iter = image.iter_img(filename)
result = [i.get_data().shape for i in iter]
```

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/tmp/test.py in <module>()
     11 img.to_filename(filename)
     12 
---> 13 iter = image.iter_img(filename)
     14 
     15 

/home/lesteve/dev/nilearn/nilearn/image/image.pyc in iter_img(imgs)
    543     output: iterator of 3D nibabel.Nifti1Image
    544     """
--> 545     return check_niimgs(imgs, return_iterator=True)

/home/lesteve/dev/nilearn/nilearn/_utils/niimg_conversions.pyc in check_niimgs(niimgs, accept_3d, return_iterator)
    389         if return_iterator:
    390             result = (_index_niimgs(niimgs, i)
--> 391                       for i in range(_get_shape(niimgs)[3]))
    392         else:
    393             result = check_niimg(niimgs)

/home/lesteve/dev/nilearn/nilearn/_utils/niimg_conversions.pyc in _get_shape(img)
     46         shape = img.shape
     47     else:
---> 48         shape = img.get_data().shape
     49     return shape
     50 

AttributeError: 'str' object has no attribute 'get_data'
```

