### PR TITLE
PR trying to address removing deprecated functions of atlas fetcher

### DIFF
--- a/examples/connectivity/plot_inverse_covariance_connectome.py
+++ b/examples/connectivity/plot_inverse_covariance_connectome.py
@@ -24,7 +24,7 @@ with the highest values.
 ##############################################################################
 # Retrieve the atlas and the data
 from nilearn import datasets
-atlas = datasets.fetch_msdl_atlas()
+atlas = datasets.fetch_atlas_msdl()
 atlas_filename = atlas['maps']
 
 # Load the labels

--- a/examples/connectivity/plot_multi_subject_connectome.py
+++ b/examples/connectivity/plot_multi_subject_connectome.py
@@ -44,7 +44,7 @@ def plot_matrices(cov, prec, title):
 ##############################################################################
 # Fetching datasets
 from nilearn import datasets
-msdl_atlas_dataset = datasets.fetch_msdl_atlas()
+msdl_atlas_dataset = datasets.fetch_atlas_msdl()
 adhd_dataset = datasets.fetch_adhd(n_subjects=n_subjects)
 
 # print basic information on the dataset

--- a/examples/connectivity/plot_probabilistic_atlas_extraction.py
+++ b/examples/connectivity/plot_probabilistic_atlas_extraction.py
@@ -22,7 +22,7 @@ with the highest values.
 ############################################################################
 # Retrieve the atlas and the data
 from nilearn import datasets
-atlas = datasets.fetch_msdl_atlas()
+atlas = datasets.fetch_atlas_msdl()
 atlas_filename = atlas['maps']
 
 # Load the labels

--- a/examples/manipulating_visualizing/plot_overlay.py
+++ b/examples/manipulating_visualizing/plot_overlay.py
@@ -21,7 +21,7 @@ The tools that we need to leverage are:
 
 from nilearn import datasets, plotting, image
 
-atlas_data = datasets.fetch_msdl_atlas()
+atlas_data = datasets.fetch_atlas_msdl()
 atlas_filename = atlas_data.maps
 
 # First plot the map for the PCC: index 4 in the atlas

--- a/nilearn/datasets/__init__.py
+++ b/nilearn/datasets/__init__.py
@@ -7,22 +7,16 @@ from .func import (fetch_haxby_simple, fetch_haxby, fetch_nyu_rest,
                    fetch_adhd, fetch_miyawaki2008,
                    fetch_localizer_contrasts, fetch_abide_pcp,
                    fetch_localizer_calculation_task, fetch_mixed_gambles)
-from .atlas import (fetch_atlas_craddock_2012, fetch_craddock_2012_atlas,
-                    fetch_atlas_destrieux_2009, fetch_atlas_harvard_oxford,
-                    fetch_harvard_oxford, fetch_atlas_msdl, fetch_msdl_atlas,
+from .atlas import (fetch_atlas_craddock_2012, fetch_atlas_destrieux_2009,
+                    fetch_atlas_harvard_oxford, fetch_atlas_msdl,
                     fetch_atlas_power_2011, fetch_atlas_smith_2009,
-                    fetch_smith_2009, fetch_atlas_yeo_2011,
-                    fetch_yeo_2011_atlas, fetch_atlas_aal_spm_12,
-                    fetch_atlas_aal)
+                    fetch_atlas_yeo_2011, fetch_atlas_aal)
 
 __all__ = ['fetch_icbm152_2009', 'load_mni152_template', 'fetch_oasis_vbm',
-           'fetch_haxby_simple', 'fetch_haxby', 'fetch_nyu_rest', 'fetch_adhd',
-           'fetch_miyawaki2008', 'fetch_localizer_contrasts',
+           'fetch_haxby_simple', 'fetch_haxby', 'fetch_nyu_rest',
+           'fetch_adhd', 'fetch_miyawaki2008', 'fetch_localizer_contrasts',
            'fetch_abide_pcp', 'fetch_localizer_calculation_task',
-           'fetch_atlas_craddock_2012', 'fetch_craddock_2012_atlas',
-           'fetch_atlas_destrieux_2009', 'fetch_atlas_harvard_oxford',
-           'fetch_harvard_oxford', 'fetch_atlas_msdl', 'fetch_msdl_atlas',
+           'fetch_atlas_craddock_2012', 'fetch_atlas_destrieux_2009',
+           'fetch_atlas_harvard_oxford', 'fetch_atlas_msdl',
            'fetch_atlas_power_2011', 'fetch_atlas_smith_2009',
-           'fetch_smith_2009', 'fetch_atlas_yeo_2011',
-           'fetch_yeo_2011_atlas', 'fetch_mixed_gambles',
-           'fetch_atlas_aal_spm_12', 'fetch_atlas_aal']
+           'fetch_atlas_yeo_2011', 'fetch_mixed_gambles', 'fetch_atlas_aal']

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -7,7 +7,6 @@ import numpy as np
 from scipy import ndimage
 
 from sklearn.datasets.base import Bunch
