### PR TITLE
Addressing the simple documentation issue suggesting a 64 bit installation

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -122,7 +122,7 @@ rich. Installing the different packages needed is time-consuming and error
 prone.
 
 :Windows and MacOSX:
-  We suggest that you install Anaconda_.
+  We suggest you to install 64 bit Anaconda_.
 
   `Enthought Canopy`_, `PythonXY <http://code.google.com/p/pythonxy/>`_ are
   other options. Enthought Canopy Express, the free version, should cover all


### PR DESCRIPTION
Added words suggesting nilearn users to install 64 bit Anaconda installation. Please suggest/comment if any additional sentences need to be added to warn users who are using 32 bit.