### PR TITLE
[MRG] Setting up appveyor ci

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
    :alt: Travis Build Status
 
 .. image:: https://ci.appveyor.com/api/projects/status/github/nilearn/nilearn?branch=master&svg=true
-   :target: https://ci.appveyor.com/project/nilearnci/nilearn
+   :target: https://ci.appveyor.com/project/nilearn-ci/nilearn
    :alt: AppVeyor Build Status
 
 .. image:: https://coveralls.io/repos/nilearn/nilearn/badge.svg?branch=master

--- a/README.rst
+++ b/README.rst
@@ -2,12 +2,12 @@
 
 .. image:: https://travis-ci.org/nilearn/nilearn.svg?branch=master
    :target: https://travis-ci.org/nilearn/nilearn
-   :alt: Build Status
+   :alt: Travis Build Status
 
-.. image:: https://ci.appveyor.com/api/projects/status/dn3b752wboo83taw?svg=true
-   :target: https://ci.appveyor.com/project/aabadie/nilearn
-   :alt: Build Status
-   
+.. image:: https://ci.appveyor.com/api/projects/status/github/nilearn/nilearn?branch=master&svg=true
+   :target: https://ci.appveyor.com/project/nilearnci/nilearn
+   :alt: AppVeyor Build Status
+
 .. image:: https://coveralls.io/repos/nilearn/nilearn/badge.svg?branch=master
    :target: https://coveralls.io/r/nilearn/nilearn
 
@@ -79,5 +79,3 @@ You can check the latest sources with the command::
 or if you have write privileges::
 
     git clone git@github.com:nilearn/nilearn
-
-

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,10 @@
    :target: https://travis-ci.org/nilearn/nilearn
    :alt: Build Status
 
+.. image:: https://ci.appveyor.com/api/projects/status/dn3b752wboo83taw?svg=true
+   :target: https://ci.appveyor.com/project/aabadie/nilearn
+   :alt: Build Status
+   
 .. image:: https://coveralls.io/repos/nilearn/nilearn/badge.svg?branch=master
    :target: https://coveralls.io/r/nilearn/nilearn
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,9 @@ environment:
   # We run the tests on 2 different target platforms for testing purpose only.
   # We use miniconda versions of Python provided by appveyor windows images
   matrix:
-    - PYTHON: "C:\\Miniconda"
+    - PYTHON: "C:\\Miniconda-x64"
       PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "32"
+      PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Miniconda3-x64"
       PYTHON_VERSION: "3.4.x"
@@ -23,15 +23,15 @@ install:
 
   # Installed prebuilt dependencies from conda
   - "conda install pip numpy=1.9.2 scipy scikit-learn nose wheel -y -q"
-  
+
   # Install other nilearn dependencies
-  - "pip install nibabel coverage"
+  - "pip install nibabel coverage matplotlib"
   - "python setup.py bdist_wheel"
   - ps: "ls dist"
 
   # Install the generated wheel package to test it
   - "pip install --pre --no-index --find-links dist/ nilearn"
-  
+
 # Not a .NET project, we build in the install step instead
 build: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   # Installed prebuilt dependencies from conda
-  - "conda install pip numpy=1.9.2 scipy scikit-learn nose wheel -y -q"
+  - "conda install pip numpy scipy scikit-learn nose wheel -y -q"
 
   # Install other nilearn dependencies
   - "pip install nibabel coverage matplotlib"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,49 @@
+environment:
+  # There is no need to run the build for all the Python version /
+  # architectures combo as the generated nilearn wheel is the same on all
+  # platforms (universal wheel).
+  # We run the tests on 2 different target platforms for testing purpose only.
+  # We use miniconda versions of Python provided by appveyor windows images
+  matrix:
+    - PYTHON: "C:\\Miniconda"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Miniconda3-x64"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "64"
+
+install:
+  # Prepend miniconda installed Python to the PATH of this build
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  # Check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # Installed prebuilt dependencies from conda
+  - "conda install pip numpy=1.9.2 scipy scikit-learn nose wheel -y -q"
+  
+  # Install other nilearn dependencies
+  - "pip install nibabel coverage"
+  - "python setup.py bdist_wheel"
+  - ps: "ls dist"
+
+  # Install the generated wheel package to test it
+  - "pip install --pre --no-index --find-links dist/ nilearn"
+  
+# Not a .NET project, we build in the install step instead
+build: false
+
+test_script:
+  # Change to a non-source folder to make sure we run the tests on the
+  # installed library.
+  - "cd C:\\"
+  - "python -c \"import nose; nose.main()\" -v -s nilearn"
+
+artifacts:
+  # Archive the generated packages in the ci.appveyor.com build report.
+  - path: dist\*
+
+#on_success:
+#  - TODO: upload the content of dist/*.whl to a public wheelhouse


### PR DESCRIPTION
Fixes #804 

Added an appveyor.yml file to configure the automatic setup of the environnement installation, nilearn dist installation and testing.

Note the environnement is set up using miniconda because I couldn't build some nilearn dependencies (scipy/scikit-learn). I tried to use python-appveyor-demo project but couldn't make it work : scipy needs lapack/blas libraries.