### PR TITLE
Add explicit explications/prints for bunches in the nilearn examples

### DIFF
--- a/examples/connectivity/plot_canica_resting_state.py
+++ b/examples/connectivity/plot_canica_resting_state.py
@@ -26,6 +26,9 @@ from nilearn import datasets
 adhd_dataset = datasets.fetch_adhd()
 func_filenames = adhd_dataset.func  # list of 4D nifti files for each subject
 
+# print basic information on the dataset
+print('Functional nifti images are at: %s' % adhd_dataset.func[0])  # 4D data
+
 ### Apply CanICA ##############################################################
 from nilearn.decomposition.canica import CanICA
 

--- a/examples/connectivity/plot_canica_resting_state.py
+++ b/examples/connectivity/plot_canica_resting_state.py
@@ -27,7 +27,8 @@ adhd_dataset = datasets.fetch_adhd()
 func_filenames = adhd_dataset.func  # list of 4D nifti files for each subject
 
 # print basic information on the dataset
-print('Functional nifti images are at: %s' % adhd_dataset.func[0])  # 4D data
+print('First functional nifti image (4D) is at: %s' %
+      adhd_dataset.func[0])  # 4D data
 
 ### Apply CanICA ##############################################################
 from nilearn.decomposition.canica import CanICA

--- a/examples/connectivity/plot_ica_resting_state.py
+++ b/examples/connectivity/plot_ica_resting_state.py
@@ -13,6 +13,10 @@ from nilearn import datasets
 nyu_dataset = datasets.fetch_nyu_rest(n_subjects=1)
 func_filename = nyu_dataset.func[0]
 
+# print basic information on the dataset
+print('Anatomical nifti image is at: %s' % nyu_dataset.anat_anon[0])
+print('Functional nifti images are at: %s' % nyu_dataset.func[0])  # 4D data
+
 ### Preprocess ################################################################
 from nilearn.input_data import NiftiMasker
 

--- a/examples/connectivity/plot_ica_resting_state.py
+++ b/examples/connectivity/plot_ica_resting_state.py
@@ -14,8 +14,10 @@ nyu_dataset = datasets.fetch_nyu_rest(n_subjects=1)
 func_filename = nyu_dataset.func[0]
 
 # print basic information on the dataset
-print('Anatomical nifti image is at: %s' % nyu_dataset.anat_anon[0])
-print('Functional nifti images are at: %s' % nyu_dataset.func[0])  # 4D data
+print('First subject anatomical nifti image (3D) is at: %s' %
+      nyu_dataset.anat_anon[0])
+print('First subject functional nifti image (4D) is at: %s' %
+      nyu_dataset.func[0])  # 4D data
 
 ### Preprocess ################################################################
 from nilearn.input_data import NiftiMasker

