### PR TITLE
Add overwrite option to _fetch_files

### DIFF
--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -14,72 +14,23 @@ import nibabel
 from nose import with_setup
 from nose.tools import assert_true, assert_equal, assert_not_equal
 
-from nilearn._utils.testing import (mock_request, wrap_chunk_read_,
-                                    FetchFilesMock, assert_raises_regex)
+from nilearn._utils.testing import assert_raises_regex
+from . import test_utils as tst
 
 from nilearn._utils.compat import _basestring
 
 from nilearn.datasets import utils, atlas, struct
 
 
-original_fetch_files = None
-original_url_request = None
-original_chunk_read = None
-mock_fetch_files = None
-mock_url_request = None
-mock_chunk_read = None
-
-
 def setup_mock():
-    global original_url_request
-    global mock_url_request
-    mock_url_request = mock_request()
-    original_url_request = utils._urllib.request
-    utils._urllib.request = mock_url_request
-
-    global original_chunk_read
-    global mock_chunk_read
-    mock_chunk_read = wrap_chunk_read_(utils._chunk_read_)
-    original_chunk_read = utils._chunk_read_
-    utils._chunk_read_ = mock_chunk_read
-
-    global original_fetch_files
-    global mock_fetch_files
-    mock_fetch_files = FetchFilesMock()
-    original_fetch_files = atlas._fetch_files
-    atlas._fetch_files = mock_fetch_files
+    return tst.setup_mock(utils, atlas)
 
 
 def teardown_mock():
-    global original_url_request
-    utils._urllib.request = original_url_request
-
-    global original_chunk_read
-    utils._chunk_read_ = original_chunk_read
-
-    global original_fetch_files
-    atlas._fetch_files = original_fetch_files
+    return tst.teardown_mock(utils, atlas)
 
 
-tmpdir = None
-currdir = os.path.dirname(os.path.abspath(__file__))
-datadir = os.path.join(currdir, 'data')
-
-
-def setup_tmpdata():
-    # create temporary dir
-    global tmpdir
-    tmpdir = mkdtemp()
-
-
-def teardown_tmpdata():
-    # remove temporary dir
-    global tmpdir
-    if tmpdir is not None:
-        shutil.rmtree(tmpdir)
-
-
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_get_dataset_dir():
     # testing folder creation under different environments, enforcing
     # a custom clean install
@@ -92,21 +43,21 @@ def test_get_dataset_dir():
     assert os.path.exists(data_dir)
     shutil.rmtree(data_dir)
 
-    expected_base_dir = os.path.join(tmpdir, 'test_nilearn_data')
+    expected_base_dir = os.path.join(tst.tmpdir, 'test_nilearn_data')
     os.environ['NILEARN_DATA'] = expected_base_dir
     data_dir = utils._get_dataset_dir('test', verbose=0)
     assert_equal(data_dir, os.path.join(expected_base_dir, 'test'))
     assert os.path.exists(data_dir)
     shutil.rmtree(data_dir)
 
-    expected_base_dir = os.path.join(tmpdir, 'nilearn_shared_data')
+    expected_base_dir = os.path.join(tst.tmpdir, 'nilearn_shared_data')
     os.environ['NILEARN_SHARED_DATA'] = expected_base_dir
     data_dir = utils._get_dataset_dir('test', verbose=0)
     assert_equal(data_dir, os.path.join(expected_base_dir, 'test'))
     assert os.path.exists(data_dir)
     shutil.rmtree(data_dir)
 
-    expected_base_dir = os.path.join(tmpdir, 'env_data')
+    expected_base_dir = os.path.join(tst.tmpdir, 'env_data')
     expected_dataset_dir = os.path.join(expected_base_dir, 'test')
     data_dir = utils._get_dataset_dir(
         'test', default_paths=[expected_dataset_dir], verbose=0)
@@ -114,11 +65,11 @@ def test_get_dataset_dir():
     assert os.path.exists(data_dir)
     shutil.rmtree(data_dir)
 
-    no_write = os.path.join(tmpdir, 'no_write')
+    no_write = os.path.join(tst.tmpdir, 'no_write')
     os.makedirs(no_write)
     os.chmod(no_write, 0o400)
 
