### PR TITLE
bugfix in findcuts()

### DIFF
--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -76,6 +76,9 @@ def find_xyz_cut_coords(img, mask=None, activation_threshold=None):
         activation_threshold = fast_abs_percentile(my_map[my_map != 0].ravel(),
                                                    80)
     mask = np.abs(my_map) > activation_threshold - 1.e-15
+    # mask may be zero everywhere in rare cases
+    if (mask.max() == 0) and (mask.min() == 0):
+        return .5 * np.array(data.shape)
     mask = largest_connected_component(mask)
     slice_x, slice_y, slice_z = ndimage.find_objects(mask)[0]
     my_map = my_map[slice_x, slice_y, slice_z]

--- a/nilearn/plotting/tests/test_find_cuts.py
+++ b/nilearn/plotting/tests/test_find_cuts.py
@@ -32,6 +32,16 @@ def test_find_cut_coords():
                                # pass. x, y, z = [24.75, 3.17, 9.875]
                                rtol=6e-2)
 
+    # regression test (cf. #473)
+    # test case: no data exceeds the activation threshold
+    data = np.ones((36, 43, 36))
+    affine = np.eye(4)
+    img = nibabel.Nifti1Image(data, affine)
+    x, y, z = find_xyz_cut_coords(img, activation_threshold=1.1)
+    np.testing.assert_array_equal(
+        np.array([x, y, z]),
+        0.5 * np.array(data.shape).astype(np.float))
+
 
 def test_find_cut_slices():
     data = np.zeros((50, 50, 50))


### PR DESCRIPTION
find_xyz_cut_coords() is currently crashing for very small values in nifti image due to failure of largest_connected_component() call.