### PR TITLE
added aal atlas download and updated reference.rst

### DIFF
--- a/doc/modules/reference.rst
+++ b/doc/modules/reference.rst
@@ -36,7 +36,7 @@ uses.
    fetch_atlas_power_2011
    fetch_atlas_smith_2009
    fetch_atlas_yeo_2011
-   fetch_atlas_aal
+   fetch_atlas_aal_spm_12
    fetch_abide_pcp
    fetch_adhd
    fetch_haxby

--- a/doc/modules/reference.rst
+++ b/doc/modules/reference.rst
@@ -36,6 +36,7 @@ uses.
    fetch_atlas_power_2011
    fetch_atlas_smith_2009
    fetch_atlas_yeo_2011
+   fetch_atlas_aal
    fetch_abide_pcp
    fetch_adhd
    fetch_haxby

--- a/nilearn/datasets/__init__.py
+++ b/nilearn/datasets/__init__.py
@@ -19,4 +19,5 @@ __all__ = ['fetch_icbm152_2009', 'load_mni152_template', 'fetch_oasis_vbm',
            'fetch_harvard_oxford', 'fetch_atlas_msdl', 'fetch_msdl_atlas',
            'fetch_atlas_power_2011', 'fetch_atlas_smith_2009',
            'fetch_smith_2009', 'fetch_atlas_yeo_2011',
-           'fetch_yeo_2011_atlas', 'fetch_mixed_gambles']
+           'fetch_yeo_2011_atlas', 'fetch_mixed_gambles',
+           'fetch_atlas_aal_spm_12']

