### PR TITLE
[MRG] Use filter_and_extract as a basis signal extractor.

### DIFF
--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -12,7 +12,7 @@ from sklearn.externals.joblib import Parallel, delayed, Memory
 from sklearn.utils.extmath import randomized_svd
 
 from ..input_data import NiftiMasker, MultiNiftiMasker, NiftiMapsMasker
-from ..input_data.base_masker import filter_and_mask
+from ..input_data.nifti_masker import filter_and_mask
 from .._utils.class_inspect import get_params
 from .._utils.cache_mixin import cache, CacheMixin
 from .._utils import as_ndarray

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -116,6 +116,26 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
 
     @abc.abstractmethod
     def transform_single_imgs(self, imgs, confounds=None, copy=True):
+        """Extract signals from a single 4D niimg.
+
+        Parameters
+        ==========
+        imgs: Niimg-like object
+            See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
+            Images to process. It must boil down to a 4D image with scans
+            number as last dimension.
+
+        confounds: array-like, optional
+            This parameter is passed to signal.clean. Please see the related
+            documentation for details.
+            shape: (number of scans, number of confounds)
+
+        Returns
+        =======
+        region_signals: 2D numpy.ndarray
+            Signal for each region.
+            shape: (number of scans, number of regions)
+        """
         raise NotImplemented()
 
     def transform(self, imgs, confounds=None):

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -135,7 +135,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
             Images to process. It must boil down to a 4D image with scans
             number as last dimension.
 
-        confounds: array-like, optional
+        confounds: CSV file or array-like, optional
             This parameter is passed to signal.clean. Please see the related
             documentation for details.
             shape: (number of scans, number of confounds)
@@ -149,17 +149,19 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         raise NotImplementedError()
 
     def transform(self, imgs, confounds=None):
-        """ Apply mask, spatial and temporal preprocessing
+        """Apply mask, spatial and temporal preprocessing
 
         Parameters
         ----------
-        imgs: list of Niimg-like objects
+        imgs: 3D/4D Niimg-like object
             See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
-            Data to be preprocessed
+            Images to process. It must boil down to a 4D image with scans
+            number as last dimension.
 