-    expected_base_dir = os.path.join(tmpdir, 'nilearn_shared_data')
+    expected_base_dir = os.path.join(tst.tmpdir, 'nilearn_shared_data')
     os.environ['NILEARN_SHARED_DATA'] = expected_base_dir
     data_dir = utils._get_dataset_dir('test',
                                       default_paths=[no_write],
@@ -131,7 +82,7 @@ def test_get_dataset_dir():
     shutil.rmtree(data_dir)
 
     # Verify exception for a path which exists and is a file
-    test_file = os.path.join(tmpdir, 'some_file')
+    test_file = os.path.join(tst.tmpdir, 'some_file')
     with open(test_file, 'w') as out:
         out.write('abcfeg')
     assert_raises_regex(OSError,
@@ -141,7 +92,7 @@ def test_get_dataset_dir():
                         'test', test_file, verbose=0)
 
 
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fail_fetch_atlas_harvard_oxford():
     # specify non-existing atlas item
     assert_raises_regex(ValueError, 'Invalid atlas name',
@@ -152,7 +103,7 @@ def test_fail_fetch_atlas_harvard_oxford():
     target_atlas = 'cort-maxprob-thr0-1mm'
     target_atlas_fname = 'HarvardOxford-' + target_atlas + '.nii.gz'
 
-    ho_dir = os.path.join(tmpdir, 'fsl', 'data', 'atlases')
+    ho_dir = os.path.join(tst.tmpdir, 'fsl', 'data', 'atlases')
     os.makedirs(ho_dir)
     nifti_dir = os.path.join(ho_dir, 'HarvardOxford')
     os.makedirs(nifti_dir)
@@ -167,7 +118,7 @@ def test_fail_fetch_atlas_harvard_oxford():
     dummy.close()
 
     ho = atlas.fetch_atlas_harvard_oxford(target_atlas,
-                                          data_dir=tmpdir)
+                                          data_dir=tst.tmpdir)
 
     assert_true(isinstance(nibabel.load(ho.maps), nibabel.Nifti1Image))
     assert_true(isinstance(ho.labels, np.ndarray))
@@ -175,9 +126,9 @@ def test_fail_fetch_atlas_harvard_oxford():
 
 
 @with_setup(setup_mock, teardown_mock)
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_atlas_craddock_2012():
-    bunch = atlas.fetch_atlas_craddock_2012(data_dir=tmpdir,
+    bunch = atlas.fetch_atlas_craddock_2012(data_dir=tst.tmpdir,
                                             verbose=0)
 
     keys = ("scorr_mean", "tcorr_mean",
@@ -190,16 +141,16 @@ def test_fetch_atlas_craddock_2012():
         "tcorr05_2level_all.nii.gz",
         "random_all.nii.gz",
     ]
-    assert_equal(len(mock_url_request.urls), 1)
+    assert_equal(len(tst.mock_url_request.urls), 1)
     for key, fn in zip(keys, filenames):
-        assert_equal(bunch[key], os.path.join(tmpdir, 'craddock_2012', fn))
+        assert_equal(bunch[key], os.path.join(tst.tmpdir, 'craddock_2012', fn))
     assert_not_equal(bunch.description, '')
 
 
 @with_setup(setup_mock, teardown_mock)
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_atlas_smith_2009():
-    bunch = atlas.fetch_atlas_smith_2009(data_dir=tmpdir, verbose=0)
+    bunch = atlas.fetch_atlas_smith_2009(data_dir=tst.tmpdir, verbose=0)
 
     keys = ("rsn20", "rsn10", "rsn70",
             "bm20", "bm10", "bm70")
@@ -212,9 +163,9 @@ def test_fetch_atlas_smith_2009():
         "bm70.nii.gz",
     ]
 
-    assert_equal(len(mock_url_request.urls), 6)
+    assert_equal(len(tst.mock_url_request.urls), 6)
     for key, fn in zip(keys, filenames):
-        assert_equal(bunch[key], os.path.join(tmpdir, 'smith_2009', fn))
+        assert_equal(bunch[key], os.path.join(tst.tmpdir, 'smith_2009', fn))
     assert_not_equal(bunch.description, '')
 
 
@@ -225,47 +176,47 @@ def test_fetch_atlas_power_2011_atlas():
 
 
 @with_setup(setup_mock, teardown_mock)
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_atlas_destrieux_2009_atlas():
-    datadir = os.path.join(tmpdir, 'destrieux_2009')
+    datadir = os.path.join(tst.tmpdir, 'destrieux_2009')
     os.mkdir(datadir)
     dummy = open(os.path.join(
         datadir, 'destrieux2009_rois_labels_lateralized.csv'), 'w')
     dummy.write("name,index")
     dummy.close()
-    bunch = atlas.fetch_atlas_destrieux_2009(data_dir=tmpdir,
+    bunch = atlas.fetch_atlas_destrieux_2009(data_dir=tst.tmpdir,
                                              verbose=0)
 
-    assert_equal(len(mock_url_request.urls), 1)
+    assert_equal(len(tst.mock_url_request.urls), 1)
     assert_equal(bunch['maps'], os.path.join(
-        tmpdir, 'destrieux_2009', 'destrieux2009_rois_lateralized.nii.gz'))
+        tst.tmpdir, 'destrieux_2009', 'destrieux2009_rois_lateralized.nii.gz'))
 
     dummy = open(os.path.join(
         datadir, 'destrieux2009_rois_labels.csv'), 'w')
     dummy.write("name,index")
     dummy.close()
     bunch = atlas.fetch_atlas_destrieux_2009(
-        lateralized=False, data_dir=tmpdir, verbose=0)
+        lateralized=False, data_dir=tst.tmpdir, verbose=0)
 
-    assert_equal(len(mock_url_request.urls), 1)
+    assert_equal(len(tst.mock_url_request.urls), 1)
     assert_equal(bunch['maps'], os.path.join(
-        tmpdir, 'destrieux_2009', 'destrieux2009_rois.nii.gz'))
+        tst.tmpdir, 'destrieux_2009', 'destrieux2009_rois.nii.gz'))
 
 
 @with_setup(setup_mock, teardown_mock)
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_atlas_msdl():
-    dataset = atlas.fetch_atlas_msdl(data_dir=tmpdir, verbose=0)
+    dataset = atlas.fetch_atlas_msdl(data_dir=tst.tmpdir, verbose=0)
     assert_true(isinstance(dataset.labels, _basestring))
     assert_true(isinstance(dataset.maps, _basestring))
