### PR TITLE
Improve Nifti masker code coverage

### DIFF
--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -170,7 +170,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
                 compute_mask = masking.compute_epi_mask
             else:
                 raise ValueError("Unknown value of mask_strategy '%s'. "
-                    "Acceptable values are 'background' and 'epi'.")
+                    "Acceptable values are 'background' and 'epi'." % self.mask_strategy)
             if self.verbose > 0:
                 print "[%s.fit] Computing the mask" % self.__class__.__name__
             imgs = _utils.check_niimgs(imgs, accept_3d=True)


### PR DESCRIPTION
Coveralls shows that `nifti_masker.py` has only ~85% code coverage, e.g. 
https://coveralls.io/builds/1973818/source?filename=nilearn%2Finput_data%2Fnifti_masker.py

It pointed out that an error case was not covered, nor was computation via the "epi" `mask_strategy` option.

I added tests for both (with epi tests based on those in `test_masking`), and added a small bugfix that I found after adding the tests.