### PR TITLE
HOTFIX: multi pca reproducibility

### DIFF
--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -116,7 +116,7 @@ class MultiPCA(BaseEstimator, TransformerMixin, CacheMixin):
         PCA.
 
     random_state: int or RandomState
-        Pseudo number generator state used for random SVD.
+        Pseudo number generator state used for randomized SVD.
 
     standardize : boolean, optional
         If standardize is True, the time-series are centered and normed:

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -25,7 +25,8 @@ def session_pca(imgs, mask_img, parameters,
                 memory_level=0,
                 memory=Memory(cachedir=None),
                 verbose=0,
-                copy=True):
+                copy=True,
+                random_state=None):
     """Filter, mask and compute PCA on Niimg-like objects
 
     This is an helper function whose first call `base_masker.filter_and_mask`
@@ -52,6 +53,9 @@ def session_pca(imgs, mask_img, parameters,
     n_components: integer, optional
         Number of components to be extracted by the PCA
 
+    random_state: int or RandomState
+        Pseudo number generator state used for random SVD.
+
     memory_level: integer, optional
         Integer indicating the level of memorization. The higher, the more
         function calls are cached.
@@ -77,7 +81,8 @@ def session_pca(imgs, mask_img, parameters,
             confounds=confounds,
             copy=copy)
     if n_components <= data.shape[0] // 4:
-        U, S, _ = randomized_svd(data.T, n_components)
+        U, S, _ = randomized_svd(data.T, n_components,
+                                 transpose=True, random_state=random_state)
     else:
         U, S, _ = linalg.svd(data.T, full_matrices=False)
     U = U.T[:n_components].copy()
@@ -109,6 +114,9 @@ class MultiPCA(BaseEstimator, TransformerMixin, CacheMixin):
     do_cca: boolean, optional
         Indicate if a Canonical Correlation Analysis must be run after the
         PCA.
+
+    random_state: int or RandomState
+        Pseudo number generator state used for random SVD.
 
     standardize : boolean, optional
         If standardize is True, the time-series are centered and normed:
@@ -171,7 +179,8 @@ class MultiPCA(BaseEstimator, TransformerMixin, CacheMixin):
     def __init__(self, n_components=20, smoothing_fwhm=None, mask=None,
                  do_cca=True, standardize=True, target_affine=None,
                  target_shape=None, low_pass=None, high_pass=None,
-                 t_r=None, memory=Memory(cachedir=None), memory_level=0,
+                 t_r=None, random_state=None,
+                 memory=Memory(cachedir=None), memory_level=0,
                  n_jobs=1, verbose=0,
                  ):
         self.mask = mask
@@ -189,6 +198,8 @@ class MultiPCA(BaseEstimator, TransformerMixin, CacheMixin):
         self.target_affine = target_affine
         self.target_shape = target_shape
         self.standardize = standardize
+
+        self.random_state = random_state
 
     def fit(self, imgs, y=None, confounds=None):
         """Compute the mask and the components
@@ -286,7 +297,8 @@ class MultiPCA(BaseEstimator, TransformerMixin, CacheMixin):
                 memory=self.memory,
                 memory_level=self.memory_level,
                 confounds=confound,
-                verbose=self.verbose
+                verbose=self.verbose,
+                random_state=self.random_state
             )
             for img, confound in zip(imgs, confounds))
         subject_pcas, subject_svd_vals = zip(*subject_pcas)
@@ -309,7 +321,8 @@ class MultiPCA(BaseEstimator, TransformerMixin, CacheMixin):
                      (index + 1) * self.n_components] = subject_pca
             data, variance, _ = self._cache(
                 randomized_svd, func_memory_level=3)(
-                    data.T, n_components=self.n_components)
+                    data.T, n_components=self.n_components, transpose=False,
+                    random_state=self.random_state)
             # as_ndarray is to get rid of memmapping
             data = as_ndarray(data.T)
         else:

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -54,7 +54,7 @@ def session_pca(imgs, mask_img, parameters,
         Number of components to be extracted by the PCA
 
     random_state: int or RandomState
-        Pseudo number generator state used for random SVD.
+        Pseudo number generator state used for randomized SVD.
 
     memory_level: integer, optional
         Integer indicating the level of memorization. The higher, the more

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -321,7 +321,7 @@ class MultiPCA(BaseEstimator, TransformerMixin, CacheMixin):
                      (index + 1) * self.n_components] = subject_pca
             data, variance, _ = self._cache(
                 randomized_svd, func_memory_level=3)(
-                    data.T, n_components=self.n_components, transpose=False,
+                    data.T, n_components=self.n_components, transpose=True,
                     random_state=self.random_state)
             # as_ndarray is to get rid of memmapping
             data = as_ndarray(data.T)

--- a/nilearn/decomposition/tests/test_multi_pca.py
+++ b/nilearn/decomposition/tests/test_multi_pca.py
@@ -35,7 +35,7 @@ def test_multi_pca():
     components1 = multi_pca.fit(data).components_
     components2 = multi_pca.fit(data).components_
     components3 = multi_pca.fit(2 * data).components_
-    np.testing.assert_array_almost_equal(components1, components2)
+    np.testing.assert_array_equal(components1, components2)
     np.testing.assert_array_almost_equal(components1, components3)
 
     # Smoke test fit with 'confounds' argument

--- a/nilearn/decomposition/tests/test_multi_pca.py
+++ b/nilearn/decomposition/tests/test_multi_pca.py
@@ -27,12 +27,16 @@ def test_multi_pca():
         data.append(nibabel.Nifti1Image(this_data, affine))
 
     mask_img = nibabel.Nifti1Image(np.ones(shape[:3], dtype=np.int8), affine)
-    multi_pca = MultiPCA(mask=mask_img, n_components=3)
+    multi_pca = MultiPCA(mask=mask_img, n_components=3,
+                         random_state=None)
 
-    # Test that the components are the same if we put twice the same data
+    # Test that the components are the same if we put twice the same data, and
+    # that fit output is deterministic
     components1 = multi_pca.fit(data).components_
-    components2 = multi_pca.fit(2 * data).components_
+    components2 = multi_pca.fit(data).components_
+    components3 = multi_pca.fit(2 * data).components_
     np.testing.assert_array_almost_equal(components1, components2)
+    np.testing.assert_array_almost_equal(components1, components3)
 
     # Smoke test fit with 'confounds' argument
     confounds = [np.arange(10).reshape(5, 2)] * 8

--- a/nilearn/decomposition/tests/test_multi_pca.py
+++ b/nilearn/decomposition/tests/test_multi_pca.py
@@ -28,7 +28,7 @@ def test_multi_pca():
 
     mask_img = nibabel.Nifti1Image(np.ones(shape[:3], dtype=np.int8), affine)
     multi_pca = MultiPCA(mask=mask_img, n_components=3,
-                         random_state=None)
+                         random_state=0)
 
     # Test that the components are the same if we put twice the same data, and
     # that fit output is deterministic


### PR DESCRIPTION
Bug #827. I force `transpose = True` for `multi_pca` to yield the same result when we put twice the same data, and if we run fit twice on the same data