### PR TITLE
Fix problem of small radius

### DIFF
--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -31,13 +31,25 @@ def _apply_mask_and_get_affinity(seeds, niimg, radius, allow_overlap,
                                       target_shape=niimg.shape[:3],
                                       interpolation='nearest')
         mask, _ = masking._load_mask_img(mask_img)
-        mask_coords = list(np.where(mask != 0))
+        mask_coords = list(zip(*np.where(mask != 0)))
 
         X = masking._apply_mask_fmri(niimg, mask_img)
     else:
-        mask_coords = list(zip(*np.ndindex(niimg.shape[:3])))
+        mask_coords = list(np.ndindex(niimg.shape[:3]))
         X = niimg.get_data().reshape([-1, niimg.shape[3]]).T
-    mask_coords = np.asarray(mask_coords)
+
+    # For each seed, get coordinates of nearest voxel
+    nearests = []
+    for sx, sy, sz in seeds:
+        nearest = np.round(coord_transform(sx, sy, sz, np.linalg.inv(affine)))
+        nearest = nearest.astype(int)
+        nearest = (nearest[0], nearest[1], nearest[2])
+        try:
+            nearests.append(mask_coords.index(nearest))
+        except ValueError:
+            nearests.append(None)
+
+    mask_coords = np.asarray(list(zip(*mask_coords)))
     mask_coords = coord_transform(mask_coords[0], mask_coords[1],
                                   mask_coords[2], affine)
     mask_coords = np.asarray(mask_coords).T
@@ -50,8 +62,13 @@ def _apply_mask_and_get_affinity(seeds, niimg, radius, allow_overlap,
 
     clf = neighbors.NearestNeighbors(radius=radius)
     A = clf.fit(mask_coords).radius_neighbors_graph(seeds)
+    for i, nearest in enumerate(nearests):
+        if nearest is None:
+            continue
+        A[i, nearest] = True
     A = A.tolil()
     # Include selfs
+
     mask_coords = mask_coords.astype(int).tolist()
     for i, seed in enumerate(seeds):
         try:

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -62,13 +62,13 @@ def _apply_mask_and_get_affinity(seeds, niimg, radius, allow_overlap,
 
     clf = neighbors.NearestNeighbors(radius=radius)
     A = clf.fit(mask_coords).radius_neighbors_graph(seeds)
+    A = A.tolil()
     for i, nearest in enumerate(nearests):
         if nearest is None:
             continue
         A[i, nearest] = True
-    A = A.tolil()
-    # Include selfs
-
+    
+    # Include the voxel containing the seed itself if not masked
     mask_coords = mask_coords.astype(int).tolist()
     for i, seed in enumerate(seeds):
         try:

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -67,7 +67,7 @@ def _apply_mask_and_get_affinity(seeds, niimg, radius, allow_overlap,
         if nearest is None:
             continue
         A[i, nearest] = True
-    
+
     # Include the voxel containing the seed itself if not masked
     mask_coords = mask_coords.astype(int).tolist()
     for i, seed in enumerate(seeds):

--- a/nilearn/input_data/tests/test_nifti_spheres_masker.py
+++ b/nilearn/input_data/tests/test_nifti_spheres_masker.py
@@ -110,7 +110,7 @@ def test_small_radius():
     seed = (1.4, 1.4, 1.4)
 
     masker = NiftiSpheresMasker([seed], radius=0.1,
-                            mask_img=nibabel.Nifti1Image(mask, affine))
+                                mask_img=nibabel.Nifti1Image(mask, affine))
     masker.fit_transform(nibabel.Nifti1Image(data, affine))
 
     # Test if masking is taken into account
@@ -118,11 +118,11 @@ def test_small_radius():
     mask[1, 1, 0] = 1
 
     masker = NiftiSpheresMasker([seed], radius=0.1,
-                            mask_img=nibabel.Nifti1Image(mask, affine))
+                                mask_img=nibabel.Nifti1Image(mask, affine))
     assert_raises_regex(ValueError, 'Sphere around seed #0 is empty',
                         masker.fit_transform,
                         nibabel.Nifti1Image(data, affine))
 
     masker = NiftiSpheresMasker([seed], radius=1.6,
-                            mask_img=nibabel.Nifti1Image(mask, affine))
+                                mask_img=nibabel.Nifti1Image(mask, affine))
     masker.fit_transform(nibabel.Nifti1Image(data, affine))