-from sklearn.utils import deprecated
 
 #from . import utils
 from .utils import _get_dataset_dir, _fetch_files, _get_dataset_descr
@@ -85,16 +84,6 @@ def fetch_atlas_craddock_2012(data_dir=None, url=None, resume=True, verbose=1):
     params = dict([('description', fdescr)] + list(zip(keys, sub_files)))
 
     return Bunch(**params)
-
-
-@deprecated('it has been replace by fetch_atlas_craddock_2012 and '
-            'will be removed in nilearn 0.1.5')
-def fetch_craddock_2012_atlas(data_dir=None, url=None, resume=True, verbose=1):
-    return fetch_atlas_craddock_2012(
-        data_dir=data_dir,
-        url=url,
-        resume=resume,
-        verbose=verbose)
 
 
 def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
@@ -288,18 +277,6 @@ def fetch_atlas_harvard_oxford(atlas_name, data_dir=None,
     return Bunch(maps=atlas_img, labels=new_names)
 
 
-@deprecated('it has been replaced by fetch_atlas_harvard_oxford and '
-            'will be removed in nilearn 0.1.5')
-def fetch_harvard_oxford(atlas_name, data_dir=None, symmetric_split=False,
-                        resume=True, verbose=1):
-
-    atlas = fetch_atlas_harvard_oxford(atlas_name, data_dir=data_dir,
-                                       symmetric_split=symmetric_split,
-                                       resume=resume, verbose=verbose)
-
-    return atlas.maps, atlas.labels
-
-
 def fetch_atlas_msdl(data_dir=None, url=None, resume=True, verbose=1):
     """Download and load the MSDL brain atlas.
 
@@ -351,13 +328,6 @@ def fetch_atlas_msdl(data_dir=None, url=None, resume=True, verbose=1):
     fdescr = _get_dataset_descr(dataset_name)
 
     return Bunch(labels=files[0], maps=files[1], description=fdescr)
-
-
-@deprecated('it has been replace by fetch_atlas_msdl and '
-            'will be removed in nilearn 0.1.5')
-def fetch_msdl_atlas(data_dir=None, url=None, resume=True, verbose=1):
-    return fetch_atlas_msdl(data_dir=data_dir, url=url,
-                            resume=resume, verbose=verbose)
 
 
 def fetch_atlas_power_2011():
@@ -482,18 +452,6 @@ def fetch_atlas_smith_2009(data_dir=None, mirror='origin', url=None,
     return Bunch(**params)
 
 
-@deprecated('it has been replace by fetch_atlas_smith_2009 and '
-            'will be removed in nilearn 0.1.5')
-def fetch_smith_2009(data_dir=None, mirror='origin', url=None, resume=True,
-                     verbose=1):
-    return fetch_atlas_smith_2009(
-        data_dir=data_dir,
-        mirror=mirror,
-        url=url,
-        resume=resume,
-        verbose=verbose)
-
-
 def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
     """Download and return file names for the Yeo 2011 parcellation.
 
@@ -570,23 +528,6 @@ def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
 
     params = dict([('description', fdescr)] + list(zip(keys, sub_files)))
     return Bunch(**params)
-
-
-@deprecated('it has been replace by fetch_atlas_yeo_2011 and '
-            'will be removed in nilearn 0.1.5')
-def fetch_yeo_2011_atlas(data_dir=None, url=None, resume=True, verbose=1):
-    return fetch_atlas_yeo_2011(
-        data_dir=data_dir,
-        url=url,
-        resume=resume,
-        verbose=verbose)
-
-
-@deprecated('it has been replace by fetch_atlas_aal and '
-            'will be removed in nilearn 0.1.5')
-def fetch_atlas_aal_spm_12(data_dir=None, url=None, resume=True, verbose=1):
-    return fetch_atlas_aal(version='SPM12', data_dir=data_dir, url=url,
-                           resume=resume, verbose=verbose)
 
 
 def fetch_atlas_aal(version='SPM12', data_dir=None, url=None, resume=True,


### PR DESCRIPTION
Removing deprecated function names according to latest release:

``` python
* fetch_msdl_atlas
* fetch_craddock_2012_atlas
* fetch_harvard_oxford
* fetch_smith_2009
* fetch_yeo_2011_atlas
* fetch_atlas_aal_spm_12
```