### PR TITLE
[MRG+1] BF: Check that mask is fitted before accessing fitted data.

### DIFF
--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -219,6 +219,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
     def inverse_transform(self, X):
         """ Transform the 2D data matrix back to an image in brain space.
         """
+        self._check_fitted()
         img = self._cache(masking.unmask)(X, self.mask_img_)
         # Be robust again memmapping that will create read-only arrays in
         # internal structures of the header: remove the memmaped array


### PR DESCRIPTION
This is in reference to https://github.com/nilearn/nilearn/pull/832 

I hit an error while calling a `Masker` without having called `fit()` first. When investigating, I saw that most maskers / functions call `_check_fitted()`. Here is a place where it was not called.

Pretty sure this is the right thing...