--- a/nilearn/input_data/tests/test_nifti_spheres_masker.py
+++ b/nilearn/input_data/tests/test_nifti_spheres_masker.py
@@ -105,6 +105,7 @@ def test_small_radius():
     data = np.random.random(shape)
     mask = np.zeros(shape)
     mask[1, 1, 1] = 1
+    mask[2, 2, 2] = 1
     affine = np.eye(4) * 1.2
     seed = (1.4, 1.4, 1.4)
 

--- a/nilearn/input_data/tests/test_nifti_spheres_masker.py
+++ b/nilearn/input_data/tests/test_nifti_spheres_masker.py
@@ -82,13 +82,46 @@ def test_nifti_spheres_masker_overlap():
 
     seeds = [(0, 0, 0), (2, 2, 2)]
 
-    overlapping_masker = NiftiSpheresMasker(seeds, radius=1, allow_overlap=True)
+    overlapping_masker = NiftiSpheresMasker(seeds, radius=1,
+                                            allow_overlap=True)
     overlapping_masker.fit_transform(fmri_img)
-    overlapping_masker = NiftiSpheresMasker(seeds, radius=2, allow_overlap=True)
+    overlapping_masker = NiftiSpheresMasker(seeds, radius=2,
+                                            allow_overlap=True)
     overlapping_masker.fit_transform(fmri_img)
 
-    noverlapping_masker = NiftiSpheresMasker(seeds, radius=1, allow_overlap=False)
+    noverlapping_masker = NiftiSpheresMasker(seeds, radius=1,
+                                             allow_overlap=False)
     noverlapping_masker.fit_transform(fmri_img)
-    noverlapping_masker = NiftiSpheresMasker(seeds, radius=2, allow_overlap=False)
+    noverlapping_masker = NiftiSpheresMasker(seeds, radius=2,
+                                             allow_overlap=False)
     assert_raises_regex(ValueError, 'Overlap detected',
                         noverlapping_masker.fit_transform, fmri_img)
+
+
+def test_small_radius():
+    affine = np.eye(4)
+    shape = (3, 3, 3)
+
+    data = np.random.random(shape)
+    mask = np.zeros(shape)
+    mask[1, 1, 1] = 1
+    affine = np.eye(4) * 1.2
+    seed = (1.4, 1.4, 1.4)
+
+    masker = NiftiSpheresMasker([seed], radius=0.1,
+                            mask_img=nibabel.Nifti1Image(mask, affine))
+    masker.fit_transform(nibabel.Nifti1Image(data, affine))
+
+    # Test if masking is taken into account
+    mask[1, 1, 1] = 0
+    mask[1, 1, 0] = 1
+
+    masker = NiftiSpheresMasker([seed], radius=0.1,
+                            mask_img=nibabel.Nifti1Image(mask, affine))
+    assert_raises_regex(ValueError, 'Sphere around seed #0 is empty',
+                        masker.fit_transform,
+                        nibabel.Nifti1Image(data, affine))
+
+    masker = NiftiSpheresMasker([seed], radius=1.6,
+                            mask_img=nibabel.Nifti1Image(mask, affine))
+    masker.fit_transform(nibabel.Nifti1Image(data, affine))


### PR DESCRIPTION
Solves the same problem as #880. Fix #873.

Here is my version of the fix. I didn't tested it extensively but, on the toy script below, it works. The code is super ugly because of the need to switch between seed representation (triplet) and coord_transform one (3 lists of coordinates).

I'm convinced that a better to do it exists but I am too tired to figure it out.

Test script:
```python
from nilearn.input_data import NiftiSpheresMasker
import numpy as np
import nibabel


data = np.random.random((3, 3, 3))
mask = np.zeros((3, 3, 3))
mask[1, 1, 1] = 1
affine = np.eye(4) * 1.2
seed = (1.4, 1.4, 1.4)

masker = NiftiSpheresMasker([seed], radius=0.1,
                            mask_img=nibabel.Nifti1Image(mask, affine))
masker.fit_transform(nibabel.Nifti1Image(data, affine))
```