### PR TITLE
FIX: Proper brain-size correction in percentile

### DIFF
--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -533,7 +533,8 @@ class BaseSpaceNet(LinearModel, RegressorMixin, CacheMixin):
         100 means 'keep all features'. This percentile is is expressed
         w.r.t the volume of a standard (MNI152) brain, and so is corrected
         at runtime to correspond to the volume of the user-supplied mask
-        (which is typically smaller).
+        (which is typically smaller). If '100' is given, all the features
+        are used, regardless of voxel size.
 
     standardize : bool, optional (default True):
         If set, then the data (X, y) are centered to have mean zero along
@@ -806,9 +807,22 @@ class BaseSpaceNet(LinearModel, RegressorMixin, CacheMixin):
         mask_volume = _get_mask_volume(self.mask_img_)
         if mask_volume > MNI152_BRAIN_VOLUME:
             warnings.warn(
-                "Brain mask is bigger than volume of standard brain!")
-        self.screening_percentile_ = self.screening_percentile * (
-            mask_volume / MNI152_BRAIN_VOLUME)
+                "Brain mask is bigger than the volume of a standard "
+                "humain brain. Strange things might happen.",
+                stacklevel=2)
+        elif mask_volume < .005 * MNI152_BRAIN_VOLUME:
+            warnings.warn(
+                "Brain mask is smaller than .5% of the volume "
+                "of a standard human brain. Strange things might happen.",
+                stacklevel=2)
+
+        screening_percentile = self.screening_percentile
+        if screening_percentile < 100:
+            screening_percentile = screening_percentile * (
+                MNI152_BRAIN_VOLUME / mask_volume)
+            screening_percentile = max(self.screening_percentile, 100)
+        # if screening_percentile is 100, we don't do anything
+
         if self.verbose > 1:
             print("Mask volume = %gmm^3 = %gcm^3" % (
                 mask_volume, mask_volume / 1.e3))
@@ -817,7 +831,9 @@ class BaseSpaceNet(LinearModel, RegressorMixin, CacheMixin):
             print("Original screening-percentile: %g" % (
                 self.screening_percentile))
             print("Volume-corrected screening-percentile: %g" % (
-                self.screening_percentile_))
+                screening_percentile))
+
+        self.screening_percentile_ = screening_percentile
 
         # main loop: loop on classes and folds
         solver_params = dict(tol=self.tol, max_iter=self.max_iter)
@@ -832,7 +848,7 @@ class BaseSpaceNet(LinearModel, RegressorMixin, CacheMixin):
                 solver_params, n_alphas=self.n_alphas, eps=self.eps,
                 is_classif=self.loss == "logistic", key=(cls, fold),
                 debias=self.debias, verbose=self.verbose,
-                screening_percentile=self.screening_percentile_
+                screening_percentile=screening_percentile
                 ) for cls in range(n_problems) for fold in range(n_folds)):
             self.best_model_params_.append((best_alpha, best_l1_ratio))
             self.alpha_grids_.append(alphas)
@@ -1007,7 +1023,8 @@ class SpaceNetClassifier(BaseSpaceNet):
         100 means 'keep all features'. This percentile is is expressed
         w.r.t the volume of a standard (MNI152) brain, and so is corrected
         at runtime by premultiplying it with the ratio of the volume of the
-        mask of the data and volume of a standard brain.
+        mask of the data and volume of a standard brain.  If '100' is given,
+        all the features are used, regardless of voxel size.
 
     standardize : bool, optional (default True):
         If set, then we'll center the data (X, y) have mean zero along axis 0.

--- a/nilearn/decoding/tests/test_space_net.py
+++ b/nilearn/decoding/tests/test_space_net.py
@@ -12,8 +12,7 @@ from sklearn.utils import extmath
 from sklearn.linear_model import Lasso
 from sklearn.utils import check_random_state
 from sklearn.linear_model import LogisticRegression
