### PR TITLE
[MRG] Make upload to nilearn.github.io more robust

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -137,7 +137,10 @@ install:
 	# first clone the nilearn.github.io repo because it may ask
 	# for password and we don't want to delay this long build in
 	# the middle of it
-	rm -rf _build/nilearn.github.io && \
+	rm -rf _build/nilearn.github.io
+	# --no-checkout just fetches the root folder without content
+	# --depth 1 is a speed optimization since we don't need the
+	# history prior to the last commit
 	git clone --no-checkout --depth 1 https://github.com/nilearn/nilearn.github.io.git _build/nilearn.github.io
 	make html
 	cd _build/ && \

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -134,10 +134,13 @@ pdf: latex
 
 install:
 	rm -rf _build/doctrees/
+	# first clone the nilearn.github.io repo because it may ask
+	# for password and we don't want to delay this long build in
+	# the middle of it
+	rm -rf _build/nilearn.github.io && \
+	git clone --no-checkout --depth 1 https://github.com/nilearn/nilearn.github.io.git _build/nilearn.github.io
 	make html
-	rm -rf _build/nilearn.github.io
 	cd _build/ && \
-        git clone git@github.com:nilearn/nilearn.github.io.git && \
 	cp -r html/* nilearn.github.io && \
 	cd nilearn.github.io && \
 	git add * && \


### PR DESCRIPTION
We were keeping a lot of stale files around for example http://nilearn.github.io/auto_examples/plot_haxby_simple.html which dates back from when all the examples were in the same folder.

Also maybe more controversial I switched from git to https authentication. As a consequence I moved the git clone as the first thing to do in order not to block `make install` in the middle when asking for the password.