### PR TITLE
Avoid exploding memory on transpose error

### DIFF
--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -635,7 +635,7 @@ def _unmask_3d(X, mask, order="C"):
     if mask.dtype != np.bool:
         raise ValueError("mask must be a boolean array")
     if X.ndim != 1:
-        raise ValueError("X must be a 1-dimensional array")
+        raise TypeError("X must be a 1-dimensional array")
 
     data = np.zeros(
         (mask.shape[0], mask.shape[1], mask.shape[2]),
@@ -665,7 +665,7 @@ def _unmask_nd(X, mask, order="C"):
     if mask.dtype != np.bool:
         raise ValueError("mask must be a boolean array")
     if X.ndim != 2:
-        raise ValueError("X must be a 2-dimensional array")
+        raise TypeError("X must be a 2-dimensional array")
     n_features = mask.sum()
     if X.shape[-1] != n_features:
         # Handle (potential) transpose as a special case, as this
@@ -673,7 +673,7 @@ def _unmask_nd(X, mask, order="C"):
         if X.shape[0] == n_features:
             X = X.T
         else:
-            raise ValueError('X must be of shape (samples, %d).' % n_features)
+            raise TypeError('X must be of shape (samples, %d).' % n_features)
 
     data = np.zeros(mask.shape + (X.shape[0],), dtype=X.dtype, order=order)
     data[mask, :] = X.T
@@ -719,8 +719,7 @@ def unmask(X, mask_img, order="F"):
     elif X.ndim == 1:
         unmasked = _unmask_3d(X, mask, order=order)
     else:
-        raise TypeError(
-            "Masked data X must be 2D or 1D array; got shape: %s" % str(
-                X.shape))
+        raise TypeError("Masked data X must be 2D or 1D array; "
+                        "got shape: %s" % str(X.shape))
 
     return Nifti1Image(unmasked, affine)

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -625,7 +625,7 @@ def _unmask_3d(X, mask, order="C"):
     Parameters
     ==========
     X: numpy.ndarray
-        Masked data. shape: (samples,)
+        Masked data. shape: (features,)
 
     mask: Niimg-like object
         See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
@@ -644,8 +644,8 @@ def _unmask_3d(X, mask, order="C"):
     return data
 
 
-def _unmask_nd(X, mask, order="C"):
-    """Take masked data and bring them back to n-dimension
+def _unmask_4d(X, mask, order="C"):
+    """Take masked data and bring them back to 4D.
 
     Parameters
     ==========
@@ -653,7 +653,7 @@ def _unmask_nd(X, mask, order="C"):
         Masked data. shape: (samples, features)
 
     mask: numpy.ndarray
-        Mask. mask.ndim must be equal to 3, and dtype equal to bool.
+        Mask. mask.ndim must be equal to 4, and dtype *must* be bool.
 
     Returns
     =======
@@ -710,7 +710,7 @@ def unmask(X, mask_img, order="F"):
     mask, affine = _load_mask_img(mask_img)
 
     if X.ndim == 2:
-        unmasked = _unmask_nd(X, mask, order=order)
+        unmasked = _unmask_4d(X, mask, order=order)
     elif X.ndim == 1:
         unmasked = _unmask_3d(X, mask, order=order)
     else:

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -666,6 +666,14 @@ def _unmask_nd(X, mask, order="C"):
         raise ValueError("mask must be a boolean array")
     if X.ndim != 2:
         raise ValueError("X must be a 2-dimensional array")
+    n_features = mask.sum()
+    if X.shape[-1] != n_features:
+        # Handle (potential) transpose as a special case, as this
+        #   mistake can lead to system-fatal memory allocation below.
+        if X.shape[0] == n_features:
+            X = X.T
+        else:
+            raise ValueError('X must be of shape (samples, %d).' % n_features)
 
     data = np.zeros(mask.shape + (X.shape[0],), dtype=X.dtype, order=order)
     data[mask, :] = X.T

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -667,13 +667,8 @@ def _unmask_nd(X, mask, order="C"):
     if X.ndim != 2:
         raise TypeError("X must be a 2-dimensional array")
     n_features = mask.sum()
-    if X.shape[-1] != n_features:
-        # Handle (potential) transpose as a special case, as this
-        #   mistake can lead to system-fatal memory allocation below.
-        if X.shape[0] == n_features:
-            X = X.T
-        else:
-            raise TypeError('X must be of shape (samples, %d).' % n_features)
+    if X.shape[1] != n_features:
+        raise TypeError('X must be of shape (samples, %d).' % n_features)
 
     data = np.zeros(mask.shape + (X.shape[0],), dtype=X.dtype, order=order)
     data[mask, :] = X.T

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -633,7 +633,7 @@ def _unmask_3d(X, mask, order="C"):
     """
 
     if mask.dtype != np.bool:
-        raise ValueError("mask must be a boolean array")
+        raise TypeError("mask must be a boolean array")
     if X.ndim != 1:
         raise TypeError("X must be a 1-dimensional array")
 
@@ -663,7 +663,7 @@ def _unmask_4d(X, mask, order="C"):
     """
 
     if mask.dtype != np.bool:
-        raise ValueError("mask must be a boolean array")
+        raise TypeError("mask must be a boolean array")
     if X.ndim != 2:
         raise TypeError("X must be a 2-dimensional array")
     n_features = mask.sum()

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -636,6 +636,9 @@ def _unmask_3d(X, mask, order="C"):
         raise TypeError("mask must be a boolean array")
     if X.ndim != 1:
         raise TypeError("X must be a 1-dimensional array")
+    n_features = mask.sum()
+    if X.shape[0] != n_features:
+        raise TypeError('X must be of shape (samples, %d).' % n_features)
 
     data = np.zeros(
         (mask.shape[0], mask.shape[1], mask.shape[2]),

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -231,7 +231,8 @@ def test_unmask():
         assert_raises(ValueError, unmask, [dummy], mask_img)
 
     # Error test: transposed vector
-    assert_raises(TypeError, unmask, np.empty(np.count_nonzero(mask_img), 1))
+    out = unmask(np.ones((np.sum(mask), 1)), mask_img)
+    assert_equal(out.shape, mask.shape + (1,))
 
 
 def test_intersect_masks():
@@ -354,3 +355,5 @@ def test_error_shape(random_state=42, shape=(3, 5, 7, 11)):
     X = rng.randn(n_samples, n_features)
     # 2D X (should be ok)
     unmask(X, mask_img)
+
+

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -230,7 +230,7 @@ def test_unmask():
         assert_raises(ValueError, unmask, dummy, mask_img)
         assert_raises(ValueError, unmask, [dummy], mask_img)
 
-    # Error test: transposed vector
+    # Transposed vector (succeeds)
     out = unmask(np.ones((np.sum(mask), 1)), mask_img)
     assert_equal(out.shape, mask.shape + (1,))
 

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -13,9 +13,9 @@ from nose.tools import assert_true, assert_false, assert_equal, \
 from nibabel import Nifti1Image
 
 from nilearn import masking
-from nilearn.masking import compute_epi_mask, compute_multi_epi_mask, \
-    compute_background_mask, unmask, intersect_masks, MaskWarning, \
-    _load_mask_img
+from nilearn.masking import (compute_epi_mask, compute_multi_epi_mask,
+                             compute_background_mask, unmask, _unmask_3d,
+                             _unmask_4d, intersect_masks, MaskWarning)
 
 from nilearn._utils.testing import write_tmp_imgs, assert_raises_regexp
 
@@ -233,6 +233,12 @@ def test_unmask():
     # Transposed vector (succeeds)
     transposed_vector = np.ones((np.sum(mask), 1))
     assert_raises(TypeError, unmask, transposed_vector, mask_img)
+    # Error test: mask type
+    assert_raises_regexp(TypeError, 'mask must be a boolean array',
+                         _unmask_3d, vec_1D, mask.astype(np.int))
+    assert_raises_regexp(TypeError, 'mask must be a boolean array',
+                         _unmask_4d, vec_2D, mask.astype(np.float64))
+
 
 
 def test_intersect_masks():

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -231,8 +231,8 @@ def test_unmask():
         assert_raises(ValueError, unmask, [dummy], mask_img)
 
     # Transposed vector (succeeds)
-    out = unmask(np.ones((np.sum(mask), 1)), mask_img)
-    assert_equal(out.shape, mask.shape + (1,))
+    transposed_vector = np.ones((np.sum(mask), 1))
+    assert_raises(TypeError, unmask, transposed_vector, mask_img)
 
 
 def test_intersect_masks():

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -230,6 +230,9 @@ def test_unmask():
         assert_raises(ValueError, unmask, dummy, mask_img)
         assert_raises(ValueError, unmask, [dummy], mask_img)
 
+    # Error test: transposed vector
+    assert_raises(TypeError, unmask, np.empty(np.count_nonzero(mask_img), 1))
+
 
 def test_intersect_masks():
     """ Test the intersect_masks function
@@ -331,7 +334,7 @@ def test_compute_multi_epi_mask():
     assert_array_equal(mask_ab, mask_ab_.get_data())
 
 
-def test_warning_shape(random_state=42, shape=(3, 5, 7, 11)):
+def test_error_shape(random_state=42, shape=(3, 5, 7, 11)):
     # open-ended `if .. elif` in masking.unmask
 
     rng = np.random.RandomState(random_state)

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -355,5 +355,3 @@ def test_error_shape(random_state=42, shape=(3, 5, 7, 11)):
     X = rng.randn(n_samples, n_features)
     # 2D X (should be ok)
     unmask(X, mask_img)
-
-

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -221,24 +221,25 @@ def test_unmask():
     assert_equal(t[0].ndim, len(shape5D))
     assert_array_equal(t[0], unmasked5D)
 
-    # Error test
-    dummy = generator.rand(500)
-    if np_version >= [1, 7, 1]:
-        assert_raises(IndexError, unmask, dummy, mask_img)
-        assert_raises(IndexError, unmask, [dummy], mask_img)
-    else:
-        assert_raises(ValueError, unmask, dummy, mask_img)
-        assert_raises(ValueError, unmask, [dummy], mask_img)
+    # Error test: shape
+    vec_1D = np.empty((500,), dtype=np.int)
+    assert_raises(TypeError, unmask, vec_1D, mask_img)
+    assert_raises(TypeError, unmask, [vec_1D], mask_img)
 
-    # Transposed vector (succeeds)
-    transposed_vector = np.ones((np.sum(mask), 1))
-    assert_raises(TypeError, unmask, transposed_vector, mask_img)
+    vec_2D = np.empty((500, 500), dtype=np.float64)
+    assert_raises(TypeError, unmask, vec_2D, mask_img)
+    assert_raises(TypeError, unmask, [vec_2D], mask_img)
+
     # Error test: mask type
     assert_raises_regexp(TypeError, 'mask must be a boolean array',
                          _unmask_3d, vec_1D, mask.astype(np.int))
     assert_raises_regexp(TypeError, 'mask must be a boolean array',
                          _unmask_4d, vec_2D, mask.astype(np.float64))
 
+    # Transposed vector
+    transposed_vector = np.ones((np.sum(mask), 1), dtype=np.bool)
+    assert_raises_regexp(TypeError, 'X must be of shape',
+                         unmask, transposed_vector, mask_img)
 
 
 def test_intersect_masks():


### PR DESCRIPTION
Fix for #458.  Now, a bit more checking occurs before allocating memory:
* If a transposed matrix (n_features, n_slices) is passed in, it is transposed before assignment.
* If a 2D matrix with no dimensions of size `n_features` exists, a friendly error is thrown.

