### PR TITLE
Simplify matplotlib backend choice and test skipping when matplotlib is not installed

### DIFF
--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -600,20 +600,15 @@ def generate_group_sparse_gaussian_graphs(
     return signals, precisions, topology
 
 
-def skip_if_running_nose(msg=None):
-    """ Raise a SkipTest if we appear to be running the nose test loader.
-
-    Parameters
-    ==========
-    msg: string, optional
-        The message issued when SkipTest is raised
+def is_nose_running():
+    """Returns whether we are running the nose test loader
     """
     if 'nose' not in sys.modules:
         return
     try:
         import nose
     except ImportError:
-        return
+        return False
     # Now check that we have the loader in the call stask
     stack = inspect.stack()
     from nose import loader
@@ -622,7 +617,18 @@ def skip_if_running_nose(msg=None):
         loader_file_name = loader_file_name[:-1]
     for _, file_name, _, _, _, _ in stack:
         if file_name == loader_file_name:
-            if msg is not None:
-                raise nose.SkipTest(msg)
-            else:
-                raise nose.SkipTest
+            return True
+    return False
+
+
+def skip_if_running_nose(msg=''):
+    """ Raise a SkipTest if we appear to be running the nose test loader.
+
+    Parameters
+    ==========
+    msg: string, optional
+        The message issued when SkipTest is raised
+    """
+    if is_nose_running():
+        import nose
+        raise nose.SkipTest(msg)

--- a/nilearn/plotting/__init__.py
+++ b/nilearn/plotting/__init__.py
@@ -3,16 +3,9 @@ Plotting code for nilearn
 """
 # Authors: Chris Filo Gorgolewski, Gael Varoquaux
 
-from ..version import (_import_module_with_version_check,
-                       OPTIONAL_MATPLOTLIB_MIN_VERSION)
-
-from .._utils.testing import skip_if_running_nose, is_nose_running
-
 ###############################################################################
 # Make sure that we don't get DISPLAY problems when running without X on
 # unices
-
-
 def _set_mpl_backend():
     try:
         # We are doing local imports here to avoid poluting our namespace
@@ -22,10 +15,13 @@ def _set_mpl_backend():
         if os.name == 'posix' and 'DISPLAY' not in os.environ:
             matplotlib.use('Agg')
     except ImportError:
+        from .._utils.testing import skip_if_running_nose
         # No need to fail when running tests
         skip_if_running_nose('matplotlib not installed')
         raise
     else:
+        from ..version import (_import_module_with_version_check,
+                               OPTIONAL_MATPLOTLIB_MIN_VERSION)
         # When matplotlib was successfully imported we need to check
         # that the version is greater that the minimum required one
         _import_module_with_version_check('matplotlib',

--- a/nilearn/plotting/__init__.py
+++ b/nilearn/plotting/__init__.py
@@ -6,6 +6,8 @@ Plotting code for nilearn
 from ..version import (_import_module_with_version_check,
                        OPTIONAL_MATPLOTLIB_MIN_VERSION)
 
+from .._utils.testing import skip_if_running_nose, is_nose_running
+
 ###############################################################################
 # Make sure that we don't get DISPLAY problems when running without X on
 # unices
@@ -16,19 +18,18 @@ def _set_mpl_backend():
         # We are doing local imports here to avoid poluting our namespace
         import matplotlib
         import os
-        # We have the problem only on posix systems
+        # Set the backend to a non-interactive one for unices without X
         if os.name == 'posix' and 'DISPLAY' not in os.environ:
-            # Agg is a backend that will do PNGs and PDFs
             matplotlib.use('Agg')
     except ImportError:
-        # No need to fail here, eg during tests
-        pass
+        # No need to fail when running tests
+        skip_if_running_nose('matplotlib not installed')
+        raise
     else:
         # When matplotlib was successfully imported we need to check
         # that the version is greater that the minimum required one
         _import_module_with_version_check('matplotlib',
                                           OPTIONAL_MATPLOTLIB_MIN_VERSION)
-
 
 _set_mpl_backend()
 

--- a/nilearn/plotting/cm.py
+++ b/nilearn/plotting/cm.py
@@ -5,14 +5,8 @@ Matplotlib colormaps useful for neuroimaging.
 """
 import numpy as _np
 
-from .._utils.testing import skip_if_running_nose
-
-try:
-    from matplotlib import cm as _cm
-    from matplotlib import colors as _colors
-except ImportError:
-    skip_if_running_nose('Could not import matplotlib')
-
+from matplotlib import cm as _cm
+from matplotlib import colors as _colors
 
 ################################################################################
 # Custom colormaps for two-tailed symmetric statistics

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -11,21 +11,15 @@ import numbers
 import numpy as np
 from scipy import sparse, stats
 
-from .._utils.testing import skip_if_running_nose
 from .._utils import new_img_like
 from .._utils.compat import _basestring
 from .. import _utils
 
-try:
-    import matplotlib.pyplot as plt
-    from matplotlib import transforms, colors
-    from matplotlib.colorbar import ColorbarBase
-    from matplotlib import cm as mpl_cm
-    from matplotlib import lines
-except ImportError:
-    skip_if_running_nose('Could not import matplotlib')
-    raise
-
+import matplotlib.pyplot as plt
+from matplotlib import transforms, colors
+from matplotlib.colorbar import ColorbarBase
+from matplotlib import cm as mpl_cm
+from matplotlib import lines
 
 # Local imports
 from . import glass_brain, cm

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -19,14 +19,9 @@ import numpy as np
 from scipy import ndimage
 from nibabel.spatialimages import SpatialImage
 
-from .._utils.testing import skip_if_running_nose
 from .._utils.numpy_conversions import as_ndarray
 
-try:
-    import matplotlib.pyplot as plt
-except ImportError:
-    skip_if_running_nose('Could not import matplotlib')
-    raise
+import matplotlib.pyplot as plt
 
 from .. import _utils
 from .._utils import new_img_like

--- a/nilearn/plotting/tests/test_cm.py
+++ b/nilearn/plotting/tests/test_cm.py
@@ -2,33 +2,18 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """ Smoke testing the cm module
 """
-from nose import SkipTest
-
-try:
-    import matplotlib as mp
-    # Make really sure that we don't try to open an Xserver connection.
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
-except ImportError:
-    raise SkipTest('Could not import matplotlib')
+import matplotlib.pyplot as plt
 
 from nilearn.plotting.cm import dim_cmap, replace_inside
 
 
 def test_dim_cmap():
     # This is only a smoke test
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
     dim_cmap(plt.cm.jet)
 
 
 def test_replace_inside():
     # This is only a smoke test
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
     replace_inside(plt.cm.jet, plt.cm.hsv, .2, .8)
     # We also test with gnuplot, which is defined using function
     if hasattr(plt.cm, 'gnuplot'):

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -1,16 +1,8 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-import nose
 import tempfile
 
-try:
-    import matplotlib as mp
-    # Make really sure that we don't try to open an Xserver connection.
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
-except ImportError:
-    raise nose.SkipTest('Could not import matplotlib')
+import matplotlib.pyplot as plt
 
 from nilearn.plotting.displays import OrthoSlicer, XSlicer, OrthoProjector
 from nilearn.datasets import load_mni152_template
@@ -21,10 +13,6 @@ from nilearn.datasets import load_mni152_template
 
 def test_demo_ortho_slicer():
     # This is only a smoke test
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
-    plt.clf()
     oslicer = OrthoSlicer(cut_coords=(0, 0, 0))
     img = load_mni152_template()
     oslicer.add_overlay(img, cmap=plt.cm.gray)
@@ -33,10 +21,6 @@ def test_demo_ortho_slicer():
 
 def test_stacked_slicer():
     # Test stacked slicers, like the XSlicer
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
-    plt.clf()
     img = load_mni152_template()
     slicer = XSlicer.init_with_figure(img=img, cut_coords=3)
     slicer.add_overlay(img, cmap=plt.cm.gray)
@@ -48,10 +32,6 @@ def test_stacked_slicer():
 
 def test_demo_ortho_projector():
     # This is only a smoke test
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
-    plt.clf()
     img = load_mni152_template()
     oprojector = OrthoProjector.init_with_figure(img=img)
     oprojector.add_overlay(img, cmap=plt.cm.gray)

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -8,17 +8,9 @@ from functools import partial
 import numpy as np
 from scipy import sparse
 
-from nose import SkipTest
 from nose.tools import assert_raises, assert_true, assert_equal
 
-try:
-    import matplotlib as mp
-    # Make really sure that we don't try to open an Xserver connection.
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
-except ImportError:
-    raise SkipTest('Could not import matplotlib')
+import matplotlib.pyplot as plt
 
 import nibabel
 
@@ -60,52 +52,43 @@ def demo_plot_roi(**kwargs):
 
 def test_demo_plot_roi():
     # This is only a smoke test
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
     demo_plot_roi()
     # Test the black background code path
     demo_plot_roi(black_bg=True)
 
-    with tempfile.TemporaryFile(suffix='.png') as fp:
+    with tempfile.NamedTemporaryFile(suffix='.png') as fp:
         out = demo_plot_roi(output_file=fp)
     assert_true(out is None)
 
 
 def test_plot_anat():
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
     img = _generate_img()
 
     # Test saving with empty plot
     z_slicer = plot_anat(anat_img=False, display_mode='z')
-    with tempfile.TemporaryFile(suffix='.png') as fp:
+    with tempfile.NamedTemporaryFile(suffix='.png') as fp:
         z_slicer.savefig(fp.name)
     z_slicer = plot_anat(display_mode='z')
-    with tempfile.TemporaryFile(suffix='.png') as fp:
+    with tempfile.NamedTemporaryFile(suffix='.png') as fp:
         z_slicer.savefig(fp.name)
 
     ortho_slicer = plot_anat(img, dim=True)
-    with tempfile.TemporaryFile(suffix='.png') as fp:
+    with tempfile.NamedTemporaryFile(suffix='.png') as fp:
         ortho_slicer.savefig(fp.name)
 
 
 def test_plot_functions():
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
     img = _generate_img()
 
     # smoke-test for each plotting function with default arguments
     for plot_func in [plot_anat, plot_img, plot_stat_map, plot_epi,
                       plot_glass_brain]:
-        with tempfile.TemporaryFile(suffix='.png') as fp:
+        with tempfile.NamedTemporaryFile(suffix='.png') as fp:
             plot_func(img, output_file=fp.name)
 
     # test for bad input arguments (cf. #510)
     ax = plt.subplot(111, rasterized=True)
-    with tempfile.TemporaryFile(suffix='.png') as fp:
+    with tempfile.NamedTemporaryFile(suffix='.png') as fp:
         plot_stat_map(
             img, symmetric_cbar=True,
             output_file=fp.name,
@@ -114,9 +97,6 @@ def test_plot_functions():
 
 
 def test_plot_glass_brain():
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
     img = _generate_img()
 
     # test plot_glass_brain with colorbar
@@ -124,9 +104,6 @@ def test_plot_glass_brain():
 
 
 def test_plot_stat_map():
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
     img = _generate_img()
 
     plot_stat_map(img, cut_coords=(80, -120, -60))
@@ -154,27 +131,21 @@ def test_plot_stat_map():
 
 
 def test_save_plot():
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
     img = _generate_img()
 
     kwargs_list = [{}, {'display_mode': 'x', 'cut_coords': 3}]
 
     for kwargs in kwargs_list:
-        with tempfile.TemporaryFile(suffix='.png') as fp:
+        with tempfile.NamedTemporaryFile(suffix='.png') as fp:
             display = plot_stat_map(img, output_file=fp.name, **kwargs)
             assert_true(display is None)
 
         display = plot_stat_map(img, **kwargs)
-        with tempfile.TemporaryFile(suffix='.png') as fp:
+        with tempfile.NamedTemporaryFile(suffix='.png') as fp:
             display.savefig(fp.name)
 
 
 def test_display_methods():
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
     img = _generate_img()
 
     display = plot_img(img)
@@ -185,9 +156,6 @@ def test_display_methods():
 
 
 def test_plot_with_axes_or_figure():
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
     img = _generate_img()
     figure = plt.figure()
     plot_img(img, figure=figure)
@@ -198,10 +166,6 @@ def test_plot_with_axes_or_figure():
 
 def test_plot_stat_map_colorbar_variations():
     # This is only a smoke test
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
-
     img_positive = _generate_img()
     data_positive = img_positive.get_data()
     rng = np.random.RandomState(42)
@@ -225,9 +189,6 @@ def test_plot_empty_slice():
     # Test that things don't crash when we give a map with nothing above
     # threshold
     # This is only a smoke test
-    mp.use('template', warn=False)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
     data = np.zeros((20, 20, 20))
     img = nibabel.Nifti1Image(data, mni_affine)
     plot_img(img, display_mode='y', threshold=1)
@@ -240,8 +201,6 @@ def test_plot_img_invalid():
 
 
 def test_plot_img_with_auto_cut_coords():
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
     data = np.zeros((20, 20, 20))
     data[3:-3, 3:-3, 3:-3] = 1
     img = nibabel.Nifti1Image(data, np.eye(4))
@@ -252,8 +211,6 @@ def test_plot_img_with_auto_cut_coords():
 
 
 def test_plot_img_with_resampling():
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
     data = _generate_img().get_data()
     affine = np.array([[1., -1.,  0.,  0.],
                        [1.,  1.,  0.,  0.],
@@ -283,8 +240,6 @@ def test_plot_noncurrent_axes():
 
 
 def test_plot_connectome():
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
     node_color = ['green', 'blue', 'k', 'cyan']
     # symmetric up to 1e-3 relative tolerance
     adjacency_matrix = np.array([[1., -2., 0.3, 0.],
@@ -345,8 +300,6 @@ def test_plot_connectome():
 
 
 def test_plot_connectome_exceptions():
-    import matplotlib.pyplot as plt
-    plt.switch_backend('template')
     node_coords = np.arange(2 * 3).reshape((2, 3))
 
     # Used to speed-up tests because the glass brain is always plotted


### PR DESCRIPTION
Matplotlib backend is set once and for all in
`nilearn/plotting/__init__.py`. Agg is used only when DISPLAY is unset. I am happy also always using Agg when running the tests but on my machine the difference for running `nosetests nilearn/plotting/tests` is something like 1.5s.

Failing to import matplotlib is only ok when running the tests. 

Protecting matplotlib imports is not needed anymore anymore in nilearn.plotting submodules.