### PR TITLE
Replace pylab import by pyplot

### DIFF
--- a/examples/connectivity/plot_ica_resting_state.py
+++ b/examples/connectivity/plot_ica_resting_state.py
@@ -47,7 +47,7 @@ component_img = masker.inverse_transform(components_masked)
 
 ### Visualize the results #####################################################
 # Show some interesting components
-import pylab as plt
+import matplotlib.pyplot as plt
 from nilearn import image
 from nilearn.plotting import plot_stat_map
 

--- a/examples/plot_haxby_simple.py
+++ b/examples/plot_haxby_simple.py
@@ -80,7 +80,7 @@ coef_img = nifti_masker.inverse_transform(coef_)
 coef_img.to_filename('haxby_svc_weights.nii')
 
 ### Visualization #############################################################
-import pylab as plt
+import matplotlib.pyplot as plt
 from nilearn.image.image import mean_img
 from nilearn.plotting import plot_roi, plot_stat_map
 
@@ -90,4 +90,3 @@ plot_stat_map(coef_img, mean_epi, title="SVM weights", display_mode="yx")
 plot_roi(nifti_masker.mask_img_, mean_epi, title="Mask", display_mode="yx")
 
 plt.show()
-

--- a/examples/plot_python_101.py
+++ b/examples/plot_python_101.py
@@ -10,6 +10,6 @@ plot it.
 import numpy as np
 t = np.linspace(1, 10, 2000)
 
-# import pylab: the module for scientific plotting
+# import pyplot: the module for scientific plotting
 import matplotlib.pyplot as plt
 plt.plot(t, np.cos(t))

--- a/examples/plot_python_101.py
+++ b/examples/plot_python_101.py
@@ -10,6 +10,6 @@ plot it.
 import numpy as np
 t = np.linspace(1, 10, 2000)
 
-# import pyplot: the module for scientific plotting
+# import matplotlib.pyplot: the module for scientific plotting
 import matplotlib.pyplot as plt
 plt.plot(t, np.cos(t))

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -17,13 +17,14 @@ from .._utils.compat import _basestring
 from .. import _utils
 
 try:
-    import pylab as pl
+    import matplotlib.pyplot as plt
     from matplotlib import transforms, colors
     from matplotlib.colorbar import ColorbarBase
     from matplotlib import cm as mpl_cm
     from matplotlib import lines
 except ImportError:
     skip_if_running_nose('Could not import matplotlib')
+    raise
 
 
 # Local imports
@@ -273,7 +274,7 @@ class GlassBrainAxes(BaseAxes):
                                 vmax=abs_line_values_max)
         abs_norm = colors.Normalize(vmin=0,
                                     vmax=abs_line_values_max)
-        value_to_color = pl.cm.ScalarMappable(norm=norm, cmap=cmap).to_rgba
+        value_to_color = plt.cm.ScalarMappable(norm=norm, cmap=cmap).to_rgba
 
         for start_end_point_3d, line_value in zip(
                 line_coords, line_values):
@@ -326,7 +327,7 @@ class BaseSlicer(object):
         """
         self.cut_coords = cut_coords
         if axes is None:
-            axes = pl.axes((0., 0., 1., 1.))
+            axes = plt.axes((0., 0., 1., 1.))
             axes.axis('off')
         self.frame_axes = axes
         axes.set_zorder(1)
@@ -358,10 +359,10 @@ class BaseSlicer(object):
 
         cut_coords = cls.find_cut_coords(img, threshold, cut_coords)
 
-        if isinstance(axes, pl.Axes) and figure is None:
+        if isinstance(axes, plt.Axes) and figure is None:
             figure = axes.figure
 
-        if not isinstance(figure, pl.Figure):
+        if not isinstance(figure, plt.Figure):
             # Make sure that we have a figure
             figsize = cls._default_figsize[:]
             
@@ -376,9 +377,9 @@ class BaseSlicer(object):
 
             if leave_space:
                 figsize[0] += 3.4
-            figure = pl.figure(figure, figsize=figsize,
+            figure = plt.figure(figure, figsize=figsize,
                             facecolor=facecolor)
-        if isinstance(axes, pl.Axes):
+        if isinstance(axes, plt.Axes):
             assert axes.figure is figure, ("The axes passed are not "
                     "in the figure")
 
@@ -485,7 +486,7 @@ class BaseSlicer(object):
         if colorbar:
             self._colorbar_show(ims[0], threshold)
 
-        pl.draw_if_interactive()
+        plt.draw_if_interactive()
 
     def add_contours(self, img, **kwargs):
         """ Contour a 3D map in all the views.
