### PR TITLE
Fix plot_connectome without any edge to draw

### DIFF
--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -1157,8 +1157,9 @@ class OrthoProjector(OrthoSlicer):
         adjacency_matrix_values = adjacency_matrix[non_zero_indices]
         for ax in self.axes.values():
             ax._add_markers(node_coords, node_color, node_size, **node_kwargs)
-            ax._add_lines(line_coords, adjacency_matrix_values, edge_cmap,
-                          **edge_kwargs)
+            if line_coords:
+                ax._add_lines(line_coords, adjacency_matrix_values, edge_cmap,
+                              **edge_kwargs)
 
         plt.draw_if_interactive()
 

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -298,6 +298,10 @@ def test_plot_connectome():
     nan_node_coords = np.arange(3 * 3).reshape(3, 3)
     plot_connectome(nan_adjacency_matrix, nan_node_coords, **kwargs)
 
+    # smoke-test where there is no edge to draw, e.g. when
+    # edge_threshold is too high
+    plot_connectome(*args, edge_threshold=1e12)
+
 
 def test_plot_connectome_exceptions():
     node_coords = np.arange(2 * 3).reshape((2, 3))


### PR DESCRIPTION
and add test.

This can happen when `edge_threshold` is too high or the adjacency matrix is diagonal for example:

```python
import numpy as np

from nilearn.plotting import plot_connectome

regions = [(10, 10, 10), (0, 0, 0)]
covariance = np.eye(2)

plot_connectome(covariance, regions)
```