-        confounds: CSV file path or 2D matrix
-            This parameter is passed to nilearn.signal.clean. Please see the
-            related documentation for details
+        confounds: CSV file or array-like, optional
+            This parameter is passed to signal.clean. Please see the related
+            documentation for details.
+            shape: (number of scans, number of confounds)
 
         Returns
         -------

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -31,8 +31,8 @@ def filter_and_extract(imgs, extraction_function,
 
     Parameters
     ----------
-    imgs: images
-        Images to be masked
+    imgs: 3D/4D Niimg-like object
+        Images to be masked. Can be 3-dimensional or 4-dimensional.
 
     extraction_function: function
         Function used to extract the time series from 4D data.

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -5,32 +5,28 @@ Transformer used to apply basic transformations on MRI data.
 # License: simplified BSD
 
 import warnings
+import abc
 
 import numpy as np
-import itertools
 
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.externals.joblib import Parallel, delayed
+from sklearn.externals.joblib import Memory
 
 from .. import masking
 from .. import image
 from .. import signal
 from .. import _utils
 from .._utils.cache_mixin import CacheMixin, cache
-from .._utils.class_inspect import enclosing_scope_name, get_params
-from .._utils.compat import _basestring, izip
-from nilearn._utils.niimg_conversions import _iter_check_niimg
+from .._utils.class_inspect import enclosing_scope_name
+from .._utils.compat import _basestring
 
 
 def filter_and_extract(imgs, extraction_function,
-                       smoothing_fwhm, t_r,
-                       standardize, detrend, low_pass, high_pass,
-                       confounds, memory, memory_level,
-                       sessions=None,
-                       target_shape=None,
-                       target_affine=None,
-                       copy=True,
-                       sample_mask=None, verbose=0):
+                       parameters,
+                       memory_level=0, memory=Memory(cachedir=None),
+                       verbose=0,
+                       confounds=None,
+                       copy=True):
     """Extract representative time series using given function.
 
     Parameters
@@ -57,9 +53,13 @@ def filter_and_extract(imgs, extraction_function,
             class_name,
             _utils._repr_niimgs(imgs)[:200]))
     imgs = _utils.check_niimg(imgs, atleast_4d=True, ensure_ndim=4)
+
+    sample_mask = parameters.get('sample_mask', None)
     if sample_mask is not None:
         imgs = image.index_img(imgs, sample_mask)
 
+    target_shape = parameters.get('target_shape', None)
+    target_affine = parameters.get('target_affine', None)
     if target_shape is not None or target_affine is not None:
         if verbose > 0:
             print("[%s] Resampling images" % class_name)
@@ -71,13 +71,13 @@ def filter_and_extract(imgs, extraction_function,
                 target_affine=target_affine,
                 copy=copy)
 
-    if smoothing_fwhm is not None:
+    if 'smoothing_fwhm' in parameters:
         if verbose > 0:
             print("[%s] Smoothing images" % class_name)
         imgs = cache(
             image.smooth_img, memory, func_memory_level=2,
             memory_level=memory_level)(
-                imgs, smoothing_fwhm)
+                imgs, parameters['smoothing_fwhm'])
 
     if verbose > 0:
         print("[%s] Extracting region signals" % class_name)
@@ -94,12 +94,18 @@ def filter_and_extract(imgs, extraction_function,
 
     if verbose > 0:
         print("[%s] Cleaning extracted signals" % class_name)
+    sessions = parameters.get('sessions', None)
     region_signals = cache(
         signal.clean, memory=memory, func_memory_level=2,
         memory_level=memory_level)(
-            region_signals, detrend=detrend, standardize=standardize, t_r=t_r,
-            low_pass=low_pass, high_pass=high_pass,
-            confounds=confounds, sessions=sessions)
+            region_signals,
+            detrend=parameters['detrend'],
+            standardize=parameters['standardize'],
+            t_r=parameters['t_r'],
+            low_pass=parameters['low_pass'],
+            high_pass=parameters['high_pass'],
+            confounds=confounds,
+            sessions=sessions)
 
     return region_signals, aux
 
@@ -108,79 +114,26 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
     """Base class for NiftiMaskers
     """
 
+    @abc.abstractmethod
     def transform_single_imgs(self, imgs, confounds=None, copy=True):
+        raise NotImplemented()
 
-        self._check_fitted()
-        params = self._get_params()
-
-        data, _ = self._cache(self.filter_and_mask,
-                              ignore=['verbose', 'memory', 'copy'])(
-                                    imgs, params,
-                                    memory_level=self.memory_level,
-                                    memory=self.memory,
-                                    verbose=self.verbose,
-                                    confounds=confounds,
-                                    copy=copy
-        )
-        return data
-
-    def transform_imgs(self, imgs_list, confounds=None, copy=True, n_jobs=1):
-        ''' Prepare multi subject data in parallel
+    def transform(self, imgs, confounds=None):
+        """ Apply mask, spatial and temporal preprocessing
 
         Parameters
         ----------
-
-        imgs_list: list of Niimg-like objects
+        imgs: list of Niimg-like objects
             See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
-            List of imgs file to prepare. One item per subject.
+            Data to be preprocessed
 