@@ -504,7 +505,7 @@ class BaseSlicer(object):
                 these contours.
         """
         self._map_show(img, type='contour', **kwargs)
-        pl.draw_if_interactive()
+        plt.draw_if_interactive()
 
     def _map_show(self, img, type='imshow', resampling_interpolation='continuous', **kwargs):
         img = reorder_img(img, resample=resampling_interpolation)
@@ -635,7 +636,7 @@ class BaseSlicer(object):
             display_ax.draw_2d(edge_mask, data_bounds, data_bounds,
                                type='imshow', cmap=single_color_cmap)
 
-        pl.draw_if_interactive()
+        plt.draw_if_interactive()
 
     def annotate(self, left_right=True, positions=True, size=12, **kwargs):
         """ Add annotations to the plot.
@@ -675,7 +676,7 @@ class BaseSlicer(object):
     def close(self):
         """ Close the figure. This is necessary to avoid leaking memory.
         """
-        pl.close(self.frame_axes.figure.number)
+        plt.close(self.frame_axes.figure.number)
 
     def savefig(self, filename, dpi=None):
         """ Save the figure to a file
@@ -1168,7 +1169,7 @@ class OrthoProjector(OrthoSlicer):
             ax._add_lines(line_coords, adjacency_matrix_values, edge_cmap,
                           **edge_kwargs)
 
-        pl.draw_if_interactive()
+        plt.draw_if_interactive()
 
 
 class XProjector(OrthoProjector):

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -23,9 +23,10 @@ from .._utils.testing import skip_if_running_nose
 from .._utils.numpy_conversions import as_ndarray
 
 try:
-    import pylab as pl
+    import matplotlib.pyplot as plt
 except ImportError:
     skip_if_running_nose('Could not import matplotlib')
+    raise
 
 from .. import _utils
 from .._utils import new_img_like
@@ -105,7 +106,7 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
         bg_img = _utils.check_niimg_3d(bg_img)
         display.add_overlay(bg_img,
                            vmin=bg_vmin, vmax=bg_vmax,
-                           cmap=pl.cm.gray, interpolation=interpolation)
+                           cmap=plt.cm.gray, interpolation=interpolation)
 
     if img is not None and img is not False:
         display.add_overlay(new_img_like(img, data, affine),
@@ -326,7 +327,7 @@ def _load_anat(anat_img=MNI152TEMPLATE, dim=False, black_bg='auto'):
 def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
               output_file=None, display_mode='ortho', figure=None,
               axes=None, title=None, annotate=True, draw_cross=True,
-              black_bg='auto', dim=False, cmap=pl.cm.gray, **kwargs):
+              black_bg='auto', dim=False, cmap=plt.cm.gray, **kwargs):
     """ Plot cuts of an anatomical image (by default 3 cuts:
         Frontal, Axial, and Lateral)
 
@@ -403,7 +404,7 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
 def plot_epi(epi_img=None, cut_coords=None, output_file=None,
              display_mode='ortho', figure=None, axes=None, title=None,
              annotate=True, draw_cross=True, black_bg=True,
-             cmap=pl.cm.spectral, **kwargs):
+             cmap=plt.cm.spectral, **kwargs):
     """ Plot cuts of an EPI image (by default 3 cuts:
         Frontal, Axial, and Lateral)
 
@@ -473,7 +474,7 @@ def plot_epi(epi_img=None, cut_coords=None, output_file=None,
 def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
              output_file=None, display_mode='ortho', figure=None, axes=None,
              title=None, annotate=True, draw_cross=True, black_bg='auto',
-             alpha=0.7, cmap=pl.cm.gist_ncar, dim=True, **kwargs):
+             alpha=0.7, cmap=plt.cm.gist_ncar, dim=True, **kwargs):
     """ Plot cuts of an ROI/mask image (by default 3 cuts: Frontal, Axial, and
         Lateral)
 
