### PR TITLE
[MRG] Flake8 diff in pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,54 +6,48 @@ virtualenv:
 env:
   global:
     - TEST_RUN_FOLDER="/tmp" # folder where the tests are run from
-  matrix:
+
+matrix:
+  # Do not wait for the allowed_failures entry to finish before
+  # setting the status
+  fast_finish: true
+  allow_failures:
+    # allow_failures seems to be keyed on the python version
+    - python: 2.7
+  include:
     # Ubuntu 14.04 versions
-    - DISTRIB="conda" PYTHON_VERSION="2.7"
-      NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.13.3"
-      SCIKIT_LEARN_VERSION="0.14.1" MATPLOTLIB_VERSION="1.3.1"
+    - env: DISTRIB="conda" PYTHON_VERSION="2.7"
+           NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.13.3"
+           SCIKIT_LEARN_VERSION="0.14.1" MATPLOTLIB_VERSION="1.3.1"
     # Ubuntu 14.04 versions without matplotlib
-    - DISTRIB="conda" PYTHON_VERSION="2.7"
-      NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.13.3"
-      SCIKIT_LEARN_VERSION="0.14.1"
-    - DISTRIB="neurodebian" PYTHON_VERSION="2.7"
-    # Trying to get as close to the minimum required versions while
-    # still having the package version available through conda
-    - DISTRIB="conda" PYTHON_VERSION="2.6"
-      NUMPY_VERSION="1.6.2" SCIPY_VERSION="0.11.0"
-      SCIKIT_LEARN_VERSION="0.13" MATPLOTLIB_VERSION="1.1.1"
-      NIBABEL_VERSION="1.1.0"
+    - env: DISTRIB="conda" PYTHON_VERSION="2.7"
+           NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.13.3"
+           SCIKIT_LEARN_VERSION="0.14.1"
+    # Neurodebian
+    - env: DISTRIB="neurodebian" PYTHON_VERSION="2.7"
+      # Trying to get as close to the minimum required versions while
+      # still having the package version available through conda
+    - env: DISTRIB="conda" PYTHON_VERSION="2.6"
+           NUMPY_VERSION="1.6.2" SCIPY_VERSION="0.11.0"
+           SCIKIT_LEARN_VERSION="0.13" MATPLOTLIB_VERSION="1.1.1"
+           NIBABEL_VERSION="1.1.0"
     # Python 3.4 with intermediary versions
-    - DISTRIB="conda" PYTHON_VERSION="3.4"
-      NUMPY_VERSION="1.8" SCIPY_VERSION="0.14"
-      SCIKIT_LEARN_VERSION="0.15" MATPLOTLIB_VERSION="1.4"
+    - env: DISTRIB="conda" PYTHON_VERSION="3.4"
+           NUMPY_VERSION="1.8" SCIPY_VERSION="0.14"
+           SCIKIT_LEARN_VERSION="0.15" MATPLOTLIB_VERSION="1.4"
     # Most recent versions
-    - DISTRIB="conda" PYTHON_VERSION="3.5"
-      NUMPY_VERSION="*" SCIPY_VERSION="*"
-      SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
+    - env: DISTRIB="conda" PYTHON_VERSION="3.5"
+           NUMPY_VERSION="*" SCIPY_VERSION="*"
+           SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
+    # FLAKE8 linting on diff wrt common ancestor with upstream/master
+    # Note: the python value is only there to trigger allow_failures
+    - python: 2.7
+      env: DISTRIB="conda" PYTHON_VERSION="2.7" FLAKE8_VERSION="*" SKIP_TESTS="true"
 
-install: 
-    - source continuous_integration/install.sh
+install: source continuous_integration/install.sh
 
-before_script:
-    - make clean
+before_script: make clean
 
-script:
-    - python continuous_integration/show-python-packages-versions.py
-    # Copy setup.cfg to TEST_RUN_FOLDER where we are going to run the tests from
-    # Mainly for nose config settings
-    - cp setup.cfg "$TEST_RUN_FOLDER"
-    # We want to back out of the current working directory to make
-    # sure we are using nilearn installed in site-packages rather
-    # than the one from the current working directory
-    # Parentheses (run in a subshell) are used to leave
-    # the current directory unchanged
-    - (cd "$TEST_RUN_FOLDER" && make -f $OLDPWD/Makefile test-code)
-    - test "$MATPLOTLIB_VERSION" == "" || make test-doc
+script: source continuous_integration/test_script.sh
 
-after_success:
-    # Ignore coveralls failures as the coveralls server is not very reliable
-    # but we don't want travis to report a failure in the github UI just
-    # because the coverage report failed to be published.
-    # coveralls need to be run from the git checkout
-    # so we need to copy the coverage results from TEST_RUN_FOLDER
-    - if [[ "$COVERAGE" == "true" ]]; then cp "$TEST_RUN_FOLDER/.coverage" .; coveralls || echo "failed"; fi
+after_success: source continuous_integration/after_success.sh  

