### PR TITLE
Refactor check niimg 

### DIFF
--- a/nilearn/_utils/__init__.py
+++ b/nilearn/_utils/__init__.py
@@ -1,7 +1,8 @@
 
-from .niimg_conversions import check_niimg, concat_niimgs, check_niimgs
+from .niimg_conversions import (check_niimg, check_niimg_3d, concat_niimgs,
+    check_niimg_4d)
 
-from .niimg import new_img_like, load_img, _repr_niimgs, copy_img
+from .niimg import new_img_like, _repr_niimgs, copy_img
 
 from .numpy_conversions import as_ndarray
 

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -35,7 +35,7 @@ def load_niimg(niimg, dtype=None):
     Parameters:
     -----------
 
-    img: Niimg-like object
+    niimg: Niimg-like object or filepath
         See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
         Image to load.
 

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -29,7 +29,7 @@ def _safe_get_data(img):
     return img.get_data()
 
 
-def load_niimg(img, dtype=None):
+def load_niimg(niimg, dtype=None):
     """Load a niimg, check if it is a nibabel SpatialImage and cast if needed
 
     Parameters:
@@ -44,14 +44,14 @@ def load_niimg(img, dtype=None):
     img: image
         A loaded image object.
     """
-    if isinstance(img, _basestring):
+    if isinstance(niimg, _basestring):
         # data is a filename, we load it
-        img = nibabel.load(img)
-    elif not isinstance(img, nibabel.spatialimages.SpatialImage):
+        niimg = nibabel.load(niimg)
+    elif not isinstance(niimg, nibabel.spatialimages.SpatialImage):
         raise TypeError("Data given cannot be loaded because it is"
                         " not compatible with nibabel format:\n"
-                        + short_repr(img))
-    return img
+                        + short_repr(niimg))
+    return niimg
 
 
 def new_img_like(ref_img, data, affine, copy_header=False):

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -29,7 +29,7 @@ def _safe_get_data(img):
     return img.get_data()
 
 
-def load_img(img, dtype=None):
+def load_niimg(img, dtype=None):
     """Load a niimg, check if it is a nibabel SpatialImage and cast if needed
 
     Parameters:

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -35,7 +35,7 @@ def load_niimg(niimg, dtype=None):
     Parameters:
     -----------
 
-    niimg: Niimg-like object or filepath
+    niimg: Niimg-like object
         See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
         Image to load.
 

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -15,8 +15,8 @@ from .compat import _basestring
 
 
 def _check_fov(img, affine, shape):
-    """ Return True if img1 and have the given field of view
-        (shape and affine), False elsewhere.
+    """ Return True if img's field of view correspond to given
+        shape and affine, False elsewhere.
     """
     img = check_niimg(img)
     return (img.shape[:3] == shape and
@@ -78,8 +78,7 @@ def check_niimg(niimg, atleast_4d=False):
 
 
 def check_niimg_3d(niimg):
-    """Check that niimg is a proper 3D niimg. Turn filenames into objects.
-
+    """Check that niimg is a proper 3D niimg-like object and load it.
     Parameters
     ----------
     niimg: Niimg-like object
@@ -257,13 +256,13 @@ def _iter_check_niimg_4d(niimgs):
                     % (i, affine, niimg.get_affine(), shape,
                        niimg.shape))
             yield niimg
-        except TypeError as e:
-            raise TypeError("Error while loading image #%d: \n%s"
-                            % (i, e.message))
+        except TypeError as exc:
+            exc.args += ('Error encoutered while loading image #%d: \n%s'
+                         % (i, exc.message))
 
 
 def check_niimg_4d(niimgs, return_iterator=False):
-    """ Check that an object is a list of niimgs and load it if necessary
+    """Check that niimg is a proper 4D niimg-like object and load it.
 
     Parameters
     ----------
@@ -276,10 +275,10 @@ def check_niimg_4d(niimgs, return_iterator=False):
         and get_affine methods are present, raise an Exception otherwise.
 
     return_iterator: boolean
-        If False, a single 4D image is returned. When `niimgs` contains 3D
-        images they are concatenated together.
         If True, an iterator of 3D images is returned. This reduces the memory
         usage when `niimgs` contains 3D images.
+        If False, a single 4D image is returned. When `niimgs` contains 3D
+        images they are concatenated together.
 
     Returns
     -------
@@ -303,8 +302,12 @@ def check_niimg_4d(niimgs, return_iterator=False):
         niimgs = load_niimg(niimgs)
         shape = niimgs.shape
         if len(shape) == 3:
-            raise TypeError("A 4D image is expected, but an image "
-                "with a shape of %s was given." % (shape, ))
+
+            raise TypeError(
+                "Data must be a 4D Niimg-like object but you provided an "
+                "image of shape %s. See "
+                "http://nilearn.github.io/building_blocks/"
+                "manipulating_mr_images.html#niimg." % (shape, ))
         if return_iterator:
             return (_index_niimgs(niimgs, i) for i in range(shape[3]))
         else:

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -299,7 +299,7 @@ def check_niimg_4d(niimgs, return_iterator=False):
     # We get rid of the 4D nifti image case, as it is the simplest case
     # Use hasattr() instead of isinstance to workaround a Python 2.6/2.7 bug
     # See http://bugs.python.org/issue7624
-    if isinstance(niimgs, basestring) or not hasattr(niimgs, "__iter__"):
+    if isinstance(niimgs, string_types) or not hasattr(niimgs, "__iter__"):
         niimgs = load_niimg(niimgs)
         shape = niimgs.shape
         if len(shape) == 3:

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -257,7 +257,8 @@ def _iter_check_niimg_4d(niimgs):
                        niimg.shape))
             yield niimg
         except TypeError as exc:
-            exc.args += ('Error encoutered while loading image #%d' % i)
+            exc.args = (('Error encountered while loading image #%d' % i,) + 
+                        exc.args)
             raise
 
 

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -25,8 +25,8 @@ def _check_same_fov(img1, img2):
             and np.allclose(img1.get_affine(), img2.get_affine()))
 
 
-def check_niimg(niimg, ensure_3d=False):
-    """Check that niimg is a proper niimg. Turn filenames into objects.
+def check_niimg(niimg):
+    """Check that niimg is a proper 3D niimg. Turn filenames into objects.
 
     Parameters
     ----------
@@ -36,13 +36,9 @@ def check_niimg(niimg, ensure_3d=False):
         call nibabel.load on it. If it is an object, check if get_data()
         and get_affine() methods are present, raise TypeError otherwise.
 
-    ensure_3d: boolean, optional
-        If ensure_3d is true, the code checks that the image passed is a
-        3D image and raises an error if not
-
     Returns
     -------
-    result: Niimg-like object
+    result: 3D Niimg-like object
         Result can be nibabel.Nifti1Image or the input, as-is. It is guaranteed
         that the returned object has get_data() and get_affine() methods.
 