-from sklearn.utils.testing import assert_warns
-from nilearn._utils.testing import assert_raises_regex
+from nilearn._utils.testing import assert_raises_regex, assert_warns
 from nilearn.decoding.space_net import (
     _EarlyStoppingCallback, _space_net_alpha_grid, MNI152_BRAIN_VOLUME,
     path_scores, BaseSpaceNet, _crop_mask, _univariate_feature_screening,

--- a/nilearn/decoding/tests/test_space_net.py
+++ b/nilearn/decoding/tests/test_space_net.py
@@ -12,11 +12,12 @@ from sklearn.utils import extmath
 from sklearn.linear_model import Lasso
 from sklearn.utils import check_random_state
 from sklearn.linear_model import LogisticRegression
+from sklearn.utils.testing import assert_warns
 from nilearn._utils.testing import assert_raises_regex
 from nilearn.decoding.space_net import (
     _EarlyStoppingCallback, _space_net_alpha_grid, MNI152_BRAIN_VOLUME,
     path_scores, BaseSpaceNet, _crop_mask, _univariate_feature_screening,
-    _get_mask_volume, SpaceNetClassifier, SpaceNetRegressor, _crop_mask)
+    _get_mask_volume, SpaceNetClassifier, SpaceNetRegressor)
 from nilearn.decoding.space_net_solvers import (_graph_net_logistic,
                                                 _graph_net_squared_loss)
 
@@ -109,7 +110,30 @@ def test_params_correctly_propagated_in_constructors():
         assert_equal(cvobj.screening_percentile, perc)
 
 
-def testlogistic_path_scores():
+def test_screening_space_net():
+    rng = check_random_state(42)
+    dim = (3, 4, 5)
+    W_init = np.zeros(dim)
+    W_init[2:3, 3:, 1:3] = 1
+
+    n = 10
+    p = dim[0] * dim[1] * dim[2]
+    X = np.ones((n, 1)) + W_init.ravel().T
+    X += rng.randn(n, p)
+    y = np.dot(X, W_init.ravel())
+    X, mask = to_niimgs(X, dim)
+
+    clf = BaseSpaceNet(mask=mask, alphas=1.,
+                 penalty="graph-net", is_classif=False, max_iter=10)
+
+    assert_warns(UserWarning, clf.fit, X, y)
+    # We gave here a very small mask, judging by standards of brain size
+    # thus the screening_percentile_ corrected for brain size should
+    # be 100%
+    assert_equal(clf.screening_percentile_, 100)
+
+
+def test_logistic_path_scores():
     iris = load_iris()
     X, y = iris.data, iris.target
     _, mask = to_niimgs(X, [2, 2, 2])

--- a/nilearn/decoding/tests/test_space_net.py
+++ b/nilearn/decoding/tests/test_space_net.py
@@ -16,7 +16,8 @@ from nilearn._utils.testing import assert_raises_regex, assert_warns
 from nilearn.decoding.space_net import (
     _EarlyStoppingCallback, _space_net_alpha_grid, MNI152_BRAIN_VOLUME,
     path_scores, BaseSpaceNet, _crop_mask, _univariate_feature_screening,
-    _get_mask_volume, SpaceNetClassifier, SpaceNetRegressor)
+    _get_mask_volume, SpaceNetClassifier, SpaceNetRegressor,
+    _adjust_screening_percentile)
 from nilearn.decoding.space_net_solvers import (_graph_net_logistic,
                                                 _graph_net_squared_loss)
 
@@ -110,26 +111,12 @@ def test_params_correctly_propagated_in_constructors():
 
 
 def test_screening_space_net():
-    rng = check_random_state(42)
-    dim = (3, 4, 5)
-    W_init = np.zeros(dim)
-    W_init[2:3, 3:, 1:3] = 1
-
-    n = 10
-    p = dim[0] * dim[1] * dim[2]
-    X = np.ones((n, 1)) + W_init.ravel().T
-    X += rng.randn(n, p)
-    y = np.dot(X, W_init.ravel())
-    X, mask = to_niimgs(X, dim)
-
-    clf = BaseSpaceNet(mask=mask, alphas=1.,
-                 penalty="graph-net", is_classif=False, max_iter=10)
-
-    assert_warns(UserWarning, clf.fit, X, y)
+    screening_percentile = assert_warns(UserWarning,
+        _adjust_screening_percentile, 10, mask)
     # We gave here a very small mask, judging by standards of brain size
     # thus the screening_percentile_ corrected for brain size should
     # be 100%
-    assert_equal(clf.screening_percentile_, 100)
+    assert_equal(screening_percentile, 100)
 
 
 def test_logistic_path_scores():


### PR DESCRIPTION
The ratio of brain size to mask volume was applied wrong in the
screening percentile.

In addition, add a bit more warnings.

Fixes #822