### PR TITLE
[MRG] Install matplotlib with conda

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,14 +15,16 @@ environment:
 
 install:
   # Prepend miniconda installed Python to the PATH of this build
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  # Add Library/bin directory to fix issue
+  # https://github.com/conda/conda/issues/1753
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON%\\Library\\bin;%PATH%"
 
   # Check that we have the expected version and architecture for Python
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   # Installed prebuilt dependencies from conda
-  - "conda install pip numpy scipy scikit-learn nose wheel -y -q"
+  - "conda install pip numpy scipy scikit-learn nose wheel matplotlib -y -q"
 
   # Install other nilearn dependencies
   - "pip install nibabel coverage"


### PR DESCRIPTION
Should fix #836. It seems that matplotlib can be installed via conda. Let's see if it helps with appveyor.