@@ -744,7 +745,7 @@ def plot_glass_brain(stat_map_img,
 
     """
     if cmap is None:
-        cmap = pl.cm.hot if black_bg else pl.cm.hot_r
+        cmap = plt.cm.hot if black_bg else plt.cm.hot_r
 
     def display_factory(display_mode):
         return functools.partial(get_projector(display_mode), alpha=alpha)

--- a/nilearn/plotting/tests/test_cm.py
+++ b/nilearn/plotting/tests/test_cm.py
@@ -8,8 +8,8 @@ try:
     import matplotlib as mp
     # Make really sure that we don't try to open an Xserver connection.
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
 except ImportError:
     raise SkipTest('Could not import matplotlib')
 
@@ -19,20 +19,18 @@ from nilearn.plotting.cm import dim_cmap, replace_inside
 def test_dim_cmap():
     # This is only a smoke test
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
-    dim_cmap(pl.cm.jet)
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
+    dim_cmap(plt.cm.jet)
 
 
 def test_replace_inside():
     # This is only a smoke test
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
-    replace_inside(pl.cm.jet, pl.cm.hsv, .2, .8)
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
+    replace_inside(plt.cm.jet, plt.cm.hsv, .2, .8)
     # We also test with gnuplot, which is defined using function
-    if hasattr(pl.cm, 'gnuplot'):
+    if hasattr(plt.cm, 'gnuplot'):
         # gnuplot is only in recent version of MPL
-        replace_inside(pl.cm.gnuplot, pl.cm.gnuplot2, .2, .8)
-
-
+        replace_inside(plt.cm.gnuplot, plt.cm.gnuplot2, .2, .8)

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -7,8 +7,8 @@ try:
     import matplotlib as mp
     # Make really sure that we don't try to open an Xserver connection.
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
 except ImportError:
     raise nose.SkipTest('Could not import matplotlib')
 
@@ -22,24 +22,24 @@ from nilearn.datasets import load_mni152_template
 def test_demo_ortho_slicer():
     # This is only a smoke test
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
-    pl.clf()
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
+    plt.clf()
     oslicer = OrthoSlicer(cut_coords=(0, 0, 0))
     img = load_mni152_template()
-    oslicer.add_overlay(img, cmap=pl.cm.gray)
+    oslicer.add_overlay(img, cmap=plt.cm.gray)
     oslicer.close()
 
 
 def test_stacked_slicer():
     # Test stacked slicers, like the XSlicer
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
-    pl.clf()
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
+    plt.clf()
     img = load_mni152_template()
     slicer = XSlicer.init_with_figure(img=img, cut_coords=3)
-    slicer.add_overlay(img, cmap=pl.cm.gray)
+    slicer.add_overlay(img, cmap=plt.cm.gray)
     # Forcing a layout here, to test the locator code
     with tempfile.TemporaryFile() as fp:
         slicer.savefig(fp)
@@ -49,12 +49,12 @@ def test_stacked_slicer():
 def test_demo_ortho_projector():
     # This is only a smoke test
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
-    pl.clf()
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
+    plt.clf()
     img = load_mni152_template()
     oprojector = OrthoProjector.init_with_figure(img=img)
-    oprojector.add_overlay(img, cmap=pl.cm.gray)
+    oprojector.add_overlay(img, cmap=plt.cm.gray)
     with tempfile.TemporaryFile() as fp:
         oprojector.savefig(fp)
     oprojector.close()

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -15,8 +15,8 @@ try:
     import matplotlib as mp
     # Make really sure that we don't try to open an Xserver connection.
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
 except ImportError:
     raise SkipTest('Could not import matplotlib')
 
@@ -61,8 +61,8 @@ def demo_plot_roi(**kwargs):
 def test_demo_plot_roi():
     # This is only a smoke test
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
     demo_plot_roi()
     # Test the black background code path
     demo_plot_roi(black_bg=True)
@@ -74,8 +74,8 @@ def test_demo_plot_roi():
 
 def test_plot_anat():
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
     img = _generate_img()
 
     # Test saving with empty plot
@@ -93,8 +93,8 @@ def test_plot_anat():
 
 def test_plot_functions():
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
     img = _generate_img()
 
     # smoke-test for each plotting function with default arguments
@@ -104,19 +104,19 @@ def test_plot_functions():
             plot_func(img, output_file=fp.name)
 
     # test for bad input arguments (cf. #510)
-    ax = pl.subplot(111, rasterized=True)
+    ax = plt.subplot(111, rasterized=True)
     with tempfile.TemporaryFile(suffix='.png') as fp:
         plot_stat_map(
             img, symmetric_cbar=True,
             output_file=fp.name,
             axes=ax, vmax=np.nan)
-    pl.close()
+    plt.close()
 
 
 def test_plot_glass_brain():
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
     img = _generate_img()
 
     # test plot_glass_brain with colorbar
@@ -125,8 +125,8 @@ def test_plot_glass_brain():
 
 def test_plot_stat_map():
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
     img = _generate_img()
 
     plot_stat_map(img, cut_coords=(80, -120, -60))
@@ -140,13 +140,13 @@ def test_plot_stat_map():
 
     # 'yx' display_mode
     plot_stat_map(img, display_mode='yx')
-    
+
     # regression test #510
     data = np.zeros((91, 109, 91))
     aff = np.eye(4)
     new_img = nibabel.Nifti1Image(data, aff)
     plot_stat_map(new_img, threshold=1000, colorbar=True)
-    
+
     rng = np.random.RandomState(42)
     data = rng.randn(91, 109, 91)
     new_img = nibabel.Nifti1Image(data, aff)
@@ -155,8 +155,8 @@ def test_plot_stat_map():
 
 def test_save_plot():
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
     img = _generate_img()
 
     kwargs_list = [{}, {'display_mode': 'x', 'cut_coords': 3}]
@@ -173,8 +173,8 @@ def test_save_plot():
 
 def test_display_methods():
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
     img = _generate_img()
 
     display = plot_img(img)
@@ -186,21 +186,21 @@ def test_display_methods():
 
 def test_plot_with_axes_or_figure():
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
     img = _generate_img()
-    figure = pl.figure()
+    figure = plt.figure()
     plot_img(img, figure=figure)
 
-    ax = pl.subplot(111)
+    ax = plt.subplot(111)
     plot_img(img, axes=ax)
 
 
 def test_plot_stat_map_colorbar_variations():
     # This is only a smoke test
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
 
     img_positive = _generate_img()
     data_positive = img_positive.get_data()
@@ -218,7 +218,7 @@ def test_plot_stat_map_colorbar_variations():
                      partial(plot_stat_map, symmetric_cbar=True, vmax=10),
                      partial(plot_stat_map, colorbar=False)]:
             func(img, cut_coords=(80, -120, -60))
-            pl.close()
+            plt.close()
 
 
 def test_plot_empty_slice():
@@ -226,8 +226,8 @@ def test_plot_empty_slice():
     # threshold
     # This is only a smoke test
     mp.use('template', warn=False)
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
     data = np.zeros((20, 20, 20))
     img = nibabel.Nifti1Image(data, mni_affine)
     plot_img(img, display_mode='y', threshold=1)
@@ -240,8 +240,8 @@ def test_plot_img_invalid():
 
 
 def test_plot_img_with_auto_cut_coords():
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
     data = np.zeros((20, 20, 20))
     data[3:-3, 3:-3, 3:-3] = 1
     img = nibabel.Nifti1Image(data, np.eye(4))
@@ -252,8 +252,8 @@ def test_plot_img_with_auto_cut_coords():
 
 
 def test_plot_img_with_resampling():
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
     data = _generate_img().get_data()
     affine = np.array([[1., -1.,  0.,  0.],
                        [1.,  1.,  0.,  0.],
@@ -268,11 +268,11 @@ def test_plot_noncurrent_axes():
     """Regression test for Issue #450"""
 
     maps_img = nibabel.Nifti1Image(np.random.random((10, 10, 10)), np.eye(4))
-    fh1 = pl.figure()
-    fh2 = pl.figure()
+    fh1 = plt.figure()
+    fh2 = plt.figure()
     ax1 = fh1.add_subplot(1, 1, 1)
 
-    assert_equal(pl.gcf(), fh2, "fh2  was the last plot created.")
+    assert_equal(plt.gcf(), fh2, "fh2  was the last plot created.")
 
     # Since we gave ax1, the figure should be plotted in fh1.
     # Before #451, it was plotted in fh2.
@@ -283,8 +283,8 @@ def test_plot_noncurrent_axes():
 
 
 def test_plot_connectome():
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
     node_color = ['green', 'blue', 'k', 'cyan']
     # symmetric up to 1e-3 relative tolerance
     adjacency_matrix = np.array([[1., -2., 0.3, 0.],
@@ -345,8 +345,8 @@ def test_plot_connectome():
 
 
 def test_plot_connectome_exceptions():
-    import pylab as pl
-    pl.switch_backend('template')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('template')
     node_coords = np.arange(2 * 3).reshape((2, 3))
 
     # Used to speed-up tests because the glass brain is always plotted


### PR DESCRIPTION
Replace pylab by pyplot. Also, I reraise the import exception because, in the case of people that doesn't have matplotlib installed, we want to raise a meaningful error and not crash in the middle of a script.