### PR TITLE
Enhances error messages for image manipulation

### DIFF
--- a/nilearn/_utils/__init__.py
+++ b/nilearn/_utils/__init__.py
@@ -1,6 +1,6 @@
 
 from .niimg_conversions import (check_niimg, check_niimg_3d, concat_niimgs,
-    check_niimg_4d, DimensionError)
+    check_niimg_4d)
 
 from .niimg import new_img_like, _repr_niimgs, copy_img
 
@@ -9,3 +9,5 @@ from .numpy_conversions import as_ndarray
 from .cache_mixin import CacheMixin
 
 from .logger import _compose_err_msg
+
+from .exceptions import DimensionError

--- a/nilearn/_utils/__init__.py
+++ b/nilearn/_utils/__init__.py
@@ -9,5 +9,3 @@ from .numpy_conversions import as_ndarray
 from .cache_mixin import CacheMixin
 
 from .logger import _compose_err_msg
-
-from .exceptions import DimensionError

--- a/nilearn/_utils/__init__.py
+++ b/nilearn/_utils/__init__.py
@@ -1,6 +1,6 @@
 
 from .niimg_conversions import (check_niimg, check_niimg_3d, concat_niimgs,
-    check_niimg_4d)
+    check_niimg_4d, DimensionError)
 
 from .niimg import new_img_like, _repr_niimgs, copy_img
 

