### PR TITLE
Fix loading dtype for plotting functions.

### DIFF
--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -47,10 +47,10 @@ def _get_target_dtype(dtype, target_dtype):
     Parameters
     ----------
 
-    dtype: type
+    dtype: dtype
         Data type of the original data
 
-    target_dtype: None, type or "auto"
+    target_dtype: {None, dtype, "auto"}
         If None, no conversion is required. If a type is provided, the
         function will check if a conversion is needed. The "auto" mode will
         automatically convert to int32 if dtype is discrete and float32 if it
@@ -59,7 +59,7 @@ def _get_target_dtype(dtype, target_dtype):
     Returns
     -------
 
-    dtype: type
+    dtype: dtype
         The data type toward which the original data should be converted.
     """
 
@@ -85,7 +85,7 @@ def load_niimg(niimg, dtype=None):
         See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
         Image to load.
 
-    dtype: type
+    dtype: {dtype, "auto"}
         Data type toward which the data should be converted. If "auto", the
         data will be converted to int32 if dtype is discrete and float32 if it
         is continuous.

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -31,6 +31,10 @@ def _safe_get_data(img):
 
 
 def _get_data_dtype(img):
+    """Returns the dtype of an image.
+    If the image is non standard (no get_data_dtype member), this function
+    relies on the data itself.
+    """
     try:
         return img.get_data_dtype()
     except AttributeError:
@@ -38,6 +42,27 @@ def _get_data_dtype(img):
 
 
 def _get_target_dtype(dtype, target_dtype):
+    """Returns a new dtype if conversion is needed
+
+    Parameters
+    ----------
+
+    dtype: type
+        Data type of the original data
+
+    target_dtype: None, type or "auto"
+        If None, no conversion is required. If a type is provided, the
+        function will check if a conversion is needed. The "auto" mode will
+        automatically convert to int32 if dtype is discrete and float32 if it
+        is continuous.
+
+    Returns
+    -------
+
+    dtype: type
+        The data type toward which the original data should be converted.
+    """
+
     if target_dtype is None:
         return None
     if target_dtype == 'auto':
@@ -59,6 +84,11 @@ def load_niimg(niimg, dtype=None):
     niimg: Niimg-like object
         See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
         Image to load.
+
+    dtype: type
+        Data type toward which the data should be converted. If "auto", the
+        data will be converted to int32 if dtype is discrete and float32 if it
+        is continuous.
 
     Returns:
     --------

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -8,7 +8,6 @@ import copy
 import gc
 import collections
 from distutils.version import LooseVersion
-import numbers
 
 import numpy as np
 import nibabel
@@ -42,7 +41,7 @@ def _get_target_dtype(dtype, target_dtype):
     if target_dtype is None:
         return None
     if target_dtype == 'auto':
-        if issubclass(dtype.type, numbers.Integral):
+        if dtype.kind == 'i':
             target_dtype = np.int32
         else:
             target_dtype = np.float32

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -62,6 +62,11 @@ def _iter_check_niimg(niimgs, ensure_ndim=None, atleast_4d=False,
 
     target_fov: tuple of affine and shape
        If specified, images are resampled to this field of view
+
+    dtype: type
+        Data type toward which the data should be converted. If "auto", the
+        data will be converted to int32 if dtype is discrete and float32 if it
+        is continuous.
     """
     ref_fov = None
     resample_to_first_img = False
@@ -133,6 +138,11 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False, dtype=None,
     atleast_4d: boolean, optional
         Indicates if a 3d image should be turned into a single-scan 4d niimg.
 
+    dtype: type
+        Data type toward which the data should be converted. If "auto", the
+        data will be converted to int32 if dtype is discrete and float32 if it
+        is continuous.
+
     Returns
     -------
     result: 3D/4D Niimg-like object
@@ -187,6 +197,11 @@ def check_niimg_3d(niimg, dtype=None):
         If niimg is a string, consider it as a path to Nifti image and
         call nibabel.load on it. If it is an object, check if get_data()
         and get_affine() methods are present, raise TypeError otherwise.