-        confounds: list of confounds, optional
-            List of confounds (2D arrays or filenames pointing to CSV
-            files). Must be of same length than imgs_list.
+        confounds: CSV file path or 2D matrix
+            This parameter is passed to nilearn.signal.clean. Please see the
+            related documentation for details
+        """
+        self._check_fitted()
 
-        copy: boolean, optional
-            If True, guarantees that output array has no memory in common with
-            input array.
-
-        n_jobs: integer, optional
-            The number of cpus to use to do the computation. -1 means
-            'all cpus'.
-        '''
-
-        if not hasattr(self, 'mask_img_'):
-            raise ValueError('It seems that %s has not been fitted. '
-                             'You must call fit() before calling transform().'
-                             % self.__class__.__name__)
-        params = get_params(self.__class__, self)
-
-        target_fov = None
-        if self.target_affine is None:
-            # Force resampling on first image
-            target_fov = 'first'
-
-        niimg_iter = _iter_check_niimg(imgs_list, ensure_ndim=None,
-                                       atleast_4d=False,
-                                       target_fov=target_fov,
-                                       memory=self.memory,
-                                       memory_level=self.memory_level,
-                                       verbose=self.verbose)
-
-        func = self._cache(self.filter_and_mask,
-                           ignore=['verbose', 'memory', 'copy'])
-        if confounds is None:
-            confounds = itertools.repeat(None, len(imgs_list))
-        for name in ('mask_img', 'mask_args', 'mask_strategy'):
-            params.pop(name, None)
-        data = Parallel(n_jobs=n_jobs)(delayed(func)(
-                                imgs, self.mask_img_,
-                                parameters=params,
-                                memory_level=self.memory_level,
-                                memory=self.memory,
-                                verbose=self.verbose,
-                                confounds=confounds,
-                                copy=copy)
-                        for imgs, confounds in izip(niimg_iter, confounds))
-        return list(zip(*data))[0]
+        return self.transform_single_imgs(imgs, confounds)
 
     def fit_transform(self, X, y=None, confounds=None, **fit_params):
         """Fit to data, then transform it

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -36,8 +36,10 @@ def filter_and_extract(imgs, extraction_function,
 
     extraction_function: function
         Function used to extract the time series from 4D data. This function
-        should take images as argument and returns a 2D array with masked
-        signals. If any other parameter is needed, a functor or a partial
+        should take images as argument and returns a tuple containing a 2D
+        array with masked signals along with a auxiliary value used if
+        returning a second value is needed.
+        If any other parameter is needed, a functor or a partial
         function must be provided.
 
     For all other parameters refer to NiftiMasker documentation

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -129,8 +129,8 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         """Extract signals from a single 4D niimg.
 
         Parameters
-        ==========
-        imgs: Niimg-like object
+        ----------
+        imgs: 3D/4D Niimg-like object
             See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
             Images to process. It must boil down to a 4D image with scans
             number as last dimension.
@@ -141,12 +141,12 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
             shape: (number of scans, number of confounds)
 
         Returns
-        =======
+        -------
         region_signals: 2D numpy.ndarray
-            Signal for each region.
-            shape: (number of scans, number of regions)
+            Signal for each element.
+            shape: (number of scans, number of elements)
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def transform(self, imgs, confounds=None):
         """ Apply mask, spatial and temporal preprocessing
@@ -160,6 +160,12 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         confounds: CSV file path or 2D matrix
             This parameter is passed to nilearn.signal.clean. Please see the
             related documentation for details
+
+        Returns
+        -------
+        region_signals: 2D numpy.ndarray
+            Signal for each element.
+            shape: (number of scans, number of elements)
         """
         self._check_fitted()
 
@@ -184,7 +190,6 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         -------
         X_new : numpy array of shape [n_samples, n_features_new]
             Transformed array.
-
         """
         # non-optimized default implementation; override when a better
         # method is possible for a given clustering algorithm

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -215,7 +215,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         return self
 
     def transform_imgs(self, imgs_list, confounds=None, copy=True, n_jobs=1):
-        ''' Prepare multi subject data in parallel
+        """Prepare multi subject data in parallel
 
         Parameters
         ----------
@@ -235,7 +235,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         n_jobs: integer, optional
             The number of cpus to use to do the computation. -1 means
             'all cpus'.
-        '''
+        """
 
         if not hasattr(self, 'mask_img_'):
             raise ValueError('It seems that %s has not been fitted. '

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -264,15 +264,15 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
                                     'copy'])
 
         func = self._cache(filter_and_mask,
-                          ignore=['verbose', 'memory', 'copy'])
+                          ignore=['verbose', 'memory', 'memory_level', 'copy'])
         data = Parallel(n_jobs=n_jobs)(
-            [delayed(func)(imgs, self.mask_img_, params,
+            delayed(func)(imgs, self.mask_img_, params,
                            memory_level=self.memory_level,
                            memory=self.memory,
                            verbose=self.verbose,
                            confounds=cfs,
                            copy=copy)
-             for imgs, cfs in izip(niimg_iter, confounds)])
+            for imgs, cfs in izip(niimg_iter, confounds))
         return list(zip(*data))[0]
 
     def transform(self, imgs, confounds=None):

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -28,7 +28,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
     CanICA (multi-subject models)
 
     Parameters
-    ==========
+    ----------
     mask_img: Niimg-like object
         See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
         Mask of the data. If not given, a mask is computed in the fit step.
@@ -97,7 +97,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         Indicate the level of verbosity. By default, nothing is printed
 
     Attributes
-    ==========
+    ----------
     mask_img_: nibabel.Nifti1Image object
         The mask of the data. If no mask was given at masker creation, contains
         the automatically computed mask.
@@ -108,7 +108,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         subject data have been resampled.
 
     See Also
-    ========
+    --------
     nilearn.image.resample_img: image resampling
     nilearn.masking.compute_epi_mask: mask computation
     nilearn.masking.apply_mask: mask application on image
@@ -235,6 +235,12 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         n_jobs: integer, optional
             The number of cpus to use to do the computation. -1 means
             'all cpus'.
+        
+        Returns
+        -------
+        region_signals: list of 2D numpy.ndarray
+            List of signal for each element per subject.
+            shape: list of (number of scans, number of elements)
         """
 
         if not hasattr(self, 'mask_img_'):

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -300,6 +300,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
             preprocessed images
         """
         self._check_fitted()
+        if not hasattr(imgs, '__iter__')\
                     or isinstance(imgs, _basestring):
                 return self.transform_single_imgs(imgs)
         return self.transform_imgs(imgs, confounds, n_jobs=self.n_jobs)

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -257,7 +257,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
             confounds = itertools.repeat(None, len(imgs_list))
 
         # Ignore the mask-computing params: they are not useful and will
-        # just invalid the cache for no good reason
+        # just invalidate the cache for no good reason
         # target_shape and target_affine are conveyed implicitly in mask_img
         params = get_params(self.__class__, self,
                             ignore=['mask_img', 'mask_args', 'mask_strategy',

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -300,8 +300,6 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
             preprocessed images
         """
         self._check_fitted()
-
-        if not hasattr(imgs, '__iter__')\
                     or isinstance(imgs, _basestring):
                 return self.transform_single_imgs(imgs)
         return self.transform_imgs(imgs, confounds, n_jobs=self.n_jobs)

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -279,7 +279,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
                            confounds=cfs,
                            copy=copy)
             for imgs, cfs in izip(niimg_iter, confounds))