--- a/nilearn/_utils/exceptions.py
+++ b/nilearn/_utils/exceptions.py
@@ -16,6 +16,24 @@ AuthorizedException = (
 
 
 class DimensionError(TypeError):
+    """Custom error type for dimension checking.
+
+    This error is used in recursive calls in check_niimg to keep track of the
+    dimensionality of the data. Its final goal it to generate a user friendly
+    message.
+
+    Parameters
+    ----------
+
+    dim_required: integer
+        Indicates the dimensonality required for the data.
+
+    dim_file: integer
+        Dimensionality of the niimg located at the lowest level of the data.
+
+    dim_list: integer
+        Dimensions added by the imbrication of the data in lists.
+    """
     def __init__(self, dim_required, dim_file, dim_list):
         self.dim_required = dim_required
         self.dim_file = dim_file
@@ -24,6 +42,12 @@ class DimensionError(TypeError):
         super(DimensionError, self).__init__()
 
     def incr(self):
+        """Increments the dimension counters
+
+        Typically called when the error is catched and re-raised to count the
+        number of recursive calls, ie the number of dimensions added by
+        imbrication in lists.
+        """
         self.dim_required += 1
         self.dim_list += 1
 

--- a/nilearn/_utils/exceptions.py
+++ b/nilearn/_utils/exceptions.py
@@ -25,14 +25,11 @@ class DimensionError(TypeError):
     Parameters
     ----------
 
-    dim_required: integer
-        Indicates the dimensonality required for the data.
+    file_dimension: integer
+        Indicates the dimensonality of the bottom-level nifti file
 
-    dim_file: integer
-        Dimensionality of the niimg located at the lowest level of the data.
-
-    dim_list: integer
-        Dimensions added by the imbrication of the data in lists.
+    required_dimension: integer
+        The dimension the nifti file should have
     """
     def __init__(self, file_dimension, required_dimension):
         self.file_dimension = file_dimension
@@ -50,13 +47,14 @@ class DimensionError(TypeError):
         """
         self.stack_counter += 1
 
-    def _get_message(self):
+    @property
+    def message(self):
         message = (
                 "Data must be a %iD Niimg-like object but you provided a "
                 "%s%iD image%s. "
                 "See http://nilearn.github.io/building_blocks/"
                 "manipulating_mr_images.html#niimg." % (
-                    self.dim_required + self.stack_counter,
+                    self.required_dimension + self.stack_counter,
                     "list of " * self.stack_counter,
                     self.file_dimension,
                     "s" * (self.stack_counter != 0)
@@ -64,10 +62,5 @@ class DimensionError(TypeError):
         )
         return message
 
-    def _set_message(self, message):
-        pass
-
     def __str__(self):
         return self.message
-
-    message = property(_get_message, _set_message)

--- a/nilearn/_utils/exceptions.py
+++ b/nilearn/_utils/exceptions.py
@@ -13,3 +13,38 @@ AuthorizedException = (
         TypeError,
         ValueError
 )
+
+
+class DimensionError(TypeError):
+    def __init__(self, dim_required, dim_file, dim_list):
+        self.dim_required = dim_required
+        self.dim_file = dim_file
+        self.dim_list = dim_list
+
+        super(DimensionError, self).__init__()
+
+    def incr(self):
+        self.dim_required += 1
+        self.dim_list += 1
+
+    def _get_message(self):
+        message = (
+                "Data must be a %iD Niimg-like object but you provided a "
+                "%s%iD image%s. "
+                "See http://nilearn.github.io/building_blocks/"
+                "manipulating_mr_images.html#niimg." % (
+                    self.dim_required,
+                    "list of " * self.dim_list,
+                    self.dim_file,
+                    "s" * (self.dim_list != 0)
+                )
+        )
+        return message
+
+    def _set_message(self, message):
+        pass
+
+    def __str__(self):
+        return self.message
+
+    message = property(_get_message, _set_message)

--- a/nilearn/_utils/exceptions.py
+++ b/nilearn/_utils/exceptions.py
@@ -34,22 +34,21 @@ class DimensionError(TypeError):
     dim_list: integer
         Dimensions added by the imbrication of the data in lists.
     """
-    def __init__(self, dim_required, dim_file, dim_list):
-        self.dim_required = dim_required
-        self.dim_file = dim_file
-        self.dim_list = dim_list
+    def __init__(self, file_dimension, required_dimension):
+        self.file_dimension = file_dimension
+        self.required_dimension = required_dimension
+        self.stack_counter = 0
 
         super(DimensionError, self).__init__()
 
-    def incr(self):
-        """Increments the dimension counters
+    def increment_stack_counter(self):
+        """Increments the counter of recursive calls.
 
-        Typically called when the error is catched and re-raised to count the
+        Called when the error is catched and re-raised to count the
         number of recursive calls, ie the number of dimensions added by
         imbrication in lists.
         """
-        self.dim_required += 1
-        self.dim_list += 1
+        self.stack_counter += 1
 
     def _get_message(self):
         message = (
@@ -57,10 +56,10 @@ class DimensionError(TypeError):
                 "%s%iD image%s. "
                 "See http://nilearn.github.io/building_blocks/"
                 "manipulating_mr_images.html#niimg." % (
-                    self.dim_required,
-                    "list of " * self.dim_list,
-                    self.dim_file,
-                    "s" * (self.dim_list != 0)
+                    self.dim_required + self.stack_counter,
+                    "list of " * self.stack_counter,
+                    self.file_dimension,
+                    "s" * (self.stack_counter != 0)
                 )
         )
         return message

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -108,7 +108,8 @@ def _iter_check_niimg(niimgs, ensure_ndim=None, atleast_4d=False,
                          % (i, img_name),) + exc.args)
             raise
         except DimensionError as exc:
-            exc.incr()
+            # Keep track of the additional dimension in the error
+            exc.increment_stack_counter()
             raise
 
 
@@ -299,7 +300,8 @@ def concat_niimgs(niimgs, dtype=np.float32, ensure_ndim=None,
     except StopIteration:
         raise TypeError('Cannot concatenate empty objects')
     except DimensionError as exc:
-        exc.incr()
+        # Keep track of the additional dimension in the error
+        exc.increment_stack_counter()
         raise
 
     # If no particular dimensionality is asked, we force consistency wrt the
@@ -313,7 +315,8 @@ def concat_niimgs(niimgs, dtype=np.float32, ensure_ndim=None,
         try:
             niimg = check_niimg(niimg, ensure_ndim=ndim)
         except DimensionError as exc:
-            exc.incr()
+            # Keep track of the additional dimension in the error
+            exc.increment_stack_counter()
             raise
         lengths.append(niimg.shape[-1] if ndim == 4 else 1)
 

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -12,6 +12,7 @@ from sklearn.externals.joblib import Memory
 from .cache_mixin import cache
 from .niimg import _safe_get_data, load_niimg, new_img_like
 from .compat import _basestring, izip
+from .exceptions import DimensionError
 
 
 def _check_fov(img, affine, shape):
@@ -38,41 +39,6 @@ def _index_img(img, index):
     return new_img_like(
         img, img.get_data()[:, :, :, index], img.get_affine(),
         copy_header=True)
-
-
-class DimensionError(TypeError):
-    def __init__(self, dim_required, dim_file, dim_list):
-        self.dim_required = dim_required
-        self.dim_file = dim_file
-        self.dim_list = dim_list
-
-        super(DimensionError, self).__init__()
-
-    def incr(self):
-        self.dim_required += 1
-        self.dim_list += 1
-
-    def _get_message(self):
-        message = (
-                "Data must be a %iD Niimg-like object but you provided a "
-                "%s%iD image%s. "
-                "See http://nilearn.github.io/building_blocks/"
-                "manipulating_mr_images.html#niimg." % (
-                    self.dim_required,
-                    "list of " * self.dim_list,
-                    self.dim_file,
-                    "s" * (self.dim_list != 0)
-                )
-        )
-        return message
-
-    def _set_message(self, message):
-        pass
-
-    def __str__(self):
-        return self.message
-
-    message = property(_get_message, _set_message)
 
 
 def _iter_check_niimg(niimgs, ensure_ndim=None, atleast_4d=False,

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -147,13 +147,9 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False,
 
     Its application is idempotent.
     """
+
     # in case of an iterable
     if hasattr(niimg, "__iter__") and not isinstance(niimg, _basestring):
-        if ensure_ndim == 3:
-            raise TypeError(
-                "Data must be a 3D Niimg-like object but you provided a %s."
-                " See http://nilearn.github.io/building_blocks/"
-                "manipulating_mr_images.html#niimg." % type(niimg))
         if return_iterator:
             return _iter_check_niimg(niimg, ensure_ndim=ensure_ndim)
         return concat_niimgs(niimg, ensure_ndim=ensure_ndim)

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -40,7 +40,7 @@ def _index_img(img, index):
         copy_header=True)
 
 
-class DimensionError(TypeError):
+class DimensionError(Exception):
     def __init__(self, dim_required, dim_file, dim_list):
         self.dim_required = dim_required
         self.dim_file = dim_file
@@ -55,7 +55,7 @@ class DimensionError(TypeError):
     def _get_message(self):
         message = (
                 "Data must be a %iD Niimg-like object but you provided a "
-                "%s%iD image. "
+                "%s%iD images. "
                 "See http://nilearn.github.io/building_blocks/"
                 "manipulating_mr_images.html#niimg." % (
                     self.dim_required,
@@ -67,6 +67,9 @@ class DimensionError(TypeError):
 
     def _set_message(self, message):
         pass
+
+    def __str__(self):
+        return self.message
 
     message = property(_get_message, _set_message)
 

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -40,7 +40,7 @@ def _index_img(img, index):
         copy_header=True)
 
 
-class DimensionError(Exception):
+class DimensionError(TypeError):
     def __init__(self, dim_required, dim_file, dim_list):
         self.dim_required = dim_required
         self.dim_file = dim_file

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -172,7 +172,7 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False,
         niimg = new_img_like(niimg, data, niimg.get_affine())
 
     if ensure_ndim is not None and len(niimg.shape) != ensure_ndim:
-        raise DimensionError(ensure_ndim, len(niimg.shape), 0)
+        raise DimensionError(len(niimg.shape), ensure_ndim)
 
     if return_iterator:
         return (_index_img(niimg, i) for i in range(niimg.shape[3]))

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -55,12 +55,13 @@ class DimensionError(Exception):
     def _get_message(self):
         message = (
                 "Data must be a %iD Niimg-like object but you provided a "
-                "%s%iD images. "
+                "%s%iD image%s. "
                 "See http://nilearn.github.io/building_blocks/"
                 "manipulating_mr_images.html#niimg." % (
                     self.dim_required,
                     "list of " * self.dim_list,
-                    self.dim_file
+                    self.dim_file,
+                    "s" * (self.dim_list != 0)
                 )
         )
         return message

--- a/nilearn/input_data/tests/test_base_masker.py
+++ b/nilearn/input_data/tests/test_base_masker.py
@@ -9,7 +9,7 @@ import nibabel
 from nilearn.input_data.base_masker import filter_and_mask
 from nilearn import image
 from nilearn._utils.testing import assert_raises_regex
-from nilearn._utils import DimensionError
+from nilearn._utils.exceptions import DimensionError
 
 
 def test_cropping_code_paths():

--- a/nilearn/input_data/tests/test_base_masker.py
+++ b/nilearn/input_data/tests/test_base_masker.py
@@ -9,6 +9,7 @@ import nibabel
 from nilearn.input_data.base_masker import filter_and_mask
 from nilearn import image
 from nilearn._utils.testing import assert_raises_regex
+from nilearn._utils import DimensionError
 
 
 def test_cropping_code_paths():
@@ -58,5 +59,5 @@ def test_filter_and_mask():
     data_img = nibabel.Nifti1Image(data, np.eye(4))
     mask_img = nibabel.Nifti1Image(mask, np.eye(4))
 
-    assert_raises_regex(TypeError, "Data must be a 3D", filter_and_mask,
+    assert_raises_regex(DimensionError, "Data must be a 3D", filter_and_mask,
                          data_img, mask_img, {})

--- a/nilearn/input_data/tests/test_multi_nifti_masker.py
+++ b/nilearn/input_data/tests/test_multi_nifti_masker.py
@@ -15,6 +15,7 @@ from distutils.version import LooseVersion
 
 from nilearn.input_data.multi_nifti_masker import MultiNiftiMasker
 from nilearn._utils.testing import assert_raises_regex, write_tmp_imgs
+from nilearn._utils import DimensionError
 
 
 def test_auto_mask():
@@ -104,7 +105,7 @@ def test_3d_images():
     mask_img_4d = Nifti1Image(np.ones((2, 2, 2, 2), dtype=np.int8),
                               affine=np.diag((4, 4, 4, 1)))
     masker2 = MultiNiftiMasker(mask_img=mask_img_4d)
-    assert_raises_regex(TypeError, "Data must be a 3D",
+    assert_raises_regex(DimensionError, "Data must be a 3D",
                         masker2.fit)
 
 

--- a/nilearn/input_data/tests/test_multi_nifti_masker.py
+++ b/nilearn/input_data/tests/test_multi_nifti_masker.py
@@ -15,7 +15,7 @@ from distutils.version import LooseVersion
 
 from nilearn.input_data.multi_nifti_masker import MultiNiftiMasker
 from nilearn._utils.testing import assert_raises_regex, write_tmp_imgs
-from nilearn._utils import DimensionError
+from nilearn._utils.exceptions import DimensionError
 
 
 def test_auto_mask():

--- a/nilearn/input_data/tests/test_nifti_labels_masker.py
+++ b/nilearn/input_data/tests/test_nifti_labels_masker.py
@@ -11,8 +11,7 @@ import numpy as np
 import nibabel
 
 from nilearn.input_data.nifti_labels_masker import NiftiLabelsMasker
-from nilearn._utils import testing
-from nilearn._utils import as_ndarray
+from nilearn._utils import testing, as_ndarray, DimensionError
 
 
 def generate_random_img(shape, length=1, affine=np.eye(4),
@@ -48,14 +47,13 @@ def test_nifti_labels_masker():
 
     # verify that 4D mask arguments are refused
     masker = NiftiLabelsMasker(labels11_img, mask_img=mask_img_4d)
-    testing.assert_raises_regex(TypeError, "Data must be a 3D",
+    testing.assert_raises_regex(DimensionError, "Data must be a 3D",
                                 masker.fit)
 
     # check exception when transform() called without prior fit()
     masker11 = NiftiLabelsMasker(labels11_img, resampling_target=None)
     testing.assert_raises_regex(
-        ValueError,
-        'has not been fitted. ', masker11.transform, fmri11_img)
+        ValueError, 'has not been fitted. ', masker11.transform, fmri11_img)
 
     # No exception raised here
     signals11 = masker11.fit().transform(fmri11_img)

--- a/nilearn/input_data/tests/test_nifti_labels_masker.py
+++ b/nilearn/input_data/tests/test_nifti_labels_masker.py
@@ -11,7 +11,8 @@ import numpy as np
 import nibabel
 
 from nilearn.input_data.nifti_labels_masker import NiftiLabelsMasker
-from nilearn._utils import testing, as_ndarray, DimensionError
+from nilearn._utils import testing, as_ndarray
+from nilearn._utils.exceptions import DimensionError
 
 
 def generate_random_img(shape, length=1, affine=np.eye(4),

--- a/nilearn/input_data/tests/test_nifti_maps_masker.py
+++ b/nilearn/input_data/tests/test_nifti_maps_masker.py
@@ -12,7 +12,7 @@ import nibabel
 
 from nilearn.input_data.nifti_labels_masker import NiftiLabelsMasker
 from nilearn.input_data.nifti_maps_masker import NiftiMapsMasker
-from nilearn._utils import testing, as_ndarray
+from nilearn._utils import testing, as_ndarray, DimensionError
 
 
 def generate_random_img(shape, length=1, affine=np.eye(4),
@@ -141,7 +141,7 @@ def test_nifti_maps_masker_2():
 
     # verify that 4D mask arguments are refused
     masker = NiftiMapsMasker(maps33_img, mask_img=mask_img_4d)
-    testing.assert_raises_regex(TypeError, "Data must be a 3D",
+    testing.assert_raises_regex(DimensionError, "Data must be a 3D",
                                 masker.fit)
 
     # Test error checking

--- a/nilearn/input_data/tests/test_nifti_maps_masker.py
+++ b/nilearn/input_data/tests/test_nifti_maps_masker.py
@@ -12,7 +12,8 @@ import nibabel
 
 from nilearn.input_data.nifti_labels_masker import NiftiLabelsMasker
 from nilearn.input_data.nifti_maps_masker import NiftiMapsMasker
-from nilearn._utils import testing, as_ndarray, DimensionError
+from nilearn._utils import testing, as_ndarray
+from nilearn._utils.exceptions import DimensionError
 
 
 def generate_random_img(shape, length=1, affine=np.eye(4),

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -17,7 +17,7 @@ from nilearn.masking import (compute_epi_mask, compute_multi_epi_mask,
                              compute_background_mask, unmask, _unmask_3d,
                              _unmask_4d, intersect_masks, MaskWarning)
 from nilearn._utils.testing import (write_tmp_imgs, assert_raises_regex)
-from nilearn._utils import DimensionError
+from nilearn._utils.exceptions import DimensionError
 
 np_version = (np.version.full_version if hasattr(np.version, 'full_version')
               else np.version.short_version)

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -17,6 +17,7 @@ from nilearn.masking import (compute_epi_mask, compute_multi_epi_mask,
                              compute_background_mask, unmask, _unmask_3d,
                              _unmask_4d, intersect_masks, MaskWarning)
 from nilearn._utils.testing import (write_tmp_imgs, assert_raises_regex)
+from nilearn._utils import DimensionError
 
 np_version = (np.version.full_version if hasattr(np.version, 'full_version')
               else np.version.short_version)
@@ -132,7 +133,7 @@ def test_apply_mask():
 
     # veriy that 4D masks are rejected
     mask_img_4d = Nifti1Image(np.ones((40, 40, 40, 2)), np.eye(4))
-    assert_raises_regex(TypeError, "Data must be a 3D",
+    assert_raises_regex(DimensionError, "Data must be a 3D",
                         masking.apply_mask, data_img, mask_img_4d)
 
     # Check that 3D data is accepted
@@ -145,7 +146,7 @@ def test_apply_mask():
     assert_equal(sorted(data_3d.tolist()), [3., 4., 12.])
 
     # Check data shape and affine
-    assert_raises_regex(TypeError, "Data must be a 3D",
+    assert_raises_regex(DimensionError, "Data must be a 3D",
                         masking.apply_mask, data_img,
                         Nifti1Image(mask[20, ...], affine))
     assert_raises(ValueError, masking.apply_mask,

--- a/nilearn/tests/test_niimg_conversions.py
+++ b/nilearn/tests/test_niimg_conversions.py
@@ -19,7 +19,8 @@ import nibabel
 from nibabel import Nifti1Image
 
 from nilearn import _utils, image
-from nilearn._utils import testing, DimensionError
+from nilearn._utils import testing
+from nilearn._utils.exceptions import DimensionError
 from nilearn._utils.testing import assert_raises_regex
 
 
@@ -127,6 +128,24 @@ def test_check_niimg_4d():
         ValueError,
         'Field of view of image #1 is different from reference FOV',
         list, c)
+
+
+def test_check_niimg():
+    affine = np.eye(4)
+    img_3d = Nifti1Image(np.ones((10, 10, 10)), affine)
+    img_4d = Nifti1Image(np.ones((10, 10, 10, 4)), affine)
+    img_3_3d = [[[img_3d, img_3d]]]
+    img_2_4d = [[img_4d, img_4d]]
+
+    assert_raises_regex(
+        DimensionError,
+        'Data must be a 2D Niimg-like object but you provided a list of list '
+        'of list of 3D images.', _utils.check_niimg, img_3_3d, ensure_ndim=2)
+
+    assert_raises_regex(
+        DimensionError,
+        'Data must be a 4D Niimg-like object but you provided a list of list '
+        'of 4D images.', _utils.check_niimg, img_2_4d, ensure_ndim=4)
 
 
 def test_repr_niimgs():

--- a/nilearn/tests/test_niimg_conversions.py
+++ b/nilearn/tests/test_niimg_conversions.py
@@ -19,7 +19,7 @@ import nibabel
 from nibabel import Nifti1Image
 
 from nilearn import _utils, image
-from nilearn._utils import testing
+from nilearn._utils import testing, DimensionError
 from nilearn._utils.testing import assert_raises_regex
 
 
@@ -107,8 +107,8 @@ def test_check_niimg_4d():
         assert_array_equal(img_1.get_affine(), img_2.get_affine())
 
     # This should raise an error: a 3D img is given and we want a 4D
-    assert_raises_regex(TypeError, 'Data must be a 4D Niimg-like object but '
-                        'you provided an image of shape',
+    assert_raises_regex(DimensionError, 'Data must be a 4D Niimg-like object but '
+                        'you provided',
                         _utils.check_niimg_4d, img_3d)
 
     # Test a Niimg-like object that does not hold a shape attribute
@@ -171,15 +171,15 @@ def test_concat_niimgs():
 
     # Regression test for #601. Dimensionality of first image was not checked
     # properly
-    assert_raises_regex(TypeError, 'Data must be a 3D Niimg-like object but '
-                        'you provided an image of shape',
+    assert_raises_regex(DimensionError, 'Data must be a 4D Niimg-like object but '
+                        'you provided',
                         _utils.concat_niimgs, [img4d], ensure_ndim=4)
 
     # check basic concatenation with equal shape/affine
     concatenated = _utils.concat_niimgs((img1, img3, img1))
 
-    assert_raises_regex(TypeError, 'Data must be a 3D Niimg-like object but '
-                        'you provided an image of shape',
+    assert_raises_regex(DimensionError, 'Data must be a 4D Niimg-like object but '
+                        'you provided',
                         _utils.concat_niimgs, [img1, img4d])
 
     # smoke-test auto_resample

--- a/nilearn/tests/test_region.py
+++ b/nilearn/tests/test_region.py
@@ -14,6 +14,7 @@ from nilearn._utils.testing import generate_timeseries, generate_regions_ts
 from nilearn._utils.testing import generate_labeled_regions, generate_maps
 from nilearn._utils.testing import generate_fake_fmri
 from nilearn._utils.testing import write_tmp_imgs, assert_raises_regex
+from nilearn._utils import DimensionError
 
 
 def test_generate_regions_ts():
@@ -109,7 +110,7 @@ def test_signals_extraction_with_labels():
     assert_true(np.all(data.std(axis=-1) > 0))
 
     # verify that 4D label images are refused
-    assert_raises_regex(TypeError, "Data must be a 3D",
+    assert_raises_regex(DimensionError, "Data must be a 3D",
                         region.img_to_signals_labels, data_img, labels_4d_img)
 
     # There must be non-zero data (safety net)
@@ -133,10 +134,10 @@ def test_signals_extraction_with_labels():
         assert_true(labels_r == list(range(1, 9)))
 
     ## Same thing, with mask.
-    assert_raises_regex(TypeError, "Data must be a 3D",
+    assert_raises_regex(DimensionError, "Data must be a 3D",
                         region.img_to_signals_labels, data_img, labels_img,
                         mask_img=mask_4d_img)
-    assert_raises_regex(TypeError, "Data must be a 3D",
+    assert_raises_regex(DimensionError, "Data must be a 3D",
                         region.signals_to_img_labels, data_img, labels_img,
                         mask_img=mask_4d_img)
 

--- a/nilearn/tests/test_region.py
+++ b/nilearn/tests/test_region.py
@@ -14,7 +14,7 @@ from nilearn._utils.testing import generate_timeseries, generate_regions_ts
 from nilearn._utils.testing import generate_labeled_regions, generate_maps
 from nilearn._utils.testing import generate_fake_fmri
 from nilearn._utils.testing import write_tmp_imgs, assert_raises_regex
-from nilearn._utils import DimensionError
+from nilearn._utils.exceptions import DimensionError
 
 
 def test_generate_regions_ts():


### PR DESCRIPTION
#601 raised the poorness of some error messages. In particular, when trying to use `index_img` on a list of 4D image.

I solved that by creating a custom type error but I don't know if it's the best way to do it.

Test script:
```python
from nilearn import image, datasets


hb = datasets.fetch_haxby()
image.index_img(hb.func, 0)
```

Previous output:
```
TypeError: Data must be a 3D Niimg-like object but you provided an image of shape (40, 64, 64, 1452). See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg
```

New output:
```
nilearn._utils.niimg_conversions.DimensionError: Data must be a 4D Niimg-like object but you provided a list of 4D images. See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
```