### PR TITLE
[MRG] Added check_embedded_nifti_masker

### DIFF
--- a/nilearn/input_data/masker_validation.py
+++ b/nilearn/input_data/masker_validation.py
@@ -1,0 +1,79 @@
+import warnings
+
+from .._utils.class_inspect import get_params
+from .multi_nifti_masker import MultiNiftiMasker
+from .nifti_masker import NiftiMasker
+
+
+def check_embedded_nifti_masker(estimator, multi_subject=True):
+    """Base function for using a masker within a BaseEstimator class
+
+    This creates a masker from instance parameters :
+    - If instance contains a mask image in mask parameter,
+    we use this image as new masker mask_img, forwarding instance parameters to
+    new masker : smoothing_fwhm, standardize, detrend, low_pass= high_pass,
+    t_r, target_affine, target_shape, mask_strategy, mask_args,
+    - If instance contains a masker in mask parameter, we use a copy of
+    this masker, overriding all instance masker related parameters.
+    In all case, we forward system parameters of instance to new masker :
+    memory, memory_level, vebose, n_jobs
+
+    Parameters
+    ----------
+    instance: object, instance of BaseEstimator
+        The object that gives us the values of the parameters
+
+    multi_subject: boolean
+        Indicates whether to return a MultiNiftiMasker or a NiftiMasker
+        (the default is True)
+
+    Returns
+    -------
+    masker: MultiNiftiMasker or NiftiMasker
+        New masker
+    """
+    masker_type = MultiNiftiMasker if multi_subject else NiftiMasker
+    estimator_params = get_params(masker_type, estimator)
+    mask = getattr(estimator, 'mask', None)
+
+    if isinstance(mask, (NiftiMasker, MultiNiftiMasker)):
+        # Creating (Multi)NiftiMasker from provided masker
+        masker_params = get_params(masker_type, mask)
+        new_masker_params = masker_params
+    else:
+        # Creating (Multi)NiftiMasker
+        # with parameters extracted from estimator
+        new_masker_params = estimator_params
+        new_masker_params['mask_img'] = mask
+    # Forwarding system parameters of instance to new masker in all case
+    if multi_subject and hasattr(estimator, 'n_jobs'):
+        # For MultiNiftiMasker only
+        new_masker_params['n_jobs'] = estimator.n_jobs
+    new_masker_params['memory'] = estimator.memory
+    new_masker_params['memory_level'] = estimator.memory_level
+    new_masker_params['verbose'] = estimator.verbose
+
+    # Raising warning if masker override parameters
+    conflict_string = ""
+    for param_key in sorted(estimator_params):
+        if new_masker_params[param_key] != estimator_params[param_key]:
+            conflict_string += ("Parameter {0:s} :\n"
+                                "    Masker parameter {1:s}"
+                                " - overriding estimator parameter {2:s}\n"
+                                ).format(param_key,
+                                         new_masker_params[param_key],
+                                         estimator_params[param_key])
+
+    if conflict_string != "":
+        warn_str = ("Overriding provided-default estimator parameters with"
+                    " provided masker parameters :\n"
+                    "{0:s}").format(conflict_string)
+        warnings.warn(warn_str)
+    masker = masker_type(**new_masker_params)
+
+    # Forwarding potential attribute of provided masker
+    if hasattr(mask, 'mask_img_'):
+        # Allow free fit of returned mask
+        masker.mask_img = mask.mask_img_
+
+    return masker

--- a/nilearn/input_data/tests/test_masker_validation.py
+++ b/nilearn/input_data/tests/test_masker_validation.py
@@ -1,0 +1,83 @@
+from nose.tools import assert_true, assert_equal
+import nibabel
+import numpy as np
+
+from sklearn.base import BaseEstimator
+from sklearn.externals.joblib import Memory
+
+from nilearn._utils.testing import assert_warns
+from nilearn.input_data.masker_validation import check_embedded_nifti_masker
+from nilearn.input_data import MultiNiftiMasker, NiftiMasker
+
+
+class OwningClass(BaseEstimator):
+
+    def __init__(self, mask=None, smoothing_fwhm=None,
+                 standardize=False, detrend=False,
+                 low_pass=None, high_pass=None, t_r=None,
+                 target_affine=None, target_shape=None,
+                 mask_strategy='background', mask_args=None,
+                 memory=Memory(cachedir=None), memory_level=0,
+                 n_jobs=1, verbose=0,
+                 dummy=None):
+        self.mask = mask
+
+        self.smoothing_fwhm = smoothing_fwhm
+        self.standardize = standardize
+        self.detrend = detrend
+        self.low_pass = low_pass
+        self.high_pass = high_pass
+        self.t_r = t_r
+        self.target_affine = target_affine
+        self.target_shape = target_shape
+        self.mask_strategy = mask_strategy
+        self.mask_args = mask_args
+        self.memory = memory
+        self.memory_level = memory_level
+        self.n_jobs = n_jobs
+        self.verbose = verbose
+        self.dummy = dummy
+
+
+def test_check_embedded_nifti_masker():
+    owner = OwningClass()
+    masker = check_embedded_nifti_masker(owner)
+    assert_true(type(masker) is MultiNiftiMasker)
+
+    for mask, multi_subject in (
+            (MultiNiftiMasker(), True), (NiftiMasker(), False)):
+        owner = OwningClass(mask=mask)
+        masker = check_embedded_nifti_masker(owner,
+                                             multi_subject=multi_subject)
+        assert_equal(type(masker), type(mask))
+        for param_key in masker.get_params():
+            if param_key not in ['memory', 'memory_level', 'n_jobs',
+                                 'verbose']:
+                assert_equal(getattr(masker, param_key),
+                            getattr(mask, param_key))
+            else:
+                assert_equal(getattr(masker, param_key),
+                            getattr(owner, param_key))
+
+    # Check use of mask as mask_img
+    shape = (6, 8, 10, 5)
+    affine = np.eye(4)
+    mask = nibabel.Nifti1Image(np.ones(shape[:3], dtype=np.int8), affine)
+    owner = OwningClass(mask=mask)
+    masker = check_embedded_nifti_masker(owner)
+    assert_true(masker.mask_img is mask)
+
+    # Check attribute forwarding
+    data = np.zeros((9, 9, 9))
+    data[2:-2, 2:-2, 2:-2] = 10
+    imgs = nibabel.Nifti1Image(data, np.eye(4))
+    mask = MultiNiftiMasker()
+    mask.fit([[imgs]])
+    owner = OwningClass(mask=mask)
+    masker = check_embedded_nifti_masker(owner)
+    assert_true(masker.mask_img is mask.mask_img_)
+
+    # Check conflict warning
+    mask = NiftiMasker(mask_strategy='epi')
+    owner = OwningClass(mask=mask)
+    assert_warns(UserWarning, check_embedded_nifti_masker, owner)


### PR DESCRIPTION
This PR adds an utility function check_embedded_nifti_masker, that retrieves a MultiNiftiMasker / NiftiMasker from the parameters of a given estimator instance.

This would be useful in decomposition module, spacenet module, spectral clustering module, and would help sorting issue #688 

Ping @dohmatob @ahoyosid @AlexandreAbraham @GaelVaroquaux 