-        return list(zip(*data))[0]
+        return [d[0] for d in data]
 
     def transform(self, imgs, confounds=None):
         """ Apply mask, spatial and temporal preprocessing

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -226,10 +226,11 @@ class NiftiLabelsMasker(BaseEstimator, TransformerMixin, CacheMixin):
                 imgs, self._resampled_labels_img_,
                 background_label=self.background_label)
 
-        target_fov = None
+        target_shape = None
+        target_affine = None
         if self.resampling_target == 'labels':
-            target_fov = (self._resampled_labels_img_.shape[:3],
-                          self._resampled_labels_img_.get_affine())
+            target_shape = self._resampled_labels_img_.shape[:3]
+            target_affine = self._resampled_labels_img_.get_affine()
 
         region_signals, labels_ = self._cache(
                 filter_and_extract,
@@ -242,7 +243,8 @@ class NiftiLabelsMasker(BaseEstimator, TransformerMixin, CacheMixin):
             # Caching
             self.memory, self.memory_level,
             # kwargs
-            target_fov=target_fov,
+            target_shape=target_shape,
+            target_affine=target_affine,
             verbose=self.verbose)
 
         self.labels_ = labels_

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -192,28 +192,6 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                              % self.__class__.__name__)
 
     def transform_single_imgs(self, imgs, confounds=None):
-        """Extract signals from images.
-
-        Parameters
-        ==========
-        imgs: Niimg-like object
-            See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
-            Images to process. It must boil down to a 4D image with scans
-            number as last dimension.
-
-        confounds: array-like, optional
-            This parameter is passed to signal.clean. Please see the related
-            documentation for details.
-            shape: (number of scans, number of confounds)
-
-        Returns
-        =======
-        signals: 2D numpy.ndarray
-            Signal for each region.
-            shape: (number of scans, number of regions)
-
-        """
-
         # We handle the resampling of labels separately because the affine of
         # the labels image should not impact the extraction of the signal.
 

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -192,6 +192,26 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                              % self.__class__.__name__)
 
     def transform_single_imgs(self, imgs, confounds=None):
+        """Extract signals from a single 4D niimg.
+
+        Parameters
+        ----------
+        imgs: 3D/4D Niimg-like object
+            See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
+            Images to process. It must boil down to a 4D image with scans
+            number as last dimension.
+
+        confounds: CSV file or array-like, optional
+            This parameter is passed to signal.clean. Please see the related
+            documentation for details.
+            shape: (number of scans, number of confounds)
+
+        Returns
+        -------
+        region_signals: 2D numpy.ndarray
+            Signal for each label.
+            shape: (number of scans, number of labels)
+        """
         # We handle the resampling of labels separately because the affine of
         # the labels image should not impact the extraction of the signal.
 

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -252,10 +252,11 @@ class NiftiMapsMasker(BaseEstimator, TransformerMixin, CacheMixin):
                 imgs, self._resampled_maps_img_,
                 mask_img=self._resampled_mask_img_)
 
-        target_fov = None
+        target_shape = None
+        target_affine = None
         if self.resampling_target != 'data':
-            target_fov = (self._resampled_maps_img_.shape[:3],
-                          self._resampled_maps_img_.get_affine())
+            target_shape = self._resampled_maps_img_.shape[:3]
+            target_affine = self._resampled_maps_img_.get_affine()
 
         region_signals, labels_ = self._cache(
             filter_and_extract, ignore=['verbose', 'memory', 'memory_level'])(
@@ -267,7 +268,8 @@ class NiftiMapsMasker(BaseEstimator, TransformerMixin, CacheMixin):
                 # Caching
                 self.memory, self.memory_level,
                 # kwargs
-                target_fov=target_fov,
+                target_shape=target_shape,
+                target_affine=target_affine,
                 verbose=self.verbose)
         self.labels_ = labels_
 

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -193,26 +193,6 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         return self.fit().transform(imgs, confounds=confounds)
 
     def transform_single_imgs(self, imgs, confounds=None):
-        """Extract signals from images.
-
-        Parameters
-        ==========
-        imgs: Niimg-like object
-            See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
-            Images to process. It must boil down to a 4D image with scans
-            number as last dimension.
-
-        confounds: array-like, optional
-            This parameter is passed to signal.clean. Please see the related
-            documentation for details.
-            shape: (number of scans, number of confounds)
-
-        Returns
-        =======
-        region_signals: 2D numpy.ndarray
-            Signal for each region.
-            shape: (number of scans, number of regions)
-        """
         # We handle the resampling of maps and mask separately because the
         # affine of the maps and mask images should not impact the extraction
         # of the signal.

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -193,6 +193,26 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         return self.fit().transform(imgs, confounds=confounds)
 
     def transform_single_imgs(self, imgs, confounds=None):
+        """Extract signals from a single 4D niimg.
+
+        Parameters
+        ----------
+        imgs: 3D/4D Niimg-like object
+            See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
+            Images to process. It must boil down to a 4D image with scans
+            number as last dimension.
+
+        confounds: CSV file or array-like, optional
+            This parameter is passed to signal.clean. Please see the related
+            documentation for details.
+            shape: (number of scans, number of confounds)
+
+        Returns
+        -------
+        region_signals: 2D numpy.ndarray
+            Signal for each map.
+            shape: (number of scans, number of maps)
+        """
         # We handle the resampling of maps and mask separately because the
         # affine of the maps and mask images should not impact the extraction
         # of the signal.

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -4,18 +4,21 @@ Transformer used to apply basic transformations on MRI data.
 # Author: Gael Varoquaux, Alexandre Abraham
 # License: simplified BSD
 
+from copy import copy as copy_object
 from sklearn.externals.joblib import Memory
 
 from .. import masking
 from .. import image
 from .. import _utils
 from .._utils import CacheMixin
-from .base_masker import BaseMasker
+from .._utils.class_inspect import get_params
+from .base_masker import BaseMasker, filter_and_extract
+from nilearn._utils.niimg_conversions import _check_same_fov
 
 
 class NiftiMasker(BaseMasker, CacheMixin):
     """Class for masking of Niimg-like objects.
