### PR TITLE
[MRG] BUG: don't normalize when confounds

### DIFF
--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -26,24 +26,20 @@ def _standardize(signals, detrend=False, normalize=True):
 
     Parameters
     ==========
-    signals : numpy.ndarray
+    signals: numpy.ndarray
         Timeseries to standardize
 
-    detrend : bool
+    detrend: bool
         if detrending of timeseries is requested
 
-    normalize : bool
+    normalize: bool
         if True, shift timeseries to zero mean value and scale
         to unit energy (sum of squares).
 
     Returns
     =======
-    std_signals : numpy.ndarray
+    std_signals: numpy.ndarray
         copy of signals, normalized.
-
-    std : numpy.ndarray
-        The standard deviation of the signals: multiply the output
-        signals by this quantity to get the original signals back
     """
     if detrend:
         signals = _detrend(signals, inplace=False)

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -26,20 +26,24 @@ def _standardize(signals, detrend=False, normalize=True):
 
     Parameters
     ==========
-    signals: numpy.ndarray
+    signals : numpy.ndarray
         Timeseries to standardize
 
-    detrend: bool
+    detrend : bool
         if detrending of timeseries is requested
 
-    normalize: bool
+    normalize : bool
         if True, shift timeseries to zero mean value and scale
         to unit energy (sum of squares).
 
     Returns
     =======
-    std_signals: numpy.ndarray
+    std_signals : numpy.ndarray
         copy of signals, normalized.
+
+    std : numpy.ndarray
+        The standard deviation of the signals: multiply the output
+        signals by this quantity to get the original signals back
     """
     if detrend:
         signals = _detrend(signals, inplace=False)
@@ -408,14 +412,9 @@ def clean(signals, detrend=True, standardize=True, confounds=None,
                       (list, tuple, _basestring, np.ndarray, type(None))):
         raise TypeError("confounds keyword has an unhandled type: %s"
                         % confounds.__class__)
-    # Standardize / detrend
-    normalize = False
-    if confounds is not None:
-        # If confounds are to be removed, then force normalization to improve
-        # matrix conditioning.
-        normalize = True
+    # detrend
     signals = _ensure_float(signals)
-    signals = _standardize(signals, normalize=normalize, detrend=detrend)
+    signals = _standardize(signals, normalize=False, detrend=detrend)
 
     # Remove confounds
     if confounds is not None:

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -279,7 +279,7 @@ def test_clean_confounds():
     # With signal: output must be orthogonal to confounds
     cleaned_signals = nisignal.clean(signals + noises, confounds=confounds,
                                       detrend=True, standardize=False)
-    assert_true(abs(np.dot(confounds.T, cleaned_signals)).max() < 100. * eps)
+    assert_true(abs(np.dot(confounds.T, cleaned_signals)).max() < 1000. * eps)
 
     # Test detrending. No trend should exist in the output.
     # Use confounds with a trend.
@@ -296,7 +296,7 @@ def test_clean_confounds():
                                       detrend=True, standardize=False)
     coeffs = np.polyfit(np.arange(cleaned_signals.shape[0]),
                         cleaned_signals, 1)
-    assert_true((abs(coeffs) < 10. * eps).all())  # trend removed
+    assert_true((abs(coeffs) < 100. * eps).all())  # trend removed
 
     # Test no-op
     input_signals = 10 * signals


### PR DESCRIPTION
Fixes #549

The signals were normlized when confounds were used, for little good
reason