### PR TITLE
Move new_img_like in image

### DIFF
--- a/nilearn/_utils/__init__.py
+++ b/nilearn/_utils/__init__.py
@@ -2,7 +2,7 @@
 from .niimg_conversions import (check_niimg, check_niimg_3d, concat_niimgs,
     check_niimg_4d)
 
-from .niimg import new_img_like, _repr_niimgs, copy_img
+from .niimg import _new_img_like, _repr_niimgs, copy_img
 
 from .numpy_conversions import as_ndarray
 

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -106,12 +106,12 @@ def load_niimg(niimg, dtype=None):
     dtype = _get_target_dtype(_get_data_dtype(niimg), dtype)
 
     if dtype is not None:
-        niimg = new_img_like(niimg, niimg.get_data().astype(dtype),
+        niimg = _new_img_like(niimg, niimg.get_data().astype(dtype),
                              niimg.get_affine())
     return niimg
 
 
-def new_img_like(ref_img, data, affine, copy_header=False):
+def _new_img_like(ref_img, data, affine=None, copy_header=False):
     """Create a new image of the same class as the reference image
 
     Parameters
@@ -149,6 +149,8 @@ def new_img_like(ref_img, data, affine, copy_header=False):
         header['glmax'] = 0.
         header['cal_max'] = np.max(data) if data.size > 0 else 0.
         header['cal_max'] = np.min(data) if data.size > 0 else 0.
+    if affine is None:
+        affine = ref_img.get_affine()
     return ref_img.__class__(data, affine, header=header)
 
 
@@ -167,7 +169,7 @@ def copy_img(img):
     """
     if not isinstance(img, nibabel.spatialimages.SpatialImage):
         raise ValueError("Input value is not an image")
-    return new_img_like(img, img.get_data().copy(), img.get_affine().copy(),
+    return _new_img_like(img, img.get_data().copy(), img.get_affine().copy(),
                         copy_header=True)
 
 

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -10,7 +10,7 @@ import itertools
 from sklearn.externals.joblib import Memory
 
 from .cache_mixin import cache
-from .niimg import _safe_get_data, load_niimg, new_img_like
+from .niimg import _safe_get_data, load_niimg, _new_img_like
 from .compat import _basestring, izip
 from .exceptions import DimensionError
 
@@ -64,7 +64,7 @@ def _check_same_fov(*args, **kwargs):
 
 def _index_img(img, index):
     """Helper function for check_niimg_4d."""
-    return new_img_like(
+    return _new_img_like(
         img, img.get_data()[:, :, :, index], img.get_affine(),
         copy_header=True)
 
@@ -201,11 +201,11 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False, dtype=None,
         # "squeeze" the image.
         data = _safe_get_data(niimg)
         affine = niimg.get_affine()
-        niimg = new_img_like(niimg, data[:, :, :, 0], affine)
+        niimg = _new_img_like(niimg, data[:, :, :, 0], affine)
     if atleast_4d and len(niimg.shape) == 3:
         data = niimg.get_data().view()
         data.shape = data.shape + (1, )
-        niimg = new_img_like(niimg, data, niimg.get_affine())
+        niimg = _new_img_like(niimg, data, niimg.get_affine())
 
     if ensure_ndim is not None and len(niimg.shape) != ensure_ndim:
         raise DimensionError(len(niimg.shape), ensure_ndim)
@@ -385,4 +385,4 @@ def concat_niimgs(niimgs, dtype=np.float32, ensure_ndim=None,
         data[..., cur_4d_index:cur_4d_index + size] = niimg.get_data()
         cur_4d_index += size
 
-    return new_img_like(first_niimg, data, first_niimg.get_affine())
+    return _new_img_like(first_niimg, data, first_niimg.get_affine())

--- a/nilearn/datasets.py
+++ b/nilearn/datasets.py
@@ -24,7 +24,8 @@ from scipy import ndimage
 from sklearn.datasets.base import Bunch
 from sklearn.utils import deprecated
 
-from ._utils import check_niimg, new_img_like
+from ._utils import check_niimg
+from .image import new_img_like
 from ._utils.compat import _basestring, BytesIO, cPickle, _urllib, md5_hash
 
 

--- a/nilearn/image/__init__.py
+++ b/nilearn/image/__init__.py
@@ -2,12 +2,12 @@
 Mathematical operations working on Niimg-like objects like -a (3+n)-D block of
 data, and an affine.
 """
-from .resampling import resample_img, reorder_img
 from .image import high_variance_confounds, smooth_img, crop_img, \
-    mean_img, swap_img_hemispheres, index_img, iter_img
+    mean_img, swap_img_hemispheres, index_img, iter_img, new_img_like
+from .resampling import resample_img, reorder_img
 from .._utils.niimg_conversions import concat_niimgs as concat_imgs
 
 __all__ = ['resample_img', 'high_variance_confounds', 'smooth_img',
            'crop_img', 'mean_img', 'reorder_img',
            'swap_img_hemispheres', 'concat_imgs',
-           'index_img', 'iter_img']
+           'index_img', 'iter_img', 'new_img_like']

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -13,13 +13,11 @@ from scipy import ndimage
 from sklearn.externals.joblib import Parallel, delayed
 
 from .. import signal
-from .resampling import reorder_img
 from .._utils import (check_niimg_4d, check_niimg_3d, check_niimg, as_ndarray,
                       _repr_niimgs)
 from .._utils.niimg_conversions import _index_img
-from .._utils.niimg import new_img_like, _safe_get_data
+from .._utils.niimg import _new_img_like, _safe_get_data, load_niimg
 from .._utils.compat import _basestring
-from .. import masking
 
 
 def high_variance_confounds(imgs, n_confounds=5, percentile=2.,
@@ -71,6 +69,7 @@ def high_variance_confounds(imgs, n_confounds=5, percentile=2.,
         ========
         nilearn.signal.high_variance_confounds
     """
+    from .. import masking
 
     if mask_img is not None:
         sigs = masking.apply_mask(imgs, mask_img)
@@ -485,6 +484,7 @@ def swap_img_hemispheres(img):
 
     Note that this does not require a change of the affine matrix.
     """
+    from .resampling import reorder_img
 
     # Check input is really a path to a nifti file or a nifti object
     img = check_niimg_3d(img)
@@ -535,3 +535,31 @@ def iter_img(imgs):
     output: iterator of 3D nibabel.Nifti1Image
     """
     return check_niimg_4d(imgs, return_iterator=True)
+
+
+def new_img_like(ref_niimg, data, affine, copy_header=False):
+    """Create a new image of the same class as the reference image
+
+    Parameters
+    ----------
+    ref_niimg: niimage
+        Reference niimage. The new image will be of the same type.
+
+    data: numpy array
+        Data to be stored in the image
+
+    affine: 4x4 numpy array
+        Transformation matrix
+
+    copy_header: boolean, optional
+        Indicated if the header of the reference image should be used to
+        create the new image
+
+    Returns
+    -------
+
+    new_img: image
+        An image which has the same type as the reference image.
+    """
+    return _new_img_like(load_niimg(ref_niimg), data, affine,
+                         copy_header=copy_header)

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -13,7 +13,7 @@ import scipy
 from scipy import ndimage, linalg
 
 from .. import _utils
-from .._utils import new_img_like
+from ..image import new_img_like
 from .._utils.compat import _basestring
 
 ###############################################################################

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -10,7 +10,7 @@ from scipy import ndimage
 from sklearn.externals.joblib import Parallel, delayed
 
 from . import _utils
-from ._utils import new_img_like
+from .image import new_img_like
 from ._utils.cache_mixin import cache
 from ._utils.ndimage import largest_connected_component, get_border_data
 from ._utils.niimg import _safe_get_data

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -11,7 +11,7 @@ import numbers
 import numpy as np
 from scipy import sparse, stats
 
-from .._utils import new_img_like
+from ..image import new_img_like
 from .._utils.compat import _basestring
 from .. import _utils
 

--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -11,7 +11,7 @@ from scipy import ndimage
 
 # Local imports
 from .._utils.ndimage import largest_connected_component
-from .._utils import new_img_like
+from ..image import new_img_like
 from .._utils.extmath import fast_abs_percentile
 from .._utils.numpy_conversions import as_ndarray
 from ..image.resampling import get_mask_bounds, coord_transform

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -24,7 +24,7 @@ from .._utils.numpy_conversions import as_ndarray
 import matplotlib.pyplot as plt
 
 from .. import _utils
-from .._utils import new_img_like
+from ..image import new_img_like
 from .._utils.extmath import fast_abs_percentile
 from .._utils.fixes.matplotlib_backports import (cbar_outline_get_xy,
                                                  cbar_outline_set_xy)

--- a/nilearn/region.py
+++ b/nilearn/region.py
@@ -12,7 +12,7 @@ from scipy import linalg, ndimage
 
 from . import _utils
 from . import masking
-from ._utils import new_img_like
+from .image import new_img_like
 
 
 # FIXME: naming scheme is not really satisfying. Any better idea appreciated.

--- a/nilearn/tests/test_niimg.py
+++ b/nilearn/tests/test_niimg.py
@@ -6,6 +6,7 @@ from nose import SkipTest
 
 from nilearn._utils.testing import assert_raises_regex
 from nilearn._utils import niimg
+from nilearn.image import new_img_like
 
 currdir = os.path.dirname(os.path.abspath(__file__))
 datadir = os.path.join(currdir, 'data')
@@ -29,4 +30,4 @@ def test_new_img_like_mgz():
     ref_img = nibabel.load(os.path.join(datadir, 'test.mgz'))
     data = np.ones(ref_img.get_data().shape, dtype=np.bool)
     affine = ref_img.get_affine()
-    niimg.new_img_like(ref_img, data, affine, copy_header=False)
+    new_img_like(ref_img, data, affine, copy_header=False)


### PR DESCRIPTION
This PR exposes `new_img_like` option. This rely on the same mechanism used but `index_img` to avoid circular import, ie a `_new_img_like` function that works on img is present in `_utils`.

This is not a fancy solution but, among all ugly solutions, it may be the best one.