-    
+
     NiftiMasker is useful when preprocessing (detrending, standardization,
     resampling, etc.) of in-mask voxels is necessary. Use case: working with
     time series of resting-state or task maps.
@@ -142,6 +145,21 @@ class NiftiMasker(BaseMasker, CacheMixin):
         self.memory_level = memory_level
         self.verbose = verbose
 
+    def _check_fitted(self):
+        if not hasattr(self, 'mask_img_'):
+            raise ValueError('It seems that %s has not been fitted. '
+                             'You must call fit() before calling transform().'
+                             % self.__class__.__name__)
+
+    def _get_call_params(self):
+        # Ignore the mask-computing params: they are not useful and will
+        # just invalid the cache for no good reason
+        # target_shape and target_affine are conveyed implicitly in mask_img
+        params = get_params(self.__class__, self,
+                            ignore=['mask_img', 'mask_args', 'mask_strategy'])
+        params['mask_img_'] = self.mask_img_
+        return params
+
     def fit(self, imgs=None, y=None):
         """Compute the mask corresponding to the data
 
@@ -170,7 +188,8 @@ class NiftiMasker(BaseMasker, CacheMixin):
                 compute_mask = masking.compute_epi_mask
             else:
                 raise ValueError("Unknown value of mask_strategy '%s'. "
-                    "Acceptable values are 'background' and 'epi'." % self.mask_strategy)
+                                 "Acceptable values are 'background' and "
+                                 "'epi'." % self.mask_strategy)
             if self.verbose > 0:
                 print("[%s.fit] Computing the mask" % self.__class__.__name__)
             self.mask_img_ = self._cache(compute_mask, ignore=['verbose'])(
@@ -197,6 +216,45 @@ class NiftiMasker(BaseMasker, CacheMixin):
             print("[%s.fit] Finished fit" % self.__class__.__name__)
         return self
 
+    @staticmethod
+    def filter_and_mask(imgs, parameters,
+                        memory_level=0,
+                        memory=Memory(cachedir=None),
+                        verbose=0,
+                        confounds=None,
+                        copy=True):
+
+        mask_img_ = parameters['mask_img_']
+        imgs = _utils.check_niimg(imgs, atleast_4d=True)
+
+        # Check whether resampling is truly necessary. If so, crop mask
+        # as small as possible in order to speed up the process
+
+        if not _check_same_fov(imgs, mask_img_):
+            parameters = copy_object(parameters)
+            # now we can crop
+            mask_img_ = image.crop_img(mask_img_, copy=False)
+            parameters['target_shape'] = mask_img_.shape
+            parameters['target_affine'] = mask_img_.get_affine()
+
+        def extraction_function(imgs):
+            return masking.apply_mask(imgs, mask_img_), imgs.get_affine()
+
+        data, affine = filter_and_extract(imgs, extraction_function,
+                                          memory_level=memory_level,
+                                          memory=memory,
+                                          verbose=verbose,
+                                          confounds=confounds, copy=copy,
+                                          **parameters)
+
+        # For _later_: missing value removal or imputing of missing data
+        # (i.e. we want to get rid of NaNs, if smoothing must be done
+        # earlier)
+        # Optionally: 'doctor_nan', remove voxels with NaNs, other option
+        # for later: some form of imputation
+
+        return data, affine
+
     def transform(self, imgs, confounds=None):
         """ Apply mask, spatial and temporal preprocessing
 