--- a/nilearn/datasets/__init__.py
+++ b/nilearn/datasets/__init__.py
@@ -8,7 +8,7 @@ from .atlas import (fetch_atlas_craddock_2012, fetch_craddock_2012_atlas,
                     fetch_harvard_oxford, fetch_atlas_msdl, fetch_msdl_atlas,
                     fetch_atlas_power_2011, fetch_atlas_smith_2009,
                     fetch_smith_2009, fetch_atlas_yeo_2011,
-                    fetch_yeo_2011_atlas)
+                    fetch_yeo_2011_atlas, fetch_atlas_aal_spm_12)
 
 __all__ = ['fetch_icbm152_2009', 'load_mni152_template', 'fetch_oasis_vbm',
            'fetch_haxby_simple', 'fetch_haxby', 'fetch_nyu_rest', 'fetch_adhd',

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1,5 +1,5 @@
 """
-Downloading NeuroImaging datasets: altas datasets
+Downloading NeuroImaging datasets: atlas datasets
 """
 import os
 import numpy as np

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -632,10 +632,7 @@ def fetch_atlas_aal_spm_12(data_dir=None, url=None, resume=True, verbose=1):
     dataset_name = "aal_spm_12"
     # keys and basenames would need to be handled for each spm_version
     # for now spm_version 12 is hardcoded.
-    keys = ("regions", "labels")
-    basenames = (
-        "AAL.nii", "AAL.xml")
-
+    basenames = ("AAL.nii", "AAL.xml")
     filenames = [(os.path.join("aal_for_SPM%i" % spm_version, f), url, opts)
                  for f in basenames]
 
@@ -653,6 +650,7 @@ def fetch_atlas_aal_spm_12(data_dir=None, url=None, resume=True, verbose=1):
     for label in root.getiterator('label'):
         labels_dict[label.find('index').text] = label.find('name').text
 
-    params = dict([('description', fdescr)] + [(keys[0], atlas_img)] +
-                  [(keys[1], labels_dict)])
+    params = {'description': fdescr, 'regions': atlas_img,
+              'labels': labels_dict}
+
     return Bunch(**params)

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -525,7 +525,7 @@ def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
 
         - "anat": anatomy image.
 
-    References
+    Notes
     -----
     For more information on this dataset's structure, see
     http://surfer.nmr.mgh.harvard.edu/fswiki/CorticalParcellation_Yeo2011
@@ -536,20 +536,6 @@ def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
     intrinsic functional connectivity. J Neurophysiol 106(3):1125-65, 2011.
 
     Licence: unknown.
-
-    Notes
-    -----
-    This atlas is the result of an automated anatomical parcellation of the
-    spatially normalized single-subject high-resolution T1 volume provided by
-    the Montreal Neurological Institute (MNI) (D. L. Collins et al., 1998,
-    Trans. Med. Imag. 17, 463–468, PubMed).
-
-    Using this parcellation method, three procedures to perform the automated
-    anatomical labeling of functional studies are proposed: (1) labeling of an
-    extremum defined by a set of coordinates, (2) percentage of voxels
-    belonging to each of the AVOI intersected by a sphere centered by a set of
-    coordinates, and (3) percentage of voxels belonging to each of the AVOI
-    intersected by an activated cluster.
     """
     if url is None:
         url = "ftp://surfer.nmr.mgh.harvard.edu/" \

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -540,7 +540,7 @@ def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
     Notes
     -----
     This atlas is the result of an automated anatomical parcellation of the
-    spatially normalized single-subject high-resolution T1 volume provided by 
+    spatially normalized single-subject high-resolution T1 volume provided by
     the Montreal Neurological Institute (MNI) (D. L. Collins et al., 1998,
     Trans. Med. Imag. 17, 463–468, PubMed).
 
@@ -599,7 +599,7 @@ def fetch_atlas_aal_spm_12(data_dir=None, url=None, resume=True, verbose=1):
     This atlas is the result of an automated anatomical parcellation of the
     spatially normalized single-subject high-resolution T1 volume provided by
     the Montreal Neurological Institute (MNI) (D. L. Collins et al., 1998,
-    Trans. Med. Imag. 17, 463–468, PubMed).
+    Trans. Med. Imag. 17, 463-468, PubMed).
 
     Parameters
     ----------

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -525,7 +525,7 @@ def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
 
         - "anat": anatomy image.
 
-    Notes
+    References
     -----
     For more information on this dataset's structure, see
     http://surfer.nmr.mgh.harvard.edu/fswiki/CorticalParcellation_Yeo2011
@@ -536,6 +536,20 @@ def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
     intrinsic functional connectivity. J Neurophysiol 106(3):1125-65, 2011.
 
     Licence: unknown.
+
+    Notes
+    -----
+    This atlas is the result of an automated anatomical parcellation of the
+    spatially normalized single-subject high-resolution T1 volume provided by 
+    the Montreal Neurological Institute (MNI) (D. L. Collins et al., 1998,
+    Trans. Med. Imag. 17, 463–468, PubMed).
+
+    Using this parcellation method, three procedures to perform the automated
+    anatomical labeling of functional studies are proposed: (1) labeling of an
+    extremum defined by a set of coordinates, (2) percentage of voxels
+    belonging to each of the AVOI intersected by a sphere centered by a set of
+    coordinates, and (3) percentage of voxels belonging to each of the AVOI
+    intersected by an activated cluster.
     """
     if url is None:
         url = "ftp://surfer.nmr.mgh.harvard.edu/" \
@@ -582,9 +596,10 @@ def fetch_yeo_2011_atlas(data_dir=None, url=None, resume=True, verbose=1):
 def fetch_atlas_aal_spm_12(data_dir=None, url=None, resume=True, verbose=1):
     """Downloads and returns the AAL template for SPM 12.
 
-    The provided images are based on the spatially normalized single-subject
-    high-resolution T1 volume provided by the Montreal Neurological Institute
-    (MNI)
+    This atlas is the result of an automated anatomical parcellation of the
+    spatially normalized single-subject high-resolution T1 volume provided by
+    the Montreal Neurological Institute (MNI) (D. L. Collins et al., 1998,
+    Trans. Med. Imag. 17, 463–468, PubMed).
 
     Parameters
     ----------

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -576,3 +576,76 @@ def fetch_yeo_2011_atlas(data_dir=None, url=None, resume=True, verbose=1):
         url=url,
         resume=resume,
         verbose=verbose)
+
+
+def fetch_atlas_aal(data_dir=None, url=None, resume=True, verbose=1):
+    """Download and return file names for the AAL for SPM 12 parcellation.
+
+    The provided images are based on the spatially normalized single-subject
+    high-resolution T1 volume provided by the Montreal Neurological Institute
+    (MNI)
+
+    Parameters
+    ----------
+    data_dir: string
+        directory where data should be downloaded and unpacked.
+
+    url: string
+        url of file to download.
+
+    spm_version: int
+        spm version of the aal files. Ex. 99, 2, 5, 8 and 12 (12 by default)
+
+    resume: bool
+        whether to resumed download of a partly-downloaded file.
+
+    verbose: int
+        verbosity level (0 means no message).
+
+    Returns
+    -------
+    data: sklearn.datasets.base.Bunch
+        dictionary-like object, keys are:
+
+        - "anat": anatomy image.
+
+        - "labels": labels id in an xml file
+
+    Notes
+    -----
+    For more information on this dataset's structure, see
+    http://www.gin.cnrs.fr/AAL-217?lang=en
+
+    N. Tzourio-Mazoyer, B. Landeau, D. Papathanassiou, F. Crivello,
+    O. Etard, N. Delcroix, B. Mazoyer, and M. Joliot.
+    NeuroImage 2002. 15 :273-28
+
+    Licence: unknown.
+    """
+    spm_version = 12
+    if url is None:
+        baseurl = "http://www.gin.cnrs.fr/AAL/aal_for_SPM%i.tar.gz"
+        url = baseurl % spm_version
+    opts = {'uncompress': True}
+
+    dataset_name = "aal"
+    # keys and basenames would need to be handled for each spm_version
+    # for now spm_version 12 is hardcoded.
+    keys = ("anat",
+            "labels")
+    basenames = (
+        "AAL.nii",
+        "AAL.xml")
+
+    filenames = [(os.path.join("aal_for_SPM%i" % spm_version, f), url, opts)
+                 for f in basenames]
+
+    data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,
+                                verbose=verbose)
+    sub_files = _fetch_files(data_dir, filenames, resume=resume,
+                             verbose=verbose)
+
+    fdescr = _get_dataset_descr(dataset_name)
+
+    params = dict([('description', fdescr)] + list(zip(keys, sub_files)))
+    return Bunch(**params)

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -650,7 +650,7 @@ def fetch_atlas_aal_spm_12(data_dir=None, url=None, resume=True, verbose=1):
     xml_tree = xml.etree.ElementTree.parse(labels_file)
     root = xml_tree.getroot()
     labels_dict = {}
-    for label in root.iter('label'):
+    for label in root.getiterator('label'):
         labels_dict[label.find('index').text] = label.find('name').text
 
     params = dict([('description', fdescr)] + [(keys[0], atlas_img)] +

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -2,7 +2,7 @@
 Downloading NeuroImaging datasets: atlas datasets
 """
 import os
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree
 import numpy as np
 from scipy import ndimage
 
@@ -605,7 +605,7 @@ def fetch_atlas_aal_spm_12(data_dir=None, url=None, resume=True, verbose=1):
     data: sklearn.datasets.base.Bunch
         dictionary-like object, keys are:
 
-        - "maps": str. path to nifti file containing regions definition.
+        - "multi_mask": str. path to nifti file containing regions.
 
         - "labels": dict. labels dictionary with their id as key and
                     name as value
@@ -632,7 +632,7 @@ def fetch_atlas_aal_spm_12(data_dir=None, url=None, resume=True, verbose=1):
     dataset_name = "aal_spm_12"
     # keys and basenames would need to be handled for each spm_version
     # for now spm_version 12 is hardcoded.
-    keys = ("maps", "labels")
+    keys = ("multi_mask", "labels")
     basenames = (
         "AAL.nii", "AAL.xml")
 
@@ -647,7 +647,7 @@ def fetch_atlas_aal_spm_12(data_dir=None, url=None, resume=True, verbose=1):
     fdescr = _get_dataset_descr(dataset_name)
 
     # We return the labels contained in the xml file as a dictionary
-    xml_tree = ET.parse(labels_file)
+    xml_tree = xml.etree.ElementTree.parse(labels_file)
     root = xml_tree.getroot()
     labels_dict = {}
     for label in root.iter('label'):

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -593,9 +593,6 @@ def fetch_atlas_aal(data_dir=None, url=None, resume=True, verbose=1):
     url: string
         url of file to download.
 
-    spm_version: int
-        spm version of the aal files. Ex. 99, 2, 5, 8 and 12 (12 by default)
-
     resume: bool
         whether to resumed download of a partly-downloaded file.
 

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -605,9 +605,9 @@ def fetch_atlas_aal_spm_12(data_dir=None, url=None, resume=True, verbose=1):
     data: sklearn.datasets.base.Bunch
         dictionary-like object, keys are:
 
-        - "multi_mask": str. path to nifti file containing regions.
+        - "regions": str. path to nifti file containing regions.
 
-        - "labels": dict. labels dictionary with their id as key and
+        - "labels": dict. labels dictionary with their region id as key and
                     name as value
 
     Notes
@@ -632,7 +632,7 @@ def fetch_atlas_aal_spm_12(data_dir=None, url=None, resume=True, verbose=1):
     dataset_name = "aal_spm_12"
     # keys and basenames would need to be handled for each spm_version
     # for now spm_version 12 is hardcoded.
-    keys = ("multi_mask", "labels")
+    keys = ("regions", "labels")
     basenames = (
         "AAL.nii", "AAL.xml")
 

--- a/nilearn/datasets/description/aal_spm_12.rst
+++ b/nilearn/datasets/description/aal_spm_12.rst
@@ -3,7 +3,7 @@ AAl atlas for SPM 12
 
 Notes
 -----
-This atlas is the result of an automated anatomical parcellation of the spatially normalized single-subject high-resolution T1 volume provided by the Montreal Neurological Institute (MNI) (D. L. Collins et al., 1998, Trans. Med. Imag. 17, 463–468, PubMed).
+This atlas is the result of an automated anatomical parcellation of the spatially normalized single-subject high-resolution T1 volume provided by the Montreal Neurological Institute (MNI) (D. L. Collins et al., 1998, Trans. Med. Imag. 17, 463-468, PubMed).
 
 Using this parcellation method, three procedures to perform the automated anatomical labeling of functional studies are proposed: (1) labeling of an extremum defined by a set of coordinates, (2) percentage of voxels belonging to each of the AVOI intersected by a sphere centered by a set of coordinates, and (3) percentage of voxels belonging to each of the AVOI intersected by an activated cluster.
 

--- a/nilearn/datasets/description/aal_spm_12.rst
+++ b/nilearn/datasets/description/aal_spm_12.rst
@@ -1,0 +1,28 @@
+AAl atlas for SPM 12
+
+
+Notes
+-----
+This atlas is the result of an automated anatomical parcellation of the spatially normalized single-subject high-resolution T1 volume provided by the Montreal Neurological Institute (MNI) (D. L. Collins et al., 1998, Trans. Med. Imag. 17, 463–468, PubMed).
+
+Using this parcellation method, three procedures to perform the automated anatomical labeling of functional studies are proposed: (1) labeling of an extremum defined by a set of coordinates, (2) percentage of voxels belonging to each of the AVOI intersected by a sphere centered by a set of coordinates, and (3) percentage of voxels belonging to each of the AVOI intersected by an activated cluster.
+
+
+Content
+-------
+    :"regions": str. path to nifti file containing regions.
+    :"labels": dict. labels dictionary with their region id as key and name as value
+
+
+References
+-----
+For more information on this dataset's structure, see
+http://www.gin.cnrs.fr/AAL-217?lang=en
+
+Automated Anatomical Labeling of Activations in SPM Using a Macroscopic
+Anatomical Parcellation of the MNI MRI Single-Subject Brain.
+N. Tzourio-Mazoyer, B. Landeau, D. Papathanassiou, F. Crivello,
+O. Etard, N. Delcroix, B. Mazoyer, and M. Joliot.
+NeuroImage 2002. 15 :273-28
+
+Licence: unknown.

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -271,6 +271,13 @@ def test_fetch_atlas_yeo_2011():
 @with_setup(setup_mock, teardown_mock)
 @with_setup(setup_tmpdata, teardown_tmpdata)
 def test_fetch_atlas_aal_spm_12():
+    ho_dir = os.path.join(tmpdir, 'aal_spm_12', 'aal_for_SPM12')
+    os.makedirs(ho_dir)
+    dummy = open(os.path.join(ho_dir, 'AAL.xml'), 'w')
+    dummy.write("<?xml version='1.0' encoding='us-ascii'?> "
+                "<metadata>"
+                "</metadata>")
+    dummy.close()
     dataset = atlas.fetch_atlas_aal_spm_12(data_dir=tmpdir, verbose=0)
     assert_true(isinstance(dataset.regions, _basestring))
     assert_equal(len(dataset.labels), 116)

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -280,5 +280,5 @@ def test_fetch_atlas_aal_spm_12():
     dummy.close()
     dataset = atlas.fetch_atlas_aal_spm_12(data_dir=tmpdir, verbose=0)
     assert_true(isinstance(dataset.regions, _basestring))
-    assert_true(isinstance(dataset.labels, dict)
+    assert_true(isinstance(dataset.labels, dict))
     assert_equal(len(mock_url_request.urls), 1)

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -266,3 +266,12 @@ def test_fetch_atlas_yeo_2011():
     assert_true(isinstance(dataset.thin_17, _basestring))
     assert_true(isinstance(dataset.thin_7, _basestring))
     assert_equal(len(mock_url_request.urls), 1)
+
+
+@with_setup(setup_mock, teardown_mock)
+@with_setup(setup_tmpdata, teardown_tmpdata)
+def test_fetch_atlas_aal():
+    dataset = atlas.fetch_atlas_aal(data_dir=tmpdir, verbose=0)
+    assert_true(isinstance(dataset.anat, _basestring))
+    assert_true(isinstance(dataset.labels, _basestring))
+    assert_equal(len(mock_url_request.urls), 1)

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -273,11 +273,10 @@ def test_fetch_atlas_yeo_2011():
 def test_fetch_atlas_aal_spm_12():
     ho_dir = os.path.join(tmpdir, 'aal_spm_12', 'aal_for_SPM12')
     os.makedirs(ho_dir)
-    dummy = open(os.path.join(ho_dir, 'AAL.xml'), 'w')
-    dummy.write("<?xml version='1.0' encoding='us-ascii'?> "
-                "<metadata>"
-                "</metadata>")
-    dummy.close()
+    with open(os.path.join(ho_dir, 'AAL.xml'), 'w') as xml_file:
+        xml_file.write("<?xml version='1.0' encoding='us-ascii'?> "
+                       "<metadata>"
+                       "</metadata>")
     dataset = atlas.fetch_atlas_aal_spm_12(data_dir=tmpdir, verbose=0)
     assert_true(isinstance(dataset.regions, _basestring))
     assert_true(isinstance(dataset.labels, dict))

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -272,6 +272,6 @@ def test_fetch_atlas_yeo_2011():
 @with_setup(setup_tmpdata, teardown_tmpdata)
 def test_fetch_atlas_aal_spm_12():
     dataset = atlas.fetch_atlas_aal_spm_12(data_dir=tmpdir, verbose=0)
-    assert_true(isinstance(dataset.maps, _basestring))
+    assert_true(isinstance(dataset.multi_mask, _basestring))
     assert_equal(len(dataset.labels), 116)
     assert_equal(len(mock_url_request.urls), 1)

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -270,8 +270,8 @@ def test_fetch_atlas_yeo_2011():
 
 @with_setup(setup_mock, teardown_mock)
 @with_setup(setup_tmpdata, teardown_tmpdata)
-def test_fetch_atlas_aal():
-    dataset = atlas.fetch_atlas_aal(data_dir=tmpdir, verbose=0)
-    assert_true(isinstance(dataset.anat, _basestring))
-    assert_true(isinstance(dataset.labels, _basestring))
+def test_fetch_atlas_aal_spm_12():
+    dataset = atlas.fetch_atlas_aal_spm_12(data_dir=tmpdir, verbose=0)
+    assert_true(isinstance(dataset.maps, _basestring))
+    assert_equal(len(dataset.labels), 116)
     assert_equal(len(mock_url_request.urls), 1)

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -280,5 +280,5 @@ def test_fetch_atlas_aal_spm_12():
     dummy.close()
     dataset = atlas.fetch_atlas_aal_spm_12(data_dir=tmpdir, verbose=0)
     assert_true(isinstance(dataset.regions, _basestring))
-    assert_equal(len(dataset.labels), 116)
+    assert_true(isinstance(dataset.labels, dict)
     assert_equal(len(mock_url_request.urls), 1)

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -272,6 +272,6 @@ def test_fetch_atlas_yeo_2011():
 @with_setup(setup_tmpdata, teardown_tmpdata)
 def test_fetch_atlas_aal_spm_12():
     dataset = atlas.fetch_atlas_aal_spm_12(data_dir=tmpdir, verbose=0)
-    assert_true(isinstance(dataset.multi_mask, _basestring))
+    assert_true(isinstance(dataset.regions, _basestring))
     assert_equal(len(dataset.labels), 116)
     assert_equal(len(mock_url_request.urls), 1)


### PR DESCRIPTION
@GaelVaroquaux I added the fetch_atlas_aal function following example from the other atlas downloaded as requested in #706 

For now I implemented the download of the SPM12 version, any other SPM version would require to hardcode reference to a lot matlab files. I dont know if this would actually be useful for the users, but can implement it if you want. What do you think?