+    
+    dtype: type
+        Data type toward which the data should be converted. If "auto", the
+        data will be converted to int32 if dtype is discrete and float32 if it
+        is continuous.
 
     Returns
     -------
@@ -219,6 +234,11 @@ def check_niimg_4d(niimg, return_iterator=False, dtype=None):
         call nibabel.load on it. If it is an object, check if get_data
         and get_affine methods are present, raise an Exception otherwise.
 
+    dtype: type
+        Data type toward which the data should be converted. If "auto", the
+        data will be converted to int32 if dtype is discrete and float32 if it
+        is continuous.
+    
     return_iterator: boolean
         If True, an iterator of 3D images is returned. This reduces the memory
         usage when `niimgs` contains 3D images.

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -63,7 +63,7 @@ def _iter_check_niimg(niimgs, ensure_ndim=None, atleast_4d=False,
     target_fov: tuple of affine and shape
        If specified, images are resampled to this field of view
 
-    dtype: type
+    dtype: {dtype, "auto"}
         Data type toward which the data should be converted. If "auto", the
         data will be converted to int32 if dtype is discrete and float32 if it
         is continuous.
@@ -138,7 +138,7 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False, dtype=None,
     atleast_4d: boolean, optional
         Indicates if a 3d image should be turned into a single-scan 4d niimg.
 
-    dtype: type
+    dtype: {dtype, "auto"}
         Data type toward which the data should be converted. If "auto", the
         data will be converted to int32 if dtype is discrete and float32 if it
         is continuous.
@@ -198,7 +198,7 @@ def check_niimg_3d(niimg, dtype=None):
         call nibabel.load on it. If it is an object, check if get_data()
         and get_affine() methods are present, raise TypeError otherwise.
     
-    dtype: type
+    dtype: {dtype, "auto"}
         Data type toward which the data should be converted. If "auto", the
         data will be converted to int32 if dtype is discrete and float32 if it
         is continuous.
@@ -234,7 +234,7 @@ def check_niimg_4d(niimg, return_iterator=False, dtype=None):
         call nibabel.load on it. If it is an object, check if get_data
         and get_affine methods are present, raise an Exception otherwise.
 
-    dtype: type
+    dtype: {dtype, "auto"}
         Data type toward which the data should be converted. If "auto", the
         data will be converted to int32 if dtype is discrete and float32 if it
         is continuous.

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -42,7 +42,7 @@ def _index_img(img, index):
 
 
 def _iter_check_niimg(niimgs, ensure_ndim=None, atleast_4d=False,
-                      target_fov=None,
+                      target_fov=None, dtype=None,
                       memory=Memory(cachedir=None),
                       memory_level=0, verbose=0):
     """Iterate over a list of niimgs and do sanity checks and resampling
@@ -71,7 +71,8 @@ def _iter_check_niimg(niimgs, ensure_ndim=None, atleast_4d=False,
     for i, niimg in enumerate(niimgs):
         try:
             niimg = check_niimg(
-                niimg, ensure_ndim=ndim_minus_one, atleast_4d=atleast_4d)
+                niimg, ensure_ndim=ndim_minus_one, atleast_4d=atleast_4d,
+                dtype=dtype)
             if i == 0:
                 ndim_minus_one = len(niimg.shape)
                 if ref_fov is None:
@@ -113,7 +114,7 @@ def _iter_check_niimg(niimgs, ensure_ndim=None, atleast_4d=False,
             raise
 
 
-def check_niimg(niimg, ensure_ndim=None, atleast_4d=False,
+def check_niimg(niimg, ensure_ndim=None, atleast_4d=False, dtype=None,
                 return_iterator=False):
     """Check that niimg is a proper 3D/4D niimg. Turn filenames into objects.
 
@@ -151,11 +152,12 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False,
     # in case of an iterable
     if hasattr(niimg, "__iter__") and not isinstance(niimg, _basestring):
         if return_iterator:
-            return _iter_check_niimg(niimg, ensure_ndim=ensure_ndim)
-        return concat_niimgs(niimg, ensure_ndim=ensure_ndim)
+            return _iter_check_niimg(niimg, ensure_ndim=ensure_ndim,
+                                     dtype=dtype)
+        return concat_niimgs(niimg, ensure_ndim=ensure_ndim, dtype=dtype)
 
     # Otherwise, it should be a filename or a SpatialImage, we load it
-    niimg = load_niimg(niimg)
+    niimg = load_niimg(niimg, dtype=dtype)
 
     if ensure_ndim == 3 and len(niimg.shape) == 4 and niimg.shape[3] == 1:
         # "squeeze" the image.
@@ -176,7 +178,7 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False,
     return niimg
 
 
-def check_niimg_3d(niimg):
+def check_niimg_3d(niimg, dtype=None):
     """Check that niimg is a proper 3D niimg-like object and load it.
     Parameters
     ----------
@@ -201,10 +203,10 @@ def check_niimg_3d(niimg):
 
     Its application is idempotent.
     """
-    return check_niimg(niimg, ensure_ndim=3)
+    return check_niimg(niimg, ensure_ndim=3, dtype=dtype)
 
 
-def check_niimg_4d(niimg, return_iterator=False):
+def check_niimg_4d(niimg, return_iterator=False, dtype=None):
     """Check that niimg is a proper 4D niimg-like object and load it.
 
     Parameters
@@ -234,7 +236,8 @@ def check_niimg_4d(niimg, return_iterator=False):
 
     Its application is idempotent.
     """
-    return check_niimg(niimg, ensure_ndim=4, return_iterator=return_iterator)
+    return check_niimg(niimg, ensure_ndim=4, return_iterator=return_iterator,
+                       dtype=dtype)
 
 
 def concat_niimgs(niimgs, dtype=np.float32, ensure_ndim=None,

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -523,6 +523,7 @@ class BaseSlicer(object):
                   resampling_interpolation='continuous',
                   threshold=None, **kwargs):
         img = reorder_img(img, resample=resampling_interpolation)
+        threshold = float(threshold) if threshold is not None else None
 
         if threshold is not None:
             data = img.get_data()

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -74,7 +74,7 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
         warnings.warn(nan_msg)
 
     if img is not False and img is not None:
-        img = _utils.check_niimg_3d(img)
+        img = _utils.check_niimg_3d(img, dtype='auto')
         data = img.get_data()
         affine = img.get_affine()
 
@@ -639,7 +639,7 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
 
     # make sure that the color range is symmetrical
     if vmax is None or symmetric_cbar in ['auto', False]:
-        stat_map_img = _utils.check_niimg_3d(stat_map_img)
+        stat_map_img = _utils.check_niimg_3d(stat_map_img, dtype='auto')
         stat_map_data = stat_map_img.get_data()
         # Avoid dealing with masked_array:
         if hasattr(stat_map_data, '_mask'):

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -149,6 +149,23 @@ def test_plot_stat_map_threshold_for_affine_with_rotation():
     assert_true(plotted_array.mask.all())
 
 
+def test_plot_stat_map_threshold_for_uint8():
+    # mask was applied in [-threshold, threshold] which is problematic
+    # for uint8 data. See https://github.com/nilearn/nilearn/issues/611
+    # for more details
+    data = 10 * np.ones((10, 10, 10), dtype='uint8')
+    affine = np.eye(4)
+    img = nibabel.Nifti1Image(data, affine)
+    threshold = np.array(5, dtype='uint8')
+    display = plot_stat_map(img, bg_img=None, threshold=threshold,
+                            display_mode='z', cut_coords=1)
+    # Next two lines retrieve the numpy array from the plot
+    ax = list(display.axes.values())[0].ax
+    plotted_array = ax.images[0].get_array()
+    # Make sure that no data is masked
+    assert_equal(plotted_array.mask.sum(), 0)
+
+
 def test_save_plot():
     img = _generate_img()
 


### PR DESCRIPTION
Fix #611.
Supersedes #621.

I introduced a `dtype='auto'` in `check_niimg` that converts data to `int32` if it is integral and `float32` if it is real. I use it in the plotting functions so that we never end up with unsigned type. However, we are not protected from unsigned values given as threshold or vmax. I solved the current problem by casting explicitely the threshold to float but I don't know if it's the best way to do.