@@ -212,5 +270,4 @@ class NiftiMasker(BaseMasker, CacheMixin):
         """
         self._check_fitted()
 
-        return self.transform_single_imgs(
-            imgs, confounds, sample_mask=self.sample_mask)
+        return self.transform_single_imgs(imgs, confounds)

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -31,7 +31,7 @@ def filter_and_mask(imgs, mask_img_, parameters,
                     confounds=None,
                     copy=True):
 
-    imgs = _utils.check_niimg(imgs, atleast_4d=True)
+    imgs = _utils.check_niimg(imgs, atleast_4d=True, ensure_ndim=4)
 
     # Check whether resampling is truly necessary. If so, crop mask
     # as small as possible in order to speed up the process

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -259,7 +259,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
                             ignore=['mask_img', 'mask_args', 'mask_strategy'])
 
         data, _ = self._cache(filter_and_mask,
-                              ignore=['verbose', 'memory', 'copy'])(
+                              ignore=['verbose', 'memory', 'memory_level', 'copy'])(
                                     imgs, self.mask_img_, params,
                                     memory_level=self.memory_level,
                                     memory=self.memory,

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -251,6 +251,26 @@ class NiftiMasker(BaseMasker, CacheMixin):
         return self
 
     def transform_single_imgs(self, imgs, confounds=None, copy=True):
+        """Apply mask, spatial and temporal preprocessing
+
+        Parameters
+        ----------
+        imgs: 3D/4D Niimg-like object
+            See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
+            Images to process. It must boil down to a 4D image with scans
+            number as last dimension.
+
+        confounds: CSV file or array-like, optional
+            This parameter is passed to signal.clean. Please see the related
+            documentation for details.
+            shape: (number of scans, number of confounds)
+
+        Returns
+        -------
+        region_signals: 2D numpy.ndarray
+            Signal for each voxel inside the mask.
+            shape: (number of scans, number of voxels)
+        """
 
         # Ignore the mask-computing params: they are not useful and will
         # just invalid the cache for no good reason

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -220,6 +220,26 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
                              % self.__class__.__name__)
 
     def transform_single_imgs(self, imgs, confounds=None):
+        """Extract signals from a single 4D niimg.
+
+        Parameters
+        ----------
+        imgs: 3D/4D Niimg-like object
+            See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
+            Images to process. It must boil down to a 4D image with scans
+            number as last dimension.
+
+        confounds: CSV file or array-like, optional
+            This parameter is passed to signal.clean. Please see the related
+            documentation for details.
+            shape: (number of scans, number of confounds)
+
+        Returns
+        -------
+        region_signals: 2D numpy.ndarray
+            Signal for each sphere.
+            shape: (number of scans, number of spheres)
+        """
         self._check_fitted()
 
         params = get_params(NiftiSpheresMasker, self)

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -220,27 +220,6 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
                              % self.__class__.__name__)
 
     def transform_single_imgs(self, imgs, confounds=None):
-        """Extract signals from Nifti-like objects.
-
-        Parameters
-        ==========
-        imgs: Niimg-like object
-            See http://nilearn.github.io/building_blocks/manipulating_mr_images.html#niimg.
-            Images to process. It must boil down to a 4D image with scans
-            number as last dimension.
-
-        confounds: array-like, optional
-            This parameter is passed to signal.clean. Please see the related
-            documentation for details.
-            shape: (number of scans, number of confounds)
-
-        Returns
-        =======
-        signals: 2D numpy.ndarray
-            Signal for each region.
-            shape: (number of scans, number of regions)
-
-        """
         self._check_fitted()
 
         params = get_params(NiftiSpheresMasker, self)

--- a/nilearn/input_data/tests/test_base_masker.py
+++ b/nilearn/input_data/tests/test_base_masker.py
@@ -6,10 +6,8 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 import nibabel
 
-from nilearn.input_data.base_masker import filter_and_mask
+from nilearn.input_data.nifti_masker import filter_and_mask
 from nilearn import image
-from nilearn._utils.testing import assert_raises_regex
-from nilearn._utils.exceptions import DimensionError
 
 
 def test_cropping_code_paths():
@@ -51,15 +49,3 @@ def test_cropping_code_paths():
                                                        parameters)
 
     assert_array_almost_equal(out_data_cropped, out_data_uncropped)
-
-
-def test_filter_and_mask():
-    data = np.zeros([20, 30, 40, 5])
-    mask = np.zeros([20, 30, 40, 2])
-    mask[10, 15, 20, :] = 1
-
-    data_img = nibabel.Nifti1Image(data, np.eye(4))
-    mask_img = nibabel.Nifti1Image(mask, np.eye(4))
-
-    assert_raises_regex(DimensionError, "Data must be a 3D", filter_and_mask,
-                        data_img, mask_img, {})

--- a/nilearn/input_data/tests/test_nifti_masker.py
+++ b/nilearn/input_data/tests/test_nifti_masker.py
@@ -20,10 +20,13 @@ from numpy.testing import assert_array_equal
 from nibabel import Nifti1Image
 import nibabel
 
-from nilearn.input_data.nifti_masker import NiftiMasker
+from nilearn.input_data.nifti_masker import NiftiMasker, filter_and_mask
 from nilearn._utils import testing
 from nilearn._utils.exceptions import DimensionError
 from nilearn.image import index_img
+from nilearn._utils.testing import assert_raises_regex
+from nilearn._utils.exceptions import DimensionError
+from nilearn._utils.class_inspect import get_params
 
 
 def test_auto_mask():
@@ -297,3 +300,18 @@ def test_compute_epi_mask():
 
     assert_false(np.allclose(mask1.get_data(),
                              mask4.get_data()[3:12, 3:12]))
+
+
+def test_filter_and_mask():
+    data = np.zeros([20, 30, 40, 5])
+    mask = np.zeros([20, 30, 40, 2])
+    mask[10, 15, 20, :] = 1
+
+    data_img = nibabel.Nifti1Image(data, np.eye(4))
+    mask_img = nibabel.Nifti1Image(mask, np.eye(4))
+
+    masker = NiftiMasker()
+    params = get_params(NiftiMasker, masker)
+
+    assert_raises_regex(DimensionError, "Data must be a 3D", filter_and_mask,
+                         data_img, mask_img, params)

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -24,7 +24,7 @@ warnings.simplefilter("always", MaskWarning)
 
 
 def _load_mask_img(mask_img, allow_empty=False):
-    ''' Check that a mask is valid, ie with two values including 0 and load it.
+    """Check that a mask is valid, ie with two values including 0 and load it.
 
     Parameters
     ----------