-    assert_equal(len(mock_url_request.urls), 1)
+    assert_equal(len(tst.mock_url_request.urls), 1)
     assert_not_equal(dataset.description, '')
 
 
 @with_setup(setup_mock, teardown_mock)
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_atlas_yeo_2011():
-    dataset = atlas.fetch_atlas_yeo_2011(data_dir=tmpdir, verbose=0)
+    dataset = atlas.fetch_atlas_yeo_2011(data_dir=tst.tmpdir, verbose=0)
     assert_true(isinstance(dataset.anat, _basestring))
     assert_true(isinstance(dataset.colors_17, _basestring))
     assert_true(isinstance(dataset.colors_7, _basestring))
@@ -273,26 +224,26 @@ def test_fetch_atlas_yeo_2011():
     assert_true(isinstance(dataset.thick_7, _basestring))
     assert_true(isinstance(dataset.thin_17, _basestring))
     assert_true(isinstance(dataset.thin_7, _basestring))
-    assert_equal(len(mock_url_request.urls), 1)
+    assert_equal(len(tst.mock_url_request.urls), 1)
     assert_not_equal(dataset.description, '')
 
 
 @with_setup(setup_mock, teardown_mock)
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_atlas_aal():
-    ho_dir = os.path.join(tmpdir, 'aal_SPM12', 'aal', 'atlas')
+    ho_dir = os.path.join(tst.tmpdir, 'aal_SPM12', 'aal', 'atlas')
     os.makedirs(ho_dir)
     with open(os.path.join(ho_dir, 'AAL.xml'), 'w') as xml_file:
         xml_file.write("<?xml version='1.0' encoding='us-ascii'?> "
                        "<metadata>"
                        "</metadata>")
-    dataset = atlas.fetch_atlas_aal(data_dir=tmpdir, verbose=0)
+    dataset = atlas.fetch_atlas_aal(data_dir=tst.tmpdir, verbose=0)
     assert_true(isinstance(dataset.regions, _basestring))
     assert_true(isinstance(dataset.labels, dict))
-    assert_equal(len(mock_url_request.urls), 1)
+    assert_equal(len(tst.mock_url_request.urls), 1)
 
     assert_raises_regex(ValueError, 'The version of AAL requested "FLS33"',
                         atlas.fetch_atlas_aal, version="FLS33",
-                        data_dir=tmpdir, verbose=0)
+                        data_dir=tst.tmpdir, verbose=0)
 
     assert_not_equal(dataset.description, '')

--- a/nilearn/datasets/tests/test_func.py
+++ b/nilearn/datasets/tests/test_func.py
@@ -5,7 +5,6 @@ Test the datasets module
 # License: simplified BSD
 
 import os
-import shutil
 import numpy as np
 from tempfile import mkdtemp
 import nibabel
@@ -14,77 +13,28 @@ from sklearn.utils import check_random_state
 from nose import with_setup
 from nose.tools import (assert_true, assert_equal, assert_raises,
                         assert_not_equal)
+from . import test_utils as tst
 
 from nilearn.datasets import utils, func
-from nilearn._utils.testing import (mock_request, wrap_chunk_read_,
-                                    FetchFilesMock)
 
 from nilearn._utils.compat import _basestring, _urllib
 
-original_fetch_files = None
-original_url_request = None
-original_chunk_read = None
-mock_fetch_files = None
-mock_url_request = None
-mock_chunk_read = None
-
 
 def setup_mock():
-    global original_url_request
-    global mock_url_request
-    mock_url_request = mock_request()
-    original_url_request = utils._urllib.request
-    utils._urllib.request = mock_url_request
-
-    global original_chunk_read
-    global mock_chunk_read
-    mock_chunk_read = wrap_chunk_read_(utils._chunk_read_)
-    original_chunk_read = utils._chunk_read_
-    utils._chunk_read_ = mock_chunk_read
-
-    global original_fetch_files
-    global mock_fetch_files
-    mock_fetch_files = FetchFilesMock()
-    original_fetch_files = func._fetch_files
-    func._fetch_files = mock_fetch_files
+    return tst.setup_mock(utils, func)
 
 
 def teardown_mock():
