### PR TITLE
Generalize colorbar axis computations for different input axis sizes

### DIFF
--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -338,7 +338,9 @@ class BaseSlicer(object):
         self._colorbar = False
         self._colorbar_width = 0.05 * bb.width
         self._colorbar_margin = dict(left=0.25 * bb.width,
-                                     right=0.02 * bb.width)
+                                     right=0.02 * bb.width,
+                                     top=0.05 * bb.height,
+                                     bottom=0.05 * bb.height)
         self._init_axes(**kwargs)
 
     @staticmethod
@@ -561,17 +563,16 @@ class BaseSlicer(object):
 
         # create new  axis for the colorbar
         figure = self.frame_axes.figure
-        x0, y0, x1, y1 = self.rect
-        y_width = y1 - y0
-
-        y_margin = 0.05 * y_width / 2.
+        _, y0, x1, y1 = self.rect
+        height = y1 - y0
         x_adjusted_width = self._colorbar_width / len(self.axes)
         x_adjusted_margin = self._colorbar_margin['right'] / len(self.axes)
-        self._colorbar_ax = figure.add_axes([
-            x1 - (x_adjusted_width + x_adjusted_margin),
-            y0 + y_margin,
-            x_adjusted_width,
-            y_width - 2 * y_margin], axis_bgcolor='w')
+        lt_wid_top_ht = [x1 - (x_adjusted_width + x_adjusted_margin),
+                         y0 + self._colorbar_margin['top'],
+                         x_adjusted_width,
+                         height - (self._colorbar_margin['top'] +
+                                   self._colorbar_margin['bottom'])]
+        self._colorbar_ax = figure.add_axes(lt_wid_top_ht, axis_bgcolor='w')
 
         our_cmap = im.cmap
         # edge case where the data has a single value

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -593,14 +593,15 @@ class BaseSlicer(object):
             self._colorbar_ax, ticks=ticks, norm=im.norm,
             orientation='vertical', cmap=our_cmap, boundaries=bounds,
             spacing='proportional')
+        self._cbar.set_ticklabels(["%.2g" % t for t in ticks])
 
         self._colorbar_ax.yaxis.tick_left()
-        self._colorbar_ax.set_yticklabels(["% 2.2g" % t for t in ticks])
-
         tick_color = 'w' if self._black_bg else 'k'
         for tick in self._colorbar_ax.yaxis.get_ticklabels():
             tick.set_color(tick_color)
         self._colorbar_ax.yaxis.set_tick_params(width=0)
+
+        self._cbar.update_ticks()
 
     def add_edges(self, img, color='r'):
         """ Plot the edges of a 3D map in all the views.

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -308,9 +308,6 @@ class BaseSlicer(object):
     """
     # This actually encodes the figsize for only one axe
     _default_figsize = [2.2, 2.6]
-    _colorbar = False
-    # pseudo absolute value
-    _colorbar_width = 0.06
     _colorbar_labels_margin = 2.8
     _axes_class = CutAxes
 
@@ -339,6 +336,8 @@ class BaseSlicer(object):
         bb = axes.get_position()
         self.rect = (bb.x0, bb.y0, bb.x1, bb.y1)
         self._black_bg = black_bg
+        self._colorbar = False
+        self._colorbar_width = 0.06 * bb.width / 2
         self._init_axes(**kwargs)
 
     @staticmethod
@@ -560,18 +559,19 @@ class BaseSlicer(object):
             offset = im.norm.vmax
 
         # create new  axis for the colorbar
-        x_adjusted_width = self._colorbar_width / len(self.axes)
-        x_adjusted_right_margin = 0.01 / len(self.axes)
         figure = self.frame_axes.figure
-        _, y0, x1, y1 = self.rect
+        x0, y0, x1, y1 = self.rect
         y_width = y1 - y0
-        y_margin = 0.05 * y_width
+        x_width = x1 - x0  # between 0 and 1
 
+        y_margin = 0.05 * y_width / 2.
+        x_adjusted_width = self._colorbar_width / len(self.axes)
+        x_adjusted_right_margin = -self._colorbar_width / len(self.axes)
         self._colorbar_ax = figure.add_axes([
             x1 - (x_adjusted_width + x_adjusted_right_margin),
             y0 + y_margin,
-            x_adjusted_width - x_adjusted_right_margin,
-            y_width - 2 * y_margin])
+            x_adjusted_width,
+            y_width - 2 * y_margin], axis_bgcolor='w')
 
         our_cmap = im.cmap
         # edge case where the data has a single value

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -337,7 +337,8 @@ class BaseSlicer(object):
         self._black_bg = black_bg
         self._colorbar = False
         self._colorbar_width = 0.05 * bb.width
-        self._colorbar_labels_margin = 0.2 * bb.width
+        self._colorbar_margin = dict(left=0.25 * bb.width,
+                                     right=0.02 * bb.width)
         self._init_axes(**kwargs)
 
     @staticmethod
@@ -562,13 +563,12 @@ class BaseSlicer(object):
         figure = self.frame_axes.figure
         x0, y0, x1, y1 = self.rect
         y_width = y1 - y0
