### PR TITLE
[MRG] Fixing path and environment variables issues + tests on windows

### DIFF
--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -1138,7 +1138,7 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
 
     # Go into specific data folder and url
     data_dir = os.path.join(data_dir, pipeline, strategy)
-    url = '/'.join([url, 'Outputs', pipeline, strategy])
+    url = os.sep.join([url, 'Outputs', pipeline, strategy])
 
     # Get the files
     results = {}
@@ -1152,7 +1152,7 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
     for derivative in derivatives:
         ext = '.1D' if derivative.startswith('rois') else '.nii.gz'
         files = [(file_id + '_' + derivative + ext,
-                  '/'.join([url, derivative,
+                  os.sep.join([url, derivative,
                             file_id + '_' + derivative + ext]),
                   {}) for file_id in file_ids]
         files = _fetch_files(data_dir, files, verbose=verbose)
@@ -1266,7 +1266,7 @@ def fetch_mixed_gambles(n_subjects=1, data_dir=None, url=None, resume=True,
         url = ("https://www.nitrc.org/frs/download.php/7229/"
                "jimura_poldrack_2012_zmaps.zip")
     opts = dict(uncompress=True)
-    files = [("zmaps/sub%03i_zmaps.nii.gz" % (j + 1), url, opts)
+    files = [("zmaps%ssub%03i_zmaps.nii.gz" % (os.sep, (j + 1)), url, opts)
              for j in range(n_subjects)]
     data_dir = _get_dataset_dir('jimura_poldrack_2012_zmaps',
                                 data_dir=data_dir)

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -1138,7 +1138,7 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
 
     # Go into specific data folder and url
     data_dir = os.path.join(data_dir, pipeline, strategy)
-    url = os.sep.join([url, 'Outputs', pipeline, strategy])
+    url = '/'.join([url, 'Outputs', pipeline, strategy])
 
     # Get the files
     results = {}
@@ -1152,8 +1152,7 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
     for derivative in derivatives:
         ext = '.1D' if derivative.startswith('rois') else '.nii.gz'
         files = [(file_id + '_' + derivative + ext,
-                  os.sep.join([url, derivative,
-                            file_id + '_' + derivative + ext]),
+                  '/'.join([url, derivative, file_id + '_' + derivative + ext]),
                   {}) for file_id in file_ids]
         files = _fetch_files(data_dir, files, verbose=verbose)
         # Load derivatives if needed

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -126,17 +126,19 @@ def test_get_dataset_dir():
     # Non writeable dir is returned because dataset may be in there.
     assert_equal(data_dir, no_write)
     assert os.path.exists(data_dir)
-    os.chmod(no_write, 0o600) # Enable write permissions back
+    # Set back write permissions in order to be able to remove the file
+    os.chmod(no_write, 0o600)
     shutil.rmtree(data_dir)
 
     # Verify exception for a path which exists and is a file
     test_file = os.path.join(tmpdir, 'some_file')
     with open(test_file, 'w') as out:
         out.write('abcfeg')
-    # Exception text raised depends on system locale
-    assert_raises_regex(OSError, 'Not a directory|introuvable',
-                        utils._get_dataset_dir, 'test', test_file,
-                        verbose=0)
+    assert_raises_regex(OSError,
+                        'Nilearn tried to store the dataset '
+                        'in the following directories, but',
+                        utils._get_dataset_dir,
+                        'test', test_file, verbose=0)
 
 
 @with_setup(setup_tmpdata, teardown_tmpdata)

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -126,13 +126,15 @@ def test_get_dataset_dir():
     # Non writeable dir is returned because dataset may be in there.
     assert_equal(data_dir, no_write)
     assert os.path.exists(data_dir)
+    os.chmod(no_write, 0o600) # Enable write permissions back
     shutil.rmtree(data_dir)
 
     # Verify exception for a path which exists and is a file
     test_file = os.path.join(tmpdir, 'some_file')
     with open(test_file, 'w') as out:
         out.write('abcfeg')
-    assert_raises_regex(OSError, 'Not a directory',
+    # Exception text raised depends on system locale
+    assert_raises_regex(OSError, 'Not a directory|introuvable',
                         utils._get_dataset_dir, 'test', test_file,
                         verbose=0)
 

--- a/nilearn/datasets/tests/test_func.py
+++ b/nilearn/datasets/tests/test_func.py
@@ -19,8 +19,7 @@ from nilearn.datasets import utils, func
 from nilearn._utils.testing import (mock_request, wrap_chunk_read_,
                                     FetchFilesMock)
 
-from nilearn._utils.compat import _basestring
-
+from nilearn._utils.compat import _basestring, _urllib
 
 original_fetch_files = None
 original_url_request = None
@@ -81,7 +80,8 @@ def teardown_tmpdata():
 
 @with_setup(setup_tmpdata, teardown_tmpdata)
 def test_fetch_haxby_simple():
-    local_url = "file://" + os.path.join(datadir, "pymvpa-exampledata.tar.bz2")
+    local_url = "file:" + _urllib.request.pathname2url(os.path.join(datadir,
+        "pymvpa-exampledata.tar.bz2"))
     haxby = func.fetch_haxby_simple(data_dir=tmpdir, url=local_url,
                                     verbose=0)
     datasetdir = os.path.join(tmpdir, 'haxby2001_simple', 'pymvpa-exampledata')
@@ -98,7 +98,8 @@ def test_fetch_haxby_simple():
 @with_setup(setup_tmpdata, teardown_tmpdata)
 def test_fail_fetch_haxby_simple():
     # Test a dataset fetching failure to validate sandboxing
-    local_url = "file://" + os.path.join(datadir, "pymvpa-exampledata.tar.bz2")
+    local_url = "file:" + _urllib.request.pathname2url(os.path.join(datadir,
+        "pymvpa-exampledata.tar.bz2"))
     datasetdir = os.path.join(tmpdir, 'haxby2001_simple', 'pymvpa-exampledata')
     os.makedirs(datasetdir)
     # Create a dummy file. If sandboxing is successful, it won't be overwritten
@@ -407,7 +408,7 @@ def test_fetch_mixed_gambles():
         mgambles = func.fetch_mixed_gambles(n_subjects=n_subjects,
                                             data_dir=tmpdir, url=local_url,
                                             verbose=0, return_raw_data=True)
-        datasetdir = os.path.join(tmpdir, "jimura_poldrack_2012_zmaps/")
+        datasetdir = os.path.join(tmpdir, "jimura_poldrack_2012_zmaps" + os.sep)
         assert_equal(mgambles["zmaps"][0], os.path.join(datasetdir, "zmaps",
                                                         "sub001_zmaps.nii.gz"))
         assert_equal(len(mgambles["zmaps"]), n_subjects)

--- a/nilearn/datasets/tests/test_func.py
+++ b/nilearn/datasets/tests/test_func.py
@@ -408,7 +408,7 @@ def test_fetch_mixed_gambles():
         mgambles = func.fetch_mixed_gambles(n_subjects=n_subjects,
                                             data_dir=tmpdir, url=local_url,
                                             verbose=0, return_raw_data=True)
-        datasetdir = os.path.join(tmpdir, "jimura_poldrack_2012_zmaps" + os.sep)
+        datasetdir = os.path.join(tmpdir, "jimura_poldrack_2012_zmaps")
         assert_equal(mgambles["zmaps"][0], os.path.join(datasetdir, "zmaps",
                                                         "sub001_zmaps.nii.gz"))
         assert_equal(len(mgambles["zmaps"]), n_subjects)

--- a/nilearn/datasets/tests/test_struct.py
+++ b/nilearn/datasets/tests/test_struct.py
@@ -123,13 +123,14 @@ def test_get_dataset_dir():
     # Non writeable dir is returned because dataset may be in there.
     assert_equal(data_dir, no_write)
     assert os.path.exists(data_dir)
+    os.chmod(no_write, 0o600)
     shutil.rmtree(data_dir)
 
     # Verify exception for a path which exists and is a file
     test_file = os.path.join(tmpdir, 'some_file')
     with open(test_file, 'w') as out:
         out.write('abcfeg')
-    assert_raises_regex(OSError, 'Not a directory',
+    assert_raises_regex(OSError, 'Not a directory|introuvable',
                         utils._get_dataset_dir, 'test', test_file,
                         verbose=0)
 

--- a/nilearn/datasets/tests/test_struct.py
+++ b/nilearn/datasets/tests/test_struct.py
@@ -130,9 +130,11 @@ def test_get_dataset_dir():
     test_file = os.path.join(tmpdir, 'some_file')
     with open(test_file, 'w') as out:
         out.write('abcfeg')
-    assert_raises_regex(OSError, 'Not a directory|introuvable',
-                        utils._get_dataset_dir, 'test', test_file,
-                        verbose=0)
+    assert_raises_regex(OSError,
+                        'Nilearn tried to store the dataset '
+                        'in the following directories, but',
+                        utils._get_dataset_dir,
+                        'test', test_file, verbose=0)
 
 
 @with_setup(setup_mock, teardown_mock)

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -16,7 +16,6 @@ from tempfile import mkdtemp, mkstemp
 from nose import with_setup
 from nose.tools import assert_true, assert_false, assert_equal
 
-
 from nilearn import datasets
 from nilearn._utils.testing import (mock_request, wrap_chunk_read_,
                                     FetchFilesMock, assert_raises_regex)
@@ -106,9 +105,12 @@ def test_get_dataset_dir():
     test_file = os.path.join(tmpdir, 'some_file')
     with open(test_file, 'w') as out:
         out.write('abcfeg')
-    assert_raises_regex(OSError, 'Not a directory|introuvable',
-                        datasets.utils._get_dataset_dir, 'test', test_file,
-                        verbose=0)
+
+    assert_raises_regex(OSError,
+                        'Nilearn tried to store the dataset in the following '
+                        'directories, but',
+                        datasets.utils._get_dataset_dir,
+                        'test', test_file, verbose=0)
 
 
 def test_md5_sum_file():

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -99,13 +99,14 @@ def test_get_dataset_dir():
     # Non writeable dir is returned because dataset may be in there.
     assert_equal(data_dir, no_write)
     assert os.path.exists(data_dir)
+    os.chmod(no_write, 0o600)
     shutil.rmtree(data_dir)
 
     # Verify exception for a path which exists and is a file
     test_file = os.path.join(tmpdir, 'some_file')
     with open(test_file, 'w') as out:
         out.write('abcfeg')
-    assert_raises_regex(OSError, 'Not a directory',
+    assert_raises_regex(OSError, 'Not a directory|introuvable',
                         datasets.utils._get_dataset_dir, 'test', test_file,
                         verbose=0)
 

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -16,6 +16,11 @@ import warnings
 import zipfile
 from .._utils.compat import _basestring, cPickle, _urllib, md5_hash
 
+# Environment variables splitter is different on Windows
+if sys.platform == 'win32':
+    ENV_SPLITTER = ';'
+else:
+    ENV_SPLITTER = ':'
 
 def _format_time(t):
     if t > 60:
@@ -209,19 +214,19 @@ def _get_dataset_dir(dataset_name, data_dir=None, default_paths=None,
     # Search given environment variables
     if default_paths is not None:
         for default_path in default_paths:
-            paths.extend([(d, True) for d in default_path.split(':')])
+            paths.extend([(d, True) for d in default_path.split(ENV_SPLITTER)])
 
     # Check data_dir which force storage in a specific location
     if data_dir is not None:
-        paths.extend([(d, False) for d in data_dir.split(':')])
+        paths.extend([(d, False) for d in data_dir.split(ENV_SPLITTER)])
     else:
         global_data = os.getenv('NILEARN_SHARED_DATA')
         if global_data is not None:
-            paths.extend([(d, False) for d in global_data.split(':')])
+            paths.extend([(d, False) for d in global_data.split(ENV_SPLITTER)])
 
         local_data = os.getenv('NILEARN_DATA')
         if local_data is not None:
-            paths.extend([(d, False) for d in local_data.split(':')])
+            paths.extend([(d, False) for d in local_data.split(ENV_SPLITTER)])
 
         paths.append((os.path.expanduser('~/nilearn_data'), False))
 

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -16,12 +16,6 @@ import warnings
 import zipfile
 from .._utils.compat import _basestring, cPickle, _urllib, md5_hash
 
-# Environment variables splitter is different on Windows
-if sys.platform == 'win32':
-    ENV_SPLITTER = ';'
-else:
-    ENV_SPLITTER = ':'
-
 def _format_time(t):
     if t > 60:
         return "%4.1fmin" % (t / 60.)
@@ -214,19 +208,19 @@ def _get_dataset_dir(dataset_name, data_dir=None, default_paths=None,
     # Search given environment variables
     if default_paths is not None:
         for default_path in default_paths:
-            paths.extend([(d, True) for d in default_path.split(ENV_SPLITTER)])
+            paths.extend([(d, True) for d in default_path.split(os.pathsep)])
 
     # Check data_dir which force storage in a specific location
     if data_dir is not None:
-        paths.extend([(d, False) for d in data_dir.split(ENV_SPLITTER)])
+        paths.extend([(d, False) for d in data_dir.split(os.pathsep)])
     else:
         global_data = os.getenv('NILEARN_SHARED_DATA')
         if global_data is not None:
-            paths.extend([(d, False) for d in global_data.split(ENV_SPLITTER)])
+            paths.extend([(d, False) for d in global_data.split(os.pathsep)])
 
         local_data = os.getenv('NILEARN_DATA')
         if local_data is not None:
-            paths.extend([(d, False) for d in local_data.split(ENV_SPLITTER)])
+            paths.extend([(d, False) for d in local_data.split(os.pathsep)])
 
         paths.append((os.path.expanduser('~/nilearn_data'), False))
 


### PR DESCRIPTION
This PR partly fix the issue #809 

But it maybe worth to merge. Summary of changes:
* fixed Environment variable split character for windows as it uses ';'
* replaced '/' with os.sep when required
* fixed permission issues when removing files in test_atlas.py/test_utils.py
* fixed file:// prefix using urllib crossplatform dedicated function "pathname2url"