### PR TITLE
Check dimensionality of first img in `concat_niimgs`

### DIFF
--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -285,19 +285,24 @@ def concat_niimgs(niimgs, dtype=np.float32, ensure_ndim=None,
 
     target_fov = 'first' if auto_resample else None
 
+    # We remove one to the dimensionality because of the list is one dimension.
+    ndim = None
+    if ensure_ndim is not None:
+        ndim = ensure_ndim - 1
+
     # First niimg is extracted to get information and for new_img_like
     first_niimg = None
 
     iterator, literator = itertools.tee(iter(niimgs))
     try:
-        first_niimg = check_niimg(next(literator))
+        first_niimg = check_niimg(next(literator), ensure_ndim=ndim)
     except StopIteration:
         raise TypeError('Cannot concatenate empty objects')
 
-    if ensure_ndim is None:
+    # If no particular dimensionality is asked, we force consistency wrt the
+    # first image
+    if ndim is None:
         ndim = len(first_niimg.shape)
-    else:
-        ndim = ensure_ndim - 1
 
     lengths = [first_niimg.shape[-1] if ndim == 4 else 1]
     for niimg in literator:

--- a/nilearn/tests/test_niimg_conversions.py
+++ b/nilearn/tests/test_niimg_conversions.py
@@ -169,6 +169,12 @@ def test_concat_niimgs():
     shape3 = (11, 22, 33)
     img1c = Nifti1Image(np.ones(shape3), affine)
 
+    # Regression test for #601. Dimensionality of first image was not checked
+    # properly
+    assert_raises_regex(TypeError, 'Data must be a 3D Niimg-like object but '
+                        'you provided an image of shape',
+                        _utils.concat_niimgs, [img4d], ensure_ndim=4)
+
     # check basic concatenation with equal shape/affine
     concatenated = _utils.concat_niimgs((img1, img3, img1))
 


### PR DESCRIPTION
Fix #601
Dimensionality was not checked for the first image, yielding a crash with a non-friendly error message.