### PR TITLE
Update _fetch_file* docstring.

### DIFF
--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -412,9 +412,9 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
     url: string
         Contains the url of the file to be downloaded.
 
-    data_dir: string, optional
-        Path of the data directory. Used to force data storage in a specified
-        location. Default: None
+    data_dir: string
+        Path of the data directory. Used for data storage in the specified
+        location.
 
     resume: bool, optional
         If true, try to resume partially downloaded files
@@ -612,8 +612,9 @@ def _fetch_files(data_dir, files, resume=True, mock=False, verbose=1):
 
     Parameters
     ----------
-    dataset_name: string
-        Unique dataset name
+    data_dir: string
+        Path of the data directory. Used for data storage in a specified
+        location.
 
     files: list of (string, string, dict)
         List of files and their corresponding url with dictionary that contains
@@ -623,10 +624,6 @@ def _fetch_files(data_dir, files, resume=True, mock=False, verbose=1):
         Options supported are 'uncompress' to indicate that the file is an
         archive, 'md5sum' to check the md5 sum of the file and 'move' if
         renaming the file or moving it to a subfolder is needed.
-
-    data_dir: string, optional
-        Path of the data directory. Used to force data storage in a specified
-        location. Default: None
 
     resume: bool, optional
         If true, try resuming download if possible


### PR DESCRIPTION
`_fetch_file` and `_fetch_files` claim that `data_dir` is optional (it is not) and that it can be `None` (it cannot be). Fix here is to change the docstrings.

It's worth noting that parameter order in the two functions is opposite: `_fetch_file(url, data_dir, ...)` vs. `_fetch_files(data_dir, files, ...)`. An additional change here could be to flip the parameters of one (I think `_fetch_files(files, data_dir, ...)` would be the way to go.