@@ -39,7 +39,7 @@ def _load_mask_img(mask_img, allow_empty=False):
     -------
     mask: numpy.ndarray
         boolean version of the mask
-    '''
+    """
     mask_img = _utils.check_niimg_3d(mask_img)
     mask = mask_img.get_data()
     values = np.unique(mask)
@@ -184,8 +184,7 @@ def compute_epi_mask(epi_img, lower_cutoff=0.2, upper_cutoff=0.85,
                      ensure_finite=True,
                      target_affine=None, target_shape=None,
                      memory=None, verbose=0,):
-    """
-    Compute a brain mask from fMRI data in 3D or 4D ndarrays.
+    """Compute a brain mask from fMRI data in 3D or 4D ndarrays.
 
     This is based on an heuristic proposed by T.Nichols:
     find the least dense point of the histogram, between fractions

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -368,7 +368,9 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
            Timeseries. Must have shape (instant number, features number).
            This array is not modified.
 
-
+    sessions : numpy array, optional
+        Add a session level to the cleaning process. Each session will be
+        cleaned independently. Must be a 1D array of n_samples elements.
 
        confounds: numpy.ndarray, str or list of
            Confounds timeseries. Shape must be

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -344,8 +344,8 @@ def _ensure_float(data):
     return data
 
 
-def clean(signals, detrend=True, standardize=True, confounds=None,
-          low_pass=None, high_pass=None, t_r=2.5):
+def clean(signals, sessions=None, detrend=True, standardize=True,
+          confounds=None, low_pass=None, high_pass=None, t_r=2.5):
     """Improve SNR on masked fMRI signals.
 
        This function can do several things on the input signals, in
@@ -367,6 +367,8 @@ def clean(signals, detrend=True, standardize=True, confounds=None,
        signals: numpy.ndarray
            Timeseries. Must have shape (instant number, features number).
            This array is not modified.
+
+
 
        confounds: numpy.ndarray, str or list of
            Confounds timeseries. Shape must be
@@ -410,16 +412,12 @@ def clean(signals, detrend=True, standardize=True, confounds=None,
                       (list, tuple, _basestring, np.ndarray, type(None))):
         raise TypeError("confounds keyword has an unhandled type: %s"
                         % confounds.__class__)
-    # detrend
-    signals = _ensure_float(signals)
-    signals = _standardize(signals, normalize=False, detrend=detrend)
-
-    # Remove confounds
+    
+    # Read confounds
     if confounds is not None:
         if not isinstance(confounds, (list, tuple)):
             confounds = (confounds, )
 
-        # Read confounds
         all_confounds = []
         for confound in confounds:
             if isinstance(confound, _basestring):
@@ -452,6 +450,27 @@ def clean(signals, detrend=True, standardize=True, confounds=None,
         confounds = np.hstack(all_confounds)
         del all_confounds
 
+    if sessions is not None:
+        if not len(sessions) == len(signals):
+            raise ValueError(('The length of the session vector (%i) '
+                              'does not match the length of the signals (%i)')
+                              % (len(sessions), len(signals)))
+        for s in np.unique(sessions):
+            session_confounds = None
+            if confounds is not None:
+                session_confounds = confounds[sessions == s]
+            signals[sessions == s, :] = \
+                clean(signals[sessions == s],
+                      detrend=detrend, standardize=standardize,
+                      confounds=session_confounds, low_pass=low_pass,
+                      high_pass=high_pass, t_r=2.5)
+
+    # detrend
+    signals = _ensure_float(signals)
+    signals = _standardize(signals, normalize=False, detrend=detrend)
+
+    # Remove confounds
+    if confounds is not None:
         confounds = _ensure_float(confounds)
         confounds = _standardize(confounds, normalize=True, detrend=detrend)
 


### PR DESCRIPTION
Address #720 step 1.2, 1.3 and 3.1.

The goal here is to establish a common basis for NiftiMasker, NiftiLabelsMasker and NiftiMapsMasker. There are a lot of advantages:
* NiftiMasker features come for free in Nifti*Maskers (sessions and sample masks)
* If we design it well, MultiNifti*Masker flavors will come for free for all Nifti*Maskers.
* Code is slightly more complicated (very slightly actually) but much smaller, making maintenance and bug tracking easier.

Steps done:
* [x] Make `filter_and_mask` rely on `filter_and_extract`
* [x] Make NiftiSpheresMasker rely on `filter_and_extract`
* [x] Make `BaseMasker` more generic. NiftiLabelsMasker and NiftiMapsMasker should inherit from it.
* [x] Make `MultiNiftiMasker` independant by inheriting `NiftiMasker`