### PR TITLE
[BF] copy_img / get_data / new_image_like side effects on nifti images (e.g troublesome when caching)

### DIFF
--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -128,7 +128,8 @@ def copy_img(img):
 
     if not isinstance(img, nibabel.spatialimages.SpatialImage):
         raise ValueError("Input value is not an image")
-    return new_img_like(img, img.get_data().copy(), img.get_affine().copy(),
+    
+    return new_img_like(img, _safe_get_data(img), img.get_affine().copy(),
                         copy_header=True)
 
 

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -128,8 +128,7 @@ def copy_img(img):
 
     if not isinstance(img, nibabel.spatialimages.SpatialImage):
         raise ValueError("Input value is not an image")
-    
-    return new_img_like(img, _safe_get_data(img), img.get_affine().copy(),
+    return new_img_like(img, _safe_get_data(img).copy(), img.get_affine().copy(),
                         copy_header=True)
 
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -589,10 +589,10 @@ def new_img_like(ref_niimg, data, affine=None, copy_header=False):
         data = as_ndarray(data, dtype=default_dtype)
     header = None
     if copy_header:
-        header = copy.copy(ref_niimg.get_header())
+        header = copy.deepcopy(ref_niimg.get_header())
+        header['glmax'] = 0.
         header['scl_slope'] = 0.
         header['scl_inter'] = 0.
-        header['glmax'] = 0.
         header['cal_max'] = np.max(data) if data.size > 0 else 0.
         header['cal_max'] = np.min(data) if data.size > 0 else 0.
     return ref_niimg.__class__(data, affine, header=header)

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -590,9 +590,9 @@ def new_img_like(ref_niimg, data, affine=None, copy_header=False):
     header = None
     if copy_header:
         header = copy.deepcopy(ref_niimg.get_header())
-        header['glmax'] = 0.
         header['scl_slope'] = 0.
         header['scl_inter'] = 0.
+        header['glmax'] = 0.
         header['cal_max'] = np.max(data) if data.size > 0 else 0.
         header['cal_max'] = np.min(data) if data.size > 0 else 0.
     return ref_niimg.__class__(data, affine, header=header)

--- a/nilearn/tests/test_niimg.py
+++ b/nilearn/tests/test_niimg.py
@@ -1,7 +1,13 @@
 import os
+import joblib
+import numpy as np
 
-from nilearn._utils.testing import assert_raises_regex
+from nibabel import Nifti1Image
+from nilearn.image import new_img_like
 from nilearn._utils import niimg
+from nilearn._utils.testing import assert_raises_regex
+from nose.tools import assert_equal
+
 
 currdir = os.path.dirname(os.path.abspath(__file__))
 
@@ -9,3 +15,23 @@ currdir = os.path.dirname(os.path.abspath(__file__))
 def test_copy_img():
     assert_raises_regex(ValueError, "Input value is not an image",
                         niimg.copy_img, 3)
+
+
+def test_copy_img_side_effect():
+    img1 = Nifti1Image(np.ones((2, 2, 2, 2)), affine=np.eye(4))
+    hash1 = joblib.hash(img1)
+    img2 = niimg.copy_img(img1)
+    hash2 = joblib.hash(img1)
+    assert_equal(hash1, hash2)
+
+
+def test_new_img_like_side_effect():
+    img1 = Nifti1Image(np.ones((2, 2, 2, 2)), affine=np.eye(4))
+    hash1 = joblib.hash(img1)
+    img2 = new_img_like(img1, np.ones((2, 2, 2, 2)), img1.get_affine().copy(), copy_header=True)
+    hash2 = joblib.hash(img1)
+    assert_equal(hash1, hash2)
+
+
+
+

--- a/nilearn/tests/test_niimg.py
+++ b/nilearn/tests/test_niimg.py
@@ -1,12 +1,15 @@
 import os
-import joblib
 import numpy as np
 
+from nose.tools import assert_equal
+
 from nibabel import Nifti1Image
+from sklearn.externals import joblib
+
 from nilearn.image import new_img_like
 from nilearn._utils import niimg
 from nilearn._utils.testing import assert_raises_regex
-from nose.tools import assert_equal
+
 
 
 currdir = os.path.dirname(os.path.abspath(__file__))
@@ -31,7 +34,3 @@ def test_new_img_like_side_effect():
     img2 = new_img_like(img1, np.ones((2, 2, 2, 2)), img1.get_affine().copy(), copy_header=True)
     hash2 = joblib.hash(img1)
     assert_equal(hash1, hash2)
-
-
-
-


### PR DESCRIPTION
Fixes #793 and adds tests for this issue. 

copy_img / get_data / new_image_like 

Header of the image in new_image_like was being modified because of a copy instead of a deepcopy. This was creating side effects on nifti images, for example, when caching.