@@ -55,29 +51,20 @@ def check_niimg(niimg, ensure_3d=False):
 
     Its application is idempotent.
     """
-    if hasattr(niimg, "__iter__") and not isinstance(niimg, _basestring):
-        if ensure_3d:
-            raise TypeError("A 3D image is expected, but an iterable was"
-                " given: %s" % short_repr(niimg))
-        if hasattr(niimg, "__len__") and len(niimg) == 0:
-            raise TypeError('An empty object - %r - was passed instead of an '
-                            'image or a list of images' % niimg)
-        return concat_niimgs(niimg)
-
     niimg = load_img(niimg)
 
-    if ensure_3d:
-        shape = niimg.shape
-        if len(shape) == 3:
-            pass
-        elif (len(shape) == 4 and shape[3] == 1):
-            # "squeeze" the image.
-            data = _safe_get_data(niimg)
-            affine = niimg.get_affine()
-            niimg = new_img_like(niimg, data[:, :, :, 0], affine)
-        else:
-            raise TypeError("A 3D image is expected, but an image "
-                "with a shape of %s was given." % (shape, ))
+    shape = niimg.shape
+    if len(shape) == 3:
+        pass
+    elif (len(shape) == 4 and shape[3] == 1):
+        # "squeeze" the image.
+        data = _safe_get_data(niimg)
+        affine = niimg.get_affine()
+        niimg = new_img_like(niimg, data[:, :, :, 0], affine)
+    else:
+        raise TypeError("A 3D image is expected, but an image "
+            "with a shape of %s was given." % (shape, ))
+
     return niimg
 
 

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -88,10 +88,6 @@ def _to_4d(data):
     return out
 
 
-def _iter_concat_niimgs():
-    pass
-
-
 def concat_niimgs(niimgs, dtype=np.float32, accept_4d=False,
                   auto_resample=False, verbose=0,
                   memory=Memory(cachedir=None), memory_level=0):

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -162,11 +162,11 @@ def concat_niimgs(niimgs, dtype=np.float32, accept_4d=False,
         A single image.
     """
 
-    if len(niimgs) == 0:
-        raise TypeError('Cannot concatenate empty objects')
-
     # get properties from first image
-    first_niimg = check_niimg(next(iter(niimgs)), atleast_4d=True)
+    try:
+        first_niimg = check_niimg(next(iter(niimgs)), atleast_4d=True)
+    except StopIteration:
+        raise TypeError('Cannot concatenate empty objects')
     target_affine = first_niimg.get_affine()
     first_data = first_niimg.get_data()
     target_item_shape = first_niimg.shape[:3]  # skip 4th/time dimension

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -257,8 +257,8 @@ def _iter_check_niimg_4d(niimgs):
                        niimg.shape))
             yield niimg
         except TypeError as exc:
-            exc.args += ('Error encoutered while loading image #%d: \n%s'
-                         % (i, exc.message))
+            exc.args += ('Error encoutered while loading image #%d' % i)
+            raise
 
 
 def check_niimg_4d(niimgs, return_iterator=False):
@@ -301,8 +301,7 @@ def check_niimg_4d(niimgs, return_iterator=False):
     if isinstance(niimgs, _basestring) or not hasattr(niimgs, "__iter__"):
         niimgs = load_niimg(niimgs)
         shape = niimgs.shape
