### PR TITLE
Add explicit vmin and vmax parameters to plotting functions

### DIFF
--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -554,12 +554,12 @@ class BaseSlicer(object):
 
             data_2d_list.append(data_2d)
 
-        if 'vmin' not in kwargs:
+        if kwargs.get('vmin') is None:
             kwargs['vmin'] = np.ma.min([d.min() for d in data_2d_list
-                                 if d is not None])
-        if 'vmax' not in kwargs:
+                                        if d is not None])
+        if kwargs.get('vmax') is None:
             kwargs['vmax'] = np.ma.max([d.max() for d in data_2d_list
-                                 if d is not None])
+                                        if d is not None])
 
         bounding_box = (xmin_, xmax_), (ymin_, ymax_), (zmin_, zmax_)
 

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -342,8 +342,8 @@ class BaseSlicer(object):
             black_bg: boolean, optional
                 If True, the background of the figure will be put to
                 black. If you wish to save figures with a black background,
-                you will need to pass "facecolor='k', edgecolor='k'" to 
-                pylab's savefig.
+                you will need to pass "facecolor='k', edgecolor='k'"
+                to matplotlib.pyplot.savefig.
 
         """
         self.cut_coords = cut_coords

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -385,8 +385,10 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
         anat_img,
         dim=dim, black_bg=black_bg)
 
-    vmin = vmin or anat_vmin
-    vmax = vmax or anat_vmax
+    if vmin is None:
+        vmin = anat_vmin
+    if vmax is None:
+        vmax = anat_vmax
 
     display = plot_img(anat_img, cut_coords=cut_coords,
                        output_file=output_file, display_mode=display_mode,

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -188,11 +188,12 @@ def plot_img(img, cut_coords=None, output_file=None, display_mode='ortho',
         black_bg: boolean, optional
             If True, the background of the image is set to be black. If
             you wish to save figures with a black background, you
-            will need to pass "facecolor='k', edgecolor='k'" to plt.savefig.
+            will need to pass "facecolor='k', edgecolor='k'"
+            to matplotlib.pyplot.savefig.
         colorbar: boolean, optional
             If True, display a colorbar on the right of the plots.
         kwargs: extra keyword arguments, optional
-            Extra keyword arguments passed to plt.imshow
+            Extra keyword arguments passed to matplotlib.pyplot.imshow
     """
     display = _plot_img_with_bg(img, cut_coords=cut_coords,
                     output_file=output_file, display_mode=display_mode,
@@ -366,13 +367,14 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
         black_bg: boolean, optional
             If True, the background of the image is set to be black. If
             you wish to save figures with a black background, you
-            will need to pass "facecolor='k', edgecolor='k'" to plt.savefig.
+            will need to pass "facecolor='k', edgecolor='k'"
+            to matplotlib.pyplot.savefig.
         cmap: matplotlib colormap, optional
             The colormap for the anat
         vmin: float
-            Lower bound for plotting, passed to plt.imshow
+            Lower bound for plotting, passed to matplotlib.pyplot.imshow
         vmax: float
-            Upper bound for plotting, passed to plt.imshow
+            Upper bound for plotting, passed to matplotlib.pyplot.imshow
 
         Notes
         -----
@@ -440,7 +442,8 @@ def plot_epi(epi_img=None, cut_coords=None, output_file=None,
         black_bg: boolean, optional
             If True, the background of the image is set to be black. If
             you wish to save figures with a black background, you
-            will need to pass "facecolor='k', edgecolor='k'" to plt.savefig.
+            will need to pass "facecolor='k', edgecolor='k'"
+            to matplotlib.pyplot.savefig.
         cmap: matplotlib colormap, optional
             The colormap for specified image
         threshold : a number, None, or 'auto'
@@ -450,9 +453,9 @@ def plot_epi(epi_img=None, cut_coords=None, output_file=None,
             as transparent. If auto is given, the threshold is determined
             magically by analysis of the image.
         vmin: float
-            Lower bound for plotting, passed to plt.imshow
+            Lower bound for plotting, passed to matplotlib.pyplot.imshow
         vmax: float
-            Upper bound for plotting, passed to plt.imshow
+            Upper bound for plotting, passed to matplotlib.pyplot.imshow
 
         Notes
         -----
@@ -519,7 +522,8 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         black_bg: boolean, optional
             If True, the background of the image is set to be black. If
             you wish to save figures with a black background, you
-            will need to pass "facecolor='k', edgecolor='k'" to plt.savefig.
+            will need to pass "facecolor='k', edgecolor='k'"
+            to matplotlib.pyplot.savefig.
         threshold : a number, None, or 'auto'
             If None is given, the image is not thresholded.
             If a number is given, it is used to threshold the image:
@@ -527,9 +531,9 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
             as transparent. If auto is given, the threshold is determined
             magically by analysis of the image.
         vmin: float
-            Lower bound for plotting, passed to plt.imshow
+            Lower bound for plotting, passed to matplotlib.pyplot.imshow
         vmax: float
-            Upper bound for plotting, passed to plt.imshow
+            Upper bound for plotting, passed to matplotlib.pyplot.imshow
 
     """
     bg_img, black_bg, bg_vmin, bg_vmax = _load_anat(bg_img, dim=dim,
@@ -610,7 +614,8 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         black_bg: boolean, optional
             If True, the background of the image is set to be black. If
             you wish to save figures with a black background, you
-            will need to pass "facecolor='k', edgecolor='k'" to plt.savefig.
+            will need to pass "facecolor='k', edgecolor='k'"
+            to matplotlib.pyplot.savefig.
         cmap: matplotlib colormap, optional
             The colormap for specified image. The ccolormap *must* be
             symmetrical.
@@ -619,7 +624,7 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
             or from 0 to vmax. Setting to 'auto' will select the latter if
             the whole image is non-negative.
         vmax: float
-            Upper bound for plotting, passed to plt.imshow
+            Upper bound for plotting, passed to matplotlib.pyplot.imshow
 
         Notes
         -----
@@ -735,15 +740,16 @@ def plot_glass_brain(stat_map_img,
         black_bg: boolean, optional
             If True, the background of the image is set to be black. If
             you wish to save figures with a black background, you
-            will need to pass "facecolor='k', edgecolor='k'" to plt.savefig.
+            will need to pass "facecolor='k', edgecolor='k'"
+            to matplotlib.pyplot.savefig.
         cmap: matplotlib colormap, optional
             The colormap for specified image
         alpha: float between 0 and 1
             Alpha transparency for the brain schematics
         vmin: float
-            Lower bound for plotting, passed to plt.imshow
+            Lower bound for plotting, passed to matplotlib.pyplot.imshow
         vmax: float
-            Upper bound for plotting, passed to plt.imshow
+            Upper bound for plotting, passed to matplotlib.pyplot.imshow
 
         Notes
         -----
@@ -833,7 +839,8 @@ def plot_connectome(adjacency_matrix, node_coords,
         black_bg: boolean, optional
             If True, the background of the image is set to be black. If
             you wish to save figures with a black background, you
-            will need to pass "facecolor='k', edgecolor='k'" to plt.savefig.
+            will need to pass "facecolor='k', edgecolor='k'"
+            to matplotlib.pyplot.savefig.
         alpha: float between 0 and 1
             Alpha transparency for the brain schematics.
         edge_kwargs: dict

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -370,9 +370,9 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
         cmap: matplotlib colormap, optional
             The colormap for the anat
         vmin: float
-            vmin passed to plt.imshow
+            Lower bound for plotting, passed to plt.imshow
         vmax: float
-            vmax passed to plt.imshow
+            Upper bound for plotting, passed to plt.imshow
 
         Notes
         -----
@@ -450,9 +450,9 @@ def plot_epi(epi_img=None, cut_coords=None, output_file=None,
             as transparent. If auto is given, the threshold is determined
             magically by analysis of the image.
         vmin: float
-            vmin passed to plt.imshow
+            Lower bound for plotting, passed to plt.imshow
         vmax: float
-            vmax passed to plt.imshow
+            Upper bound for plotting, passed to plt.imshow
 
         Notes
         -----
@@ -527,9 +527,9 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
             as transparent. If auto is given, the threshold is determined
             magically by analysis of the image.
         vmin: float
-            vmin passed to plt.imshow
+            Lower bound for plotting, passed to plt.imshow
         vmax: float
-            vmax passed to plt.imshow
+            Upper bound for plotting, passed to plt.imshow
 
     """
     bg_img, black_bg, bg_vmin, bg_vmax = _load_anat(bg_img, dim=dim,
@@ -619,7 +619,7 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
             or from 0 to vmax. Setting to 'auto' will select the latter if
             the whole image is non-negative.
         vmax: float
-            vmax passed to plt.imshow
+            Upper bound for plotting, passed to plt.imshow
 
         Notes
         -----
@@ -741,9 +741,9 @@ def plot_glass_brain(stat_map_img,
         alpha: float between 0 and 1
             Alpha transparency for the brain schematics
         vmin: float
-            vmin passed to plt.imshow
+            Lower bound for plotting, passed to plt.imshow
         vmax: float
-            vmax passed to plt.imshow
+            Upper bound for plotting, passed to plt.imshow
 
         Notes
         -----


### PR DESCRIPTION
rather than relying on kwargs. Fixes #524.

Better suggestions for vmin/vmax docstring documentation more than welcome. At the moment this is a bit cryptic:

```
vmin: float
    vmin passed to plt.imshow
vmax: float
    vmax passed to plt.imshow
```