### PR TITLE
Move group sparse covariance

### DIFF
--- a/doc/connectivity/connectome_extraction.rst
+++ b/doc/connectivity/connectome_extraction.rst
@@ -124,7 +124,7 @@ estimate multiple connectomes for each, with a similar structure but
 differing connection values across subjects.
 
 For this, nilearn provides the
-:class:`nilearn.group_sparse_covariance.GroupSparseCovarianceCV`
+:class:`nilearn.connectome.GroupSparseCovarianceCV`
 estimator. Its usage is similar to the GraphLassoCV object, but it takes
 a list of time series::
 
@@ -138,7 +138,7 @@ And it provides one estimated covariance and inverse-covariance
 
 |
 
-.. currentmodule:: nilearn.group_sparse_covariance
+.. currentmodule:: nilearn.connectome.group_sparse_covariance
 
 One specific case where this may be interesting is for group analysis
 across multiple subjects. Indeed, one challenge when doing statistics on
@@ -202,7 +202,7 @@ It is also possible to fit a graph lasso on data from every subject all
 together.
 
 Finally, we use the
-:class:`nilearn.group_sparse_covariance.GroupSparseCovarianceCV` [#]_.
+:class:`nilearn.connectome.GroupSparseCovarianceCV` [#]_.
 
 
 

--- a/doc/connectivity/connectome_extraction.rst
+++ b/doc/connectivity/connectome_extraction.rst
@@ -138,7 +138,7 @@ And it provides one estimated covariance and inverse-covariance
 
 |
 
-.. currentmodule:: nilearn.connectome.group_sparse_covariance
+.. currentmodule:: nilearn.connectome
 
 One specific case where this may be interesting is for group analysis
 across multiple subjects. Indeed, one challenge when doing statistics on

--- a/doc/developers/group_sparse_covariance.rst
+++ b/doc/developers/group_sparse_covariance.rst
@@ -5,7 +5,7 @@ Group-sparse covariance estimation
 ..
     Explain which case is implemented (p=2, unpenalized diagonal)
 
-.. currentmodule:: nilearn.group_sparse_covariance
+.. currentmodule:: nilearn.connectome.group_sparse_covariance
 
 
 This page gives technical information on the

--- a/doc/developers/group_sparse_covariance.rst
+++ b/doc/developers/group_sparse_covariance.rst
@@ -5,7 +5,7 @@ Group-sparse covariance estimation
 ..
     Explain which case is implemented (p=2, unpenalized diagonal)
 
-.. currentmodule:: nilearn.connectome.group_sparse_covariance
+.. currentmodule:: nilearn.connectome
 
 
 This page gives technical information on the

--- a/examples/connectivity/plot_multi_subject_connectome.py
+++ b/examples/connectivity/plot_multi_subject_connectome.py
@@ -82,7 +82,7 @@ for func_filename, confound_filename in zip(func_filenames,
 
 # Computing group-sparse precision matrices ###################################
 print("-- Computing group-sparse precision matrices ...")
-from nilearn.group_sparse_covariance import GroupSparseCovarianceCV
+from nilearn.connectome import GroupSparseCovarianceCV
 gsc = GroupSparseCovarianceCV(verbose=2)
 gsc.fit(subject_time_series)
 

--- a/examples/connectivity/plot_simulated_connectome.py
+++ b/examples/connectivity/plot_simulated_connectome.py
@@ -36,7 +36,7 @@ for n in range(n_displayed):
 
 
 # Run group-sparse covariance on all subjects
-from nilearn.group_sparse_covariance import GroupSparseCovarianceCV
+from nilearn.connectome import GroupSparseCovarianceCV
 gsc = GroupSparseCovarianceCV(max_iter=50, verbose=1)
 gsc.fit(subjects)
 

--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -17,8 +17,8 @@ datasets                --- Utilities to download NeuroImaging datasets
 decoding                --- Decoding tools and algorithms
 decomposition           --- Includes a subject level variant of the ICA
                             algorithm called Canonical ICA
-group_sparse_covariance --- Implementation of algorithm for sparse
-                            multi-subjects learning of Gaussian graphical models
+connectome              --- Set of tools for computing functional connectivity matrices
+                            and for sparse multi-subjects learning of Gaussian graphical models
 image                   --- Set of functions defining mathematical operations
                             working on Niimg-like objects
 input_data              --- includes scikit-learn tranformers and tools to
@@ -35,7 +35,7 @@ signal                  --- Set of preprocessing functions for time series
 import gzip
 
 # list all submodules available in nilearn
-__all__ = ['datasets', 'decoding', 'decomposition', 'group_sparse_covariance',
+__all__ = ['datasets', 'decoding', 'decomposition', 'connectome',
            'image', 'input_data', 'masking', 'mass_univariate', 'plotting',
            'region', 'signal']
 

--- a/nilearn/connectome/__init__.py
+++ b/nilearn/connectome/__init__.py
@@ -7,3 +7,6 @@ of Gaussian graphical models.
 from .connectivity_matrices import sym_to_vec, ConnectivityMeasure
 
 from .group_sparse_covariance import GroupSparseCovariance, GroupSparseCovarianceCV
+
+__all__ = ['sym_to_vec', 'ConnectivityMeasure',
+           'GroupSparseCovariance', 'GroupSparseCovarianceCV']

--- a/nilearn/connectome/__init__.py
+++ b/nilearn/connectome/__init__.py
@@ -1,1 +1,9 @@
+"""
+Tools for computing functional connectivity matrices and also
+implementation of algorithm for sparse multi subjects learning
+of Gaussian graphical models.
+"""
+
 from .connectivity_matrices import sym_to_vec, ConnectivityMeasure
+
+from .group_sparse_covariance import GroupSparseCovariance, GroupSparseCovarianceCV

--- a/nilearn/connectome/group_sparse_covariance.py
+++ b/nilearn/connectome/group_sparse_covariance.py
@@ -21,9 +21,9 @@ from sklearn.base import BaseEstimator
 
 from sklearn.externals.joblib import Memory, delayed, Parallel
 
-from ._utils import CacheMixin
-from ._utils import logger
-from ._utils.extmath import is_spd
+from .._utils import CacheMixin
+from .._utils import logger
+from .._utils.extmath import is_spd
 
 
 def compute_alpha_max(emp_covs, n_samples):
@@ -654,7 +654,7 @@ def group_sparse_scores(precisions, n_samples, emp_covs, alpha,
 
     log_lik = 0
     for k in range(n_subjects):
-        log_lik_k = - np.sum(emp_covs[...,  k] * precisions[..., k]) 
+        log_lik_k = - np.sum(emp_covs[...,  k] * precisions[..., k])
         log_lik_k += fast_logdet(precisions[..., k])
         log_lik += n_samples[k] * log_lik_k
 
@@ -774,7 +774,7 @@ def group_sparse_covariance_path(train_subjs, alphas, test_subjs=None,
     """
     train_covs, train_n_samples = empirical_covariances(
         train_subjs, assume_centered=False, standardize=True)
- 
+
     scores = []
     precisions_list = []
     for alpha in alphas:

--- a/nilearn/connectome/tests/test_group_sparse_covariance.py
+++ b/nilearn/connectome/tests/test_group_sparse_covariance.py
@@ -2,10 +2,9 @@ from nose.tools import assert_equal, assert_true, assert_raises
 
 import numpy as np
 from nilearn._utils.testing import generate_group_sparse_gaussian_graphs
-from nilearn.group_sparse_covariance import (group_sparse_covariance,
-                                             group_sparse_scores,
-                                             GroupSparseCovariance,
-                                             GroupSparseCovarianceCV)
+from nilearn.connectome.group_sparse_covariance import (group_sparse_covariance,
+                                                        group_sparse_scores)
+from nilearn.connectome import GroupSparseCovariance, GroupSparseCovarianceCV
 
 
 def test_group_sparse_covariance():


### PR DESCRIPTION
Trying to Fix Issue #850 

See #850 for more details.
1. Moved file ```group_sparse_covariance``` to ```nilearn.connectome```
2. Moved test files
3. Changed doc and examples accordingly.
