### PR TITLE
CanICA / MultiPCA: Fix interface / avoid warning for fitting with and without images

### DIFF
--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -189,7 +189,7 @@ class MultiPCA(BaseEstimator, TransformerMixin):
         self.target_shape = target_shape
         self.standardize = standardize
 
-    def fit(self, imgs=None, y=None, confounds=None):
+    def fit(self, imgs, y=None, confounds=None):
         """Compute the mask and the components
 
         Parameters
@@ -255,7 +255,14 @@ class MultiPCA(BaseEstimator, TransformerMixin):
                     warnings.warn('Parameter %s of the masker overriden'
                                   % param_name)
                 setattr(self.masker_, param_name, our_param)
-        self.masker_.fit(imgs)
+
+        # Masker warns if it has a mask_img and is passed
+        # imgs to fit().  Avoid the warning by being careful
+        # when calling fit.
+        if self.masker_.mask_img is None:
+            self.masker_.fit(imgs)
+        else:
+            self.masker_.fit()
         self.mask_img_ = self.masker_.mask_img_
 
         parameters = get_params(MultiNiftiMasker, self)

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -1,8 +1,11 @@
 """Test CanICA"""
-import nibabel
+
 import numpy as np
 from numpy.testing import assert_array_almost_equal
-from nose.tools import assert_true
+from nose.tools import assert_true, assert_raises
+
+import nibabel
+
 from nilearn.decomposition.canica import CanICA
 
 
@@ -60,6 +63,9 @@ def test_canica_square_img():
     assert_true(np.sum(K_abs > .9) == 4)
     K_abs[K_abs > .9] -= 1
     assert_array_almost_equal(K_abs, 0, 1)
+
+    # Smoke test to make sure an error is raised when no data is passed.
+    assert_raises(TypeError, canica.fit)
 
 if __name__ == "__main__":
     test_canica_square_img()

--- a/nilearn/decomposition/tests/test_multi_pca.py
+++ b/nilearn/decomposition/tests/test_multi_pca.py
@@ -1,13 +1,14 @@
 """
 Test the multi-PCA module
 """
-import nibabel
+
 import numpy as np
+from nose.tools import assert_raises
 
-import nose
+import nibabel
 
-from nilearn.input_data import MultiNiftiMasker
 from nilearn.decomposition.multi_pca import MultiPCA
+from nilearn.input_data import MultiNiftiMasker
 
 
 def test_multi_pca():
@@ -42,7 +43,7 @@ def test_multi_pca():
 
     # Check that asking for too little components raises a ValueError
     multi_pca = MultiPCA()
-    nose.tools.assert_raises(ValueError, multi_pca.fit, data[:2])
+    assert_raises(ValueError, multi_pca.fit, data[:2])
 
     # Smoke test the use of a masker and without CCA
     multi_pca = MultiPCA(mask=MultiNiftiMasker(mask_args=dict(opening=0)),
@@ -51,3 +52,6 @@ def test_multi_pca():
 
     # Smoke test the transform and inverse_transform
     multi_pca.inverse_transform(multi_pca.transform(data[-2:]))
+
+    # Smoke test to fit with no img
+    assert_raises(TypeError, multi_pca.fit)


### PR DESCRIPTION
I'm separating this issue out of https://github.com/nilearn/nilearn/pull/371, as I think it's a simple issue / bugfix to cleanly discuss on its own.

CanICA and MultiPCA require `imgs` to be passed to their `fit` functions.  However,
* `MultiPCA` lists `imgs` as an optional parameter.
* When either of these classes are created with an explicit `mask_img`, their `fit()` function raises a warning (despite users doing the right thing).

Fixes:
* Make `imgs` a required parameter.
* Call the downstream masker with `imgs`, only if it has no `mask_img`.