### PR TITLE
Fix threshold application during plotting for affine with rotation

### DIFF
--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -490,19 +490,10 @@ class BaseSlicer(object):
 
         img = _utils.check_niimg_3d(img)
 
-        if threshold is not None:
-            data = img.get_data()
-            if threshold == 0:
-                data = np.ma.masked_equal(data, 0, copy=False)
-            else:
-                data = np.ma.masked_inside(data, -threshold, threshold,
-                                           copy=False)
-            img = new_img_like(img, data, img.get_affine())
-
         # Make sure that add_overlay shows consistent default behavior
         # with plot_stat_map
         kwargs.setdefault('interpolation', 'nearest')
-        ims = self._map_show(img, type='imshow', **kwargs)
+        ims = self._map_show(img, type='imshow', threshold=threshold, **kwargs)
 
         if colorbar:
             self._colorbar_show(ims[0], threshold)
@@ -528,8 +519,19 @@ class BaseSlicer(object):
         self._map_show(img, type='contour', **kwargs)
         plt.draw_if_interactive()
 
-    def _map_show(self, img, type='imshow', resampling_interpolation='continuous', **kwargs):
+    def _map_show(self, img, type='imshow',
+                  resampling_interpolation='continuous',
+                  threshold=None, **kwargs):
         img = reorder_img(img, resample=resampling_interpolation)
+
+        if threshold is not None:
+            data = img.get_data()
+            if threshold == 0:
+                data = np.ma.masked_equal(data, 0, copy=False)
+            else:
+                data = np.ma.masked_inside(data, -threshold, threshold,
+                                           copy=False)
+            img = new_img_like(img, data, img.get_affine())
 
         affine = img.get_affine()
         data = img.get_data()

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -130,6 +130,25 @@ def test_plot_stat_map():
     plot_stat_map(new_img, threshold=1000, colorbar=True)
 
 
+def test_plot_stat_map_threshold_for_affine_with_rotation():
+    # threshold was not being applied when affine has a rotation
+    # see https://github.com/nilearn/nilearn/issues/599 for more details
+    data = np.random.randn(10, 10, 10)
+    # matrix with rotation
+    affine = np.array([[-3., 1., 0., 1.],
+                       [-1., -3., 0., -2.],
+                       [0., 0., 3., 3.],
+                       [0., 0., 0., 1.]])
+    img = nibabel.Nifti1Image(data, affine)
+    display = plot_stat_map(img, bg_img=None, threshold=1e6,
+                            display_mode='z', cut_coords=1)
+    # Next two lines retrieve the numpy array from the plot
+    ax = list(display.axes.values())[0].ax
+    plotted_array = ax.images[0].get_array()
+    # Given the high threshold the array should be entirely masked
+    assert_true(plotted_array.mask.all())
+
+
 def test_save_plot():
     img = _generate_img()
 


### PR DESCRIPTION
* threshold application is done after image reordering/resampling
* add regression test

Fix #599.