--- a/examples/connectivity/plot_inverse_covariance_connectome.py
+++ b/examples/connectivity/plot_inverse_covariance_connectome.py
@@ -40,7 +40,8 @@ masker = NiftiMapsMasker(maps_img=atlas_filename, standardize=True,
 data = datasets.fetch_adhd(n_subjects=1)
 
 # print basic information on the dataset
-print('Functional nifti images are at: %s' % data.func[0])  # 4D data
+print('First subject functional nifti images (4D) are at: %s' %
+      data.func[0])  # 4D data
 
 time_series = masker.fit_transform(data.func[0],
                                    confounds=data.confounds)

--- a/examples/connectivity/plot_inverse_covariance_connectome.py
+++ b/examples/connectivity/plot_inverse_covariance_connectome.py
@@ -39,6 +39,9 @@ masker = NiftiMapsMasker(maps_img=atlas_filename, standardize=True,
 
 data = datasets.fetch_adhd(n_subjects=1)
 
+# print basic information on the dataset
+print('Functional nifti images are at: %s' % data.func[0])  # 4D data
+
 time_series = masker.fit_transform(data.func[0],
                                    confounds=data.confounds)
 

--- a/examples/connectivity/plot_multi_subject_connectome.py
+++ b/examples/connectivity/plot_multi_subject_connectome.py
@@ -47,6 +47,9 @@ from nilearn import datasets
 msdl_atlas_dataset = datasets.fetch_msdl_atlas()
 adhd_dataset = datasets.fetch_adhd(n_subjects=n_subjects)
 
+# print basic information on the dataset
+print('Functional nifti images are at: %s' % adhd_dataset.func[0])  # 4D data
+
 
 # Extracting region signals ###################################################
 from nilearn import image

--- a/examples/connectivity/plot_multi_subject_connectome.py
+++ b/examples/connectivity/plot_multi_subject_connectome.py
@@ -48,7 +48,8 @@ msdl_atlas_dataset = datasets.fetch_msdl_atlas()
 adhd_dataset = datasets.fetch_adhd(n_subjects=n_subjects)
 
 # print basic information on the dataset
-print('Functional nifti images are at: %s' % adhd_dataset.func[0])  # 4D data
+print('First subject functional nifti image (4D) is at: %s' %
+      adhd_dataset.func[0])  # 4D data
 
 
 # Extracting region signals ###################################################

--- a/examples/connectivity/plot_probabilistic_atlas_extraction.py
+++ b/examples/connectivity/plot_probabilistic_atlas_extraction.py
@@ -38,6 +38,9 @@ masker = NiftiMapsMasker(maps_img=atlas_filename, standardize=True,
 
 data = datasets.fetch_adhd(n_subjects=1)
 
+# print basic dataset information
+print('Resting-state nifti images are located at: %s' % data.func[0])
+
 time_series = masker.fit_transform(data.func[0],
                                    confounds=data.confounds)
 

--- a/examples/connectivity/plot_probabilistic_atlas_extraction.py
+++ b/examples/connectivity/plot_probabilistic_atlas_extraction.py
@@ -39,7 +39,8 @@ masker = NiftiMapsMasker(maps_img=atlas_filename, standardize=True,
 data = datasets.fetch_adhd(n_subjects=1)
 
 # print basic dataset information
-print('Resting-state nifti images are located at: %s' % data.func[0])
+print('First subject resting-state nifti image (4D) is located at: %s' %
+      data.func[0])
 
 time_series = masker.fit_transform(data.func[0],
                                    confounds=data.confounds)

--- a/examples/connectivity/plot_rest_clustering.py
+++ b/examples/connectivity/plot_rest_clustering.py
@@ -22,6 +22,10 @@ from nilearn import input_data
 from nilearn.plotting.img_plotting import plot_roi, plot_epi
 nyu_dataset = datasets.fetch_nyu_rest(n_subjects=1)
 
+# print basic information on the dataset
+print('Anatomical nifti image is at: %s' % nyu_dataset.anat_anon[0])
+print('Functional nifti images are at: %s' % nyu_dataset.func[0])  # 4D data
+
 # This is resting-state data: the background has not been removed yet,
 # thus we need to use mask_strategy='epi' to compute the mask from the
 # EPI images

--- a/examples/connectivity/plot_rest_clustering.py
+++ b/examples/connectivity/plot_rest_clustering.py
@@ -23,8 +23,10 @@ from nilearn.plotting.img_plotting import plot_roi, plot_epi
 nyu_dataset = datasets.fetch_nyu_rest(n_subjects=1)
 
 # print basic information on the dataset
-print('Anatomical nifti image is at: %s' % nyu_dataset.anat_anon[0])
-print('Functional nifti images are at: %s' % nyu_dataset.func[0])  # 4D data
+print('First subject anatomical nifti image (3D) is at: %s' %
+      nyu_dataset.anat_anon[0])
+print('First subject functional nifti image (4D) is at: %s' %
+      nyu_dataset.func[0])  # 4D data
 
 # This is resting-state data: the background has not been removed yet,
 # thus we need to use mask_strategy='epi' to compute the mask from the

--- a/examples/connectivity/plot_signal_extraction.py
+++ b/examples/connectivity/plot_signal_extraction.py
@@ -25,6 +25,7 @@ from nilearn import datasets
 
 # Retrieve our atlas
 atlas_filename, labels = datasets.fetch_harvard_oxford('cort-maxprob-thr25-2mm')
+print('Atlas ROIs are located at: %s' % atlas_filename)  # 4D data
 
 # And one subject of resting-state data
 data = datasets.fetch_adhd(n_subjects=1)

--- a/examples/connectivity/plot_signal_extraction.py
+++ b/examples/connectivity/plot_signal_extraction.py
@@ -25,7 +25,8 @@ from nilearn import datasets
 
 # Retrieve our atlas
 atlas_filename, labels = datasets.fetch_harvard_oxford('cort-maxprob-thr25-2mm')
-print('Atlas ROIs are located at: %s' % atlas_filename)  # 4D data
+print('Atlas ROIs are located in nifti image (4D) at: %s' %
+      atlas_filename)  # 4D data
 
 # And one subject of resting-state data
 data = datasets.fetch_adhd(n_subjects=1)

--- a/examples/decoding/plot_haxby_anova_svm.py
+++ b/examples/decoding/plot_haxby_anova_svm.py
@@ -12,6 +12,10 @@ from nilearn import datasets
 import numpy as np
 haxby_dataset = datasets.fetch_haxby_simple()
 
+# print basic information on the dataset
+print('Mask nifti images are located at: ' % haxby_dataset.mask[0])
+print('Functional nifti images are located at: ' % haxby_dataset.func[0])
+
 y, session = np.loadtxt(haxby_dataset.session_target).astype("int").T
 conditions = np.recfromtxt(haxby_dataset.conditions_target)['f0']
 

--- a/examples/decoding/plot_haxby_anova_svm.py
+++ b/examples/decoding/plot_haxby_anova_svm.py
@@ -13,8 +13,9 @@ import numpy as np
 haxby_dataset = datasets.fetch_haxby_simple()
 
 # print basic information on the dataset
-print('Mask nifti images are located at: ' % haxby_dataset.mask[0])
-print('Functional nifti images are located at: ' % haxby_dataset.func[0])
+print('Mask nifti image (3D) is located at: %s' % haxby_dataset.mask)
+print('Functional nifti image (4D) is located at: %s' %
+      haxby_dataset.func)
 
 y, session = np.loadtxt(haxby_dataset.session_target).astype("int").T
 conditions = np.recfromtxt(haxby_dataset.conditions_target)['f0']

--- a/examples/decoding/plot_haxby_different_estimators.py
+++ b/examples/decoding/plot_haxby_different_estimators.py
@@ -13,8 +13,10 @@ from nilearn import datasets
 haxby_dataset = datasets.fetch_haxby(n_subjects=1)
 
 # print basic information on the dataset
-print('Anatomical nifti image is at: %s' % haxby_dataset.anat[0])
-print('Functional nifti images are at: %s' % haxby_dataset.func[0])  # 4D data
+print('First subject anatomical nifti image (3D) located is at: %s' %
+      haxby_dataset.anat[0])
+print('First subject functional nifti image (4D) is located at: %s' %
+      haxby_dataset.func[0])
 
 # load labels
 import numpy as np

--- a/examples/decoding/plot_haxby_different_estimators.py
+++ b/examples/decoding/plot_haxby_different_estimators.py
@@ -12,6 +12,10 @@ import time
 from nilearn import datasets
 haxby_dataset = datasets.fetch_haxby(n_subjects=1)
 
+# print basic information on the dataset
+print('Anatomical nifti image is at: %s' % haxby_dataset.anat[0])
+print('Functional nifti images are at: %s' % haxby_dataset.func[0])  # 4D data
+
 # load labels
 import numpy as np
 labels = np.recfromcsv(haxby_dataset.session_target[0], delimiter=" ")

--- a/examples/decoding/plot_haxby_full_analysis.py
+++ b/examples/decoding/plot_haxby_full_analysis.py
@@ -18,6 +18,10 @@ that have been defined via a standard GLM-based analysis.
 from nilearn import datasets
 haxby_dataset = datasets.fetch_haxby(n_subjects=1)
 
+# print basic information on the dataset
+print('Anatomical nifti image is at: %s' % haxby_dataset.anat[0])
+print('Functional nifti images are at: %s' % haxby_dataset.func[0])  # 4D data
+
 # Load nilearn NiftiMasker, the practical masking and unmasking tool
 from nilearn.input_data import NiftiMasker
 

--- a/examples/decoding/plot_haxby_full_analysis.py
+++ b/examples/decoding/plot_haxby_full_analysis.py
@@ -19,8 +19,10 @@ from nilearn import datasets
 haxby_dataset = datasets.fetch_haxby(n_subjects=1)
 
 # print basic information on the dataset
-print('Anatomical nifti image is at: %s' % haxby_dataset.anat[0])
-print('Functional nifti images are at: %s' % haxby_dataset.func[0])  # 4D data
+print('First subject anatomical nifti image (3D) located is at: %s' %
+      haxby_dataset.anat[0])
+print('First subject functional nifti image (4D) is located at: %s' %
+      haxby_dataset.func[0])
 
 # Load nilearn NiftiMasker, the practical masking and unmasking tool
 from nilearn.input_data import NiftiMasker

--- a/examples/decoding/plot_haxby_grid_search.py
+++ b/examples/decoding/plot_haxby_grid_search.py
@@ -39,8 +39,8 @@ import numpy as np
 haxby_dataset = datasets.fetch_haxby_simple()
 
 # print basic information on the dataset
-print('Mask nifti images are located at: ' % haxby_dataset.mask[0])
-print('Functional nifti images are located at: ' % haxby_dataset.func[0])
+print('Mask nifti image (3D) is located at: %s' % haxby_dataset.mask)
+print('Functional nifti image (4D) are located at: %s' % haxby_dataset.func)
 
 y, session = np.loadtxt(haxby_dataset.session_target).astype('int').T
 conditions = np.recfromtxt(haxby_dataset.conditions_target)['f0']

--- a/examples/decoding/plot_haxby_grid_search.py
+++ b/examples/decoding/plot_haxby_grid_search.py
@@ -38,6 +38,10 @@ from nilearn import datasets
 import numpy as np
 haxby_dataset = datasets.fetch_haxby_simple()
 
+# print basic information on the dataset
+print('Mask nifti images are located at: ' % haxby_dataset.mask[0])
+print('Functional nifti images are located at: ' % haxby_dataset.func[0])
+
 y, session = np.loadtxt(haxby_dataset.session_target).astype('int').T
 conditions = np.recfromtxt(haxby_dataset.conditions_target)['f0']
 

--- a/examples/decoding/plot_haxby_multiclass.py
+++ b/examples/decoding/plot_haxby_multiclass.py
@@ -13,6 +13,11 @@ from matplotlib import pyplot as plt
 from nilearn import datasets
 import numpy as np
 haxby_dataset = datasets.fetch_haxby_simple()
+
+# print basic information on the dataset
+print('Mask nifti images are located at: ' % haxby_dataset.mask[0])
+print('Functional nifti images are located at: ' % haxby_dataset.func[0])
+
 func_filename = haxby_dataset.func
 mask_filename = haxby_dataset.mask
 

--- a/examples/decoding/plot_haxby_multiclass.py
+++ b/examples/decoding/plot_haxby_multiclass.py
@@ -15,8 +15,8 @@ import numpy as np
 haxby_dataset = datasets.fetch_haxby_simple()
 
 # print basic information on the dataset
-print('Mask nifti images are located at: ' % haxby_dataset.mask[0])
-print('Functional nifti images are located at: ' % haxby_dataset.func[0])
+print('Mask nifti images are located at: %s' % haxby_dataset.mask)
+print('Functional nifti images are located at: %s' % haxby_dataset.func)
 
 func_filename = haxby_dataset.func
 mask_filename = haxby_dataset.mask

--- a/examples/decoding/plot_haxby_searchlight.py
+++ b/examples/decoding/plot_haxby_searchlight.py
@@ -16,6 +16,10 @@ from nilearn import datasets
 
 haxby_dataset = datasets.fetch_haxby_simple()
 
+# print basic information on the dataset
+print('Anatomical nifti images are located at: ' % haxby_dataset.anat[0])
+print('Functional nifti images are located at: ' % haxby_dataset.func[0])
+
 fmri_filename = haxby_dataset.func
 fmri_img = nibabel.load(fmri_filename)
 y, session = np.loadtxt(haxby_dataset.session_target).astype('int').T

--- a/examples/decoding/plot_haxby_searchlight.py
+++ b/examples/decoding/plot_haxby_searchlight.py
@@ -17,8 +17,8 @@ from nilearn import datasets
 haxby_dataset = datasets.fetch_haxby_simple()
 
 # print basic information on the dataset
-print('Anatomical nifti images are located at: ' % haxby_dataset.anat[0])
-print('Functional nifti images are located at: ' % haxby_dataset.func[0])
+print('Anatomical nifti image (3D) is located at: %s' % haxby_dataset.mask)
+print('Functional nifti image (4D) is located at: %s' % haxby_dataset.func)
 
 fmri_filename = haxby_dataset.func
 fmri_img = nibabel.load(fmri_filename)

--- a/examples/decoding/plot_haxby_stimuli.py
+++ b/examples/decoding/plot_haxby_stimuli.py
@@ -15,6 +15,10 @@ from nilearn import datasets
 haxby_dataset = datasets.fetch_haxby(n_subjects=0, fetch_stimuli=True)
 stimulus_information = haxby_dataset.stimuli
 
+# print basic information on the dataset
+print('Anatomical nifti images are located at: ' % haxby_dataset.anat[0])
+print('Functional nifti images are located at: ' % haxby_dataset.func[0])
+
 for stim_type in sorted(stimulus_information.keys()):
     if stim_type == b'controls':
         # skip control images, there are too many

--- a/examples/decoding/plot_haxby_stimuli.py
+++ b/examples/decoding/plot_haxby_stimuli.py
@@ -12,14 +12,8 @@ import matplotlib.pyplot as plt
 
 from nilearn import datasets
 
-haxby_dataset = datasets.fetch_haxby(n_subjects=1, fetch_stimuli=True)
-# stimulus_information = haxby_dataset.stimuli
-
-# print basic information on the dataset
-print('First subject anatomical nifti image (3D) located is at: %s' %
-      haxby_dataset.anat[0])
-print('First subject functional nifti image (4D) is located at: %s' %
-      haxby_dataset.func[0])
+haxby_dataset = datasets.fetch_haxby(n_subjects=0, fetch_stimuli=True)
+stimulus_information = haxby_dataset.stimuli
 
 for stim_type in sorted(stimulus_information.keys()):
     if stim_type == b'controls':

--- a/examples/decoding/plot_haxby_stimuli.py
+++ b/examples/decoding/plot_haxby_stimuli.py
@@ -12,12 +12,14 @@ import matplotlib.pyplot as plt
 
 from nilearn import datasets
 
-haxby_dataset = datasets.fetch_haxby(n_subjects=0, fetch_stimuli=True)
-stimulus_information = haxby_dataset.stimuli
+haxby_dataset = datasets.fetch_haxby(n_subjects=1, fetch_stimuli=True)
+# stimulus_information = haxby_dataset.stimuli
 
 # print basic information on the dataset
-print('Anatomical nifti images are located at: ' % haxby_dataset.anat[0])
-print('Functional nifti images are located at: ' % haxby_dataset.func[0])
+print('First subject anatomical nifti image (3D) located is at: %s' %
+      haxby_dataset.anat[0])
+print('First subject functional nifti image (4D) is located at: %s' %
+      haxby_dataset.func[0])
 
 for stim_type in sorted(stimulus_information.keys()):
     if stim_type == b'controls':

--- a/examples/decoding/plot_miyawaki_reconstruction.py
+++ b/examples/decoding/plot_miyawaki_reconstruction.py
@@ -28,7 +28,7 @@ t0 = time.time()
 miyawaki_dataset = datasets.fetch_miyawaki2008()
 
 # print basic information on the dataset
-print('Functional nifti images are at: %s' %
+print('First functional nifti image (4D) is located at: %s' %
       miyawaki_dataset.func[0])  # 4D data
 
 X_random_filenames = miyawaki_dataset.func[12:]

--- a/examples/decoding/plot_miyawaki_reconstruction.py
+++ b/examples/decoding/plot_miyawaki_reconstruction.py
@@ -26,6 +26,11 @@ sys.stderr.write("Fetching dataset...")
 t0 = time.time()
 
 miyawaki_dataset = datasets.fetch_miyawaki2008()
+
+# print basic information on the dataset
+print('Functional nifti images are at: %s' %
+      miyawaki_dataset.func[0])  # 4D data
+
 X_random_filenames = miyawaki_dataset.func[12:]
 X_figure_filenames = miyawaki_dataset.func[:12]
 y_random_filenames = miyawaki_dataset.label[12:]

--- a/examples/decoding/plot_oasis_vbm.py
+++ b/examples/decoding/plot_oasis_vbm.py
@@ -45,7 +45,7 @@ import matplotlib.pyplot as plt
 from nilearn import datasets
 from nilearn.input_data import NiftiMasker
 
-n_subjects = 100  # more subjects requires more memory
+n_subjects = 2  # more subjects requires more memory
 
 ### Load Oasis dataset ########################################################
 oasis_dataset = datasets.fetch_oasis_vbm(n_subjects=n_subjects)
@@ -53,10 +53,10 @@ gray_matter_map_filenames = oasis_dataset.gray_matter_maps
 age = oasis_dataset.ext_vars['age'].astype(float)
 
 # print basic information on the dataset
-print('Gray-matter anatomy images are at: %s' %
-      oasis_dataset.gray_matter_maps[0])  # 4D data
-print('White-matter anatomy images are at: %s' %
-      oasis_dataset.white_matter_maps[0])  # 4D data
+print('First gray-matter anatomy image (3D) is located at: %s' %
+      oasis_dataset.gray_matter_maps[0])  # 3D data
+print('First white-matter anatomy image (3D) is located at: %s' %
+      oasis_dataset.white_matter_maps[0])  # 3D data
 
 ### Preprocess data ###########################################################
 nifti_masker = NiftiMasker(

--- a/examples/decoding/plot_oasis_vbm.py
+++ b/examples/decoding/plot_oasis_vbm.py
@@ -45,7 +45,7 @@ import matplotlib.pyplot as plt
 from nilearn import datasets
 from nilearn.input_data import NiftiMasker
 
-n_subjects = 2  # more subjects requires more memory
+n_subjects = 100  # more subjects requires more memory
 
 ### Load Oasis dataset ########################################################
 oasis_dataset = datasets.fetch_oasis_vbm(n_subjects=n_subjects)

--- a/examples/decoding/plot_oasis_vbm.py
+++ b/examples/decoding/plot_oasis_vbm.py
@@ -52,6 +52,12 @@ oasis_dataset = datasets.fetch_oasis_vbm(n_subjects=n_subjects)
 gray_matter_map_filenames = oasis_dataset.gray_matter_maps
 age = oasis_dataset.ext_vars['age'].astype(float)
 
+# print basic information on the dataset
+print('Gray-matter anatomy images are at: %s' %
+      oasis_dataset.gray_matter_maps[0])  # 4D data
+print('White-matter anatomy images are at: %s' %
+      oasis_dataset.white_matter_maps[0])  # 4D data
+
 ### Preprocess data ###########################################################
 nifti_masker = NiftiMasker(
     standardize=False,

--- a/examples/manipulating_visualizing/plot_atlas.py
+++ b/examples/manipulating_visualizing/plot_atlas.py
@@ -11,5 +11,7 @@ from nilearn import plotting
 
 atlas_filename, labels = datasets.fetch_harvard_oxford('cort-maxprob-thr25-2mm')
 
+print('Atlas ROIs are located at: %s' % atlas_filename)
+
 plotting.plot_roi(atlas_filename, title="Harvard Oxford atlas")
 plt.show()

--- a/examples/manipulating_visualizing/plot_demo_plotting.py
+++ b/examples/manipulating_visualizing/plot_demo_plotting.py
@@ -16,8 +16,10 @@ from nilearn import plotting, image
 haxby_dataset = datasets.fetch_haxby(n_subjects=1)
 
 # print basic information on the dataset
-print('Anatomical nifti image is at: %s' % haxby_dataset.anat[0])
-print('Functional nifti images are at: %s' % haxby_dataset.func[0])  # 4D data
+print('First subject anatomical nifti image (3D) is at: %s' %
+      haxby_dataset.anat[0])
+print('First subject functional nifti image (4D) is at: %s' %
+      haxby_dataset.func[0])  # 4D data
 
 haxby_anat_filename = haxby_dataset.anat[0]
 haxby_mask_filename = haxby_dataset.mask_vt[0]

--- a/examples/manipulating_visualizing/plot_demo_plotting.py
+++ b/examples/manipulating_visualizing/plot_demo_plotting.py
@@ -14,6 +14,11 @@ from nilearn import plotting, image
 # localizer dataset to have contrast maps
 
 haxby_dataset = datasets.fetch_haxby(n_subjects=1)
+
+# print basic information on the dataset
+print('Anatomical nifti image is at: %s' % haxby_dataset.anat[0])
+print('Functional nifti images are at: %s' % haxby_dataset.func[0])  # 4D data
+
 haxby_anat_filename = haxby_dataset.anat[0]
 haxby_mask_filename = haxby_dataset.mask_vt[0]
 haxby_func_filename = haxby_dataset.func[0]

--- a/examples/manipulating_visualizing/plot_haxby_masks.py
+++ b/examples/manipulating_visualizing/plot_haxby_masks.py
@@ -11,6 +11,10 @@ import matplotlib.pyplot as plt
 from nilearn import datasets
 haxby_dataset = datasets.fetch_haxby()
 
+# print basic information on the dataset
+print('Anatomical nifti image is at: %s' % haxby_dataset.anat[0])
+print('Functional nifti images are at: %s' % haxby_dataset.func[0])  # 4D data
+
 # Build the mean image because we have no anatomic data
 from nilearn import image
 func_filename = haxby_dataset.func[0]

--- a/examples/manipulating_visualizing/plot_haxby_masks.py
+++ b/examples/manipulating_visualizing/plot_haxby_masks.py
@@ -12,8 +12,10 @@ from nilearn import datasets
 haxby_dataset = datasets.fetch_haxby()
 
 # print basic information on the dataset
-print('Anatomical nifti image is at: %s' % haxby_dataset.anat[0])
-print('Functional nifti images are at: %s' % haxby_dataset.func[0])  # 4D data
+print('First subject anatomical nifti image (3D) is at: %s' %
+      haxby_dataset.anat[0])
+print('First subject functional nifti image (4D) is at: %s' %
+      haxby_dataset.func[0])  # 4D data
 
 # Build the mean image because we have no anatomic data
 from nilearn import image

--- a/examples/manipulating_visualizing/plot_haxby_mass_univariate.py
+++ b/examples/manipulating_visualizing/plot_haxby_mass_univariate.py
@@ -37,6 +37,10 @@ from nilearn.mass_univariate import permuted_ols
 ### Load Haxby dataset ########################################################
 haxby_dataset = datasets.fetch_haxby_simple()
 
+# print basic information on the dataset
+print('Mask nifti images are located at: ' % haxby_dataset.mask[0])
+print('Functional nifti images are located at: ' % haxby_dataset.func[0])
+
 ### Mask data #################################################################
 mask_filename = haxby_dataset.mask
 nifti_masker = NiftiMasker(

--- a/examples/manipulating_visualizing/plot_haxby_mass_univariate.py
+++ b/examples/manipulating_visualizing/plot_haxby_mass_univariate.py
@@ -38,8 +38,8 @@ from nilearn.mass_univariate import permuted_ols
 haxby_dataset = datasets.fetch_haxby_simple()
 
 # print basic information on the dataset
-print('Mask nifti images are located at: ' % haxby_dataset.mask[0])
-print('Functional nifti images are located at: ' % haxby_dataset.func[0])
+print('Mask nifti image (3D) is located at: %s' % haxby_dataset.mask)
+print('Functional nifti image (4D) is located at: %s' % haxby_dataset.func)
 
 ### Mask data #################################################################
 mask_filename = haxby_dataset.mask

--- a/examples/manipulating_visualizing/plot_localizer_mass_univariate_methods.py
+++ b/examples/manipulating_visualizing/plot_localizer_mass_univariate_methods.py
@@ -30,7 +30,7 @@ localizer_dataset = datasets.fetch_localizer_contrasts(
     ['left button press (auditory cue)'], n_subjects=n_samples)
 
 # print basic information on the dataset
-print('First functional nifti images are located at: %s' %
+print('First contrast nifti image (3D) is located at: %s' %
       localizer_dataset.cmaps[0])
 
 tested_var = localizer_dataset.ext_vars['pseudo']

--- a/examples/manipulating_visualizing/plot_localizer_mass_univariate_methods.py
+++ b/examples/manipulating_visualizing/plot_localizer_mass_univariate_methods.py
@@ -28,6 +28,11 @@ from nilearn.mass_univariate import permuted_ols
 n_samples = 94
 localizer_dataset = datasets.fetch_localizer_contrasts(
     ['left button press (auditory cue)'], n_subjects=n_samples)
+
+# print basic information on the dataset
+print('First functional nifti images are located at: %s' %
+      localizer_dataset.cmaps[0])
+
 tested_var = localizer_dataset.ext_vars['pseudo']
 # Quality check / Remove subjects with bad tested variate
 mask_quality_check = np.where(tested_var != b'None')[0]

--- a/examples/manipulating_visualizing/plot_mask_computation.py
+++ b/examples/manipulating_visualizing/plot_mask_computation.py
@@ -33,7 +33,7 @@ from nilearn.plotting.img_plotting import plot_roi
 miyawaki_dataset = datasets.fetch_miyawaki2008()
 
 # print basic information on the dataset
-print('Functional nifti images are at: %s' %
+print('First functional nifti image (4D) is located at: %s' %
       miyawaki_dataset.func[0])  # 4D data
 
 miyawaki_filename = miyawaki_dataset.func[0]

--- a/examples/manipulating_visualizing/plot_mask_computation.py
+++ b/examples/manipulating_visualizing/plot_mask_computation.py
@@ -31,8 +31,12 @@ from nilearn.plotting.img_plotting import plot_roi
 
 # Load Miyawaki dataset
 miyawaki_dataset = datasets.fetch_miyawaki2008()
-miyawaki_filename = miyawaki_dataset.func[0]
 
+# print basic information on the dataset
+print('Functional nifti images are at: %s' %
+      miyawaki_dataset.func[0])  # 4D data
+
+miyawaki_filename = miyawaki_dataset.func[0]
 miyawaki_mean_img = image.mean_img(miyawaki_filename)
 
 # This time, we can use the NiftiMasker without changing the default mask

--- a/examples/manipulating_visualizing/plot_roi_extraction.py
+++ b/examples/manipulating_visualizing/plot_roi_extraction.py
@@ -20,6 +20,10 @@ from nilearn import datasets
 import nibabel
 haxby_dataset = datasets.fetch_haxby(n_subjects=1)
 
+# print basic information on the dataset
+print('Anatomical nifti image is at: %s' % haxby_dataset.anat[0])
+print('Functional nifti images are at: %s' % haxby_dataset.func[0])  # 4D data
+
 # Second, load the labels
 import numpy as np
 

--- a/examples/manipulating_visualizing/plot_roi_extraction.py
+++ b/examples/manipulating_visualizing/plot_roi_extraction.py
@@ -21,8 +21,10 @@ import nibabel
 haxby_dataset = datasets.fetch_haxby(n_subjects=1)
 
 # print basic information on the dataset
-print('Anatomical nifti image is at: %s' % haxby_dataset.anat[0])
-print('Functional nifti images are at: %s' % haxby_dataset.func[0])  # 4D data
+print('First subject anatomical nifti image (3D) located is at: %s' %
+      haxby_dataset.anat[0])
+print('First subject functional nifti image (4D) is located at: %s' %
+      haxby_dataset.func[0])
 
 # Second, load the labels
 import numpy as np

--- a/examples/manipulating_visualizing/plot_smooth_mean_image.py
+++ b/examples/manipulating_visualizing/plot_smooth_mean_image.py
@@ -14,6 +14,10 @@ are expected.
 from nilearn import datasets, plotting, image
 
 data = datasets.fetch_adhd(n_subjects=1)
+
+# Print basic information on the dataset
+print('Functional nifti images are located at: %s' % data.func[0])
+
 first_epi_file = data.func[0]
 
 # First the compute the mean image, from the 4D series of image

--- a/examples/manipulating_visualizing/plot_smooth_mean_image.py
+++ b/examples/manipulating_visualizing/plot_smooth_mean_image.py
@@ -16,7 +16,8 @@ from nilearn import datasets, plotting, image
 data = datasets.fetch_adhd(n_subjects=1)
 
 # Print basic information on the dataset
-print('Functional nifti images are located at: %s' % data.func[0])
+print('First subject functional nifti image (4D) are located at: %s' %
+      data.func[0])
 
 first_epi_file = data.func[0]
 

--- a/examples/manipulating_visualizing/plot_visualization.py
+++ b/examples/manipulating_visualizing/plot_visualization.py
@@ -14,8 +14,10 @@ from nilearn.plotting.img_plotting import plot_epi, plot_roi
 haxby_dataset = datasets.fetch_haxby(n_subjects=1)
 
 # print basic information on the dataset
-print('Anatomical nifti image is at: %s' % haxby_dataset.anat[0])
-print('Functional nifti images are at: %s' % haxby_dataset.func[0])  # 4D data
+print('First anatomical nifti image (3D) located is at: %s' %
+      haxby_dataset.anat[0])
+print('First functional nifti image (4D) is located at: %s' %
+      haxby_dataset.func[0])
 
 ### Visualization #############################################################
 

--- a/examples/manipulating_visualizing/plot_visualization.py
+++ b/examples/manipulating_visualizing/plot_visualization.py
@@ -13,6 +13,10 @@ from nilearn.plotting.img_plotting import plot_epi, plot_roi
 
 haxby_dataset = datasets.fetch_haxby(n_subjects=1)
 
+# print basic information on the dataset
+print('Anatomical nifti image is at: %s' % haxby_dataset.anat[0])
+print('Functional nifti images are at: %s' % haxby_dataset.func[0])  # 4D data
+
 ### Visualization #############################################################
 
 import matplotlib.pyplot as plt

--- a/examples/plot_haxby_simple.py
+++ b/examples/plot_haxby_simple.py
@@ -12,6 +12,10 @@ stream.
 from nilearn import datasets
 haxby_dataset = datasets.fetch_haxby()
 
+# print basic information on the dataset
+print('Anatomical nifti image is at: %s' % haxby_dataset.anat[0])
+print('Functional nifti images are at: %s' % haxby_dataset.func[0])  # 4D data
+
 ### Load Target labels ########################################################
 
 import numpy as np

--- a/examples/plot_haxby_simple.py
+++ b/examples/plot_haxby_simple.py
@@ -13,8 +13,10 @@ from nilearn import datasets
 haxby_dataset = datasets.fetch_haxby()
 
 # print basic information on the dataset
-print('Anatomical nifti image is at: %s' % haxby_dataset.anat[0])
-print('Functional nifti images are at: %s' % haxby_dataset.func[0])  # 4D data
+print('First subject anatomical nifti image (3D) is at: %s' %
+      haxby_dataset.anat[0])
+print('First subject functional nifti images (4D) are at: %s' %
+      haxby_dataset.func[0])  # 4D data
 
 ### Load Target labels ########################################################
 

--- a/examples/plot_nifti_simple.py
+++ b/examples/plot_nifti_simple.py
@@ -12,6 +12,10 @@ from nilearn import datasets
 from nilearn.input_data import NiftiMasker
 nyu_dataset = datasets.fetch_nyu_rest(n_subjects=1)
 
+# print basic information on the dataset
+print('Anatomical nifti image is at: %s' % nyu_dataset.anat_anon[0])
+print('Functional nifti images are at: %s' % nyu_dataset.func[0])  # 4D data
+
 ### Compute the mask ##########################################################
 
 # As this is raw resting-state EPI, the background is noisy and we cannot

--- a/examples/plot_nifti_simple.py
+++ b/examples/plot_nifti_simple.py
@@ -13,8 +13,9 @@ from nilearn.input_data import NiftiMasker
 nyu_dataset = datasets.fetch_nyu_rest(n_subjects=1)
 
 # print basic information on the dataset
-print('Anatomical nifti image is at: %s' % nyu_dataset.anat_anon[0])
-print('Functional nifti images are at: %s' % nyu_dataset.func[0])  # 4D data
+print('First anatomical nifti image (3D) is at: %s' % nyu_dataset.anat_anon[0])
+print('First functional nifti image (4D) is at: %s' %
+      nyu_dataset.func[0])  # 4D data
 
 ### Compute the mask ##########################################################
 


### PR DESCRIPTION
Newcommers to nilearn (not seldomly: and to python) have expressed difficulty in understanding the format in which the datasets are represented.

It would therefore be helpful to
- show in the code that bunches are minor modifications of dictionaries
- print where the (fetched/located) files are actually located on the disk
- show how to access the important dataset parts right after first access