### PR TITLE
Simple L1 dictionary learning

### DIFF
--- a/examples/connectivity/plot_dict_learning_resting_state.py
+++ b/examples/connectivity/plot_dict_learning_resting_state.py
@@ -50,7 +50,7 @@ print('[Example] Dumping results')
 components_imgs = []
 # Retrieve learned spatial maps in brain space
 for i, estimator in enumerate(estimators):
-    components_img = estimator.masker_.inverse_transform(estimator.components_[indices[:, i]])
+    components_img = estimator.masker_.inverse_transform(estimator.components_)
     components_img.to_filename('%s_resting_state.nii.gz' % type(estimator).__name__)
     components_imgs.append(components_img)
 

--- a/examples/connectivity/plot_dict_learning_resting_state.py
+++ b/examples/connectivity/plot_dict_learning_resting_state.py
@@ -20,15 +20,6 @@ import numpy as np
 ### Load ADHD rest dataset ####################################################
 from nilearn import datasets
 
-# OUTPUT DIR
-import os
-import datetime
-
-try:
-    os.makedirs(output_dir)
-except OSError:
-    pass
-
 adhd_dataset = datasets.fetch_adhd(n_subjects=10)
 func_filenames = adhd_dataset.func  # list of 4D nifti files for each subject
 

--- a/examples/connectivity/plot_dict_learning_resting_state.py
+++ b/examples/connectivity/plot_dict_learning_resting_state.py
@@ -45,7 +45,7 @@ n_components = 50
 dict_learning = DictLearning(n_components=n_components, smoothing_fwhm=6.,
                              memory="nilearn_cache", memory_level=5,
                              threshold=1., verbose=2, random_state=0,
-                             n_jobs=1, n_init=1, alpha=6, n_iter=1000)
+                             n_jobs=1, n_init=1, alpha=3, n_iter=1000)
 
 dict_learning.fit(func_filenames)
 

--- a/examples/connectivity/plot_dict_learning_resting_state.py
+++ b/examples/connectivity/plot_dict_learning_resting_state.py
@@ -17,6 +17,9 @@ Pre-prints for paper is available on hal
 
 ### Load ADHD rest dataset ####################################################
 from nilearn import datasets
+# For linear assignment (should be moved in non user space...)
+from sklearn.utils.linear_assignment_ import linear_assignment
+import numpy as np
 
 adhd_dataset = datasets.fetch_adhd(n_subjects=20, data_dir='/media/data/neuro')
 func_filenames = adhd_dataset.func  # list of 4D nifti files for each subject
@@ -26,38 +29,59 @@ print('First functional nifti image (4D) is at: %s' %
       adhd_dataset.func[0])  # 4D data
 
 ### Apply DictLearning ########################################################
-from nilearn.decomposition.dict_learning import DictLearning, CanICA
-n_components = 30
+from nilearn.decomposition.dict_learning import DictLearning
+from nilearn.decomposition.canica import CanICA
+from nilearn.decomposition.multi_pca import MultiPCA
+n_components = 50
 
-estimators = [('Dictionary Learning',
-              DictLearning(n_components=n_components, smoothing_fwhm=6.,
-                             memory="nilearn_cache", memory_level=5, verbose=2, random_state=0,
-                             n_jobs=1, n_init=1, alpha=5, n_iter='auto')),
-              ('Canonical Independent Component Analysis',
-               CanICA(n_components=n_components, smoothing_fwhm=6.,
-                             memory="nilearn_cache", memory_level=5, verbose=2, random_state=0,
-                             n_jobs=1, n_init=1))
-              ]
+dict_learning = DictLearning(n_components=n_components, smoothing_fwhm=6.,
+                             memory="/media/data/nilearn_cache", memory_level=5, verbose=2, random_state=0,
+                             n_jobs=1, alpha=7, n_iter=1000)
+canica = CanICA(n_components=n_components, smoothing_fwhm=6.,
+                memory="/media/data/nilearn_cache", memory_level=5, verbose=2, random_state=0,
+                n_jobs=1, n_init=1, threshold=1.)
 
-for name, estimator in estimators:
-dict_learning.fit(func_filenames)
+multi_pca = MultiPCA(n_components=n_components, smoothing_fwhm=6.,
+                memory="/media/data/nilearn_cache", memory_level=5, verbose=2)
 
-print('')
+estimators = [canica, dict_learning]
+
+
+for estimator in estimators:
+    estimator.fit(func_filenames)
+
+
+# np.save('temp', np.concatenate([estimator.components_ for estimator in estimators]))
+# import numpy as np
+# from sklearn.utils.linear_assignment_ import linear_assignment
+print('[Example] Aligning maps')
+K = np.corrcoef(np.concatenate([estimator.components_ for estimator in estimators]))
+K[np.isinf(K)] = 0
+K = np.nan_to_num(K)
+K = K[:n_components, n_components:]
+indices = linear_assignment(1-K)
+
 print('[Example] Dumping results')
 
+components_imgs = []
 # Retrieve learned spatial maps in brain space
-components_img = estimator.masker_.inverse_transform(estimator.components_)
-components_img.to_filename('%s_resting_state.nii.gz')
+for i, estimator in enumerate(estimators):
+    components_img = estimator.masker_.inverse_transform(estimator.components_[indices[:, i]])
+    components_img.to_filename('%s_resting_state.nii.gz' % type(estimator).__name__)
+    components_imgs.append(components_img)
 
 ### Visualize the results #####################################################
 # Show some interesting components
 import matplotlib.pyplot as plt
-from nilearn.plotting import plot_stat_map
-from nilearn.image import iter_img
+from nilearn.plotting import plot_stat_map, find_xyz_cut_coords
+from nilearn.image import index_img
 
-for i, cur_img in enumerate(iter_img(components_img)):
+for i in range(n_components):
     if i % 3 == 0:
-        plot_stat_map(cur_img, title="Component %d" % i,
-                      colorbar=False)
+        fig, axes = plt.subplots(nrows=3)
+        cut_coords = find_xyz_cut_coords(index_img(components_imgs[0], i))
+        for estimator, cur_img, ax in zip(estimators, components_imgs, axes):
+            plot_stat_map(index_img(cur_img, i), title="Component %d" % i, axes=ax,
+                          cut_coords=cut_coords, colorbar=False)
 
 plt.show()

--- a/examples/connectivity/plot_dict_learning_resting_state.py
+++ b/examples/connectivity/plot_dict_learning_resting_state.py
@@ -18,8 +18,6 @@ Pre-prints for paper is available on hal
 ### Load ADHD rest dataset ####################################################
 from nilearn import datasets
 # For linear assignment (should be moved in non user space...)
-from sklearn.utils.linear_assignment_ import linear_assignment
-import numpy as np
 
 adhd_dataset = datasets.fetch_adhd(n_subjects=20, data_dir='/media/data/neuro')
 func_filenames = adhd_dataset.func  # list of 4D nifti files for each subject
@@ -31,35 +29,21 @@ print('First functional nifti image (4D) is at: %s' %
 ### Apply DictLearning ########################################################
 from nilearn.decomposition.dict_learning import DictLearning
 from nilearn.decomposition.canica import CanICA
-from nilearn.decomposition.multi_pca import MultiPCA
-n_components = 50
+
+n_components = 10
 
 dict_learning = DictLearning(n_components=n_components, smoothing_fwhm=6.,
                              memory="/media/data/nilearn_cache", memory_level=5, verbose=2, random_state=0,
-                             n_jobs=1, alpha=7, n_iter=1000)
+                             n_jobs=1, alpha=6, n_iter=1000)
 canica = CanICA(n_components=n_components, smoothing_fwhm=6.,
                 memory="/media/data/nilearn_cache", memory_level=5, verbose=2, random_state=0,
-                n_jobs=1, n_init=1, threshold=1.)
-
-multi_pca = MultiPCA(n_components=n_components, smoothing_fwhm=6.,
-                memory="/media/data/nilearn_cache", memory_level=5, verbose=2)
+                n_jobs=1, n_init=1, threshold=3.)
 
 estimators = [canica, dict_learning]
 
 
 for estimator in estimators:
     estimator.fit(func_filenames)
-
-
-# np.save('temp', np.concatenate([estimator.components_ for estimator in estimators]))
-# import numpy as np
-# from sklearn.utils.linear_assignment_ import linear_assignment
-print('[Example] Aligning maps')
-K = np.corrcoef(np.concatenate([estimator.components_ for estimator in estimators]))
-K[np.isinf(K)] = 0
-K = np.nan_to_num(K)
-K = K[:n_components, n_components:]
-indices = linear_assignment(1-K)
 
 print('[Example] Dumping results')
 
@@ -77,9 +61,9 @@ from nilearn.plotting import plot_stat_map, find_xyz_cut_coords
 from nilearn.image import index_img
 
 for i in range(n_components):
-    if i % 3 == 0:
+    if i % 2 == 0:
         fig, axes = plt.subplots(nrows=3)
-        cut_coords = find_xyz_cut_coords(index_img(components_imgs[0], i))
+        cut_coords = find_xyz_cut_coords(index_img(components_imgs[1], i))
         for estimator, cur_img, ax in zip(estimators, components_imgs, axes):
             plot_stat_map(index_img(cur_img, i), title="Component %d" % i, axes=ax,
                           cut_coords=cut_coords, colorbar=False)

