### PR TITLE
ENH: plotting: add title and annotation kwargs to _plt_img_with_bg

### DIFF
--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -425,10 +425,10 @@ class BaseSlicer(object):
             text: string
                 The text of the title
             x: float, optional
-                The horizontal position of the title on the frame in 
+                The horizontal position of the title on the frame in
                 fraction of the frame width.
             y: float, optional
-                The vertical position of the title on the frame in 
+                The vertical position of the title on the frame in
                 fraction of the frame height.
             size: integer, optional
                 The size of the title text.
@@ -675,21 +675,15 @@ class BaseSlicer(object):
         """
         kwargs = kwargs.copy()
         if not 'color' in kwargs:
-            if self._black_bg:
-                kwargs['color'] = 'w'
-            else:
-                kwargs['color'] = 'k'
-
-        bg_color = ('k' if self._black_bg else 'w')
+            kwargs['color'] = ('w' if self._black_bg else 'k')
+        if not 'bg_color' in kwargs:
+            kwargs['bg_color'] = ('k' if self._black_bg else 'w')
         if left_right:
             for display_ax in self.axes.values():
-                display_ax.draw_left_right(size=size, bg_color=bg_color,
-                                       **kwargs)
-
+                display_ax.draw_left_right(size=size, **kwargs)
         if positions:
             for display_ax in self.axes.values():
-                display_ax.draw_position(size=size, bg_color=bg_color,
-                                       **kwargs)
+                display_ax.draw_position(size=size, **kwargs)
 
     def close(self):
         """ Close the figure. This is necessary to avoid leaking memory.

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -46,7 +46,7 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
                       bg_vmin=None, bg_vmax=None, interpolation="nearest",
                       display_factory=get_slicer,
                       cbar_vmin=None, cbar_vmax=None,
-                      **kwargs):
+                      annotation_kwargs={}, title_kwargs={}, **kwargs):
     """ Internal function, please refer to the docstring of plot_img for parameters
         not listed below.
 
@@ -60,6 +60,12 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
             passed to the add_overlay calls
         display_factory: function
             takes a display_mode argument and return a display class
+        annotation_kwargs : dict
+            additional kwargs for annotation attributes (e.g. size, color,
+            bgcolor, weight).
+        title_kwargs : dict
+            additional kwargs for title attributes (e.g. size, color, bgcolor,
+            weight).
     """
     show_nan_msg = False
     if vmax is not None and np.isnan(vmax):
@@ -110,11 +116,11 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
                             **kwargs)
 
     if annotate:
-        display.annotate()
+        display.annotate(**annotation_kwargs)
     if draw_cross:
         display.draw_cross()
     if title is not None and not title == '':
-        display.title(title)
+        display.title(title, **title_kwargs)
     if (cbar_vmax is not None) or (cbar_vmin is not None):
         if hasattr(display, '_cbar'):
             cbar = display._cbar


### PR DESCRIPTION
The plotting utilities in nilearn are pretty nice!

This is a simple pull request to add optional title and annotation kwarg dictionaries to `_plt_img_with_bg`.  This is intended to make it easier for users to edit the title and/or annotation font size, color, etc. via functions such as `plot_roi` or `plot_img`

example usage:
```python
plotting.plot_roi(roi_nii,
                  title='roi label',
                  annotation_kwargs=dict(size=10),
                  title_kwargs=dict(size=12, color='k', bgcolor='w',
                                    weight='bold', alpha=0.))
```

If there is already another simple way to do this, please let me know.  If you are interested in this implementation, I can explicitly list these arguments in the docstrings to `plot_roi`, etc so that they are easier for users to find, instead of leaving them "hidden" within **kwargs as presently implemented.

Also, one minor inconsistency is that the background color argument for the title is `bgcolor`, while for the annotation it would be `bg_color`.  Is it worth changing the implementation in `plotting.displays.BaseSlicer` to make the names consistent?
