### PR TITLE
ENH: Extend iter_img to return iterator on 3D image

### DIFF
--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -19,6 +19,7 @@ from sklearn.externals.joblib import Parallel, delayed
 from .. import signal
 from .._utils import (check_niimg_4d, check_niimg_3d, check_niimg, as_ndarray,
                       _repr_niimgs)
+from .._utils.exceptions import DimensionError
 from .._utils.niimg_conversions import _index_img, _check_same_fov
 from .._utils.niimg import _safe_get_data
 from .._utils.compat import _basestring
@@ -536,14 +537,19 @@ def iter_img(imgs):
 
     Parameters
     ----------
-    imgs: 4D Niimg-like object
+    imgs: 3D or 4D Niimg-like object
         See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
 
     Returns
     -------
     output: iterator of 3D nibabel.Nifti1Image
     """
-    return check_niimg_4d(imgs, return_iterator=True)
+
+    try:
+        return check_niimg_4d(imgs, return_iterator=True)
+    except DimensionError:
+        # Wrap a 3D image in a dummy list.
+        return check_niimg_4d([imgs], return_iterator=True)
 
 
 def new_img_like(ref_niimg, data, affine=None, copy_header=False):

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -1,10 +1,12 @@
 """
 Test image pre-processing functions
 """
-from nose.tools import assert_true, assert_false
+
+from nose.tools import assert_true, assert_false, assert_equal
 from distutils.version import LooseVersion
 from nose import SkipTest
 
+import collections
 import platform
 import os
 import nibabel
@@ -333,8 +335,9 @@ def test_index_img():
 
 def test_iter_img():
     img_3d = nibabel.Nifti1Image(np.ones((3, 4, 5)), np.eye(4))
-    testing.assert_raises_regex(TypeError, '4D Niimg-like',
-                                image.iter_img, img_3d)
+    img_3d_iter = image.iter_img(img_3d)
+    assert_true(isinstance(img_3d_iter, collections.Iterable))
+    assert_equal(len(list(img_3d_iter)), 1)
 
     affine = np.array([[1., 2., 3., 4.],
                        [5., 6., 7., 8.],


### PR DESCRIPTION
This is in reference to https://github.com/nilearn/nilearn/pull/832

Neurovault has mixed 3D and 4D images. I decimate each image into 3D by calling `iter_img`: 
https://github.com/bcipolli/nilearn/commit/82dc576903441a60cdfdd37609ca585ee57f3d11#diff-f88135c18752640fe6895cbceaa3ea4cR106

That code required an `if` statement decide whether to iterate or append the image, as `iter_img` fails on a 3D image. I couldn't figure out why the error is raised. I believe that neurovault is the first dataset with mixed 3D/4D images, so I conjectured that it's just because it wasn't necessary before.

So, to simplify the example, I changed the behavior to return an iterator (with one 3D image in it), rather than show an error.