### PR TITLE
Use izip to iterate on _iter_check_niimg to avoid memory/fd explosion

### DIFF
--- a/nilearn/_utils/compat.py
+++ b/nilearn/_utils/compat.py
@@ -15,6 +15,7 @@ if sys.version_info[0] == 3:
     StringIO = io.StringIO
     BytesIO = io.BytesIO
     _urllib = urllib
+    izip = zip
 
     def md5_hash(string):
         m = hashlib.md5()
@@ -27,10 +28,12 @@ else:
     import urllib2
     import urlparse
     import types
+    import itertools
 
     _basestring = basestring
     cPickle = cPickle
     StringIO = BytesIO = StringIO.StringIO
+    izip = itertools.izip
 
     class _module_lookup(object):
         modules = [urlparse, urllib2, urllib]

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -11,7 +11,7 @@ from sklearn.externals.joblib import Memory
 
 from .cache_mixin import cache
 from .niimg import _safe_get_data, load_niimg, new_img_like
-from .compat import _basestring
+from .compat import _basestring, izip
 
 
 def _check_fov(img, affine, shape):
@@ -314,7 +314,7 @@ def concat_niimgs(niimgs, dtype=np.float32, ensure_ndim=None,
     data = np.ndarray(target_shape + (sum(lengths), ),
                       order="F", dtype=dtype)
     cur_4d_index = 0
-    for index, (size, niimg) in enumerate(zip(lengths, _iter_check_niimg(
+    for index, (size, niimg) in enumerate(izip(lengths, _iter_check_niimg(
             iterator, atleast_4d=True, target_fov=target_fov,
             memory=memory, memory_level=memory_level))):
 

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -18,7 +18,7 @@ from .. import signal
 from .. import _utils
 from .._utils.cache_mixin import CacheMixin, cache
 from .._utils.class_inspect import enclosing_scope_name, get_params
-from .._utils.compat import _basestring
+from .._utils.compat import _basestring, izip
 from nilearn._utils.niimg_conversions import _iter_check_niimg
 
 
@@ -215,7 +215,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
                                 verbose=self.verbose,
                                 confounds=confounds,
                                 copy=copy)
-                          for imgs, confounds in zip(niimg_iter, confounds))
+                          for imgs, confounds in izip(niimg_iter, confounds))
         return list(zip(*data))[0]
 
     def fit_transform(self, X, y=None, confounds=None, **fit_params):

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -190,16 +190,15 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
                              % self.__class__.__name__)
         params = get_params(self.__class__, self)
 
-        reference_affine = None
+        target_fov = None
         if self.target_affine is None:
-            # Load the first image and use it as a reference for all other
-            # subjects
-            reference_affine = _utils.check_niimg(imgs_list[0]).get_affine()
+            # Force resampling on first image
+            target_fov = 'first'
 
-        fov = (self.mask_img_.get_affine(), self.mask_img_.shape)
         niimg_iter = _iter_check_niimg(imgs_list, ensure_ndim=None,
                                        atleast_4d=False,
-                                       target_fov=fov, memory=self.memory,
+                                       target_fov=target_fov,
+                                       memory=self.memory,
                                        memory_level=self.memory_level,
                                        verbose=self.verbose)
 


### PR DESCRIPTION
Fix #584.

Basically, it uses a proper zip iterator when using _iter_check_niimg, otherwise the list of niimg is precaclulated and the number of file descriptors (or memory) could explode.

Cannot create a reliable test for that.

Ping @mrahim @banilo could you validate that (don't try on drago since the number of fd allowed on it is now tremendous).