### PR TITLE
[MRG+1] Add python3.5 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,12 @@ env:
       NUMPY_VERSION="1.6.2" SCIPY_VERSION="0.11.0"
       SCIKIT_LEARN_VERSION="0.13" MATPLOTLIB_VERSION="1.1.1"
       NIBABEL_VERSION="1.1.0"
-    # Most recent versions
+    # Python 3.4 with intermediary versions
     - DISTRIB="conda" PYTHON_VERSION="3.4"
+      NUMPY_VERSION="1.8" SCIPY_VERSION="0.14"
+      SCIKIT_LEARN_VERSION="0.15" MATPLOTLIB_VERSION="1.4"
+    # Most recent versions
+    - DISTRIB="conda" PYTHON_VERSION="3.5"
       NUMPY_VERSION="*" SCIPY_VERSION="*"
       SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
 

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -792,7 +792,7 @@ class BaseSpaceNet(LinearModel, RegressorMixin, CacheMixin):
                                      classifier=self.is_classif))
         else:
             # no cross-validation needed, user supplied all params
-            self.cv_ = [(range(n_samples), [])]
+            self.cv_ = [(np.arange(n_samples), [])]
         n_folds = len(self.cv_)
 
         # scores & mean weights map over all folds

--- a/nilearn/decoding/tests/test_space_net.py
+++ b/nilearn/decoding/tests/test_space_net.py
@@ -116,7 +116,7 @@ def testlogistic_path_scores():
     alphas = [1., .1, .01]
     test_scores, best_w = logistic_path_scores(
         _graph_net_logistic, X, y, mask, alphas, .5,
-        range(len(X)), range(len(X)), {})[:2]
+        np.arange(len(X)), np.arange(len(X)), {})[:2]
     test_scores = test_scores[0]
     assert_equal(len(test_scores), len(alphas))
     assert_equal(X.shape[1] + 1, len(best_w))
@@ -130,7 +130,7 @@ def test_squared_loss_path_scores():
     alphas = [1., .1, .01]
     test_scores, best_w = squared_loss_path_scores(
         _graph_net_squared_loss, X, y, mask, alphas, .5,
-        range(len(X)), range(len(X)), {})[:2]
+        np.arange(len(X)), np.arange(len(X)), {})[:2]
     test_scores = test_scores[0]
     assert_equal(len(test_scores), len(alphas))
     assert_equal(X.shape[1] + 1, len(best_w))


### PR DESCRIPTION
The Python 3.5 now has the most recent versions. This uncovered a buglet in space_net.py for python 3 and numpy < 1.9 ... @dohmatob maybe you just want to glance a the fix?

The root issue is that:

```python
import numpy as np

array = np.arange(10)
array[range(3)]
```

doesn't work in numpy < 1.9 (array index can not be an iterator). It does the right thing in numpy >= 1.9.