-        x_width = x1 - x0  # between 0 and 1
 
         y_margin = 0.05 * y_width / 2.
         x_adjusted_width = self._colorbar_width / len(self.axes)
-        x_adjusted_right_margin = self._colorbar_width / len(self.axes)
+        x_adjusted_margin = self._colorbar_margin['right'] / len(self.axes)
         self._colorbar_ax = figure.add_axes([
-            x1 - (x_adjusted_width + x_adjusted_right_margin),
+            x1 - (x_adjusted_width + x_adjusted_margin),
             y0 + y_margin,
             x_adjusted_width,
             y_width - 2 * y_margin], axis_bgcolor='w')
@@ -777,8 +777,8 @@ class OrthoSlicer(BaseSlicer):
 
         if self._colorbar:
             adjusted_width = self._colorbar_width / len(self.axes)
-            right_margin = self._colorbar_width / len(self.axes)
-            ticks_margin = self._colorbar_labels_margin / len(self.axes)
+            right_margin = self._colorbar_margin['right'] / len(self.axes)
+            ticks_margin = self._colorbar_margin['left'] / len(self.axes)
             x1 = x1 - (adjusted_width + ticks_margin + right_margin)
 
         for display_ax in display_ax_dict.values():
@@ -937,8 +937,8 @@ class BaseStackedSlicer(BaseSlicer):
 
         if self._colorbar:
             adjusted_width = self._colorbar_width/len(self.axes)
-            right_margin = self._colorbar_width / len(self.axes)
-            ticks_margin = adjusted_width * self._colorbar_labels_margin
+            right_margin = self._colorbar_margin['right'] / len(self.axes)
+            ticks_margin = self._colorbar_margin['left'] / len(self.axes)
             x1 = x1 - (adjusted_width + right_margin + ticks_margin)
 
         for display_ax in display_ax_dict.values():


### PR DESCRIPTION
The colorbar axis code was in some places assuming that the axis size would be [0, 0, 1, 1].  This is not always the case, in particular when using subplots.

I've generalized the code to work for axis sizes in general.  I also abstracted a new variable, `colorbar_margin`, to try and improve code readability.  There was also code in there to control the tick formatting, that wasn't working properly; rather than remove it, I fixed it to work.

## Old Image (single)
![figure_1](https://cloud.githubusercontent.com/assets/4072455/6375552/a4e00010-bccc-11e4-9a82-6dbca0bb6488.png)
## New Image (single)
![new_figure_1](https://cloud.githubusercontent.com/assets/4072455/6375562/b8c260d2-bccc-11e4-8584-dca13556e991.png)
## Old Image (1x3 grid)
![figure_2](https://cloud.githubusercontent.com/assets/4072455/6375553/a4e601ae-bccc-11e4-9c39-44bfb79b5876.png)
## New Image (1x3 grid)
![new_figure_2](https://cloud.githubusercontent.com/assets/4072455/6375564/ba3293ec-bccc-11e4-8a9f-35e60600c6ce.png)
## Old Image (4x4 grid)
![screen shot 2015-02-25 at 8 35 35 am](https://cloud.githubusercontent.com/assets/4072455/6375556/a98160be-bccc-11e4-9290-a7be93c4f12d.png)
## New Image (4x4 grid)
![new_figure_3](https://cloud.githubusercontent.com/assets/4072455/6375578/cbafd698-bccc-11e4-9386-2d834151bc9e.png)

## This also works fine for code without color bars:
![new_figure_4](https://cloud.githubusercontent.com/assets/4072455/6375692/9ab8e6fa-bccd-11e4-8343-0d7882ff3ea6.png)
## And for 'ortho' plots:
![new_figure_5](https://cloud.githubusercontent.com/assets/4072455/6375693/9abc86d4-bccd-11e4-907c-a60b5f90b426.png)

Code for producing these images, in case you'd like to test:
```python
import matplotlib.pyplot as plt

from nilearn import datasets
from nilearn.plotting import plot_stat_map, plot_glass_brain
from nilearn.image import index_img, iter_img

msdl_atlas_dataset = datasets.fetch_msdl_atlas()
maps_img = msdl_atlas_dataset.maps

# Just a single plot
plot_stat_map(index_img(maps_img, 0), display_mode='z', cut_coords=1)

# Row of subplots
fh = plt.figure()
for pi, img in enumerate(iter_img(index_img(maps_img, slice(None, 3)))):
    ax = fh.add_subplot(1, 3, pi + 1)
    plot_stat_map(img, axes=ax, display_mode='z', cut_coords=1)

# Grid of subplots
fh = plt.figure()
for pi, img in enumerate(iter_img(index_img(maps_img, slice(None, 16)))):
    ax = fh.add_subplot(4, 4, pi + 1)
    plot_stat_map(img, axes=ax, display_mode='z', cut_coords=1)

# No colorbars:
plot_glass_brain(index_img(maps_img, 0))

# Just a single plot
plot_stat_map(index_img(maps_img, 0))

plt.show()
```
