### PR TITLE
[MRG+1] Makes loading of CSV files more robust

### DIFF
--- a/nilearn/_utils/numpy_conversions.py
+++ b/nilearn/_utils/numpy_conversions.py
@@ -140,7 +140,7 @@ def csv_to_array(csv_path, delimiters=' \t,;', **kwargs):
         Each character of the delimiters string is a potential delimiters for
         the CSV file.
 
-    **kwargs: keyword arguments
+    kwargs: keyword arguments
         The additional keyword arguments are passed to numpy.genfromtxt when
         loading the CSV.
 

--- a/nilearn/_utils/numpy_conversions.py
+++ b/nilearn/_utils/numpy_conversions.py
@@ -137,7 +137,7 @@ def csv_to_array(csv_path, delimiters=' \t,;', **kwargs):
     # First, we try genfromtxt which works in most cases.
     array = np.genfromtxt(csv_path, **kwargs)
 
-    if array.ndim == 1 and np.isnan(array[0]):
+    if array.ndim <= 1 and np.all(np.isnan(array)):
         # If the delimiter is not known genfromtxt generates an array full of
         # nan. In that case, we try to guess the delimiter
         try:

--- a/nilearn/_utils/numpy_conversions.py
+++ b/nilearn/_utils/numpy_conversions.py
@@ -133,12 +133,12 @@ def csv_to_array(csv_path, delimiters=' \t,;', **kwargs):
 
     Parameters
     ----------
-
     csv_path: string
         Path of the CSV file to load.
 
     delimiters: string
-        String containing the possible delimiters for the CSV file.
+        Each character of the delimiters string is a potential delimiters for
+        the CSV file.
 
     **kwargs: keyword arguments
         The additional keyword arguments are passed to numpy.genfromtxt when
@@ -146,7 +146,6 @@ def csv_to_array(csv_path, delimiters=' \t,;', **kwargs):
 
     Returns
     -------
