### PR TITLE
[MRG] Plot prob atlas 691

### DIFF
--- a/doc/connectivity/resting_state_networks.rst
+++ b/doc/connectivity/resting_state_networks.rst
@@ -61,16 +61,18 @@ each component separately.
     :start-after: ### Visualize the results #####################################################
 
 .. image :: ../auto_examples/connectivity/images/plot_canica_resting_state_001.png
+   :align: center
+   :target: ../auto_examples/connectivity/plot_canica_resting_state.html
 
 .. |left_img| image:: ../auto_examples/connectivity/images/plot_canica_resting_state_003.png
    :target: ../auto_examples/connectivity/plot_canica_resting_state.html
-   :width: 48%
+   :width: 33%
 
 .. |right_img| image:: ../auto_examples/connectivity/images/plot_canica_resting_state_004.png
    :target: ../auto_examples/connectivity/plot_canica_resting_state.html
-   :width: 48%
+   :width: 33%
 
-|left_img| |right_img|
+.. centered:: |left_img| |right_img|
 
 .. seealso::
 

--- a/doc/connectivity/resting_state_networks.rst
+++ b/doc/connectivity/resting_state_networks.rst
@@ -53,7 +53,9 @@ object.
 Visualizing the results
 ========================
 
-We can visualize the components as in the previous examples. The first plot shows a map generated from all the components. Then we plot the activation of each component separately.
+We can visualize the components as in the previous examples. The first plot
+shows a map generated from all the components. Then we plot the activation of
+each component separately.
 
 .. literalinclude:: ../../examples/connectivity/plot_canica_resting_state.py
     :start-after: ### Visualize the results #####################################################

--- a/doc/connectivity/resting_state_networks.rst
+++ b/doc/connectivity/resting_state_networks.rst
@@ -54,17 +54,19 @@ Visualizing the results
 ========================
 
 We can visualize the components as in the previous examples. The first plot
-shows a map generated from all the components. Then we plot the activation of
+shows a map generated from all the components. Then we plot an axial cut for
 each component separately.
 
 .. literalinclude:: ../../examples/connectivity/plot_canica_resting_state.py
     :start-after: ### Visualize the results #####################################################
 
-.. |left_img| image:: ../auto_examples/connectivity/images/plot_canica_resting_state_002.png
+.. image :: ../auto_examples/connectivity/images/plot_canica_resting_state_001.png
+
+.. |left_img| image:: ../auto_examples/connectivity/images/plot_canica_resting_state_003.png
    :target: ../auto_examples/connectivity/plot_canica_resting_state.html
    :width: 48%
 
-.. |right_img| image:: ../auto_examples/connectivity/images/plot_canica_resting_state_003.png
+.. |right_img| image:: ../auto_examples/connectivity/images/plot_canica_resting_state_004.png
    :target: ../auto_examples/connectivity/plot_canica_resting_state.html
    :width: 48%
 

--- a/doc/connectivity/resting_state_networks.rst
+++ b/doc/connectivity/resting_state_networks.rst
@@ -53,7 +53,7 @@ object.
 Visualizing the results
 ========================
 
-We can visualize the components as in the previous examples.
+We can visualize the components as in the previous examples. The first plot shows a map generated from all the components. Then we plot the activation of each component separately.
 
 .. literalinclude:: ../../examples/connectivity/plot_canica_resting_state.py
     :start-after: ### Visualize the results #####################################################

--- a/examples/connectivity/plot_canica_resting_state.py
+++ b/examples/connectivity/plot_canica_resting_state.py
@@ -4,7 +4,7 @@ Group analysis of resting-state fMRI with ICA: CanICA
 
 An example applying CanICA to resting-state data. This example applies it
 to 40 subjects of the ADHD200 datasets. Then it plots a map with all the
-components together and axial cut for each of the components separately.
+components together and an axial cut for each of the components separately.
 
 CanICA is an ICA method for group-level analysis of fMRI data. Compared
 to other strategies, it brings a well-controlled group model, as well as a

--- a/examples/connectivity/plot_canica_resting_state.py
+++ b/examples/connectivity/plot_canica_resting_state.py
@@ -3,7 +3,8 @@ Group analysis of resting-state fMRI with ICA: CanICA
 =====================================================
 
 An example applying CanICA to resting-state data. This example applies it
-to 40 subjects of the ADHD200 datasets.
+to 40 subjects of the ADHD200 datasets. Then it plots a map with all the
+components together and a z coordinate map for each of the components separately.
 
 CanICA is an ICA method for group-level analysis of fMRI data. Compared
 to other strategies, it brings a well-controlled group model, as well as a
@@ -46,11 +47,16 @@ components_img = canica.masker_.inverse_transform(canica.components_)
 components_img.to_filename('canica_resting_state.nii.gz')
 
 ### Visualize the results #####################################################
-# Show some interesting components
+
 import matplotlib.pyplot as plt
+from nilearn.plotting import plot_prob_atlas
 from nilearn.plotting import plot_stat_map
 from nilearn.image import iter_img
 
+# Plot all ICA components
+plot_prob_atlas(components_img, title='All ICA components')
+
+# Show some interesting components
 for i, cur_img in enumerate(iter_img(components_img)):
     plot_stat_map(cur_img, display_mode="z", title="IC %d" % i, cut_coords=1,
                   colorbar=False)

--- a/examples/connectivity/plot_canica_resting_state.py
+++ b/examples/connectivity/plot_canica_resting_state.py
@@ -4,7 +4,7 @@ Group analysis of resting-state fMRI with ICA: CanICA
 
 An example applying CanICA to resting-state data. This example applies it
 to 40 subjects of the ADHD200 datasets. Then it plots a map with all the
-components together and a z coordinate map for each of the components separately.
+components together and axial cut for each of the components separately.
 
 CanICA is an ICA method for group-level analysis of fMRI data. Compared
 to other strategies, it brings a well-controlled group model, as well as a
@@ -53,10 +53,10 @@ from nilearn.plotting import plot_prob_atlas
 from nilearn.plotting import plot_stat_map
 from nilearn.image import iter_img
 
-# Plot all ICA components
+# Plot all ICA components together
 plot_prob_atlas(components_img, title='All ICA components')
 
-# Show some interesting components
+# Plot the map for each ICA component separately
 for i, cur_img in enumerate(iter_img(components_img)):
     plot_stat_map(cur_img, display_mode="z", title="IC %d" % i, cut_coords=1,
                   colorbar=False)


### PR DESCRIPTION
Solution for #691. Added a line to plot the components together as an atlas before the individual plot of the components. Updated documentation accordingly.

Here the resulting plot:
![plot_prob_atlas](https://cloud.githubusercontent.com/assets/8766915/8748265/b88dcb32-2c99-11e5-8988-3cd585aba6ce.png)
