### PR TITLE
[MRG] Fix output data dtype after resampling for 4d images

### DIFF
--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -461,6 +461,9 @@ def resample_img(img, target_affine=None, target_shape=None,
 
     all_img = (slice(None), ) * 3
 
+    # Iter over a set of 3D volumes, as the interpolation problem is
+    # separable in the extra dimensions. This reduces the
+    # computational cost
     for ind in np.ndindex(*other_shape):
         _resample_one_img(data[all_img + ind], A, A_inv, b, target_shape,
                           interpolation_order,

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -453,27 +453,18 @@ def resample_img(img, target_affine=None, target_shape=None,
     if isinstance(target_shape, np.ndarray):
         target_shape = target_shape.tolist()
     target_shape = tuple(target_shape)
-    # For images with dimensions larger than 3D:
-    if len(data_shape) > 3:
-        # Iter in a set of 3D volumes, as the interpolation problem is
-        # separable in the extra dimensions. This reduces the
-        # computational cost
-        other_shape = data_shape[3:]
-        resampled_data = np.ndarray(list(target_shape) + other_shape,
-                                    order=order)
 
-        all_img = (slice(None), ) * 3
+    # Code is generic enough to work for both 3D and 4D images
+    other_shape = data_shape[3:]
+    resampled_data = np.empty(list(target_shape) + other_shape,
+                              order=order, dtype=data.dtype)
 
-        for ind in np.ndindex(*other_shape):
-            _resample_one_img(data[all_img + ind], A, A_inv, b, target_shape,
-                      interpolation_order,
-                      out=resampled_data[all_img + ind],
-                      copy=not input_img_is_string)
-    else:
-        resampled_data = np.empty(target_shape, data.dtype)
-        _resample_one_img(data, A, A_inv, b, target_shape,
+    all_img = (slice(None), ) * 3
+
+    for ind in np.ndindex(*other_shape):
+        _resample_one_img(data[all_img + ind], A, A_inv, b, target_shape,
                           interpolation_order,
-                          out=resampled_data,
+                          out=resampled_data[all_img + ind],
                           copy=not input_img_is_string)
 
     return new_img_like(img, resampled_data, target_affine)

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -454,10 +454,16 @@ def resample_img(img, target_affine=None, target_shape=None,
         target_shape = target_shape.tolist()
     target_shape = tuple(target_shape)
 
+    if interpolation == 'continuous' and data.dtype.kind == 'i':
+        resampled_data_dtype = np.dtype(
+            data.dtype.name.replace('int', 'float'))
+    else:
+        resampled_data_dtype = data.dtype
+
     # Code is generic enough to work for both 3D and 4D images
     other_shape = data_shape[3:]
     resampled_data = np.empty(list(target_shape) + other_shape,
-                              order=order, dtype=data.dtype)
+                              order=order, dtype=resampled_data_dtype)
 
     all_img = (slice(None), ) * 3
 

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -116,8 +116,8 @@ def test_resampling_with_affine():
             rot_img = resample_img(Nifti1Image(data, np.eye(4)),
                                    target_affine=rot,
                                    interpolation='nearest')
-            np.testing.assert_almost_equal(np.max(data),
-                                           np.max(rot_img.get_data()))
+            assert_equal(np.max(data),
+                         np.max(rot_img.get_data()))
             assert_equal(rot_img.get_data().dtype, data.dtype)
 
 

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -106,14 +106,19 @@ def test_resampling_with_affine():
     """ Test resampling with a given rotation part of the affine.
     """
     prng = np.random.RandomState(10)
-    data = prng.randint(4, size=(1, 4, 4))
-    for angle in (0, np.pi, np.pi / 2., np.pi / 4., np.pi / 3.):
-        rot = rotation(0, angle)
-        rot_img = resample_img(Nifti1Image(data, np.eye(4)),
-                               target_affine=rot,
-                               interpolation='nearest')
-        np.testing.assert_almost_equal(np.max(data),
-                                       np.max(rot_img.get_data()))
+
+    data_3d = prng.randint(4, size=(1, 4, 4))
+    data_4d = prng.randint(4, size=(1, 4, 4, 3))
+
+    for data in [data_3d, data_4d]:
+        for angle in (0, np.pi, np.pi / 2., np.pi / 4., np.pi / 3.):
+            rot = rotation(0, angle)
+            rot_img = resample_img(Nifti1Image(data, np.eye(4)),
+                                   target_affine=rot,
+                                   interpolation='nearest')
+            np.testing.assert_almost_equal(np.max(data),
+                                           np.max(rot_img.get_data()))
+            assert_equal(rot_img.get_data().dtype, data.dtype)
 
 
 def test_resampling_error_checks():


### PR DESCRIPTION
for 4d images. The dtype after resampling was always 'float64' for 4d images

* Share same code for 3d and 4d images
* add test for dtype equality before and after resampling

An example that highlights the issue:

```python
import numpy as np

import nibabel as nib

from nilearn import image

img_4d = nib.Nifti1Image(np.ones((10, 10, 10, 5), dtype='int64'), np.eye(4))
resampled_img = image.resample_img(img_4d, 2. * np.eye(4))
print('img_4d dtype:       ', img_4d.get_data().dtype)
print('resampled_img dtype:', resampled_img.get_data().dtype)
```

and its output:

```
img_4d dtype:        int64
resampled_img dtype: float64
```