--- a/examples/connectivity/plot_dict_learning_resting_state.py
+++ b/examples/connectivity/plot_dict_learning_resting_state.py
@@ -1,0 +1,71 @@
+"""
+Group analysis of resting-state fMRI with dictionary learning: DictLearning
+=====================================================
+
+An example applying dictionary learning to resting-state data. This example applies it
+to 10 subjects of the ADHD200 datasets.
+
+Dictionary learning is a sparsity based decomposition method for extracting spatial maps.
+
+    * Gael Varoquaux et al.
+    Multi-subject dictionary learning to segment an atlas of brain spontaneous activity
+    Information Processing in Medical Imaging, 2011, pp. 562-573, Lecture Notes in Computer Science
+
+Pre-prints for paper is available on hal
+(http://hal.archives-ouvertes.fr)
+"""
+
+import numpy as np
+
+### Load ADHD rest dataset ####################################################
+from nilearn import datasets
+
+# OUTPUT DIR
+import os
+import datetime
+
+output_dir = os.path.expanduser('~/work/output/nilearn/plot_dict_learning_resting_state')
+output_dir = os.path.join(output_dir, datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S'))
+try:
+    os.makedirs(output_dir)
+except OSError:
+    pass
+
+adhd_dataset = datasets.fetch_adhd(n_subjects=10)
+func_filenames = adhd_dataset.func  # list of 4D nifti files for each subject
+
+# print basic information on the dataset
+print('First functional nifti image (4D) is at: %s' %
+      adhd_dataset.func[0])  # 4D data
+
+### Apply DictLearning ########################################################
+from nilearn.decomposition.dict_learning import DictLearning
+n_components = 50
+
+dict_learning = DictLearning(n_components=n_components, smoothing_fwhm=6.,
+                             memory="nilearn_cache", memory_level=5,
+                             threshold=1., verbose=2, random_state=0,
+                             n_jobs=1, n_init=1, alpha=3.7, n_iter=1000)
+
+dict_learning.fit(func_filenames)
+
+print('')
+print('[Example] Dumping results')
+
+# Retrieve the independent components in brain space
+components_img = dict_learning.masker_.inverse_transform(dict_learning.components_)
+# components_img is a Nifti Image object, and can be saved to a file with
+# the following line:
+components_img.to_filename('dict_learning_resting_state.nii.gz')
+
+### Visualize the results #####################################################
+# Show some interesting components
+import matplotlib.pyplot as plt
+from nilearn.plotting import plot_stat_map
+from nilearn.image import iter_img
+
+for i, cur_img in enumerate(iter_img(components_img)):
+    plot_stat_map(cur_img, display_mode="z", title="IC %d" % i, cut_coords=1,
+                  colorbar=False)
+
+plt.show()

--- a/examples/connectivity/plot_dict_learning_resting_state.py
+++ b/examples/connectivity/plot_dict_learning_resting_state.py
@@ -15,12 +15,10 @@ Pre-prints for paper is available on hal
 (http://hal.archives-ouvertes.fr)
 """
 
-import numpy as np
-
 ### Load ADHD rest dataset ####################################################
 from nilearn import datasets
 
-adhd_dataset = datasets.fetch_adhd(n_subjects=10)
+adhd_dataset = datasets.fetch_adhd(n_subjects=20, data_dir='/media/data/neuro')
 func_filenames = adhd_dataset.func  # list of 4D nifti files for each subject
 
 # print basic information on the dataset
@@ -29,12 +27,11 @@ print('First functional nifti image (4D) is at: %s' %
 
 ### Apply DictLearning ########################################################
 from nilearn.decomposition.dict_learning import DictLearning
-n_components = 50
+n_components = 30
 
 dict_learning = DictLearning(n_components=n_components, smoothing_fwhm=6.,
-                             memory="nilearn_cache", memory_level=5,
-                             threshold=1., verbose=2, random_state=0,
-                             n_jobs=1, n_init=1, alpha=3, n_iter=1000)
+                             memory="nilearn_cache", memory_level=5, verbose=2, random_state=0,
+                             n_jobs=1, n_init=1, alpha=5, n_iter='auto')
 
 dict_learning.fit(func_filenames)
 
@@ -52,7 +49,7 @@ from nilearn.plotting import plot_stat_map
 from nilearn.image import iter_img
 
 for i, cur_img in enumerate(iter_img(components_img)):
-    if i % 10 == 0:
+    if i % 3 == 0:
         plot_stat_map(cur_img, title="Component %d" % i,
                       colorbar=False)
 

--- a/examples/connectivity/plot_dict_learning_resting_state.py
+++ b/examples/connectivity/plot_dict_learning_resting_state.py
@@ -26,21 +26,28 @@ print('First functional nifti image (4D) is at: %s' %
       adhd_dataset.func[0])  # 4D data
 
 ### Apply DictLearning ########################################################
-from nilearn.decomposition.dict_learning import DictLearning
+from nilearn.decomposition.dict_learning import DictLearning, CanICA
 n_components = 30
 
-dict_learning = DictLearning(n_components=n_components, smoothing_fwhm=6.,
+estimators = [('Dictionary Learning',
+              DictLearning(n_components=n_components, smoothing_fwhm=6.,
                              memory="nilearn_cache", memory_level=5, verbose=2, random_state=0,
-                             n_jobs=1, n_init=1, alpha=5, n_iter='auto')
+                             n_jobs=1, n_init=1, alpha=5, n_iter='auto')),
+              ('Canonical Independent Component Analysis',
+               CanICA(n_components=n_components, smoothing_fwhm=6.,
+                             memory="nilearn_cache", memory_level=5, verbose=2, random_state=0,
+                             n_jobs=1, n_init=1))
+              ]
 
+for name, estimator in estimators:
 dict_learning.fit(func_filenames)
 
 print('')
 print('[Example] Dumping results')
 
 # Retrieve learned spatial maps in brain space
-components_img = dict_learning.masker_.inverse_transform(dict_learning.components_)
-components_img.to_filename('dict_learning_resting_state.nii.gz')
+components_img = estimator.masker_.inverse_transform(estimator.components_)
+components_img.to_filename('%s_resting_state.nii.gz')
 
 ### Visualize the results #####################################################
 # Show some interesting components

--- a/examples/connectivity/plot_dict_learning_resting_state.py
+++ b/examples/connectivity/plot_dict_learning_resting_state.py
@@ -24,8 +24,6 @@ from nilearn import datasets
 import os
 import datetime
 
-output_dir = os.path.expanduser('~/work/output/nilearn/plot_dict_learning_resting_state')
-output_dir = os.path.join(output_dir, datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S'))
 try:
     os.makedirs(output_dir)
 except OSError:
@@ -52,10 +50,8 @@ dict_learning.fit(func_filenames)
 print('')
 print('[Example] Dumping results')
 
-# Retrieve the independent components in brain space
+# Retrieve learned spatial maps in brain space
 components_img = dict_learning.masker_.inverse_transform(dict_learning.components_)
-# components_img is a Nifti Image object, and can be saved to a file with
-# the following line:
 components_img.to_filename('dict_learning_resting_state.nii.gz')
 
 ### Visualize the results #####################################################

--- a/examples/connectivity/plot_dict_learning_resting_state.py
+++ b/examples/connectivity/plot_dict_learning_resting_state.py
@@ -45,7 +45,7 @@ n_components = 50
 dict_learning = DictLearning(n_components=n_components, smoothing_fwhm=6.,
                              memory="nilearn_cache", memory_level=5,
                              threshold=1., verbose=2, random_state=0,
-                             n_jobs=1, n_init=1, alpha=3.7, n_iter=1000)
+                             n_jobs=1, n_init=1, alpha=6, n_iter=1000)
 
 dict_learning.fit(func_filenames)
 
@@ -65,7 +65,8 @@ from nilearn.plotting import plot_stat_map
 from nilearn.image import iter_img
 
 for i, cur_img in enumerate(iter_img(components_img)):
-    plot_stat_map(cur_img, display_mode="z", title="IC %d" % i, cut_coords=1,
-                  colorbar=False)
+    if i % 10 == 0:
+        plot_stat_map(cur_img, title="Component %d" % i,
+                      colorbar=False)
 
 plt.show()

--- a/examples/connectivity/plot_dict_learning_resting_state.py
+++ b/examples/connectivity/plot_dict_learning_resting_state.py
@@ -27,8 +27,7 @@ print('First functional nifti image (4D) is at: %s' %
       adhd_dataset.func[0])  # 4D data
 
 ### Apply DictLearning ########################################################
-from nilearn.decomposition.dict_learning import DictLearning
-from nilearn.decomposition.canica import CanICA
+from nilearn.decomposition import DictLearning, CanICA
 
 n_components = 10
 

--- a/examples/connectivity/plot_dict_learning_resting_state.py
+++ b/examples/connectivity/plot_dict_learning_resting_state.py
@@ -16,63 +16,56 @@ Pre-prints for paper is available on hal
 """
 from joblib import Memory
 
-def generate_maps():
-    ### Load ADHD rest dataset ####################################################
-    from nilearn import datasets
-    # For linear assignment (should be moved in non user space...)
+### Load ADHD rest dataset ####################################################
+from nilearn import datasets
+# For linear assignment (should be moved in non user space...)
 
-    adhd_dataset = datasets.fetch_adhd(n_subjects=20)
-    func_filenames = adhd_dataset.func  # list of 4D nifti files for each subject
+adhd_dataset = datasets.fetch_adhd(n_subjects=20)
+func_filenames = adhd_dataset.func  # list of 4D nifti files for each subject
 
-    # print basic information on the dataset
-    print('First functional nifti image (4D) is at: %s' %
-          adhd_dataset.func[0])  # 4D data
+# print basic information on the dataset
+print('First functional nifti image (4D) is at: %s' %
+      adhd_dataset.func[0])  # 4D data
 
-    ### Apply DictLearning ########################################################
-    from nilearn.decomposition import DictLearning, CanICA
+### Apply DictLearning ########################################################
+from nilearn.decomposition import DictLearning, CanICA
 
-    n_components = 10
+n_components = 10
 
-    dict_learning = DictLearning(n_components=n_components, smoothing_fwhm=6.,
-                                 memory="nilearn_cache", memory_level=5, verbose=2, random_state=0,
-                                 n_jobs=1, alpha=6, n_iter=1000)
-    canica = CanICA(n_components=n_components, smoothing_fwhm=6., memory_level=5, verbose=2, random_state=0,
-                    memory="nilearn_cache", n_jobs=1, n_init=1, threshold=3.)
+dict_learning = DictLearning(n_components=n_components, smoothing_fwhm=6.,
+                             memory="nilearn_cache", memory_level=5, verbose=2, random_state=0,
+                             n_jobs=1, alpha=6, n_iter=1000)
+canica = CanICA(n_components=n_components, smoothing_fwhm=6., memory_level=5, verbose=2, random_state=0,
+                memory="nilearn_cache", n_jobs=1, n_init=1, threshold=3.)
 
-    estimators = [canica, dict_learning]
+estimators = [canica, dict_learning]
 
-    components_imgs = []
+components_imgs = []
 
-    for estimator in estimators:
-        print('[Example] Learning maps using %s model' % type(estimator).__name__)
-        estimator.fit(func_filenames)
-        print('[Example] Dumping results')
-        components_img = estimator.masker_.inverse_transform(estimator.components_)
-        components_img.to_filename('%s_resting_state.nii.gz' % type(estimator).__name__)
-        components_imgs.append(components_img)
-    return estimators, components_imgs
+for estimator in estimators:
+    print('[Example] Learning maps using %s model' % type(estimator).__name__)
+    estimator.fit(func_filenames)
+    print('[Example] Dumping results')
+    components_img = estimator.masker_.inverse_transform(estimator.components_)
+    components_img.to_filename('%s_resting_state.nii.gz' % type(estimator).__name__)
+    components_imgs.append(components_img)
 
 ### Visualize the results #####################################################
 # Show some interesting components
 import matplotlib.pyplot as plt
-from nilearn.plotting import plot_prob_atlas
+from nilearn.plotting import plot_stat_map, find_xyz_cut_coords
+from nilearn.image import index_img
 
-mem = Memory(cachedir='nilearn_data')
-
-estimators, components_imgs = mem.cache(generate_maps)()
-
-fig, axes = plt.subplots(nrows=2)
-for estimator, components_img, ax in zip(estimators, components_imgs, axes):
-    plot_prob_atlas(components_img, axes=ax)
+mem = Memory(cachedir='~/nilearn_cache')
 
 print('[Example] Displaying')
 
-# for i in range(n_components):
-#     if i % 2 == 0:
-#         fig, axes = plt.subplots(nrows=2)
-#         cut_coords = find_xyz_cut_coords(index_img(components_imgs[1], i))
-#         for estimator, cur_img, ax in zip(estimators, components_imgs, axes):
-#             plot_stat_map(index_img(cur_img, i), title="Component %d" % i, axes=ax,
-#                           cut_coords=cut_coords, colorbar=False)
+for i in range(n_components):
+    if i % 2 == 0:
+        fig, axes = plt.subplots(nrows=2)
+        cut_coords = find_xyz_cut_coords(index_img(components_imgs[1], i))
+        for estimator, cur_img, ax in zip(estimators, components_imgs, axes):
+            plot_stat_map(index_img(cur_img, i), title="Component %d" % i, axes=ax,
+                          cut_coords=cut_coords, colorbar=False)
 
 plt.show()

--- a/examples/connectivity/plot_dict_learning_resting_state.py
+++ b/examples/connectivity/plot_dict_learning_resting_state.py
@@ -14,55 +14,65 @@ Dictionary learning is a sparsity based decomposition method for extracting spat
 Pre-prints for paper is available on hal
 (http://hal.archives-ouvertes.fr)
 """
+from joblib import Memory
 
-### Load ADHD rest dataset ####################################################
-from nilearn import datasets
-# For linear assignment (should be moved in non user space...)
+def generate_maps():
+    ### Load ADHD rest dataset ####################################################
+    from nilearn import datasets
+    # For linear assignment (should be moved in non user space...)
 
-adhd_dataset = datasets.fetch_adhd(n_subjects=20)
-func_filenames = adhd_dataset.func  # list of 4D nifti files for each subject
+    adhd_dataset = datasets.fetch_adhd(n_subjects=20)
+    func_filenames = adhd_dataset.func  # list of 4D nifti files for each subject
 
-# print basic information on the dataset
-print('First functional nifti image (4D) is at: %s' %
-      adhd_dataset.func[0])  # 4D data
+    # print basic information on the dataset
+    print('First functional nifti image (4D) is at: %s' %
+          adhd_dataset.func[0])  # 4D data
 
-### Apply DictLearning ########################################################
-from nilearn.decomposition import DictLearning, CanICA
+    ### Apply DictLearning ########################################################
+    from nilearn.decomposition import DictLearning, CanICA
 
-n_components = 10
+    n_components = 10
 
-dict_learning = DictLearning(n_components=n_components, smoothing_fwhm=6.,
-                             memory="nilearn_cache", memory_level=5, verbose=2, random_state=0,
-                             n_jobs=1, alpha=6, n_iter=1000)
-canica = CanICA(n_components=n_components, smoothing_fwhm=6., memory_level=5, verbose=2, random_state=0,
-                memory="nilearn_cache", n_jobs=1, n_init=1, threshold=3.)
+    dict_learning = DictLearning(n_components=n_components, smoothing_fwhm=6.,
+                                 memory="nilearn_cache", memory_level=5, verbose=2, random_state=0,
+                                 n_jobs=1, alpha=6, n_iter=1000)
+    canica = CanICA(n_components=n_components, smoothing_fwhm=6., memory_level=5, verbose=2, random_state=0,
+                    memory="nilearn_cache", n_jobs=1, n_init=1, threshold=3.)
 
-estimators = [canica, dict_learning]
+    estimators = [canica, dict_learning]
 
-components_imgs = []
+    components_imgs = []
 
-for estimator in estimators:
-    print('[Example] Learning maps using %s model' % type(estimator).__name__)
-    estimator.fit(func_filenames)
-    print('[Example] Dumping results')
-    components_img = estimator.masker_.inverse_transform(estimator.components_)
-    components_img.to_filename('%s_resting_state.nii.gz' % type(estimator).__name__)
-    components_imgs.append(components_img)
-
+    for estimator in estimators:
+        print('[Example] Learning maps using %s model' % type(estimator).__name__)
+        estimator.fit(func_filenames)
+        print('[Example] Dumping results')
+        components_img = estimator.masker_.inverse_transform(estimator.components_)
+        components_img.to_filename('%s_resting_state.nii.gz' % type(estimator).__name__)
+        components_imgs.append(components_img)
+    return estimators, components_imgs
 
 ### Visualize the results #####################################################
 # Show some interesting components
 import matplotlib.pyplot as plt
-from nilearn.plotting import plot_stat_map, find_xyz_cut_coords
-from nilearn.image import index_img
+from nilearn.plotting import plot_prob_atlas
+
+mem = Memory(cachedir='nilearn_data')
+
+estimators, components_imgs = mem.cache(generate_maps)()
+
+fig, axes = plt.subplots(nrows=2)
+for estimator, components_img, ax in zip(estimators, components_imgs, axes):
+    plot_prob_atlas(components_img, axes=ax)
 
 print('[Example] Displaying')
-for i in range(n_components):
-    if i % 2 == 0:
-        fig, axes = plt.subplots(nrows=3)
-        cut_coords = find_xyz_cut_coords(index_img(components_imgs[1], i))
-        for estimator, cur_img, ax in zip(estimators, components_imgs, axes):
-            plot_stat_map(index_img(cur_img, i), title="Component %d" % i, axes=ax,
-                          cut_coords=cut_coords, colorbar=False)
+
+# for i in range(n_components):
+#     if i % 2 == 0:
+#         fig, axes = plt.subplots(nrows=2)
+#         cut_coords = find_xyz_cut_coords(index_img(components_imgs[1], i))
+#         for estimator, cur_img, ax in zip(estimators, components_imgs, axes):
+#             plot_stat_map(index_img(cur_img, i), title="Component %d" % i, axes=ax,
+#                           cut_coords=cut_coords, colorbar=False)
 
 plt.show()

--- a/examples/connectivity/plot_dict_learning_resting_state.py
+++ b/examples/connectivity/plot_dict_learning_resting_state.py
@@ -19,7 +19,7 @@ Pre-prints for paper is available on hal
 from nilearn import datasets
 # For linear assignment (should be moved in non user space...)
 
-adhd_dataset = datasets.fetch_adhd(n_subjects=20, data_dir='/media/data/neuro')
+adhd_dataset = datasets.fetch_adhd(n_subjects=20)
 func_filenames = adhd_dataset.func  # list of 4D nifti files for each subject
 
 # print basic information on the dataset
@@ -33,26 +33,23 @@ from nilearn.decomposition.canica import CanICA
 n_components = 10
 
 dict_learning = DictLearning(n_components=n_components, smoothing_fwhm=6.,
-                             memory="/media/data/nilearn_cache", memory_level=5, verbose=2, random_state=0,
+                             memory="nilearn_cache", memory_level=5, verbose=2, random_state=0,
                              n_jobs=1, alpha=6, n_iter=1000)
-canica = CanICA(n_components=n_components, smoothing_fwhm=6.,
-                memory="/media/data/nilearn_cache", memory_level=5, verbose=2, random_state=0,
-                n_jobs=1, n_init=1, threshold=3.)
+canica = CanICA(n_components=n_components, smoothing_fwhm=6., memory_level=5, verbose=2, random_state=0,
+                memory="nilearn_cache", n_jobs=1, n_init=1, threshold=3.)
 
 estimators = [canica, dict_learning]
 
+components_imgs = []
 
 for estimator in estimators:
+    print('[Example] Learning maps using %s model' % type(estimator).__name__)
     estimator.fit(func_filenames)
-
-print('[Example] Dumping results')
-
-components_imgs = []
-# Retrieve learned spatial maps in brain space
-for i, estimator in enumerate(estimators):
+    print('[Example] Dumping results')
     components_img = estimator.masker_.inverse_transform(estimator.components_)
     components_img.to_filename('%s_resting_state.nii.gz' % type(estimator).__name__)
     components_imgs.append(components_img)
+
 
 ### Visualize the results #####################################################
 # Show some interesting components
@@ -60,6 +57,7 @@ import matplotlib.pyplot as plt
 from nilearn.plotting import plot_stat_map, find_xyz_cut_coords
 from nilearn.image import index_img
 
+print('[Example] Displaying')
 for i in range(n_components):
     if i % 2 == 0:
         fig, axes = plt.subplots(nrows=3)

--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -50,11 +50,12 @@ class CanICA(MultiPCA, CacheMixin):
         their variance is put to 1 in the time dimension.
 
     threshold: None, 'auto' or float
-        If None, no thresholding is applied. If 'auto',
+        Passed to CanICA. If None, no thresholding is applied. If 'auto',
         then we apply a thresholding that will keep the n_voxels,
         more intense voxels across all the maps, n_voxels being the number
         of voxels in a brain volume. A float value indicates the
-        ratio of voxels to keep (2. means keeping 2 x n_voxels voxels).
+        ratio of voxels to keep (2. means that the maps will together
+        have 2 x n_voxels non-zero voxels ).
 
     n_init: int, optional
         The number of times the fastICA algorithm is restarted

--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -5,11 +5,10 @@ CanICA
 # Author: Alexandre Abraham, Gael Varoquaux,
 # License: BSD 3 clause
 from distutils.version import LooseVersion
-
 from operator import itemgetter
+
 import numpy as np
 from scipy.stats import scoreatpercentile
-
 import sklearn
 from sklearn.decomposition import fastica
 from sklearn.externals.joblib import Memory, delayed, Parallel
@@ -113,7 +112,6 @@ class CanICA(MultiPCA, CacheMixin):
                  threshold='auto', n_init=10,
                  standardize=True,
                  random_state=0,
-                 keep_data_mem=False,
                  target_affine=None, target_shape=None,
                  low_pass=None, high_pass=None, t_r=None,
                  # Common options
@@ -124,8 +122,7 @@ class CanICA(MultiPCA, CacheMixin):
             mask=mask, memory=memory, memory_level=memory_level,
             n_jobs=n_jobs, verbose=verbose, do_cca=do_cca,
             n_components=n_components, smoothing_fwhm=smoothing_fwhm,
-            target_affine=target_affine, target_shape=target_shape,
-            keep_data_mem=keep_data_mem)
+            target_affine=target_affine, target_shape=target_shape)
         self.threshold = threshold
         self.random_state = random_state
         self.low_pass = low_pass

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -4,20 +4,15 @@ DictLearning
 
 # Author: Arthur Mensch
 # License: BSD 3 clause
-from ..input_data.base_masker import filter_and_mask
 
 import numpy as np
-
 from sklearn.externals.joblib import Memory
-
-from .._utils import as_ndarray
-
-
-from .canica import CanICA
-from .._utils.cache_mixin import CacheMixin
-
 from sklearn.linear_model import Ridge
 from sklearn.decomposition import MiniBatchDictionaryLearning
+
+from .._utils import as_ndarray
+from .canica import CanICA
+from .._utils.cache_mixin import CacheMixin
 
 class DictLearning(CanICA, MiniBatchDictionaryLearning, CacheMixin):
     """Perform a map learning algorithm based on component sparsity (rather than independance),
@@ -181,7 +176,7 @@ class DictLearning(CanICA, MiniBatchDictionaryLearning, CacheMixin):
             print('[DictLearning] Learning code')
         self.components_ = MiniBatchDictionaryLearning.transform(self, self.data_flat_.T).T
         self.components_ = as_ndarray(self.components_)
-        # flip signs in each component so that peak is +ve
+        # flip signs in each composant positive part is l1 larger than negative part
         for component in self.components_:
             if np.sum(component[component > 0]) < - np.sum(component[component <= 0]):
                 component *= -1

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -21,7 +21,7 @@ from sklearn.decomposition import MiniBatchDictionaryLearning
 from sklearn.decomposition.pca import RandomizedPCA
 
 class DictLearning(CanICA, MiniBatchDictionaryLearning, CacheMixin):
-    """Perform Dictionary Learning analysis.
+    """Perform Dictionary Learning analysis on a CanICA initialization : yields more stable maps
 
     Parameters
     ----------

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -8,6 +8,7 @@ DictLearning
 import numpy as np
 from sklearn.externals.joblib import Memory
 from sklearn.linear_model import Ridge
+
 from sklearn.decomposition import MiniBatchDictionaryLearning
 
 from .._utils import as_ndarray
@@ -39,24 +40,12 @@ class DictLearning(CanICA, MiniBatchDictionaryLearning, CacheMixin):
         If smoothing_fwhm is not None, it gives the size in millimeters of the
         spatial smoothing to apply to the signal.
 
-    do_cca: boolean, optional
-        Indicate if a Canonical Correlation Analysis must be run after the
-        PCA.
-
     standardize : boolean, optional
         If standardize is True, the time-series are centered and normed:
         their variance is put to 1 in the time dimension.
 
-    threshold: None, 'auto' or float
-        Passed to CanICA. If None, no thresholding is applied. If 'auto',
-        then we apply a thresholding that will keep the n_voxels,
-        more intense voxels across all the maps, n_voxels being the number
-        of voxels in a brain volume. A float value indicates the
-        ratio of voxels to keep (2. means that the maps will together
-        have 2 x n_voxels non-zero voxels ).
-
-    n_init: int, optional
-        The number of times the fastICA algorithm is restarted
+    alpha: float, optional, default=1
+        Sparsity controlling parameter
 
     random_state: int or RandomState
         Pseudo number generator state used for random sampling.
@@ -99,11 +88,7 @@ class DictLearning(CanICA, MiniBatchDictionaryLearning, CacheMixin):
 
     References
     ----------
-    * G. Varoquaux et al. "A group model for stable multi-subject ICA on
-      fMRI datasets", NeuroImage Vol 51 (2010), p. 288-299
 
-    * G. Varoquaux et al. "ICA-based sparse features recovery from fMRI
-      datasets", IEEE ISBI 2010, p. 1177
     """
 
     def __init__(self, mask=None, n_components=20,
@@ -113,7 +98,6 @@ class DictLearning(CanICA, MiniBatchDictionaryLearning, CacheMixin):
                  target_affine=None, target_shape=None,
                  low_pass=None, high_pass=None, t_r=None,
                  alpha=1,
-                 batch_size=10,
                  n_iter=1000,
                  # Common options
                  memory=Memory(cachedir=None), memory_level=0,
@@ -131,7 +115,7 @@ class DictLearning(CanICA, MiniBatchDictionaryLearning, CacheMixin):
         self._keep_data_mem = True
         # Setting n_jobs = 1 as it is slower otherwise
         MiniBatchDictionaryLearning.__init__(self, n_components=n_components, alpha=alpha,
-                                             n_iter=n_iter, batch_size=batch_size,
+                                             n_iter=n_iter, batch_size=10,
                                              fit_algorithm='lars',
                                              transform_algorithm='lasso_lars',
                                              transform_alpha=alpha,

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -106,7 +106,7 @@ class DictLearning(CanICA, MiniBatchDictionaryLearning, CacheMixin):
     """
 
     def __init__(self, mask=None, n_components=20,
-                 smoothing_fwhm=6, n_init=10,
+                 smoothing_fwhm=6,
                  standardize=True,
                  random_state=0,
                  target_affine=None, target_shape=None,
@@ -121,7 +121,7 @@ class DictLearning(CanICA, MiniBatchDictionaryLearning, CacheMixin):
         CanICA.__init__(self,
                         mask=mask, memory=memory, memory_level=memory_level,
                         n_jobs=n_jobs, verbose=verbose, do_cca=True,
-                        threshold=float(n_components), n_init=n_init,
+                        threshold=float(n_components), n_init=1,
                         n_components=n_components, smoothing_fwhm=smoothing_fwhm,
                         target_affine=target_affine, target_shape=target_shape,
                         random_state=random_state, high_pass=high_pass, low_pass=low_pass,
@@ -142,7 +142,8 @@ class DictLearning(CanICA, MiniBatchDictionaryLearning, CacheMixin):
     def _init_dict(self, imgs, y=None, confounds=None):
 
         CanICA.fit(self, imgs, y=y, confounds=confounds)
-        self.data_flat_ = np.concatenate(self.data_flat_, axis=0)
+        if isinstance(self.data_flat_, tuple):  # several subjects
+            self.data_flat_ = np.concatenate(self.data_flat_, axis=0)
         if self.n_iter == 'auto':
             # ceil(self.data_fat.shape[0] / self.batch_size)
             self.n_iter = (self.data_flat_.shape[0] - 1) / self.batch_size + 1

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -52,7 +52,8 @@ class DictLearning(CanICA, MiniBatchDictionaryLearning, CacheMixin):
         then we apply a thresholding that will keep the n_voxels,
         more intense voxels across all the maps, n_voxels being the number
         of voxels in a brain volume. A float value indicates the
-        ratio of voxels to keep (2. means keeping 2 x n_voxels voxels).
+        ratio of voxels to keep (2. means that the maps will together
+        have 2 x n_voxels non-zero voxels ).
 
     n_init: int, optional
         The number of times the fastICA algorithm is restarted
@@ -89,7 +90,7 @@ class DictLearning(CanICA, MiniBatchDictionaryLearning, CacheMixin):
         Rough estimator of the amount of memory used by caching. Higher value
         means more memory for caching.
 
-    n_jobs: integer, optional
+    n_jobs: integer, optional, default=1
         The number of CPUs to use to do the computation. -1 means
         'all CPUs', -2 'all CPUs but one', and so on.
 

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -20,8 +20,8 @@ from sklearn.linear_model import Ridge
 from sklearn.decomposition import MiniBatchDictionaryLearning
 
 class DictLearning(CanICA, MiniBatchDictionaryLearning, CacheMixin):
-    """Perform a map learning algorithm based on componentsparsity, over a CanICA initialization,
-    which yields more stable maps thatn CanICA.
+    """Perform a map learning algorithm based on component sparsity (rather than independance),
+     over a CanICA initialization, which yields more stable maps than CanICA.
 
     Parameters
     ----------

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -126,8 +126,8 @@ class DictLearning(CanICA, MiniBatchDictionaryLearning, CacheMixin):
                         target_affine=target_affine, target_shape=target_shape,
                         random_state=random_state, high_pass=high_pass, low_pass=low_pass,
                         t_r=t_r,
-                        keep_data_mem=True,
                         standardize=standardize)
+        self._keep_data_mem = True
         # Setting n_jobs = 1 as it is slower otherwise
         MiniBatchDictionaryLearning.__init__(self, n_components=n_components, alpha=alpha,
                                              n_iter=n_iter, batch_size=batch_size,
@@ -140,7 +140,6 @@ class DictLearning(CanICA, MiniBatchDictionaryLearning, CacheMixin):
                                              n_jobs=1)
 
     def _init_dict(self, imgs, y=None, confounds=None):
-
         CanICA.fit(self, imgs, y=y, confounds=confounds)
         if isinstance(self.data_flat_, tuple):  # several subjects
             self.data_flat_ = np.concatenate(self.data_flat_, axis=0)

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -8,6 +8,7 @@ DictLearning
 import numpy as np
 from sklearn.externals.joblib import Memory
 from sklearn.linear_model import Ridge
+
 from sklearn.decomposition import dict_learning_online
 
 from .._utils import as_ndarray
@@ -16,8 +17,8 @@ from .._utils.cache_mixin import CacheMixin
 
 
 class DictLearning(CanICA, CacheMixin):
-    """Perform a map learning algorithm based on component sparsity (rather than independance),
-     over a CanICA initialization, which yields more stable maps than CanICA.
+    """Perform a map learning algorithm based on component sparsity,
+     over a CanICA initialization.  This yields more stable maps than CanICA.
 
     Parameters
     ----------

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -7,6 +7,8 @@ DictLearning
 
 from distutils.version import LooseVersion
 
+import sklearn
+
 import numpy as np
 from sklearn.externals.joblib import Memory
 from sklearn.linear_model import Ridge
@@ -153,14 +155,14 @@ class DictLearning(CanICA, CacheMixin):
             print('[DictLearning] Learning dictionary')
         parameters = {}
         if LooseVersion(sklearn.__version__).version > [0, 12]:
-            parameters['chunk_size'] = 10
-        else:
             parameters['batch_size'] = 10
+        else:
+            parameters['chunk_size'] = 10
         self.components_, _ = self._cache(dict_learning_online, func_memory_level=2)(
             self.data_flat_.T,
             self.n_components,
             alpha=self.alpha,
-            n_iter=self.n_iter, batch_size=10,
+            n_iter=self.n_iter,
             method='lars',
             return_code=True,
             verbose=max(0, self.verbose - 1),

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -5,6 +5,8 @@ DictLearning
 # Author: Arthur Mensch
 # License: BSD 3 clause
 
+from distutils.version import LooseVersion
+
 import numpy as np
 from sklearn.externals.joblib import Memory
 from sklearn.linear_model import Ridge
@@ -149,6 +151,11 @@ class DictLearning(CanICA, CacheMixin):
 
         if self.verbose:
             print('[DictLearning] Learning dictionary')
+        parameters = {}
+        if LooseVersion(sklearn.__version__).version > [0, 12]:
+            parameters['chunk_size'] = 10
+        else:
+            parameters['batch_size'] = 10
         self.components_, _ = self._cache(dict_learning_online, func_memory_level=2)(
             self.data_flat_.T,
             self.n_components,
@@ -159,7 +166,7 @@ class DictLearning(CanICA, CacheMixin):
             verbose=max(0, self.verbose - 1),
             random_state=self.random_state,
             shuffle=True,
-            n_jobs=1)
+            n_jobs=1, **parameters)
         self.components_ = self.components_.T
         if self.verbose:
             print('')

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -8,7 +8,6 @@ DictLearning
 from distutils.version import LooseVersion
 
 import sklearn
-
 import numpy as np
 from sklearn.externals.joblib import Memory
 from sklearn.linear_model import Ridge
@@ -154,7 +153,7 @@ class DictLearning(CanICA, CacheMixin):
         if self.verbose:
             print('[DictLearning] Learning dictionary')
         parameters = {}
-        if LooseVersion(sklearn.__version__).version > [0, 12]:
+        if LooseVersion(sklearn.__version__).version >= [0, 13]:
             parameters['batch_size'] = 10
         else:
             parameters['chunk_size'] = 10

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -8,7 +8,6 @@ DictLearning
 import numpy as np
 from sklearn.externals.joblib import Memory
 from sklearn.linear_model import Ridge
-
 from sklearn.decomposition import dict_learning_online
 
 from .._utils import as_ndarray
@@ -152,7 +151,7 @@ class DictLearning(CanICA, CacheMixin):
             print('[DictLearning] Learning dictionary')
         self.components_, _ = self._cache(dict_learning_online, func_memory_level=2)(
             self.data_flat_.T,
-            n_components=self.n_components,
+            self.n_components,
             alpha=self.alpha,
             n_iter=self.n_iter, batch_size=10,
             method='lars',

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -2,97 +2,19 @@
 PCA dimension reduction on multiple subjects
 """
 import itertools
-import warnings
 
 import numpy as np
-from scipy import linalg
-import nibabel
-from sklearn.base import BaseEstimator, TransformerMixin, clone
-
-from sklearn.externals.joblib import Parallel, delayed, Memory
-
+from sklearn.externals.joblib import Memory
 from sklearn.utils.extmath import randomized_svd
+from sklearn.base import TransformerMixin
 
-from ..input_data import NiftiMasker, MultiNiftiMasker, NiftiMapsMasker
-from ..input_data.base_masker import filter_and_mask
-from .._utils.class_inspect import get_params
-from .._utils.cache_mixin import cache, CacheMixin
+from ..input_data import NiftiMapsMasker
+from .._utils.cache_mixin import CacheMixin
 from .._utils import as_ndarray
-from .._utils.compat import _basestring
+from .single_pca import SinglePCA
 
 
-def session_pca(imgs, mask_img, parameters,
-                n_components=20,
-                confounds=None,
-                memory_level=0,
-                memory=Memory(cachedir=None),
-                verbose=0,
-                return_data=False,
-                copy=True,
-                random_state=0):
-    """Filter, mask and compute PCA on Niimg-like objects
-
-    This is an helper function whose first call `base_masker.filter_and_mask`
-    and then apply a PCA to reduce the number of time series.
-
-    Parameters
-    ----------
-    imgs: list of Niimg-like objects
-        See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
-        List of subject data
-
-    mask_img: Niimg-like object
-        See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
-        Mask to apply on the data
-
-    parameters: dictionary
-        Dictionary of parameters passed to `filter_and_mask`. Please see the
-        documentation of the `NiftiMasker` for more informations.
-
-    confounds: CSV file path or 2D matrix
-        This parameter is passed to signal.clean. Please see the
-        corresponding documentation for details.
-
-    n_components: integer, optional
-        Number of components to be extracted by the PCA
-
-    memory_level: integer, optional
-        Integer indicating the level of memorization. The higher, the more
-        function calls are cached.
-
-    memory: joblib.Memory
-        Used to cache the function calls.
-
-    verbose: integer, optional
-        Indicate the level of verbosity (0 means no messages).
-
-    copy: boolean, optional
-        Whether or not data should be copied
-    """
-
-    data, affine = cache(
-        filter_and_mask, memory,
-        func_memory_level=2, memory_level=memory_level,
-        ignore=['verbose', 'memory', 'memory_level', 'copy'])(
-            imgs, mask_img, parameters,
-            memory_level=memory_level,
-            memory=memory,
-            verbose=verbose,
-            confounds=confounds,
-            copy=copy)
-    if n_components <= data.shape[0] // 4:
-        U, S, _ = randomized_svd(data.T, n_components)
-    else:
-        U, S, _ = linalg.svd(data.T, full_matrices=False)
-    U = U.T[:n_components].copy()
-    S = S[:n_components]
-    if return_data:
-        return U, S, data
-    else:
-        return U, S
-
-
-class MultiPCA(BaseEstimator, TransformerMixin, CacheMixin):
+class MultiPCA(SinglePCA, TransformerMixin, CacheMixin):
     """Perform Multi Subject Principal Component Analysis.
 
     Perform a PCA on each subject and stack the results. An optional Canonical
@@ -184,22 +106,15 @@ class MultiPCA(BaseEstimator, TransformerMixin, CacheMixin):
                  t_r=None, memory=Memory(cachedir=None), memory_level=0,
                  n_jobs=1, verbose=0,
                  ):
-        self.mask = mask
-        self.memory = memory
-        self.memory_level = memory_level
-        self.n_jobs = n_jobs
-        self.verbose = verbose
-        self.low_pass = low_pass
-        self.high_pass = high_pass
-        self.t_r = t_r
-        self._keep_data_mem = False
 
-        self.do_cca = do_cca
-        self.n_components = n_components
-        self.smoothing_fwhm = smoothing_fwhm
-        self.target_affine = target_affine
-        self.target_shape = target_shape
-        self.standardize = standardize
+        SinglePCA.__init__(self, n_components=n_components,
+                           smoothing_fwhm=smoothing_fwhm,
+                           mask=mask,
+                           standardize=standardize, target_affine=target_affine,
+                           target_shape=target_shape,
+                           low_pass=low_pass, high_pass=high_pass,
+                           t_r=t_r, memory=memory, memory_level=memory_level,
+                           n_jobs=n_jobs, verbose=verbose, do_cca=do_cca)
 
     def fit(self, imgs, y=None, confounds=None):
         """Compute the mask and the components
@@ -211,106 +126,12 @@ class MultiPCA(BaseEstimator, TransformerMixin, CacheMixin):
             Data on which the PCA must be calculated. If this is a list,
             the affine is considered the same for all.
         """
+        SinglePCA.fit(self, imgs, confounds=confounds)
 
-        # Hack to support single-subject data:
-        if isinstance(imgs, (_basestring, nibabel.Nifti1Image)):
-            imgs = [imgs]
-            # This is a very incomplete hack, as it won't work right for
-            # single-subject list of 3D filenames
-        if len(imgs) == 0:
-            # Common error that arises from a null glob. Capture
-            # it early and raise a helpful message
-            raise ValueError('Need one or more Niimg-like objects as input, '
-                             'an empty list was given.')
-        if confounds is None:
-            confounds = [None] * len(imgs)  # itertools.repeat(None, len(imgs))
+        subject_pcas = self.components_list_
+        subject_svd_vals = self.variance_list_
 
-        # First, learn the mask
-        if not isinstance(self.mask, (NiftiMasker, MultiNiftiMasker)):
-            self.masker_ = MultiNiftiMasker(mask_img=self.mask,
-                                            smoothing_fwhm=self.smoothing_fwhm,
-                                            target_affine=self.target_affine,
-                                            target_shape=self.target_shape,
-                                            standardize=self.standardize,
-                                            low_pass=self.low_pass,
-                                            high_pass=self.high_pass,
-                                            mask_strategy='epi',
-                                            t_r=self.t_r,
-                                            memory=self.memory,
-                                            memory_level=self.memory_level,
-                                            n_jobs=self.n_jobs,
-                                            verbose=max(0, self.verbose - 1))
-        else:
-            try:
-                self.masker_ = clone(self.mask)
-            except TypeError as e:
-                # Workaround for a joblib bug: in joblib 0.6, a Memory object
-                # with cachedir = None cannot be cloned.
-                masker_memory = self.mask.memory
-                if masker_memory.cachedir is None:
-                    self.mask.memory = None
-                    self.masker_ = clone(self.mask)
-                    self.mask.memory = masker_memory
-                    self.masker_.memory = Memory(cachedir=None)
-                else:
-                    # The error was raised for another reason
-                    raise e
-
-            for param_name in ['target_affine', 'target_shape',
-                               'smoothing_fwhm', 'low_pass', 'high_pass',
-                               't_r', 'memory', 'memory_level']:
-                our_param = getattr(self, param_name)
-                if our_param is None:
-                    # Default value
-                    continue
-                if getattr(self.masker_, param_name) is not None:
-                    warnings.warn('Parameter %s of the masker overriden'
-                                  % param_name)
-                setattr(self.masker_, param_name, our_param)
-
-        # Masker warns if it has a mask_img and is passed
-        # imgs to fit().  Avoid the warning by being careful
-        # when calling fit.
-        if self.masker_.mask_img is None:
-            self.masker_.fit(imgs)
-        else:
-            self.masker_.fit()
-        self.mask_img_ = self.masker_.mask_img_
-
-        parameters = get_params(MultiNiftiMasker, self)
-        # Remove non specific and redudent parameters
-        for param_name in ['memory', 'memory_level', 'confounds',
-                           'verbose', 'n_jobs']:
-            parameters.pop(param_name, None)
-
-        parameters['detrend'] = True
-
-        # Now do the subject-level signal extraction (i.e. data-loading +
-        # PCA)
-
-        subject_pcas = Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
-            delayed(session_pca)(
-                img,
-                self.masker_.mask_img_,
-                parameters,
-                n_components=self.n_components,
-                memory=self.memory,
-                memory_level=self.memory_level,
-                return_data=self._keep_data_mem,
-                confounds=confound,
-                verbose=self.verbose
-            )
-            for img, confound in zip(imgs, confounds))
-        if self._keep_data_mem:
-            subject_pcas, subject_svd_vals, subject_data_set = zip(*subject_pcas)
-        else:
-            subject_pcas, subject_svd_vals = zip(*subject_pcas)
-
-        if len(imgs) > 1:
-            if not self.do_cca:
-                for subject_pca, subject_svd_val in \
-                        zip(subject_pcas, subject_svd_vals):
-                    subject_pca *= subject_svd_val[:, np.newaxis]
+        if len(subject_pcas) > 1:
             data = np.empty((len(imgs) * self.n_components,
                             subject_pcas[0].shape[1]),
                             dtype=subject_pcas[0].dtype)
@@ -330,12 +151,10 @@ class MultiPCA(BaseEstimator, TransformerMixin, CacheMixin):
         else:
             data = subject_pcas[0]
             variance = subject_svd_vals[0]
-            if self._keep_data_mem:
-                subject_data_set = subject_data_set[0]
+
         self.components_ = data
         self.variance_ = variance
-        if self._keep_data_mem:
-            self.data_flat_ = subject_data_set
+
         return self
 
     def transform(self, imgs, confounds=None):

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -2,10 +2,10 @@
 PCA dimension reduction on multiple subjects
 """
 import itertools
-import numpy as np
 import warnings
-from scipy import linalg
 
+import numpy as np
+from scipy import linalg
 import nibabel
 from sklearn.base import BaseEstimator, TransformerMixin, clone
 from sklearn.externals.joblib import Parallel, delayed, Memory
@@ -140,7 +140,7 @@ class MultiPCA(BaseEstimator, TransformerMixin, CacheMixin):
         documentation for details
 
     keep_data_mem: boolean,
-        Keep data in memory
+        Keep unmasked data in memory (useful to reuse unmasked data from super classes)
 
     memory: instance of joblib.Memory or string
         Used to cache the masking process.

--- a/nilearn/decomposition/single_pca.py
+++ b/nilearn/decomposition/single_pca.py
@@ -1,0 +1,240 @@
+"""
+PCA dimension reduction on single subjects
+"""
+import warnings
+
+from scipy import linalg
+import nibabel
+from sklearn.base import BaseEstimator, clone
+from sklearn.externals.joblib import Parallel, delayed, Memory
+from sklearn.utils.extmath import randomized_svd
+from sklearn.utils.validation import check_random_state
+import numpy as np
+
+from .._utils.class_inspect import get_params
+from ..input_data import NiftiMasker, MultiNiftiMasker
+from ..input_data.base_masker import filter_and_mask
+from .._utils.cache_mixin import CacheMixin, cache
+from .._utils.compat import _basestring
+
+def session_pca(imgs, mask_img, parameters,
+                n_components=20,
+                confounds=None,
+                memory_level=0,
+                memory=Memory(cachedir=None),
+                verbose=0,
+                reduction=True,
+                copy=True,
+                random_state=0):
+    """Filter, mask and compute PCA on Niimg-like objects
+
+    This is an helper function whose first call `base_masker.filter_and_mask`
+    and then apply a PCA to reduction the number of time series.
+
+    Parameters
+    ----------
+    imgs: list of Niimg-like objects
+        See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
+        List of subject data
+
+    mask_img: Niimg-like object
+        See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
+        Mask to apply on the data
+
+    parameters: dictionary
+        Dictionary of parameters passed to `filter_and_mask`. Please see the
+        documentation of the `NiftiMasker` for more informations.
+
+    confounds: CSV file path or 2D matrix
+        This parameter is passed to signal.clean. Please see the
+        corresponding documentation for details.
+
+    n_components: integer, optional
+        Number of components to be extracted by the PCA
+
+    memory_level: integer, optional
+        Integer indicating the level of memorization. The higher, the more
+        function calls are cached.
+
+    memory: joblib.Memory
+        Used to cache the function calls.
+
+    verbose: integer, optional
+        Indicate the level of verbosity (0 means no messages).
+
+    copy: boolean, optional
+        Whether or not data should be copied
+
+    random_state: int or RandomState
+        Pseudo number generator state used for random sampling.
+
+    random_state:
+    """
+
+    data, affine = cache(
+        filter_and_mask, memory,
+        func_memory_level=2, memory_level=memory_level,
+        ignore=['verbose', 'memory', 'memory_level', 'copy'])(
+            imgs, mask_img, parameters,
+            memory_level=memory_level,
+            memory=memory,
+            verbose=verbose,
+            confounds=confounds,
+            copy=copy)
+    if reduction:
+        if n_components <= data.shape[0] // 4:
+            U, S, _ = cache(randomized_svd, memory, memory_level=memory_level,
+                            func_memory_level=2)(
+                data.T, n_components, random_state=random_state)
+        else:
+            U, S, _ = cache(linalg.svd, memory, memory_level=memory_level,
+                            func_memory_level=2)(
+                data.T, full_matrices=False)
+        U = U.T[:n_components].copy()
+        S = S[:n_components]
+        return U, S
+    else:
+        return data
+
+
+class SinglePCA(BaseEstimator, CacheMixin):
+
+    def __init__(self, n_components=20, smoothing_fwhm=None, mask=None,
+                 standardize=True, target_affine=None,
+                 target_shape=None, low_pass=None, high_pass=None,
+                 t_r=None, memory=Memory(cachedir=None), memory_level=0,
+                 n_jobs=1, verbose=0,
+                 do_cca=False,
+                 random_state=None
+                 ):
+        self.mask = mask
+        self.memory = memory
+        self.memory_level = memory_level
+        self.n_jobs = n_jobs
+        self.verbose = verbose
+        self.low_pass = low_pass
+        self.high_pass = high_pass
+        self.t_r = t_r
+
+        self.n_components = n_components
+        self.smoothing_fwhm = smoothing_fwhm
+        self.target_affine = target_affine
+        self.target_shape = target_shape
+        self.standardize = standardize
+        self.random_state = random_state
+
+        self.do_cca = do_cca
+
+    def fit(self, imgs, y=None, confounds=None):
+        """Compute the mask and the components
+
+        Parameters
+        ----------
+        imgs: list of Niimg-like objects
+            See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
+            Data on which the PCA must be calculated. If this is a list,
+            the affine is considered the same for all.
+        """
+
+        random_state = check_random_state(self.random_state)
+        # Hack to support single-subject data:
+        if isinstance(imgs, (_basestring, nibabel.Nifti1Image)):
+            imgs = [imgs]
+            # This is a very incomplete hack, as it won't work right for
+            # single-subject list of 3D filenames
+        if len(imgs) == 0:
+            # Common error that arises from a null glob. Capture
+            # it early and raise a helpful message
+            raise ValueError('Need one or more Niimg-like objects as input, '
+                             'an empty list was given.')
+        if confounds is None:
+            confounds = [None] * len(imgs)  # itertools.repeat(None, len(imgs))
+
+        # First, learn the mask
+        if not isinstance(self.mask, (NiftiMasker, MultiNiftiMasker)):
+            self.masker_ = MultiNiftiMasker(mask_img=self.mask,
+                                            smoothing_fwhm=self.smoothing_fwhm,
+                                            target_affine=self.target_affine,
+                                            target_shape=self.target_shape,
+                                            standardize=self.standardize,
+                                            low_pass=self.low_pass,
+                                            high_pass=self.high_pass,
+                                            mask_strategy='epi',
+                                            t_r=self.t_r,
+                                            memory=self.memory,
+                                            memory_level=self.memory_level,
+                                            n_jobs=self.n_jobs,
+                                            verbose=max(0, self.verbose - 1))
+        else:
+            try:
+                self.masker_ = clone(self.mask)
+            except TypeError as e:
+                # Workaround for a joblib bug: in joblib 0.6, a Memory object
+                # with cachedir = None cannot be cloned.
+                masker_memory = self.mask.memory
+                if masker_memory.cachedir is None:
+                    self.mask.memory = None
+                    self.masker_ = clone(self.mask)
+                    self.mask.memory = masker_memory
+                    self.masker_.memory = Memory(cachedir=None)
+                else:
+                    # The error was raised for another reason
+                    raise e
+
+            for param_name in ['target_affine', 'target_shape',
+                               'smoothing_fwhm', 'low_pass', 'high_pass',
+                               't_r', 'memory', 'memory_level']:
+                our_param = getattr(self, param_name)
+                if our_param is None:
+                    # Default value
+                    continue
+                if getattr(self.masker_, param_name) is not None:
+                    warnings.warn('Parameter %s of the masker overriden'
+                                  % param_name)
+                setattr(self.masker_, param_name, our_param)
+
+        # Masker warns if it has a mask_img and is passed
+        # imgs to fit().  Avoid the warning by being careful
+        # when calling fit.
+        if self.masker_.mask_img is None:
+            self.masker_.fit(imgs)
+        else:
+            self.masker_.fit()
+        self.mask_img_ = self.masker_.mask_img_
+
+        # Now do the subject-level signal extraction (i.e. data-loading +
+        # PCA)
+        if self.verbose:
+            print("[SinglePCA] Learning subject level PCAs")
+        subject_pcas = Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
+            delayed(self._cache(session_pca, func_memory_level=1))(
+                img,
+                self.masker_.mask_img_,
+                self._get_filter_and_mask_parameters(),
+                n_components=self.n_components,
+                memory=self.memory,
+                memory_level=self.memory_level,
+                confounds=confound,
+                verbose=self.verbose,
+                random_state=random_state,
+            )
+            for img, confound in zip(imgs, confounds))
+        subject_pcas, subject_svd_vals = zip(*subject_pcas)
+        if not self.do_cca:
+            for subject_pca, subject_svd_val in \
+                    zip(subject_pcas, subject_svd_vals):
+                subject_pca *= subject_svd_val[:, np.newaxis]
+
+        self.components_list_ = subject_pcas
+        self.variance_list_ = subject_svd_vals
+
+    def _get_filter_and_mask_parameters(self):
+        parameters = get_params(MultiNiftiMasker, self)
+        # Remove non specific and redudent parameters
+        for param_name in ['memory', 'memory_level', 'confounds',
+                           'verbose', 'n_jobs']:
+            parameters.pop(param_name, None)
+
+        parameters['detrend'] = True
+        return parameters
+

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -1,0 +1,42 @@
+__author__ = 'arthur'
+
+from nilearn.decomposition.tests.test_canica import _make_canica_test_data, _make_canica_components
+from nilearn.decomposition.dict_learning import DictLearning
+from sklearn.utils.linear_assignment_ import linear_assignment
+from nilearn._utils.testing import assert_less_equal
+from numpy.testing import assert_array_almost_equal
+from nilearn.image import iter_img
+
+import numpy as np
+
+def test_dict_learning():
+    data, mask_img, components, rng = _make_canica_test_data()
+
+    dict_learning = DictLearning(n_components=4, random_state=rng, mask=mask_img,
+                                 smoothing_fwhm=0., n_init=1, n_iter=100, alpha=0.1)
+    dict_learning.fit(data)
+    maps = dict_learning.masker_.inverse_transform(dict_learning.components_).get_data()
+    maps = np.reshape(np.rollaxis(maps, 3, 0), (4, 400))
+
+    K = np.corrcoef(np.concatenate((components, maps)))[4:, :4]
+    indices = linear_assignment(-K)
+    K = K.take(indices[:, 1], axis=1).take(indices[:, 0], axis=0)
+    assert_array_almost_equal(np.abs(K), np.eye(4), 1)
+
+def test_component_sign():
+    # We should have a heuristic that flips the sign of components in
+    # DictLearning to have more positive values than negative values, for
+    # instance by making sure that the largest value is positive.
+
+    data, mask_img, components, rng = _make_canica_test_data(n_subjects=2, noisy=True)
+    for mp in components:
+        assert_less_equal(-mp.min(), mp.max())
+
+    # run CanICA many times (this is known to produce different results)
+    canica = DictLearning(n_components=4, random_state=rng, mask=mask_img)
+    for _ in range(3):
+        canica.fit(data)
+        for mp in iter_img(canica.masker_.inverse_transform(
+                canica.components_)):
+            mp = mp.get_data()
+            assert_less_equal(-mp.min(), mp.max())

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -9,6 +9,7 @@ from nilearn.image import iter_img
 
 import numpy as np
 
+
 def test_dict_learning():
     data, mask_img, components, rng = _make_canica_test_data()
 

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -23,6 +23,7 @@ def test_dict_learning():
     K = K.take(indices[:, 1], axis=1).take(indices[:, 0], axis=0)
     assert_array_almost_equal(np.abs(K), np.eye(4), 1)
 
+
 def test_component_sign():
     # We should have a heuristic that flips the sign of components in
     # DictLearning to have more positive values than negative values, for

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -21,7 +21,7 @@ def test_dict_learning():
 
     K = np.corrcoef(np.concatenate((components, maps)))[4:, :4]
     indices = linear_assignment(-K)
-    K = K.take(indices[:, 1], axis=1).take(indices[:, 0], axis=0)
+    K = K[indices[:, 0], :][:, indices[:, 1]]
     assert_array_almost_equal(np.abs(K), np.eye(4), 1)
 
 

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -14,7 +14,7 @@ def test_dict_learning():
     data, mask_img, components, rng = _make_canica_test_data()
 
     dict_learning = DictLearning(n_components=4, random_state=rng, mask=mask_img,
-                                 smoothing_fwhm=0., n_init=3, n_iter=100, alpha=4)
+                                 smoothing_fwhm=0., n_iter=100, alpha=4)
     dict_learning.fit(data)
     maps = dict_learning.masker_.inverse_transform(dict_learning.components_).get_data()
     maps = np.reshape(np.rollaxis(maps, 3, 0), (4, 400))
@@ -36,7 +36,7 @@ def test_component_sign():
 
     # run CanICA many times (this is known to produce different results)
     dict_learning = DictLearning(n_components=4, random_state=rng, mask=mask_img,
-                                 smoothing_fwhm=0., n_init=1, n_iter=100, alpha=1)
+                                 smoothing_fwhm=0., n_iter=100, alpha=1)
     dict_learning.fit(data)
     for mp in iter_img(dict_learning.masker_.inverse_transform(
             dict_learning.components_)):

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -1,6 +1,5 @@
-__author__ = 'arthur'
-
 from sklearn.utils.linear_assignment_ import linear_assignment
+
 from numpy.testing import assert_array_almost_equal
 import numpy as np
 
@@ -26,6 +25,7 @@ def test_dict_learning():
 
 
 def test_component_sign():
+    # Regression test
     # We should have a heuristic that flips the sign of components in
     # DictLearning to have more positive values than negative values, for
     # instance by making sure that the largest value is positive.

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -1,5 +1,10 @@
+from distutils.version import LooseVersion
+
+import sklearn
+
 from sklearn.utils.linear_assignment_ import linear_assignment
-from numpy.testing import assert_array_almost_equal
+
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 import numpy as np
 
 from nilearn.decomposition.tests.test_canica import _make_canica_test_data
@@ -27,9 +32,17 @@ def test_dict_learning():
 
     K = np.abs(components.dot(maps.T))
 
-    indices = linear_assignment(1-K)
-    K = K[indices[:, 0], :][:, indices[:, 1]]
-    assert_array_almost_equal(np.abs(K), np.eye(4), 1)
+    if LooseVersion(sklearn.__version__).version > [0, 12]:
+        indices = linear_assignment(1-K)
+        K = K[indices[:, 0], :][:, indices[:, 1]]
+        assert_array_almost_equal(np.abs(K), np.eye(4), 1)
+    else:
+        a = np.sum(np.abs(K) > 1e-1, axis=1)
+        b = np.sum(np.abs(K) > 1e-1, axis=0)
+        c = np.sum(np.abs(K) > 1e-1)
+        assert_array_equal(a, np.ones(4))
+        assert_array_equal(b, np.ones(4))
+        assert(c == 4)
 
 
 def test_component_sign():

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -2,8 +2,6 @@ from distutils.version import LooseVersion
 
 import sklearn
 
-from sklearn.utils.linear_assignment_ import linear_assignment
-
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 import numpy as np
 
@@ -33,6 +31,7 @@ def test_dict_learning():
     K = np.abs(components.dot(maps.T))
 
     if LooseVersion(sklearn.__version__).version > [0, 12]:
+        from sklearn.utils.linear_assignment_ import linear_assignment
         indices = linear_assignment(1-K)
         K = K[indices[:, 0], :][:, indices[:, 1]]
         assert_array_almost_equal(np.abs(K), np.eye(4), 1)

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -61,3 +61,6 @@ def test_component_sign():
             dict_learning.components_)):
         mp = mp.get_data()
         assert_less_equal(np.sum(mp[mp <= 0]), np.sum(mp[mp > 0]))
+
+if __name__ == '__main__':
+    test_dict_learning()

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -1,7 +1,6 @@
 from distutils.version import LooseVersion
 
 import sklearn
-
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 import numpy as np
 
@@ -30,7 +29,7 @@ def test_dict_learning():
 
     K = np.abs(components.dot(maps.T))
 
-    if LooseVersion(sklearn.__version__).version > [0, 12]:
+    if LooseVersion(sklearn.__version__).version >= [0, 13]:
         from sklearn.utils.linear_assignment_ import linear_assignment
         indices = linear_assignment(1-K)
         K = K[indices[:, 0], :][:, indices[:, 1]]

--- a/nilearn/decomposition/tests/test_multi_pca.py
+++ b/nilearn/decomposition/tests/test_multi_pca.py
@@ -4,14 +4,13 @@ Test the multi-PCA module
 
 import numpy as np
 from nose.tools import assert_raises
-
 import nibabel
+from numpy.testing import assert_almost_equal
 
 from nilearn.decomposition.multi_pca import MultiPCA
 from nilearn.input_data import MultiNiftiMasker
-
-from numpy.testing import assert_almost_equal
 from nilearn.decomposition.tests.test_canica import _make_canica_test_data
+
 
 def test_multi_pca():
     # Smoke test the MultiPCA
@@ -60,7 +59,8 @@ def test_multi_pca():
 
 def test_multi_pca_data_mem():
     data, mask_img, components, rng = _make_canica_test_data()
-    multi_pca = MultiPCA(mask=mask_img, n_components=3, keep_data_mem=True)
+    multi_pca = MultiPCA(mask=mask_img, n_components=3)
+    multi_pca._keep_data_mem = True
     multi_pca.fit(data)
     multi_pca.masker_.set_params(detrend=True)
     assert_almost_equal(multi_pca.data_flat_,  multi_pca.masker_.transform(data))

--- a/nilearn/decomposition/tests/test_multi_pca.py
+++ b/nilearn/decomposition/tests/test_multi_pca.py
@@ -10,6 +10,8 @@ import nibabel
 from nilearn.decomposition.multi_pca import MultiPCA
 from nilearn.input_data import MultiNiftiMasker
 
+from numpy.testing import assert_almost_equal
+from nilearn.decomposition.tests.test_canica import _make_canica_test_data
 
 def test_multi_pca():
     # Smoke test the MultiPCA
@@ -55,3 +57,10 @@ def test_multi_pca():
 
     # Smoke test to fit with no img
     assert_raises(TypeError, multi_pca.fit)
+
+def test_multi_pca_data_mem():
+    data, mask_img, components, rng = _make_canica_test_data()
+    multi_pca = MultiPCA(mask=mask_img, n_components=3, keep_data_mem=True)
+    multi_pca.fit(data)
+    multi_pca.masker_.set_params(detrend=True)
+    assert_almost_equal(multi_pca.data_flat_,  multi_pca.masker_.transform(data))

--- a/nilearn/decomposition/tests/test_multi_pca.py
+++ b/nilearn/decomposition/tests/test_multi_pca.py
@@ -9,7 +9,6 @@ from numpy.testing import assert_almost_equal
 
 from nilearn.decomposition.multi_pca import MultiPCA
 from nilearn.input_data import MultiNiftiMasker
-from nilearn.decomposition.tests.test_canica import _make_canica_test_data
 
 
 def test_multi_pca():
@@ -56,11 +55,3 @@ def test_multi_pca():
 
     # Smoke test to fit with no img
     assert_raises(TypeError, multi_pca.fit)
-
-def test_multi_pca_data_mem():
-    data, mask_img, components, rng = _make_canica_test_data()
-    multi_pca = MultiPCA(mask=mask_img, n_components=3)
-    multi_pca._keep_data_mem = True
-    multi_pca.fit(data)
-    multi_pca.masker_.set_params(detrend=True)
-    assert_almost_equal(multi_pca.data_flat_,  multi_pca.masker_.transform(data))


### PR DESCRIPTION
This PR contains the basic code for l1 dictionary learning. This could constitute a base for next week sprint
@GaelVaroquaux @agramfort @bthirion  

### Integration within nilearn
I made a few design choices that should be discussed:
- I use a composition pattern over CanICA : this allows the code to be quite concise but leads to a loss of flexibility regarding initialization of the dictionary learning algorithm
- I use a flag `keep_data_mem` in MultiPCA to prevent us from loading several time (from files or from cache) the filtered and masked data. This make the code a bit more complicated, but I think this is the price to pay if we want to keep the NiftiMasker embedded within `decomposition` classes (which in itself may be discussed).
- [ ] Tests are needed

### Efficiency

This code is based on scikit-learn 0.16.1, though it should work on every scikit-learn release since dictionary learning has been introduced. With this version, coordinate descent for DL does not work (on read-only data), see https://github.com/scikit-learn/scikit-learn/pull/4775. However, `cd` is faster once this issue is fixed (see attached file, so it should be used instead of `lars` whenever it becomes possible. Discussion with @ogrisel also leads to think that `cd` method could be made way faster.

Maps are held in the code matrix of the DL formulation. We therefore need to compute back the code after learning the dictionary online. Presently, most of the computation time is spent computing back the code after the dictionary learning part. A simple way to speed up results consist in reducing the dictionary with a RandomizedPCA after the dictionary learning part (RandomizedPCA reduce `lasso_cd` computation time, and has a lower computation cost - linear in data dimension, but with a smaller coefficient).

Two benchmarks can illustrate these points : version with RandomizedPCA is in blue, without in red. Output maps are almost not distinguishable. Reduction is quite experimental, but we can be sure that `cd` is better than `lars` in our context.

Coordinate descent
<img src="https://cloud.githubusercontent.com/assets/4078691/8569732/c13ce6d0-257a-11e5-89a1-2b6708b5cbbd.png" width="300px" />

LARS
<img src="https://cloud.githubusercontent.com/assets/4078691/8569733/c4b2fd0e-257a-11e5-8978-afcaba3bec64.png" width="300px" />

### Examples
I adapted the code from the CanICA example. I guess a more pertinent example would be to demonstrate DL effectiveness over ICA (which is the method that the community knows about). For this, we could rely on a scoring function embedded in MultiPCA, which should show better results for DL (explained variance ratio or reproducibility may be a good measure). I can provide the code for explained variance (should it be in another PR, or maybe in PR #630 ?)

#### Visualization
@KamalakerDadi It would be great if we could make use of PR #588 to demonstrate DL ability along with plotting power of nilearn.

### Cross validation
For the moment, we do not provide cross validation facilities for alpha. However, it should stay within the same range as the one provided in the example, as :
- Resolution in the direction of features does not vary a lot (from 1 to 10 I would say) from one dataset to another), which makes choice of alpha non critical
- Dictionary learning algorithm from scikit-learn is suppose to scale its regularization parameters so as to obtain similar sparsity for same input parameter. However, I think that regularization scaling is not made properly in scikit-learn (see https://github.com/scikit-learn/scikit-learn/pull/4873 in function `_sparse_encode`, comments to come), so we cannot rely on this

### Online setting
This implementation is based on an online algorithm for dictionary leaning. However, that way we do this today is actually online in the direction of features (i.e. voxels in our case), due to the fact that we call `dict_learning_online` on the transposed dataset (we use MiniBatchDictionaryLearning but it is more logical to use MiniBatchSparsePCA).

This does not allow the use of `partial_fit` on batches of samples from a dataset (Nifti file after Nifti file for instance).

For large datasets (e.g. HCP), this is a big problem, as we have to load the whole dataset (1,5TB) in memory before starting the algorithm. @lesteve PR #613 has begun adressing the issue of large data analysis within nilearn, and it would therefore be logical to find a solution to this design issue.

One solution would therefore consists in changing the current paradigm in `scikit-learn`, so as to be able to learn the dictionary in an online setting. This is what is proposed in https://github.com/scikit-learn/scikit-learn/pull/4873. I wrote nilearn code based on this PR, which could be introduced in the future.

#### Initialization
Initialization for such large data setting would then need to be studied (especially the sensitivy of the algorithm to this initialization). For example, we could try on doing an ICA on only a subset of the input data.

### Further development

- Group-level Dictionary learning

@AlexandreAbraham provided code for MSDL in PR #88, which could be considered for further development. This would be more involved, would yield better results but would be slower. Another direction to consider would be cohort-level brain mapping https://hal.inria.fr/hal-00841502, which may integrate more smoothly with scikit-learn API.

- Regularization methods

We use a l1 regularization on the code to enforce sparsity. New https://github.com/scikit-learn/scikit-learn/pull/4873 sparse PCA used elastic-net ball constraint for this purpose. We could also consider ways to integrate better regularizations, such as TV @dohmatob.
