### PR TITLE
FIX: doc link to examples

### DIFF
--- a/doc/connectivity/resting_state_networks.rst
+++ b/doc/connectivity/resting_state_networks.rst
@@ -136,17 +136,17 @@ Visualizing the results
     :start-after: # Visualize the results
 
 .. |left_img_decomp| image:: ../auto_examples/connectivity/images/sphx_glr_plot_compare_resting_state_decomposition_001.png
-   :target: ../auto_examples/plot_compare_resting_state_decomposition.html
+   :target: ../auto_examples/connectivity/plot_compare_resting_state_decomposition.html
    :width: 50%
 .. |right_img_decomp| image:: ../auto_examples/connectivity/images/sphx_glr_plot_compare_resting_state_decomposition_003.png
-   :target: ../auto_examples/plot_compare_resting_state_decomposition.html
+   :target: ../auto_examples/connectivity/plot_compare_resting_state_decomposition.html
    :width: 50%
 
 .. |left_img_decomp_single| image:: ../auto_examples/connectivity/images/sphx_glr_plot_compare_resting_state_decomposition_002.png
-   :target: ../auto_examples/plot_compare_resting_state_decomposition.html
+   :target: ../auto_examples/connectivity/plot_compare_resting_state_decomposition.html
    :width: 50%
 .. |right_img_decomp_single| image:: ../auto_examples/connectivity/images/sphx_glr_plot_compare_resting_state_decomposition_004.png
-   :target: ../auto_examples/plot_compare_resting_state_decomposition.html
+   :target: ../auto_examples/connectivity/plot_compare_resting_state_decomposition.html
    :width: 50%
 
 


### PR DESCRIPTION
Fixing image link to dictionary learning examples.

Would be great to provide a developer section describing shortly the generated doc tree, especially for sphinx gallery, I guess we all loose time on this :)