--- a/continuous_integration/after_success.sh
+++ b/continuous_integration/after_success.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+# Ignore coveralls failures as the coveralls server is not very reliable
+# but we don't want travis to report a failure in the github UI just
+# because the coverage report failed to be published.
+# coveralls need to be run from the git checkout
+# so we need to copy the coverage results from TEST_RUN_FOLDER
+if [[ "$SKIP_TESTS" != "true" && "$COVERAGE" == "true" ]]; then
+    cp "$TEST_RUN_FOLDER/.coverage" .
+    coveralls || echo "Coveralls upload failed"
+fi

--- a/continuous_integration/flake8_diff.sh
+++ b/continuous_integration/flake8_diff.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -e
+
+# Travis does the git clone with a limited depth (50 at the time of
+# writing). This may not be enough to find the common ancestor with
+# $REMOTE/master so we unshallow the git checkout
+git fetch --unshallow || echo "Unshallowing the git checkout failed"
+
+# Tackle both common cases of origin and upstream as remote
+# Note: upstream has priority if it exists
+git remote -v
+git remote | grep upstream && REMOTE=upstream || REMOTE=origin
+git fetch -v $REMOTE master:remote_master
+
+# Find common ancestor between HEAD and remote_master
+COMMIT=$(git merge-base @ remote_master) || \
+    echo "No common ancestor found for $(git show @ -q) and $(git show remote_master -q)"
+
+if [ -z "$COMMIT" ]; then
+    # clean-up created branch
+    git branch -D remote_master
+    exit 1
+fi
+
+echo Common ancestor is:
+git show $COMMIT --stat
+
+echo Running flake8 on the diff in the range\
+     "$(git rev-parse --short $COMMIT)..$(git rev-parse --short @)" \
+     "($(git rev-list $COMMIT.. | wc -l) commit(s)):"
+git diff $COMMIT | flake8 --diff && echo -e "No problem detected by flake8\n"
+
+# clean-up created branch
+git branch -D remote_master

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -35,7 +35,7 @@ print_conda_requirements() {
     #   - for scikit-learn, SCIKIT_LEARN_VERSION is used
     TO_INSTALL_ALWAYS="pip nose"
     REQUIREMENTS="$TO_INSTALL_ALWAYS"
-    TO_INSTALL_MAYBE="python numpy scipy matplotlib scikit-learn"
+    TO_INSTALL_MAYBE="python numpy scipy matplotlib scikit-learn flake8"
     for PACKAGE in $TO_INSTALL_MAYBE; do
         # Capitalize package name and add _VERSION
         PACKAGE_VERSION_VARNAME="${PACKAGE^^}_VERSION"
@@ -104,4 +104,8 @@ if [[ "$COVERAGE" == "true" ]]; then
     pip install coverage coveralls
 fi
 
-python setup.py install
+# numpy not installed when skipping the tests so we do not want to run
+# setup.py install
+if [[ "$SKIP_TESTS" != "true" ]]; then
+    python setup.py install
+fi

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+if [[ -n "$FLAKE8_VERSION" ]]; then
+    source continuous_integration/flake8_diff.sh
+fi
+
+if [[ "$SKIP_TESTS" != "true" ]]; then
+    python continuous_integration/show-python-packages-versions.py
+    # Copy setup.cfg to TEST_RUN_FOLDER where we are going to run the tests from
+    # Mainly for nose config settings
+    cp setup.cfg "$TEST_RUN_FOLDER"
+    # We want to back out of the current working directory to make
+    # sure we are using nilearn installed in site-packages rather
+    # than the one from the current working directory
+    # Parentheses (run in a subshell) are used to leave
+    # the current directory unchanged
+    (cd "$TEST_RUN_FOLDER" && make -f $OLDPWD/Makefile test-code)
+    test "$MATPLOTLIB_VERSION" == "" || make test-doc
+fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,6 @@ ignore-files=(plot_.*.py|conf\.py)
 
 [wheel]
 universal=1
+
+[flake8]
+ignore=E402

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,4 +18,7 @@ ignore-files=(plot_.*.py|conf\.py)
 universal=1
 
 [flake8]
+# For PEP8 error codes see
+# http://pep8.readthedocs.org/en/latest/intro.html#error-codes
+# E402: module level import not at top of file
 ignore=E402


### PR DESCRIPTION
Add this as a separate entry in the Travis build matrix. For now this
entry is marked as "allowed_failures".

* add flake8_diff.sh that finds the common ancestor between the branch
and upstream/master (or origin/master) and flake8 the diff with respect
to this common ancestor
* general .travis.yml refactor to follow more closely the Travis-CI docs.
* move each build step into its own script
* additional SKIP_TESTS environment variable to be able to skip the
  tests. This is useful when you only want to do the flake8 --diff part
* Ignore 'module level import not at top of file' in setup.cfg, because
  we have plenty of those in our examples.