-
     array: numpy.ndarray
         An array containing the data loaded from the CSV file.
     """

--- a/nilearn/_utils/numpy_conversions.py
+++ b/nilearn/_utils/numpy_conversions.py
@@ -164,7 +164,7 @@ def csv_to_array(csv_path, delimiters=' \t,;', **kwargs):
                 dialect = csv.Sniffer().sniff(csv_file.readline(), delimiters)
         except csv.Error as e:
             raise TypeError(
-                'Could not read CSV file [%s]: %s' % (csv_path, e.message))
+                'Could not read CSV file [%s]: %s' % (csv_path, e.args[0]))
 
         array = np.genfromtxt(csv_path, delimiter=dialect.delimiter, **kwargs)
 

--- a/nilearn/_utils/numpy_conversions.py
+++ b/nilearn/_utils/numpy_conversions.py
@@ -129,7 +129,26 @@ def as_ndarray(arr, copy=False, dtype=None, order='K'):
 
 
 def csv_to_array(csv_path, delimiters=' \t,;', **kwargs):
-    """Read a CSV file by guessing the delimiter
+    """Read a CSV file by trying to guess its delimiter
+
+    Parameters
+    ----------
+
+    csv_path: string
+        Path of the CSV file to load.
+
+    delimiters: string
+        String containing the possible delimiters for the CSV file.
+
+    **kwargs: keyword arguments
+        The additional keyword arguments are passed to numpy.genfromtxt when
+        loading the CSV.
+
+    Returns
+    -------
+
+    array: numpy.ndarray
+        An array containing the data loaded from the CSV file.
     """
     if not isinstance(csv_path, _basestring):
         raise TypeError('CSV must be a file path. Got a CSV of type: %s' %

--- a/nilearn/_utils/numpy_conversions.py
+++ b/nilearn/_utils/numpy_conversions.py
@@ -4,7 +4,9 @@ Validation and conversion utilities for numpy.
 # Author: Gael Varoquaux, Alexandre Abraham, Philippe Gervais
 # License: simplified BSD
 
+import csv
 import numpy as np
+from .compat import _basestring
 
 
 def _asarray(arr, dtype=None, order=None):
@@ -124,3 +126,19 @@ def as_ndarray(arr, copy=False, dtype=None, order='K'):
         raise ValueError("Type not handled: %s" % arr.__class__)
 
     return ret
+
+
+def csv_to_array(csv_path, delimiters=' \t,;'):
+    """Read a CSV file by guessing the delimiter
+    """
+    if not isinstance(csv_path, _basestring):
+        raise TypeError('CSV must be a file path. Got a CSV of type: %s' %
+                        type(csv_path))
+    try:
+        with open(csv_path, 'r') as csv_file:
+            dialect = csv.Sniffer().sniff(csv_file.readline(), delimiters)
+    except csv.Error as e:
+        raise TypeError(
+            'Could not read CSV file [%s]: %s' % (csv_path, e.message))
+
+    return np.genfromtxt(csv_path, delimiter=dialect.delimiter)

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -17,6 +17,7 @@ from sklearn.utils import gen_even_slices
 from distutils.version import LooseVersion
 
 from ._utils.compat import _basestring
+from ._utils.numpy_conversions import csv_to_array
 
 np_version = distutils.version.LooseVersion(np.version.short_version).version
 
@@ -423,13 +424,13 @@ def clean(signals, detrend=True, standardize=True, confounds=None,
         for confound in confounds:
             if isinstance(confound, _basestring):
                 filename = confound
-                confound = np.genfromtxt(filename)
+                confound = csv_to_array(filename)
                 if np.isnan(confound.flat[0]):
                     # There may be a header
                     if np_version >= [1, 4, 0]:
-                        confound = np.genfromtxt(filename, skip_header=1)
+                        confound = csv_to_array(filename, skip_header=1)
                     else:
-                        confound = np.genfromtxt(filename, skiprows=1)
+                        confound = csv_to_array(filename, skiprows=1)
                 if confound.shape[0] != signals.shape[0]:
                     raise ValueError("Confound signal has an incorrect length")
 

--- a/nilearn/tests/test_numpy_conversions.py
+++ b/nilearn/tests/test_numpy_conversions.py
@@ -235,7 +235,8 @@ def test_as_ndarray():
 
 def test_csv_to_array():
     # Create a phony CSV file
-    with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as csv_file:
+    with tempfile.NamedTemporaryFile(suffix='.csv', delete=False,
+                                     mode='wt') as csv_file:
         csv_file.write('1.,2.,3.,4.,5.\n')
         csv_file.close()
         assert_true(np.allclose(csv_to_array(csv_file.name),

--- a/nilearn/tests/test_numpy_conversions.py
+++ b/nilearn/tests/test_numpy_conversions.py
@@ -242,4 +242,4 @@ def test_csv_to_array():
         assert_true(np.allclose(csv_to_array(csv_file.name),
                      np.asarray([1., 2., 3., 4., 5.])))
         assert_raises(TypeError, csv_to_array, csv_file.name, delimiters='?!')
-        os.unlink(csv_file.name)
+        os.remove(csv_file.name)

--- a/nilearn/tests/test_numpy_conversions.py
+++ b/nilearn/tests/test_numpy_conversions.py
@@ -235,11 +235,9 @@ def test_as_ndarray():
 
 def test_csv_to_array():
     # Create a phony CSV file
-    with tempfile.NamedTemporaryFile(suffix='.csv', delete=False,
-                                     mode='wt') as csv_file:
+    with tempfile.NamedTemporaryFile(suffix='.csv', mode='wt') as csv_file:
         csv_file.write('1.,2.,3.,4.,5.\n')
-        csv_file.close()
+        csv_file.flush()
         assert_true(np.allclose(csv_to_array(csv_file.name),
                      np.asarray([1., 2., 3., 4., 5.])))
         assert_raises(TypeError, csv_to_array, csv_file.name, delimiters='?!')
-        os.remove(csv_file.name)

--- a/nilearn/tests/test_numpy_conversions.py
+++ b/nilearn/tests/test_numpy_conversions.py
@@ -1,15 +1,16 @@
 """
 Test the numpy_conversions module
 
-This test file is in nilearn/tests because nosetests seems to ignore modules whose
-name starts with an underscore
+This test file is in nilearn/tests because nosetests seems to ignore modules
+whose name starts with an underscore
 """
 import numpy as np
 import os
+import tempfile
 
 from nose.tools import assert_true, assert_raises
 
-from nilearn._utils.numpy_conversions import as_ndarray
+from nilearn._utils.numpy_conversions import as_ndarray, csv_to_array
 
 
 def are_arrays_identical(arr1, arr2):
@@ -230,3 +231,13 @@ def test_as_ndarray():
     ## Unhandled cases
     assert_raises(ValueError, as_ndarray, "test string")
     assert_raises(ValueError, as_ndarray, [], order="invalid")
+
+
+def test_csv_to_array():
+    # Create a phony CSV file
+    with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as csv_file:
+        csv_file.write('1.,2.,3.,4.,5.\n')
+        csv_file.close()
+        assert_true(np.allclose(csv_to_array(csv_file.name),
+                     np.asarray([1., 2., 3., 4., 5.])))
+        assert_raises(TypeError, csv_to_array, csv_file, delimiters='?!')

--- a/nilearn/tests/test_numpy_conversions.py
+++ b/nilearn/tests/test_numpy_conversions.py
@@ -240,5 +240,5 @@ def test_csv_to_array():
         csv_file.close()
         assert_true(np.allclose(csv_to_array(csv_file.name),
                      np.asarray([1., 2., 3., 4., 5.])))
-        assert_raises(TypeError, csv_to_array, csv_file, delimiters='?!')
-        os.unlink(csv_file)
+        assert_raises(TypeError, csv_to_array, csv_file.name, delimiters='?!')
+        os.unlink(csv_file.name)

--- a/nilearn/tests/test_numpy_conversions.py
+++ b/nilearn/tests/test_numpy_conversions.py
@@ -241,3 +241,4 @@ def test_csv_to_array():
         assert_true(np.allclose(csv_to_array(csv_file.name),
                      np.asarray([1., 2., 3., 4., 5.])))
         assert_raises(TypeError, csv_to_array, csv_file, delimiters='?!')
+        os.unlink(csv_file)

--- a/nilearn/tests/test_numpy_conversions.py
+++ b/nilearn/tests/test_numpy_conversions.py
@@ -239,5 +239,5 @@ def test_csv_to_array():
         csv_file.write('1.,2.,3.,4.,5.\n')
         csv_file.flush()
         assert_true(np.allclose(csv_to_array(csv_file.name),
-                     np.asarray([1., 2., 3., 4., 5.])))
+                    np.asarray([1., 2., 3., 4., 5.])))
         assert_raises(TypeError, csv_to_array, csv_file.name, delimiters='?!')


### PR DESCRIPTION
Fix #628.

This PR modifies CSV loading for confounds.
If `np.genfromtxt` fails, we try to guess the delimiter in the file (most of the time, a comma).