-    global original_url_request
-    utils._urllib.request = original_url_request
-
-    global original_chunk_read
-    utils._chunk_read_ = original_chunk_read
-
-    global original_fetch_files
-    func._fetch_files = original_fetch_files
+    return tst.teardown_mock(utils, func)
 
 
-currdir = os.path.dirname(os.path.abspath(__file__))
-datadir = os.path.join(currdir, 'data')
-tmpdir = None
-
-
-def setup_tmpdata():
-    # create temporary dir
-    global tmpdir
-    tmpdir = mkdtemp()
-
-
-def teardown_tmpdata():
-    # remove temporary dir
-    global tmpdir
-    if tmpdir is not None:
-        shutil.rmtree(tmpdir)
-
-
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_haxby_simple():
-    local_url = "file:" + _urllib.request.pathname2url(os.path.join(datadir,
+    local_url = "file:" + _urllib.request.pathname2url(os.path.join(tst.datadir,
         "pymvpa-exampledata.tar.bz2"))
-    haxby = func.fetch_haxby_simple(data_dir=tmpdir, url=local_url,
+    haxby = func.fetch_haxby_simple(data_dir=tst.tmpdir, url=local_url,
                                     verbose=0)
-    datasetdir = os.path.join(tmpdir, 'haxby2001_simple', 'pymvpa-exampledata')
+    datasetdir = os.path.join(tst.tmpdir, 'haxby2001_simple', 'pymvpa-exampledata')
     for key, file in [
             ('session_target', 'attributes.txt'),
             ('func', 'bold.nii.gz'),
@@ -95,12 +45,12 @@ def test_fetch_haxby_simple():
     assert_equal(haxby['mask'], os.path.join(datasetdir, 'mask.nii.gz'))
 
 
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fail_fetch_haxby_simple():
     # Test a dataset fetching failure to validate sandboxing
-    local_url = "file:" + _urllib.request.pathname2url(os.path.join(datadir,
+    local_url = "file:" + _urllib.request.pathname2url(os.path.join(tst.datadir,
         "pymvpa-exampledata.tar.bz2"))
-    datasetdir = os.path.join(tmpdir, 'haxby2001_simple', 'pymvpa-exampledata')
+    datasetdir = os.path.join(tst.tmpdir, 'haxby2001_simple', 'pymvpa-exampledata')
     os.makedirs(datasetdir)
     # Create a dummy file. If sandboxing is successful, it won't be overwritten
     dummy = open(os.path.join(datasetdir, 'attributes.txt'), 'w')
@@ -118,7 +68,7 @@ def test_fail_fetch_haxby_simple():
     ]
 
     assert_raises(IOError, utils._fetch_files,
-                  os.path.join(tmpdir, 'haxby2001_simple'), files,
+                  os.path.join(tst.tmpdir, 'haxby2001_simple'), files,
                   verbose=0)
     dummy = open(os.path.join(datasetdir, 'attributes.txt'), 'r')
     stuff = dummy.read(5)
@@ -127,13 +77,13 @@ def test_fail_fetch_haxby_simple():
 
 
 @with_setup(setup_mock, teardown_mock)
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_haxby():
     for i in range(1, 6):
-        haxby = func.fetch_haxby(data_dir=tmpdir, n_subjects=i,
+        haxby = func.fetch_haxby(data_dir=tst.tmpdir, n_subjects=i,
                                  verbose=0)
         # subject_data + (md5 + mask if first subj)
-        assert_equal(len(mock_url_request.urls), 1 + 2 * (i == 1))
+        assert_equal(len(tst.mock_url_request.urls), 1 + 2 * (i == 1))
         assert_equal(len(haxby.func), i)
         assert_equal(len(haxby.anat), i)
         assert_equal(len(haxby.session_target), i)
@@ -143,27 +93,27 @@ def test_fetch_haxby():
         assert_equal(len(haxby.mask_house), i)
         assert_equal(len(haxby.mask_face_little), i)
         assert_equal(len(haxby.mask_house_little), i)
-        mock_url_request.reset()
+        tst.mock_url_request.reset()
         assert_not_equal(haxby.description, '')
 
 
 @with_setup(setup_mock, teardown_mock)
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_nyu_rest():
     # First session, all subjects
-    nyu = func.fetch_nyu_rest(data_dir=tmpdir, verbose=0)
-    assert_equal(len(mock_url_request.urls), 2)
+    nyu = func.fetch_nyu_rest(data_dir=tst.tmpdir, verbose=0)
+    assert_equal(len(tst.mock_url_request.urls), 2)
     assert_equal(len(nyu.func), 25)
     assert_equal(len(nyu.anat_anon), 25)
     assert_equal(len(nyu.anat_skull), 25)
     assert_true(np.all(np.asarray(nyu.session) == 1))
 
     # All sessions, 12 subjects
-    mock_url_request.reset()
-    nyu = func.fetch_nyu_rest(data_dir=tmpdir, sessions=[1, 2, 3],
+    tst.mock_url_request.reset()
+    nyu = func.fetch_nyu_rest(data_dir=tst.tmpdir, sessions=[1, 2, 3],
                               n_subjects=12, verbose=0)
     # Session 1 has already been downloaded
-    assert_equal(len(mock_url_request.urls), 2)
+    assert_equal(len(tst.mock_url_request.urls), 2)
     assert_equal(len(nyu.func), 36)
     assert_equal(len(nyu.anat_anon), 36)
     assert_equal(len(nyu.anat_skull), 36)
@@ -175,9 +125,9 @@ def test_fetch_nyu_rest():
 
 
 @with_setup(setup_mock, teardown_mock)
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_adhd():
-    local_url = "file://" + datadir
+    local_url = "file://" + tst.datadir
 
     sub1 = [3902469, 7774305, 3699991]
     sub2 = [2014113, 4275075, 1019436,
@@ -194,43 +144,43 @@ def test_fetch_adhd():
             9744150, 1562298, 3205761, 3624598]
     subs = np.array(sub1 + sub2 + sub3 + sub4, dtype='i8')
     subs = subs.view(dtype=[('Subject', 'i8')])
-    mock_fetch_files.add_csv(
+    tst.mock_fetch_files.add_csv(
         'ADHD200_40subs_motion_parameters_and_phenotypics.csv',
         subs)
 
-    adhd = func.fetch_adhd(data_dir=tmpdir, url=local_url,
+    adhd = func.fetch_adhd(data_dir=tst.tmpdir, url=local_url,
                            n_subjects=12, verbose=0)
     assert_equal(len(adhd.func), 12)
     assert_equal(len(adhd.confounds), 12)
-    assert_equal(len(mock_url_request.urls), 13)  # Subjects + phenotypic
+    assert_equal(len(tst.mock_url_request.urls), 13)  # Subjects + phenotypic
     assert_not_equal(adhd.description, '')
 
 
 @with_setup(setup_mock, teardown_mock)
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_miyawaki2008():
-    dataset = func.fetch_miyawaki2008(data_dir=tmpdir, verbose=0)
+    dataset = func.fetch_miyawaki2008(data_dir=tst.tmpdir, verbose=0)
     assert_equal(len(dataset.func), 32)
     assert_equal(len(dataset.label), 32)
     assert_true(isinstance(dataset.mask, _basestring))
     assert_equal(len(dataset.mask_roi), 38)
-    assert_equal(len(mock_url_request.urls), 1)
+    assert_equal(len(tst.mock_url_request.urls), 1)
     assert_not_equal(dataset.description, '')
 
 
 @with_setup(setup_mock, teardown_mock)
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_localizer_contrasts():
-    local_url = "file://" + datadir
+    local_url = "file://" + tst.datadir
     ids = np.asarray([('S%2d' % i).encode() for i in range(94)])
     ids = ids.view(dtype=[('subject_id', 'S3')])
-    mock_fetch_files.add_csv('cubicwebexport.csv', ids)
-    mock_fetch_files.add_csv('cubicwebexport2.csv', ids)
+    tst.mock_fetch_files.add_csv('cubicwebexport.csv', ids)
+    tst.mock_fetch_files.add_csv('cubicwebexport2.csv', ids)
 
     # Disabled: cannot be tested without actually fetching covariates CSV file
     # All subjects
     dataset = func.fetch_localizer_contrasts(["checkerboard"],
-                                             data_dir=tmpdir,
+                                             data_dir=tst.tmpdir,
                                              url=local_url,
                                              verbose=0)
     assert_true(dataset.anats is None)
@@ -244,7 +194,7 @@ def test_fetch_localizer_contrasts():
     # 20 subjects
     dataset = func.fetch_localizer_contrasts(["checkerboard"],
                                              n_subjects=20,
-                                             data_dir=tmpdir,
+                                             data_dir=tst.tmpdir,
                                              url=local_url,
                                              verbose=0)
     assert_true(dataset.anats is None)
@@ -258,7 +208,7 @@ def test_fetch_localizer_contrasts():
     # Multiple contrasts
     dataset = func.fetch_localizer_contrasts(
         ["checkerboard", "horizontal checkerboard"],
-        n_subjects=20, data_dir=tmpdir,
+        n_subjects=20, data_dir=tst.tmpdir,
         verbose=0)
     assert_true(dataset.anats is None)
     assert_true(dataset.tmaps is None)
@@ -270,7 +220,7 @@ def test_fetch_localizer_contrasts():
 
     # get_anats=True
     dataset = func.fetch_localizer_contrasts(["checkerboard"],
-                                             data_dir=tmpdir,
+                                             data_dir=tst.tmpdir,
                                              url=local_url,
                                              get_anats=True,
                                              verbose=0)
@@ -285,7 +235,7 @@ def test_fetch_localizer_contrasts():
 
     # get_masks=True
     dataset = func.fetch_localizer_contrasts(["checkerboard"],
-                                             data_dir=tmpdir,
+                                             data_dir=tst.tmpdir,
                                              url=local_url,
                                              get_masks=True,
                                              verbose=0)
@@ -300,7 +250,7 @@ def test_fetch_localizer_contrasts():
 
     # get_tmaps=True
     dataset = func.fetch_localizer_contrasts(["checkerboard"],
-                                             data_dir=tmpdir,
+                                             data_dir=tst.tmpdir,
                                              url=local_url,
                                              get_tmaps=True,
                                              verbose=0)
@@ -315,7 +265,7 @@ def test_fetch_localizer_contrasts():
 
     # all get_*=True
     dataset = func.fetch_localizer_contrasts(["checkerboard"],
-                                             data_dir=tmpdir,
+                                             data_dir=tst.tmpdir,
                                              url=local_url,
                                              get_anats=True,
                                              get_masks=True,
@@ -336,17 +286,17 @@ def test_fetch_localizer_contrasts():
 
 
 @with_setup(setup_mock, teardown_mock)
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_localizer_calculation_task():
-    local_url = "file://" + datadir
+    local_url = "file://" + tst.datadir
     ids = np.asarray(['S%2d' % i for i in range(94)])
     ids = ids.view(dtype=[('subject_id', 'S3')])
-    mock_fetch_files.add_csv('cubicwebexport.csv', ids)
-    mock_fetch_files.add_csv('cubicwebexport2.csv', ids)
+    tst.mock_fetch_files.add_csv('cubicwebexport.csv', ids)
+    tst.mock_fetch_files.add_csv('cubicwebexport2.csv', ids)
 
     # Disabled: cannot be tested without actually fetching covariates CSV file
     # All subjects
-    dataset = func.fetch_localizer_calculation_task(data_dir=tmpdir,
+    dataset = func.fetch_localizer_calculation_task(data_dir=tst.tmpdir,
                                                     url=local_url,
                                                     verbose=0)
     assert_true(isinstance(dataset.ext_vars, np.recarray))
@@ -356,7 +306,7 @@ def test_fetch_localizer_calculation_task():
 
     # 20 subjects
     dataset = func.fetch_localizer_calculation_task(n_subjects=20,
-                                                    data_dir=tmpdir,
+                                                    data_dir=tst.tmpdir,
                                                     url=local_url,
                                                     verbose=0)
     assert_true(isinstance(dataset.ext_vars, np.recarray))
@@ -367,19 +317,19 @@ def test_fetch_localizer_calculation_task():
 
 
 @with_setup(setup_mock, teardown_mock)
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_abide_pcp():
-    local_url = "file://" + datadir
+    local_url = "file://" + tst.datadir
     ids = [('50%03d' % i).encode() for i in range(800)]
     filenames = ['no_filename'] * 800
     filenames[::2] = ['filename'] * 400
     pheno = np.asarray(list(zip(ids, filenames)), dtype=[('subject_id', int),
                                                          ('FILE_ID', 'U11')])
     # pheno = pheno.T.view()
-    mock_fetch_files.add_csv('Phenotypic_V1_0b_preprocessed1.csv', pheno)
+    tst.mock_fetch_files.add_csv('Phenotypic_V1_0b_preprocessed1.csv', pheno)
 
     # All subjects
-    dataset = func.fetch_abide_pcp(data_dir=tmpdir, url=local_url,
+    dataset = func.fetch_abide_pcp(data_dir=tst.tmpdir, url=local_url,
                                    quality_checked=False, verbose=0)
     assert_equal(len(dataset.func_preproc), 400)
     assert_not_equal(dataset.description, '')
@@ -400,15 +350,15 @@ def test__load_mixed_gambles():
 
 
 @with_setup(setup_mock)
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_mixed_gambles():
-    local_url = "file://" + os.path.join(datadir,
+    local_url = "file://" + os.path.join(tst.datadir,
                                          "jimura_poldrack_2012_zmaps.zip")
     for n_subjects in [1, 5, 16]:
         mgambles = func.fetch_mixed_gambles(n_subjects=n_subjects,
-                                            data_dir=tmpdir, url=local_url,
+                                            data_dir=tst.tmpdir, url=local_url,
                                             verbose=0, return_raw_data=True)
-        datasetdir = os.path.join(tmpdir, "jimura_poldrack_2012_zmaps")
+        datasetdir = os.path.join(tst.tmpdir, "jimura_poldrack_2012_zmaps")
         assert_equal(mgambles["zmaps"][0], os.path.join(datasetdir, "zmaps",
                                                         "sub001_zmaps.nii.gz"))
         assert_equal(len(mgambles["zmaps"]), n_subjects)

--- a/nilearn/datasets/tests/test_struct.py
+++ b/nilearn/datasets/tests/test_struct.py
@@ -11,72 +11,23 @@ from tempfile import mkdtemp
 
 from nose import with_setup
 from nose.tools import assert_true, assert_equal, assert_not_equal
+from . import test_utils as tst
 
 from nilearn.datasets import utils, struct
-from nilearn._utils.testing import (mock_request, wrap_chunk_read_,
-                                    FetchFilesMock, assert_raises_regex)
+from nilearn._utils.testing import assert_raises_regex
 
 from nilearn._utils.compat import _basestring
 
 
-original_fetch_files = None
-original_url_request = None
-original_chunk_read = None
-mock_fetch_files = None
-mock_url_request = None
-mock_chunk_read = None
-
-
 def setup_mock():
-    global original_url_request
-    global mock_url_request
-    mock_url_request = mock_request()
-    original_url_request = utils._urllib.request
-    utils._urllib.request = mock_url_request
-
-    global original_chunk_read
-    global mock_chunk_read
-    mock_chunk_read = wrap_chunk_read_(utils._chunk_read_)
-    original_chunk_read = utils._chunk_read_
-    utils._chunk_read_ = mock_chunk_read
-
-    global original_fetch_files
-    global mock_fetch_files
-    mock_fetch_files = FetchFilesMock()
-    original_fetch_files = struct._fetch_files
-    struct._fetch_files = mock_fetch_files
+    return tst.setup_mock(utils, struct)
 
 
 def teardown_mock():
-    global original_url_request
-    utils._urllib.request = original_url_request
-
-    global original_chunk_read
-    utils._chunk_read_ = original_chunk_read
-
-    global original_fetch_files
-    struct._fetch_files = original_fetch_files
+    return tst.teardown_mock(utils, struct)
 
 
-currdir = os.path.dirname(os.path.abspath(__file__))
-datadir = os.path.join(currdir, 'data')
-tmpdir = None
-
-
-def setup_tmpdata():
-    # create temporary dir
-    global tmpdir
-    tmpdir = mkdtemp()
-
-
-def teardown_tmpdata():
-    # remove temporary dir
-    global tmpdir
-    if tmpdir is not None:
-        shutil.rmtree(tmpdir)
-
-
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_get_dataset_dir():
     # testing folder creation under different environments, enforcing
     # a custom clean install
@@ -89,21 +40,21 @@ def test_get_dataset_dir():
     assert os.path.exists(data_dir)
     shutil.rmtree(data_dir)
 
-    expected_base_dir = os.path.join(tmpdir, 'test_nilearn_data')
+    expected_base_dir = os.path.join(tst.tmpdir, 'test_nilearn_data')
     os.environ['NILEARN_DATA'] = expected_base_dir
     data_dir = utils._get_dataset_dir('test', verbose=0)
     assert_equal(data_dir, os.path.join(expected_base_dir, 'test'))
     assert os.path.exists(data_dir)
     shutil.rmtree(data_dir)
 
-    expected_base_dir = os.path.join(tmpdir, 'nilearn_shared_data')
+    expected_base_dir = os.path.join(tst.tmpdir, 'nilearn_shared_data')
     os.environ['NILEARN_SHARED_DATA'] = expected_base_dir
     data_dir = utils._get_dataset_dir('test', verbose=0)
     assert_equal(data_dir, os.path.join(expected_base_dir, 'test'))
     assert os.path.exists(data_dir)
     shutil.rmtree(data_dir)
 
-    expected_base_dir = os.path.join(tmpdir, 'env_data')
+    expected_base_dir = os.path.join(tst.tmpdir, 'env_data')
     expected_dataset_dir = os.path.join(expected_base_dir, 'test')
     data_dir = utils._get_dataset_dir(
         'test', default_paths=[expected_dataset_dir], verbose=0)
@@ -111,11 +62,11 @@ def test_get_dataset_dir():
     assert os.path.exists(data_dir)
     shutil.rmtree(data_dir)
 
-    no_write = os.path.join(tmpdir, 'no_write')
+    no_write = os.path.join(tst.tmpdir, 'no_write')
     os.makedirs(no_write)
     os.chmod(no_write, 0o400)
 
-    expected_base_dir = os.path.join(tmpdir, 'nilearn_shared_data')
+    expected_base_dir = os.path.join(tst.tmpdir, 'nilearn_shared_data')
     os.environ['NILEARN_SHARED_DATA'] = expected_base_dir
     data_dir = utils._get_dataset_dir('test',
                                       default_paths=[no_write],
@@ -127,7 +78,7 @@ def test_get_dataset_dir():
     shutil.rmtree(data_dir)
 
     # Verify exception for a path which exists and is a file
-    test_file = os.path.join(tmpdir, 'some_file')
+    test_file = os.path.join(tst.tmpdir, 'some_file')
     with open(test_file, 'w') as out:
         out.write('abcfeg')
     assert_raises_regex(OSError,
@@ -138,9 +89,9 @@ def test_get_dataset_dir():
 
 
 @with_setup(setup_mock, teardown_mock)
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_icbm152_2009():
-    dataset = struct.fetch_icbm152_2009(data_dir=tmpdir, verbose=0)
+    dataset = struct.fetch_icbm152_2009(data_dir=tst.tmpdir, verbose=0)
     assert_true(isinstance(dataset.csf, _basestring))
     assert_true(isinstance(dataset.eye_mask, _basestring))
     assert_true(isinstance(dataset.face_mask, _basestring))
@@ -151,20 +102,20 @@ def test_fetch_icbm152_2009():
     assert_true(isinstance(dataset.t2, _basestring))
     assert_true(isinstance(dataset.t2_relax, _basestring))
     assert_true(isinstance(dataset.wm, _basestring))
-    assert_equal(len(mock_url_request.urls), 1)
+    assert_equal(len(tst.mock_url_request.urls), 1)
     assert_not_equal(dataset.description, '')
 
 
 @with_setup(setup_mock, teardown_mock)
-@with_setup(setup_tmpdata, teardown_tmpdata)
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_oasis_vbm():
-    local_url = "file://" + datadir
+    local_url = "file://" + tst.datadir
     ids = np.asarray(['OAS1_%4d' % i for i in range(457)])
     ids = ids.view(dtype=[('ID', 'S9')])
-    mock_fetch_files.add_csv('oasis_cross-sectional.csv', ids)
+    tst.mock_fetch_files.add_csv('oasis_cross-sectional.csv', ids)
 
     # Disabled: cannot be tested without actually fetching covariates CSV file
-    dataset = struct.fetch_oasis_vbm(data_dir=tmpdir, url=local_url,
+    dataset = struct.fetch_oasis_vbm(data_dir=tst.tmpdir, url=local_url,
                                      verbose=0)
     assert_equal(len(dataset.gray_matter_maps), 403)
     assert_equal(len(dataset.white_matter_maps), 403)
@@ -172,9 +123,9 @@ def test_fetch_oasis_vbm():
     assert_true(isinstance(dataset.white_matter_maps[0], _basestring))
     assert_true(isinstance(dataset.ext_vars, np.recarray))
     assert_true(isinstance(dataset.data_usage_agreement, _basestring))
-    assert_equal(len(mock_url_request.urls), 3)
+    assert_equal(len(tst.mock_url_request.urls), 3)
 
-    dataset = struct.fetch_oasis_vbm(data_dir=tmpdir, url=local_url,
+    dataset = struct.fetch_oasis_vbm(data_dir=tst.tmpdir, url=local_url,
                                      dartel_version=False, verbose=0)
     assert_equal(len(dataset.gray_matter_maps), 415)
     assert_equal(len(dataset.white_matter_maps), 415)
@@ -182,7 +133,7 @@ def test_fetch_oasis_vbm():
     assert_true(isinstance(dataset.white_matter_maps[0], _basestring))
     assert_true(isinstance(dataset.ext_vars, np.recarray))
     assert_true(isinstance(dataset.data_usage_agreement, _basestring))
-    assert_equal(len(mock_url_request.urls), 4)
+    assert_equal(len(tst.mock_url_request.urls), 4)
     assert_not_equal(dataset.description, '')
 
 

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -34,14 +34,35 @@ def setup_tmpdata():
     tmpdir = mkdtemp()
 
 
-def setup_mock():
-    global url_request
-    url_request = mock_request()
-    datasets.utils._urllib.request = url_request
-    datasets.utils._chunk_read_ = wrap_chunk_read_(datasets.utils._chunk_read_)
-    global file_mock
-    file_mock = FetchFilesMock()
-    datasets.utils._fetch_files = file_mock  # overwrite the actual function
+def setup_mock(utils_mod=datasets.utils, dataset_mod=datasets.utils):
+    global original_url_request
+    global mock_url_request
+    mock_url_request = mock_request()
+    original_url_request = utils_mod._urllib.request
+    utils_mod._urllib.request = mock_url_request
+
+    global original_chunk_read
+    global mock_chunk_read
+    mock_chunk_read = wrap_chunk_read_(utils_mod._chunk_read_)
+    original_chunk_read = utils_mod._chunk_read_
+    utils_mod._chunk_read_ = mock_chunk_read
+
+    global original_fetch_files
+    global mock_fetch_files
+    mock_fetch_files = FetchFilesMock()
+    original_fetch_files = dataset_mod._fetch_files
+    dataset_mod._fetch_files = mock_fetch_files
+
+
+def teardown_mock(utils_mod=datasets.utils, dataset_mod=datasets.utils):
+    global original_url_request
+    utils_mod._urllib.request = original_url_request
+
+    global original_chunk_read
+    utils_mod.chunk_read_ = original_chunk_read
+
+    global original_fetch_files
+    dataset_mod._fetch_files = original_fetch_files
 
 
 def teardown_tmpdata():

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -301,3 +301,69 @@ def test_uncompress():
     shutil.rmtree(dtemp)
 
     os.remove(temp)
+
+
+@with_setup(setup_mock, teardown_mock)
+@with_setup(setup_tmpdata, teardown_tmpdata)
+def test_fetch_file_overwrite():
+    # overwrite non-exiting file.
+    fil = datasets.utils._fetch_file(url='http://foo/', data_dir=tmpdir,
+                                     verbose=0, overwrite=True)
+    assert_equal(len(mock_url_request.urls), 1)
+    assert_true(os.path.exists(fil))
+    with open(fil, 'r') as fp:
+        assert_equal(fp.read(), '')
+
+    # Modify content
+    with open(fil, 'w') as fp:
+        fp.write('some content')
+
+    # Don't overwrite existing file.
+    fil = datasets.utils._fetch_file(url='http://foo/', data_dir=tmpdir,
+                                     verbose=0, overwrite=False)
+    assert_equal(len(mock_url_request.urls), 1)
+    assert_true(os.path.exists(fil))
+    with open(fil, 'r') as fp:
+        assert_equal(fp.read(), 'some content')
+
+    # Overwrite existing file.
+    fil = datasets.utils._fetch_file(url='http://foo/', data_dir=tmpdir,
+                                     verbose=0, overwrite=True)
+    assert_equal(len(mock_url_request.urls), 1)
+    assert_true(os.path.exists(fil))
+    with open(fil, 'r') as fp:
+        assert_equal(fp.read(), '')
+
+
+
+@with_setup(setup_mock, teardown_mock)
+@with_setup(setup_tmpdata, teardown_tmpdata)
+def test_fetch_files_overwrite():
+    # overwrite non-exiting file.
+    files = ('1.txt', 'http://foo/1.txt')
+    fil = datasets.utils._fetch_files(data_dir=tmpdir, verbose=0,
+                                      files=[files + (dict(overwrite=True),)])
+    assert_equal(len(mock_url_request.urls), 1)
+    assert_true(os.path.exists(fil[0]))
+    with open(fil[0], 'r') as fp:
+        assert_equal(fp.read(), '')
+
+    # Modify content
+    with open(fil[0], 'w') as fp:
+        fp.write('some content')
+
+    # Don't overwrite existing file.
+    fil = datasets.utils._fetch_files(data_dir=tmpdir, verbose=0,
+                                      files=[files + (dict(overwrite=False),)])
+    assert_equal(len(mock_url_request.urls), 1)
+    assert_true(os.path.exists(fil[0]))
+    with open(fil[0], 'r') as fp:
+        assert_equal(fp.read(), 'some content')
+
+    # Overwrite existing file.
+    fil = datasets.utils._fetch_files(data_dir=tmpdir, verbose=0,
+                                      files=[files + (dict(overwrite=True),)])
+    assert_equal(len(mock_url_request.urls), 1)
+    assert_true(os.path.exists(fil[0]))
+    with open(fil[0], 'r') as fp:
+        assert_equal(fp.read(), '')

--- a/nilearn/tests/test_niimg.py
+++ b/nilearn/tests/test_niimg.py
@@ -4,7 +4,6 @@ from nilearn._utils.testing import assert_raises_regex
 from nilearn._utils import niimg
 
 currdir = os.path.dirname(os.path.abspath(__file__))
-datadir = os.path.join(currdir, 'data')
 
 
 def test_copy_img():


### PR DESCRIPTION
This PR attempts to solve three issues:
* `_fetch_files` cannot overwrite existing files (note: `_fetch_file` actually allows this)
* `_fetch_file`'s `overwrite=True` flag is not tested.
* `setup_mock`, `teardown_mock`, `setup_tmpdata`, `teardown_tmpdata` is copied across `datasets/tests/test_*.py`, including an orphaned copy in `test_utils.py`.

The first is the only one I care about; the other two I dealt with while trying to test this.

I would like to use this functionality in the NeuroVault downloader. Since those datasets are dynamic, previous data may need to be overwritten.