-        if len(shape) == 3:
-
+        if len(shape) != 4:
             raise TypeError(
                 "Data must be a 4D Niimg-like object but you provided an "
                 "image of shape %s. See "
@@ -311,7 +310,7 @@ def check_niimg_4d(niimgs, return_iterator=False):
         if return_iterator:
             return (_index_niimgs(niimgs, i) for i in range(shape[3]))
         else:
-            return check_niimg(niimgs)
+            return niimgs
 
     # We now have 3 types of input:
     # * a true list

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -298,7 +298,7 @@ def check_niimg_4d(niimgs, return_iterator=False):
     # We get rid of the 4D nifti image case, as it is the simplest case
     # Use hasattr() instead of isinstance to workaround a Python 2.6/2.7 bug
     # See http://bugs.python.org/issue7624
-    if isinstance(niimgs, string_types) or not hasattr(niimgs, "__iter__"):
+    if isinstance(niimgs, _basestring) or not hasattr(niimgs, "__iter__"):
         niimgs = load_niimg(niimgs)
         shape = niimgs.shape
         if len(shape) == 3:

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -23,7 +23,7 @@ import numpy as np
 from scipy import ndimage
 from sklearn.datasets.base import Bunch
 
-from ._utils import load_img, new_img_like
+from ._utils import check_niimg, new_img_like
 from ._utils.compat import _basestring, BytesIO, cPickle, _urllib, md5_hash
 
 
@@ -1406,7 +1406,8 @@ def fetch_nyu_rest(n_subjects=None, sessions=[1], data_dir=None, resume=True,
         session += [i] * n_subjects
 
     dataset_name = 'nyu_rest'
-    data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir, verbose=verbose)
+    data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,
+                                verbose=verbose)
     anat_anon = _fetch_files(data_dir, anat_anon, resume=resume,
                              verbose=verbose)
     anat_skull = _fetch_files(data_dir, anat_skull, resume=resume,
@@ -1664,7 +1665,7 @@ def fetch_harvard_oxford(atlas_name, data_dir=None, symmetric_split=False,
         raise ValueError("Region splitting not supported for probabilistic "
                          "atlases")
 
-    atlas_img = load_img(atlas_img)
+    atlas_img = check_niimg(atlas_img)
     atlas = atlas_img.get_data()
 
     labels = np.unique(atlas)
@@ -2380,7 +2381,8 @@ def fetch_oasis_vbm(n_subjects=None, dartel_version=True,
     file_names = (file_names_gm + file_names_wm
                   + file_names_extvars + file_names_dua)
     dataset_name = 'oasis1'
-    data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir, verbose=verbose)
+    data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,
+                                verbose=verbose)
     files = _fetch_files(data_dir, file_names, resume=resume,
                          verbose=verbose)
 
@@ -2438,7 +2440,7 @@ def load_mni152_template():
     path = os.path.join(package_directory, "data", "avg152T1_brain.nii.gz")
 
     # XXX Should we load the image here?
-    return load_img(path)
+    return check_niimg(path)
 
 
 def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -366,7 +366,7 @@ def _compute_mean(imgs, target_affine=None,
     from . import resampling
     input_repr = _repr_niimgs(imgs)
 
-    imgs = check_niimgs(imgs, accept_3d=True)
+    imgs = check_niimgs(imgs)
     mean_img = _safe_get_data(imgs)
     if not mean_img.ndim in (3, 4):
         raise ValueError('Computation expects 3D or 4D '

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -14,7 +14,8 @@ from sklearn.externals.joblib import Parallel, delayed
 
 from .. import signal
 from .resampling import reorder_img
-from .._utils import check_niimgs, check_niimg, as_ndarray, _repr_niimgs
+from .._utils import (check_niimg_4d, check_niimg_3d, check_niimg, as_ndarray,
+                      _repr_niimgs)
 from .._utils.niimg_conversions import _index_niimgs
 from .._utils.niimg import new_img_like, _safe_get_data
 from .._utils.compat import _basestring
@@ -75,7 +76,7 @@ def high_variance_confounds(imgs, n_confounds=5, percentile=2.,
         sigs = masking.apply_mask(imgs, mask_img)
     else:
         # Load the data only if it doesn't need to be masked
-        imgs = check_niimgs(imgs)
+        imgs = check_niimg_4d(imgs)
         sigs = as_ndarray(imgs.get_data())
         # Not using apply_mask here saves memory in most cases.
         del imgs  # help reduce memory consumption
@@ -291,7 +292,7 @@ def _crop_img_to(img, slices, copy=True):
         Cropped version of the input image
     """
 
-    img = check_niimg(img)
+    img = check_niimg_3d(img)
 
     data = img.get_data()
     affine = img.get_affine()
@@ -340,7 +341,7 @@ def crop_img(img, rtol=1e-8, copy=True):
         Cropped version of the input image
     """
 
-    img = check_niimg(img)
+    img = check_niimg_3d(img)
     data = img.get_data()
     infinity_norm = max(-data.min(), data.max())
     passes_threshold = np.logical_or(data < -rtol * infinity_norm,
@@ -366,7 +367,7 @@ def _compute_mean(imgs, target_affine=None,
     from . import resampling
     input_repr = _repr_niimgs(imgs)
 
-    imgs = check_niimgs(imgs)
+    imgs = check_niimg(imgs)
     mean_img = _safe_get_data(imgs)
     if not mean_img.ndim in (3, 4):
         raise ValueError('Computation expects 3D or 4D '
@@ -486,7 +487,7 @@ def swap_img_hemispheres(img):
     """
 
     # Check input is really a path to a nifti file or a nifti object
-    img = check_niimg(img)
+    img = check_niimg_3d(img)
 
     # get nifti in x-y-z order
     img = reorder_img(img)
@@ -517,7 +518,7 @@ def index_img(imgs, index):
     output: nibabel.Nifti1Image
 
     """
-    imgs = check_niimgs(imgs)
+    imgs = check_niimg_4d(imgs)
     return _index_niimgs(imgs, index)
 
 
@@ -533,4 +534,4 @@ def iter_img(imgs):
     -------
     output: iterator of 3D nibabel.Nifti1Image
     """
-    return check_niimgs(imgs, return_iterator=True)
+    return check_niimg_4d(imgs, return_iterator=True)

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -184,7 +184,7 @@ def get_mask_bounds(img):
         reorder_img to ensure that it is the case.
 
     """
-    img = _utils.check_niimg(img)
+    img = _utils.check_niimg_3d(img)
     mask = _utils.numpy_conversions._asarray(img.get_data(), dtype=np.bool)
     affine = img.get_affine()
     (xmin, xmax), (ymin, ymax), (zmin, zmax) = get_bounds(mask.shape, affine)
@@ -370,9 +370,9 @@ def resample_img(img, target_affine=None, target_shape=None,
     else:
         input_img_is_string = False
 
-    # noop cases
     img = _utils.check_niimg(img)
 
+    # noop cases
     if target_affine is None and target_shape is None:
         if copy and not input_img_is_string:
             img = _utils.copy_img(img)

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -279,7 +279,7 @@ def test_concat_imgs():
 
 def test_index_img():
     img_3d = nibabel.Nifti1Image(np.ones((3, 4, 5)), np.eye(4))
-    testing.assert_raises_regex(TypeError, 'A 4D image is expected',
+    testing.assert_raises_regex(TypeError, '4D Niimg-like',
                                 image.index_img, img_3d, 0)
 
     affine = np.array([[1., 2., 3., 4.],
@@ -311,7 +311,7 @@ def test_index_img():
 
 def test_iter_img():
     img_3d = nibabel.Nifti1Image(np.ones((3, 4, 5)), np.eye(4))
-    testing.assert_raises_regex(TypeError, 'A 4D image is expected',
+    testing.assert_raises_regex(TypeError, '4D Niimg-like',
                                 image.iter_img, img_3d)
 
     affine = np.array([[1., 2., 3., 4.],

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -279,8 +279,8 @@ def test_concat_imgs():
 
 def test_index_img():
     img_3d = nibabel.Nifti1Image(np.ones((3, 4, 5)), np.eye(4))
-    testing.assert_raises_regex(TypeError, 'Niimg-like object',
-                                image.index_img, img_3d, 0)
+    testing.assert_raises_regexp(TypeError, 'A 4D image is expected',
+                                 image.index_img, img_3d, 0)
 
     affine = np.array([[1., 2., 3., 4.],
                        [5., 6., 7., 8.],
@@ -311,8 +311,8 @@ def test_index_img():
 
 def test_iter_img():
     img_3d = nibabel.Nifti1Image(np.ones((3, 4, 5)), np.eye(4))
-    testing.assert_raises_regex(TypeError, 'Niimg-like object',
-                                image.iter_img, img_3d)
+    testing.assert_raises_regexp(TypeError, 'A 4D image is expected',
+                                 image.iter_img, img_3d)
 
     affine = np.array([[1., 2., 3., 4.],
                        [5., 6., 7., 8.],

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -279,8 +279,8 @@ def test_concat_imgs():
 
 def test_index_img():
     img_3d = nibabel.Nifti1Image(np.ones((3, 4, 5)), np.eye(4))
-    testing.assert_raises_regexp(TypeError, 'A 4D image is expected',
-                                 image.index_img, img_3d, 0)
+    testing.assert_raises_regex(TypeError, 'A 4D image is expected',
+                                image.index_img, img_3d, 0)
 
     affine = np.array([[1., 2., 3., 4.],
                        [5., 6., 7., 8.],
@@ -311,8 +311,8 @@ def test_index_img():
 
 def test_iter_img():
     img_3d = nibabel.Nifti1Image(np.ones((3, 4, 5)), np.eye(4))
-    testing.assert_raises_regexp(TypeError, 'A 4D image is expected',
-                                 image.iter_img, img_3d)
+    testing.assert_raises_regex(TypeError, 'A 4D image is expected',
+                                image.iter_img, img_3d)
 
     affine = np.array([[1., 2., 3., 4.],
                        [5., 6., 7., 8.],

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -38,9 +38,9 @@ def filter_and_mask(imgs, mask_img_,
     if verbose > 0:
         class_name = enclosing_scope_name(stack_level=2)
 
-    mask_img_ = _utils.check_niimg(mask_img_)
+    mask_img_ = _utils.check_niimg_3d(mask_img_)
 
-    imgs = _utils.check_niimgs(imgs)
+    imgs = _utils.check_niimg(imgs, atleast_4d=True)
     if sample_mask is not None:
         imgs = image.index_img(imgs, sample_mask)
 
@@ -140,7 +140,7 @@ def _safe_filter_and_mask(imgs, mask_img_,
                          confounds=None,
                          reference_affine=None,
                          copy=True):
-    imgs = _utils.check_niimgs(imgs)
+    imgs = _utils.check_niimg(imgs)
 
     # If there is a reference affine, we may have to force resampling
     target_affine = parameters['target_affine']
@@ -217,7 +217,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         if self.target_affine is None:
             # Load the first image and use it as a reference for all other
             # subjects
-            reference_affine = _utils.check_niimgs(imgs_list[0]).get_affine()
+            reference_affine = _utils.check_niimg(imgs_list[0]).get_affine()
 
         func = self._cache(_safe_filter_and_mask, func_memory_level=1,
                            ignore=['verbose', 'memory', 'copy'])

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -38,9 +38,9 @@ def filter_and_mask(imgs, mask_img_,
     if verbose > 0:
         class_name = enclosing_scope_name(stack_level=2)
 
-    mask_img_ = _utils.check_niimg(mask_img_, ensure_3d=True)
+    mask_img_ = _utils.check_niimg(mask_img_)
 
-    imgs = _utils.check_niimgs(imgs, accept_3d=True)
+    imgs = _utils.check_niimgs(imgs)
     if sample_mask is not None:
         imgs = image.index_img(imgs, sample_mask)
 
@@ -140,7 +140,7 @@ def _safe_filter_and_mask(imgs, mask_img_,
                          confounds=None,
                          reference_affine=None,
                          copy=True):
-    imgs = _utils.check_niimgs(imgs, accept_3d=True)
+    imgs = _utils.check_niimgs(imgs)
 
     # If there is a reference affine, we may have to force resampling
     target_affine = parameters['target_affine']
@@ -217,8 +217,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         if self.target_affine is None:
             # Load the first image and use it as a reference for all other
             # subjects
-            reference_affine = _utils.check_niimgs(imgs_list[0],
-                                                   accept_3d=True).get_affine()
+            reference_affine = _utils.check_niimgs(imgs_list[0]).get_affine()
 
         func = self._cache(_safe_filter_and_mask, func_memory_level=1,
                            ignore=['verbose', 'memory', 'copy'])

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -170,7 +170,7 @@ class MultiNiftiMasker(BaseMasker, CacheMixin):
             for img in imgs:
                 # Note that data is not loaded into memory at this stage
                 # if img is a string
-                data.append(_utils.check_niimgs(img, accept_3d=True))
+                data.append(_utils.check_niimgs(img))
 
             mask_args = (self.mask_args if self.mask_args is not None
                          else {})
@@ -199,7 +199,7 @@ class MultiNiftiMasker(BaseMasker, CacheMixin):
                              ' requested (imgs != None) while a mask has'
                              ' been provided at masker creation. Given mask'
                              ' will be used.' % self.__class__.__name__)
-            self.mask_img_ = _utils.check_niimg(self.mask_img, ensure_3d=True)
+            self.mask_img_ = _utils.check_niimg(self.mask_img)
 
         # If resampling is requested, resample the mask as well.
         # Resampling: allows the user to change the affine, the shape or both.

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -167,10 +167,6 @@ class MultiNiftiMasker(BaseMasker, CacheMixin):
                                  "(e.g. Nifti1Image objects or filenames)."
                                  "%r is an invalid input"
                                  % (self.__class__.__name__, imgs))
-            for img in imgs:
-                # Note that data is not loaded into memory at this stage
-                # if img is a string
-                data.append(_utils.check_niimgs(img))
 
             mask_args = (self.mask_args if self.mask_args is not None
                          else {})
@@ -199,7 +195,7 @@ class MultiNiftiMasker(BaseMasker, CacheMixin):
                              ' requested (imgs != None) while a mask has'
                              ' been provided at masker creation. Given mask'
                              ' will be used.' % self.__class__.__name__)
-            self.mask_img_ = _utils.check_niimg(self.mask_img)
+            self.mask_img_ = _utils.check_niimg_3d(self.mask_img)
 
         # If resampling is requested, resample the mask as well.
         # Resampling: allows the user to change the affine, the shape or both.

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -129,12 +129,12 @@ class NiftiLabelsMasker(BaseEstimator, TransformerMixin, CacheMixin):
         logger.log("loading data from %s" %
                    _utils._repr_niimgs(self.labels_img)[:200],
                    verbose=self.verbose)
-        self.labels_img_ = _utils.check_niimg(self.labels_img)
+        self.labels_img_ = _utils.check_niimg_3d(self.labels_img)
         if self.mask_img is not None:
             logger.log("loading data from %s" %
                        _utils._repr_niimgs(self.mask_img)[:200],
                        verbose=self.verbose)
-            self.mask_img_ = _utils.check_niimg(self.mask_img)
+            self.mask_img_ = _utils.check_niimg_3d(self.mask_img)
         else:
             self.mask_img_ = None
 
@@ -207,7 +207,7 @@ class NiftiLabelsMasker(BaseEstimator, TransformerMixin, CacheMixin):
 
         logger.log("loading images: %s" %
                    _utils._repr_niimgs(imgs)[:200], verbose=self.verbose)
-        imgs = _utils.check_niimgs(imgs)
+        imgs = _utils.check_niimg_4d(imgs)
 
         if self.resampling_target == "data":
             if not hasattr(self, '_resampled_labels_img_'):

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -134,7 +134,7 @@ class NiftiLabelsMasker(BaseEstimator, TransformerMixin, CacheMixin):
             logger.log("loading data from %s" %
                        _utils._repr_niimgs(self.mask_img)[:200],
                        verbose=self.verbose)
-            self.mask_img_ = _utils.check_niimg(self.mask_img, ensure_3d=True)
+            self.mask_img_ = _utils.check_niimg(self.mask_img)
         else:
             self.mask_img_ = None
 

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -137,13 +137,13 @@ class NiftiMapsMasker(BaseEstimator, TransformerMixin, CacheMixin):
         logger.log("loading regions from %s" %
                    _utils._repr_niimgs(self.maps_img)[:200],
                    verbose=self.verbose)
-        self.maps_img_ = _utils.check_niimgs(self.maps_img)
+        self.maps_img_ = _utils.check_niimg_4d(self.maps_img)
 
         if self.mask_img is not None:
             logger.log("loading mask from %s" %
                        _utils._repr_niimgs(self.mask_img)[:200],
                        verbose=self.verbose)
-            self.mask_img_ = _utils.check_niimg(self.mask_img)
+            self.mask_img_ = _utils.check_niimg_3d(self.mask_img)
         else:
             self.mask_img_ = None
 
@@ -223,7 +223,7 @@ class NiftiMapsMasker(BaseEstimator, TransformerMixin, CacheMixin):
 
         logger.log("loading images from %s" %
                    _utils._repr_niimgs(imgs)[:200], verbose=self.verbose)
-        imgs = _utils.check_niimgs(imgs)
+        imgs = _utils.check_niimg_4d(imgs)
 
 
         if not hasattr(self, '_resampled_maps_img_'):

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -137,13 +137,13 @@ class NiftiMapsMasker(BaseEstimator, TransformerMixin, CacheMixin):
         logger.log("loading regions from %s" %
                    _utils._repr_niimgs(self.maps_img)[:200],
                    verbose=self.verbose)
-        self.maps_img_ = _utils.check_niimg(self.maps_img)
+        self.maps_img_ = _utils.check_niimgs(self.maps_img)
 
         if self.mask_img is not None:
             logger.log("loading mask from %s" %
                        _utils._repr_niimgs(self.mask_img)[:200],
                        verbose=self.verbose)
-            self.mask_img_ = _utils.check_niimg(self.mask_img, ensure_3d=True)
+            self.mask_img_ = _utils.check_niimg(self.mask_img)
         else:
             self.mask_img_ = None
 

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -173,7 +173,6 @@ class NiftiMasker(BaseMasker, CacheMixin):
                     "Acceptable values are 'background' and 'epi'." % self.mask_strategy)
             if self.verbose > 0:
                 print("[%s.fit] Computing the mask" % self.__class__.__name__)
-            imgs = _utils.check_niimgs(imgs)
             self.mask_img_ = self._cache(compute_mask,
                               func_memory_level=1,
                               ignore=['verbose'])(
@@ -181,7 +180,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
                 verbose=max(0, self.verbose - 1),
                 **mask_args)
         else:
-            self.mask_img_ = _utils.check_niimg(self.mask_img)
+            self.mask_img_ = _utils.check_niimg_3d(self.mask_img)
 
         # If resampling is requested, resample also the mask
         # Resampling: allows the user to change the affine, the shape or both

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -173,7 +173,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
                     "Acceptable values are 'background' and 'epi'." % self.mask_strategy)
             if self.verbose > 0:
                 print("[%s.fit] Computing the mask" % self.__class__.__name__)
-            imgs = _utils.check_niimgs(imgs, accept_3d=True)
+            imgs = _utils.check_niimgs(imgs)
             self.mask_img_ = self._cache(compute_mask,
                               func_memory_level=1,
                               ignore=['verbose'])(
@@ -181,8 +181,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
                 verbose=max(0, self.verbose - 1),
                 **mask_args)
         else:
-            self.mask_img_ = _utils.check_niimg(self.mask_img,
-                                                ensure_3d=True)
+            self.mask_img_ = _utils.check_niimg(self.mask_img)
 
         # If resampling is requested, resample also the mask
         # Resampling: allows the user to change the affine, the shape or both

--- a/nilearn/input_data/tests/test_base_masker.py
+++ b/nilearn/input_data/tests/test_base_masker.py
@@ -58,5 +58,5 @@ def test_filter_and_mask():
     data_img = nibabel.Nifti1Image(data, np.eye(4))
     mask_img = nibabel.Nifti1Image(mask, np.eye(4))
 
-    assert_raises_regexp(TypeError, "A 3D image is expected", filter_and_mask,
+    assert_raises_regex(TypeError, "A 3D image is expected", filter_and_mask,
                          data_img, mask_img, {})

--- a/nilearn/input_data/tests/test_base_masker.py
+++ b/nilearn/input_data/tests/test_base_masker.py
@@ -55,5 +55,8 @@ def test_filter_and_mask():
     mask = np.zeros([20, 30, 40, 2])
     mask[10, 15, 20, :] = 1
 
-    assert_raises_regex(TypeError, "A 3D image is expected", filter_and_mask,
-                        data, mask, {})
+    data_img = nibabel.Nifti1Image(data, np.eye(4))
+    mask_img = nibabel.Nifti1Image(mask, np.eye(4))
+
+    assert_raises_regexp(TypeError, "A 3D image is expected", filter_and_mask,
+                         data_img, mask_img, {})

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -40,7 +40,7 @@ def _load_mask_img(mask_img, allow_empty=False):
     mask: numpy.ndarray
         boolean version of the mask
     '''
-    mask_img = _utils.check_niimg(mask_img)
+    mask_img = _utils.check_niimg_3d(mask_img)
     mask = mask_img.get_data()
     values = np.unique(mask)
 
@@ -254,7 +254,7 @@ def compute_epi_mask(epi_img, lower_cutoff=0.2, upper_cutoff=0.85,
     if verbose > 0:
         print("EPI mask computation")
 
-    epi_img = _utils.check_niimgs(epi_img)
+    epi_img = _utils.check_niimg(epi_img)
 
     # Delayed import to avoid circular imports
     from .image.image import _compute_mean
@@ -421,7 +421,7 @@ def compute_background_mask(data_imgs, border_size=2,
     if verbose > 0:
         print("Background mask computation")
 
-    data_imgs = _utils.check_niimgs(data_imgs)
+    data_imgs = _utils.check_niimg(data_imgs)
 
     # Delayed import to avoid circular imports
     from .image.image import _compute_mean
@@ -562,7 +562,7 @@ def apply_mask(imgs, mask_img, dtype='f',
     When using smoothing, ensure_finite is set to True, as non-finite
     values would spread accross the image.
     """
-    mask_img = _utils.check_niimg(mask_img, ensure_3d=False)
+    mask_img = _utils.check_niimg_3d(mask_img)
     mask, mask_affine = _load_mask_img(mask_img)
     mask_img = new_img_like(mask_img, mask, mask_affine)
     return _apply_mask_fmri(imgs, mask_img, dtype=dtype,
@@ -579,7 +579,7 @@ def _apply_mask_fmri(imgs, mask_img, dtype='f',
     values (this is checked for in apply_mask, not in this function).
     """
 
-    mask_img = _utils.check_niimg(mask_img)
+    mask_img = _utils.check_niimg_3d(mask_img)
     mask_affine = mask_img.get_affine()
     mask_data = _utils.as_ndarray(mask_img.get_data(),
                                   dtype=np.bool)
@@ -587,7 +587,7 @@ def _apply_mask_fmri(imgs, mask_img, dtype='f',
     if smoothing_fwhm is not None:
         ensure_finite = True
 
-    imgs_img = _utils.check_niimgs(imgs)
+    imgs_img = _utils.check_niimg_4d(imgs)
     affine = imgs_img.get_affine()[:3, :3]
 
     if not np.allclose(mask_affine, imgs_img.get_affine()):
@@ -711,7 +711,7 @@ def unmask(X, mask_img, order="F"):
             ret.append(unmask(x, mask_img, order=order))  # 1-level recursion
         return ret
 
-    mask_img = _utils.check_niimg(mask_img, ensure_3d=False)
+    mask_img = _utils.check_niimg_3d(mask_img)
     mask, affine = _load_mask_img(mask_img)
 
     if X.ndim == 2:

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -40,8 +40,7 @@ def _load_mask_img(mask_img, allow_empty=False):
     mask: numpy.ndarray
         boolean version of the mask
     '''
-    # 3D image for mask_img not enforced here on purpose
-    mask_img = _utils.check_niimg(mask_img, ensure_3d=False)
+    mask_img = _utils.check_niimg(mask_img)
     mask = mask_img.get_data()
     values = np.unique(mask)
 
@@ -255,7 +254,7 @@ def compute_epi_mask(epi_img, lower_cutoff=0.2, upper_cutoff=0.85,
     if verbose > 0:
         print("EPI mask computation")
 
-    epi_img = _utils.check_niimgs(epi_img, accept_3d=True)
+    epi_img = _utils.check_niimgs(epi_img)
 
     # Delayed import to avoid circular imports
     from .image.image import _compute_mean
@@ -422,7 +421,7 @@ def compute_background_mask(data_imgs, border_size=2,
     if verbose > 0:
         print("Background mask computation")
 
-    data_imgs = _utils.check_niimgs(data_imgs, accept_3d=True)
+    data_imgs = _utils.check_niimgs(data_imgs)
 
     # Delayed import to avoid circular imports
     from .image.image import _compute_mean
@@ -580,7 +579,7 @@ def _apply_mask_fmri(imgs, mask_img, dtype='f',
     values (this is checked for in apply_mask, not in this function).
     """
 
-    mask_img = _utils.check_niimg(mask_img, ensure_3d=True)
+    mask_img = _utils.check_niimg(mask_img)
     mask_affine = mask_img.get_affine()
     mask_data = _utils.as_ndarray(mask_img.get_data(),
                                   dtype=np.bool)

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -354,7 +354,7 @@ class BaseSlicer(object):
                          **kwargs):
         # deal with "fake" 4D images
         if img is not None and img is not False:
-            img = _utils.check_niimg(img)
+            img = _utils.check_niimg_3d(img)
 
         cut_coords = cls.find_cut_coords(img, threshold, cut_coords)
 
@@ -466,7 +466,7 @@ class BaseSlicer(object):
         else:
             self._colorbar = colorbar
 
-        img = _utils.check_niimg(img)
+        img = _utils.check_niimg_3d(img)
 
         if threshold is not None:
             data = img.get_data()

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -354,7 +354,7 @@ class BaseSlicer(object):
                          **kwargs):
         # deal with "fake" 4D images
         if img is not None and img is not False:
-            img = _utils.check_niimg(img, ensure_3d=True)
+            img = _utils.check_niimg(img)
 
         cut_coords = cls.find_cut_coords(img, threshold, cut_coords)
 
@@ -466,7 +466,7 @@ class BaseSlicer(object):
         else:
             self._colorbar = colorbar
 
-        img = _utils.check_niimg(img, ensure_3d=True)
+        img = _utils.check_niimg(img)
 
         if threshold is not None:
             data = img.get_data()

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -63,7 +63,7 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
             takes a display_mode argument and return a display class
     """
     if img is not False and img is not None:
-        img = _utils.check_niimg(img)
+        img = _utils.check_niimg_3d(img)
         data = img.get_data()
         affine = img.get_affine()
 
@@ -87,7 +87,7 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
         colorbar=colorbar)
 
     if bg_img is not None:
-        bg_img = _utils.check_niimg(bg_img)
+        bg_img = _utils.check_niimg_3d(bg_img)
         display.add_overlay(bg_img,
                            vmin=bg_vmin, vmax=bg_vmax,
                            cmap=pl.cm.gray, interpolation=interpolation)
@@ -264,7 +264,7 @@ def _load_anat(anat_img=MNI152TEMPLATE, dim=False, black_bg='auto'):
             if black_bg == 'auto':
                 black_bg = False
         else:
-            anat_img = _utils.check_niimg(anat_img)
+            anat_img = _utils.check_niimg_3d(anat_img)
             if dim or black_bg == 'auto':
                 # We need to inspect the values of the image
                 data = anat_img.get_data()
@@ -611,7 +611,7 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
 
     # make sure that the color range is symmetrical
     if ('vmax' not in kwargs) or (symmetric_cbar in ['auto', False]):
-        stat_map_img = _utils.check_niimg(stat_map_img)
+        stat_map_img = _utils.check_niimg_3d(stat_map_img)
         stat_map_data = stat_map_img.get_data()
         # Avoid dealing with masked_array:
         if hasattr(stat_map_data, '_mask'):

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -63,7 +63,7 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
             takes a display_mode argument and return a display class
     """
     if img is not False and img is not None:
-        img = _utils.check_niimg(img, ensure_3d=True)
+        img = _utils.check_niimg(img)
         data = img.get_data()
         affine = img.get_affine()
 
@@ -87,7 +87,7 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
         colorbar=colorbar)
 
     if bg_img is not None:
-        bg_img = _utils.check_niimg(bg_img, ensure_3d=True)
+        bg_img = _utils.check_niimg(bg_img)
         display.add_overlay(bg_img,
                            vmin=bg_vmin, vmax=bg_vmax,
                            cmap=pl.cm.gray, interpolation=interpolation)
@@ -264,7 +264,7 @@ def _load_anat(anat_img=MNI152TEMPLATE, dim=False, black_bg='auto'):
             if black_bg == 'auto':
                 black_bg = False
         else:
-            anat_img = _utils.check_niimg(anat_img, ensure_3d=True)
+            anat_img = _utils.check_niimg(anat_img)
             if dim or black_bg == 'auto':
                 # We need to inspect the values of the image
                 data = anat_img.get_data()
@@ -611,7 +611,7 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
 
     # make sure that the color range is symmetrical
     if ('vmax' not in kwargs) or (symmetric_cbar in ['auto', False]):
-        stat_map_img = _utils.check_niimg(stat_map_img, ensure_3d=True)
+        stat_map_img = _utils.check_niimg(stat_map_img)
         stat_map_data = stat_map_img.get_data()
         # Avoid dealing with masked_array:
         if hasattr(stat_map_data, '_mask'):

--- a/nilearn/region.py
+++ b/nilearn/region.py
@@ -65,7 +65,7 @@ def img_to_signals_labels(imgs, labels_img, mask_img=None,
     nilearn.region.img_to_signals_maps
     """
 
-    labels_img = _utils.check_niimg(labels_img, ensure_3d=True)
+    labels_img = _utils.check_niimg(labels_img)
 
     # TODO: Make a special case for list of strings (load one image at a
     # time).
@@ -80,7 +80,7 @@ def img_to_signals_labels(imgs, labels_img, mask_img=None,
         raise ValueError("labels_img and imgs affines must be identical")
 
     if mask_img is not None:
-        mask_img = _utils.check_niimg(mask_img, ensure_3d=True)
+        mask_img = _utils.check_niimg(mask_img)
         if mask_img.shape != target_shape:
             raise ValueError("mask_img and imgs shapes must be identical.")
         if abs(mask_img.get_affine() - target_affine).max() > 1e-9:
@@ -151,14 +151,14 @@ def signals_to_img_labels(signals, labels_img, mask_img=None,
     nilearn.region.signals_to_img_maps
     """
 
-    labels_img = _utils.check_niimg(labels_img, ensure_3d=True)
+    labels_img = _utils.check_niimg(labels_img)
 
     signals = np.asarray(signals)
     target_affine = labels_img.get_affine()
     target_shape = labels_img.shape[:3]
 
     if mask_img is not None:
-        mask_img = _utils.check_niimg(mask_img, ensure_3d=True)
+        mask_img = _utils.check_niimg(mask_img)
         if mask_img.shape != target_shape:
             raise ValueError("mask_img and labels_img shapes "
                              "must be identical.")
@@ -236,7 +236,7 @@ def img_to_signals_maps(imgs, maps_img, mask_img=None):
     nilearn.region.signals_to_img_maps
     """
 
-    maps_img = _utils.check_niimg(maps_img)
+    maps_img = _utils.check_niimgs(maps_img)
     imgs = _utils.check_niimgs(imgs)
     affine = imgs.get_affine()
     shape = imgs.shape[:3]
@@ -250,7 +250,7 @@ def img_to_signals_maps(imgs, maps_img, mask_img=None):
     maps_data = maps_img.get_data()
 
     if mask_img is not None:
-        mask_img = _utils.check_niimg(mask_img, ensure_3d=True)
+        mask_img = _utils.check_niimg(mask_img)
         if mask_img.shape != shape:
             raise ValueError("mask_img and imgs shapes must be identical.")
         if abs(mask_img.get_affine() - affine).max() > 1e-9:

--- a/nilearn/region.py
+++ b/nilearn/region.py
@@ -65,11 +65,11 @@ def img_to_signals_labels(imgs, labels_img, mask_img=None,
     nilearn.region.img_to_signals_maps
     """
 
-    labels_img = _utils.check_niimg(labels_img)
+    labels_img = _utils.check_niimg_3d(labels_img)
 
     # TODO: Make a special case for list of strings (load one image at a
     # time).
-    imgs = _utils.check_niimgs(imgs)
+    imgs = _utils.check_niimg_4d(imgs)
     target_affine = imgs.get_affine()
     target_shape = imgs.shape[:3]
 
@@ -80,7 +80,7 @@ def img_to_signals_labels(imgs, labels_img, mask_img=None,
         raise ValueError("labels_img and imgs affines must be identical")
 
     if mask_img is not None:
-        mask_img = _utils.check_niimg(mask_img)
+        mask_img = _utils.check_niimg_3d(mask_img)
         if mask_img.shape != target_shape:
             raise ValueError("mask_img and imgs shapes must be identical.")
         if abs(mask_img.get_affine() - target_affine).max() > 1e-9:
@@ -151,14 +151,14 @@ def signals_to_img_labels(signals, labels_img, mask_img=None,
     nilearn.region.signals_to_img_maps
     """
 
-    labels_img = _utils.check_niimg(labels_img)
+    labels_img = _utils.check_niimg_3d(labels_img)
 
     signals = np.asarray(signals)
     target_affine = labels_img.get_affine()
     target_shape = labels_img.shape[:3]
 
     if mask_img is not None:
-        mask_img = _utils.check_niimg(mask_img)
+        mask_img = _utils.check_niimg_3d(mask_img)
         if mask_img.shape != target_shape:
             raise ValueError("mask_img and labels_img shapes "
                              "must be identical.")
@@ -236,8 +236,8 @@ def img_to_signals_maps(imgs, maps_img, mask_img=None):
     nilearn.region.signals_to_img_maps
     """
 
-    maps_img = _utils.check_niimgs(maps_img)
-    imgs = _utils.check_niimgs(imgs)
+    maps_img = _utils.check_niimg_4d(maps_img)
+    imgs = _utils.check_niimg_4d(imgs)
     affine = imgs.get_affine()
     shape = imgs.shape[:3]
 
@@ -250,7 +250,7 @@ def img_to_signals_maps(imgs, maps_img, mask_img=None):
     maps_data = maps_img.get_data()
 
     if mask_img is not None:
-        mask_img = _utils.check_niimg(mask_img)
+        mask_img = _utils.check_niimg_3d(mask_img)
         if mask_img.shape != shape:
             raise ValueError("mask_img and imgs shapes must be identical.")
         if abs(mask_img.get_affine() - affine).max() > 1e-9:
@@ -301,13 +301,13 @@ def signals_to_img_maps(region_signals, maps_img, mask_img=None):
     nilearn.region.img_to_signals_maps
     """
 
-    maps_img = _utils.check_niimg(maps_img)
+    maps_img = _utils.check_niimg_4d(maps_img)
     maps_data = maps_img.get_data()
     shape = maps_img.shape[:3]
     affine = maps_img.get_affine()
 
     if mask_img is not None:
-        mask_img = _utils.check_niimg(mask_img)
+        mask_img = _utils.check_niimg_3d(mask_img)
         if mask_img.shape != shape:
             raise ValueError("mask_img and maps_img shapes must be identical.")
         if abs(mask_img.get_affine() - affine).max() > 1e-9:

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -359,5 +359,5 @@ def test_error_shape(random_state=42, shape=(3, 5, 7, 11)):
     assert_raises(TypeError, unmask, X, mask_img)
 
     X = rng.randn(n_samples, n_features)
-    # 2D X (should be ok)
-    unmask(X, mask_img)
+    # Raises an error because the mask is 4D
+    assert_raises(TypeError, unmask, X, mask_img)

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -200,26 +200,6 @@ def test_unmask():
             assert_true(t[0].flags["F_CONTIGUOUS"])
             assert_array_equal(t[0], unmasked3D)
 
-    # 5D test
-    shape5D = (10, 20, 30, 40, 41)
-    data5D = generator.rand(*shape5D)
-    mask = generator.randint(2, size=shape5D[:-1])
-    mask_img = Nifti1Image(mask, np.eye(4))
-    mask = mask.astype(bool)
-
-    masked5D = data5D[mask, :].T
-    unmasked5D = data5D.copy()
-    unmasked5D[-mask, :] = 0
-
-    t = unmask(masked5D, mask_img).get_data()
-    assert_equal(t.ndim, len(shape5D))
-    assert_array_equal(t, unmasked5D)
-    t = unmask([masked5D], mask_img)
-    t = [t_.get_data() for t_ in t]
-    assert_true(isinstance(t, list))
-    assert_equal(t[0].ndim, len(shape5D))
-    assert_array_equal(t[0], unmasked5D)
-
     # Error test: shape
     vec_1D = np.empty((500,), dtype=np.int)
     assert_raises(TypeError, unmask, vec_1D, mask_img)
@@ -246,7 +226,7 @@ def test_intersect_masks():
     """
 
     # Create dummy masks
-    mask_a = np.zeros((4, 4), dtype=np.bool)
+    mask_a = np.zeros((4, 4, 1), dtype=np.bool)
     mask_a[2:4, 2:4] = 1
     mask_a_img = Nifti1Image(mask_a.astype(int), np.eye(4))
 
@@ -260,7 +240,7 @@ def test_intersect_masks():
     # |   |   | X | X |
     # +---+---+---+---+
 
-    mask_b = np.zeros((4, 4), dtype=np.bool)
+    mask_b = np.zeros((4, 4, 1), dtype=np.bool)
     mask_b[1:3, 1:3] = 1
     mask_b_img = Nifti1Image(mask_b.astype(int), np.eye(4))
 
@@ -274,7 +254,7 @@ def test_intersect_masks():
     # |   |   |   |   |
     # +---+---+---+---+
 
-    mask_c = np.zeros((4, 4), dtype=np.bool)
+    mask_c = np.zeros((4, 4, 1), dtype=np.bool)
     mask_c[:, 2] = 1
     mask_c[0, 0] = 1
     mask_c_img = Nifti1Image(mask_c.astype(int), np.eye(4))
@@ -289,7 +269,7 @@ def test_intersect_masks():
     # |   |   | X |   |
     # +---+---+---+---+
 
-    mask_ab = np.zeros((4, 4), dtype=np.bool)
+    mask_ab = np.zeros((4, 4, 1), dtype=np.bool)
     mask_ab[2, 2] = 1
     mask_ab_ = intersect_masks([mask_a_img, mask_b_img], threshold=1.)
     assert_array_equal(mask_ab, mask_ab_.get_data())

--- a/nilearn/tests/test_niimg_conversions.py
+++ b/nilearn/tests/test_niimg_conversions.py
@@ -40,7 +40,7 @@ class PhonyNiimage(nibabel.spatialimages.SpatialImage):
         return self.data.shape
 
 
-def test_check_niimg():
+def test_check_niimg_3d():
     # check error for non-forced but necessary resampling
     assert_raises_regex(TypeError, 'nibabel format',
                         _utils.check_niimg, 0)
@@ -50,51 +50,51 @@ def test_check_niimg():
                         _utils.check_niimg, [])
 
     # Check that a filename does not raise an error
-    data = np.zeros((40, 40, 40, 2))
+    data = np.zeros((40, 40, 40, 1))
     data[20, 20, 20] = 1
     data_img = Nifti1Image(data, np.eye(4))
 
     with testing.write_tmp_imgs(data_img, create_files=True) as filename:
-        _utils.check_niimg(filename)
+        _utils.check_niimg_3d(filename)
 
 
-def test_check_niimgs():
+def test_check_niimg_4d():
     assert_raises_regex(TypeError, 'nibabel format',
-                        _utils.check_niimgs, 0)
+                        _utils.check_niimg_4d, 0)
 
     assert_raises_regex(TypeError, 'empty object',
-                        _utils.check_niimgs, [])
+                        _utils.check_niimg_4d, [])
 
     affine = np.eye(4)
     img_3d = Nifti1Image(np.ones((10, 10, 10)), affine)
 
     # Tests with return_iterator=False
-    img_4d_1 = _utils.check_niimgs([img_3d, img_3d])
+    img_4d_1 = _utils.check_niimg_4d([img_3d, img_3d])
     assert_true(img_4d_1.get_data().shape == (10, 10, 10, 2))
     assert_array_equal(img_4d_1.get_affine(), affine)
 
-    img_4d_2 = _utils.check_niimgs(img_4d_1)
+    img_4d_2 = _utils.check_niimg_4d(img_4d_1)
     assert_array_equal(img_4d_2.get_data(), img_4d_2.get_data())
     assert_array_equal(img_4d_2.get_affine(), img_4d_2.get_affine())
 
     # Tests with return_iterator=True
-    img_3d_iterator = _utils.check_niimgs([img_3d, img_3d],
+    img_3d_iterator = _utils.check_niimg_4d([img_3d, img_3d],
                                           return_iterator=True)
     img_3d_iterator_length = sum(1 for _ in img_3d_iterator)
     assert_true(img_3d_iterator_length == 2)
 
-    img_3d_iterator_1 = _utils.check_niimgs([img_3d, img_3d],
+    img_3d_iterator_1 = _utils.check_niimg_4d([img_3d, img_3d],
                                             return_iterator=True)
-    img_3d_iterator_2 = _utils.check_niimgs(img_3d_iterator_1,
+    img_3d_iterator_2 = _utils.check_niimg_4d(img_3d_iterator_1,
                                             return_iterator=True)
     for img_1, img_2 in zip(img_3d_iterator_1, img_3d_iterator_2):
         assert_true(img_1.get_data().shape == (10, 10, 10))
         assert_array_equal(img_1.get_data(), img_2.get_data())
         assert_array_equal(img_1.get_affine(), img_2.get_affine())
 
-    img_3d_iterator_1 = _utils.check_niimgs([img_3d, img_3d],
+    img_3d_iterator_1 = _utils.check_niimg_4d([img_3d, img_3d],
                                             return_iterator=True)
-    img_3d_iterator_2 = _utils.check_niimgs(img_4d_1,
+    img_3d_iterator_2 = _utils.check_niimg_4d(img_4d_1,
                                             return_iterator=True)
     for img_1, img_2 in zip(img_3d_iterator_1, img_3d_iterator_2):
         assert_true(img_1.get_data().shape == (10, 10, 10))
@@ -103,13 +103,11 @@ def test_check_niimgs():
 
     # This should raise an error: a 3D img is given and we want a 4D
     assert_raises_regex(TypeError, 'image',
-                        _utils.check_niimgs, img_3d)
-    # This shouldn't raise an error
-    _utils.check_niimgs(img_3d)
+                        _utils.check_niimg_4d, img_3d)
 
     # Test a Niimg-like object that does not hold a shape attribute
     phony_img = PhonyNiimage()
-    _utils.check_niimgs(phony_img)
+    _utils.check_niimg_4d(phony_img)
 
 
 def test_repr_niimgs():

--- a/nilearn/tests/test_niimg_conversions.py
+++ b/nilearn/tests/test_niimg_conversions.py
@@ -49,11 +49,6 @@ def test_check_niimg():
     assert_raises_regex(TypeError, 'empty object',
                         _utils.check_niimg, [])
 
-    # Test ensure_3d
-    # check error for non-forced but necessary resampling
-    assert_raises_regex(TypeError, '3D',
-                        _utils.check_niimg, ['test.nii', ], ensure_3d=True)
-
     # Check that a filename does not raise an error
     data = np.zeros((40, 40, 40, 2))
     data[20, 20, 20] = 1
@@ -61,19 +56,6 @@ def test_check_niimg():
 
     with testing.write_tmp_imgs(data_img, create_files=True) as filename:
         _utils.check_niimg(filename)
-
-    # Test ensure_3d with a in-memory object
-    assert_raises_regex(TypeError, '3D',
-                        _utils.check_niimg, data, ensure_3d=True)
-
-    # Test ensure_3d with a non 3D image
-    assert_raises_regex(TypeError, '3D',
-                        _utils.check_niimg, data_img, ensure_3d=True)
-
-    # Test ensure_3d with a 4D image with a length 1 4th dim
-    data = np.zeros((40, 40, 40, 1))
-    data_img = Nifti1Image(data, np.eye(4))
-    _utils.check_niimg(data_img, ensure_3d=True)
 
 
 def test_check_niimgs():
@@ -123,7 +105,7 @@ def test_check_niimgs():
     assert_raises_regex(TypeError, 'image',
                         _utils.check_niimgs, img_3d)
     # This shouldn't raise an error
-    _utils.check_niimgs(img_3d, accept_3d=True)
+    _utils.check_niimgs(img_3d)
 
     # Test a Niimg-like object that does not hold a shape attribute
     phony_img = PhonyNiimage()
@@ -168,7 +150,7 @@ def test_concat_niimgs():
     img1b = Nifti1Image(np.ones(shape2), affine)
 
     shape3 = (11, 22, 33)
-    img1c = Nifti1Image(np.ones(shape2), affine)
+    img1c = Nifti1Image(np.ones(shape3), affine)
 
     # check basic concatenation with equal shape/affine
     concatenated = _utils.concat_niimgs((img1, img3, img1),

--- a/nilearn/tests/test_niimg_conversions.py
+++ b/nilearn/tests/test_niimg_conversions.py
@@ -109,6 +109,19 @@ def test_check_niimg_4d():
     phony_img = PhonyNiimage()
     _utils.check_niimg_4d(phony_img)
 
+    a = nibabel.Nifti1Image(np.zeros((10, 10, 10)), np.eye(4))
+    b = np.zeros((10, 10, 10))
+    c = _utils.check_niimg_4d([a, b], return_iterator=True)
+    assert_raises_regex(TypeError, 'Error encountered while loading image #1',
+                        list, c)
+
+    b = nibabel.Nifti1Image(np.zeros((10, 20, 10)), np.eye(4))
+    c = _utils.check_niimg_4d([a, b], return_iterator=True)
+    assert_raises_regex(
+        ValueError,
+        'Field of view of image #1 is different from reference FOV',
+        list, c)
+
 
 def test_repr_niimgs():
     # Test with file path

--- a/nilearn/tests/test_region.py
+++ b/nilearn/tests/test_region.py
@@ -215,7 +215,7 @@ def test_signal_extraction_with_maps():
     maps_data = maps_img.get_data()
     data = np.zeros(shape + (n_instants,), dtype=np.float32)
 
-    mask_4d_img = np.ones((shape + (2, )))
+    mask_4d_img = nibabel.Nifti1Image(np.ones((shape + (2, ))), np.eye(4))
 
     signals = np.zeros((n_instants, maps_data.shape[-1]))
     for n in range(maps_data.shape[-1]):


### PR DESCRIPTION
This PR restore the original behavior of check_niimg and check_niimgs:
* check_niimg loads 3D niimages
* check_niimgs loads 4D niimages

This is a first step toward cleaner file loading in nilearn.