### PR TITLE
[MRG] Memory check based on memory profiler

### DIFF
--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -102,6 +102,8 @@ else
     exit 1
 fi
 
+pip install psutil memory_profiler
+
 if [[ "$COVERAGE" == "true" ]]; then
     pip install coverage coveralls
 fi

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -1,6 +1,5 @@
-"""Utilities for testing nilearn.
-"""
-# Author: Alexandre Abrahame, Philippe Gervais
+"""Utilities for testing nilearn."""
+# Author: Alexandre Abraham, Philippe Gervais
 # License: simplified BSD
 import contextlib
 import functools
@@ -10,6 +9,7 @@ import re
 import sys
 import tempfile
 import warnings
+import gc
 
 import numpy as np
 import scipy.signal
@@ -58,6 +58,65 @@ except ImportError:
             warnings.simplefilter("ignore", warning_class)
             output = func(*args, **kw)
         return output
+
+
+# we use memory_profiler library for memory consumption checks
+try:
+    from memory_profiler import memory_usage
+
+    def with_memory_profiler(func):
+        """A decorator to skip tests requiring memory_profiler."""
+        return func
+
+    def memory_used(func, *args, **kwargs):
+        """Compute memory usage when executing func."""
+        gc.collect()
+        mem_use = memory_usage((func, args, kwargs), interval=0.001)
+        return max(mem_use) - min(mem_use)
+
+except ImportError:
+    def with_memory_profiler(func):
+        """A decorator to skip tests requiring memory_profiler."""
+        def dummy_func():
+            import nose
+            raise nose.SkipTest('Test requires memory_profiler.')
+        return dummy_func
+
+    memory_usage = memory_used = None
+
+
+def assert_memory_less_than(memory_limit, tolerance,
+                            callable_obj, *args, **kwargs):
+    """Check memory consumption of a callable stays below a given limit.
+
+    Parameters
+    ----------
+    memory_limit : int
+        The expected memory limit in MiB.
+    tolerance: float
+        As memory_profiler results have some variability, this adds some
+        tolerance around memory_limit. Accepted values are in range [0.0, 1.0].
+    callable_obj: callable
+        The function to be called to check memory consumption.
+
+    """
+    mem_used = memory_used(callable_obj, *args, **kwargs)
+
+    if mem_used > memory_limit * (1 + tolerance):
+        raise ValueError("Memory consumption measured ({0:.2f} MiB) is "
+                         "greater than required memory limit ({1} MiB) within "
+                         "accepted tolerance ({2:.2f}%)."
+                         "".format(mem_used, memory_limit, tolerance * 100))
+
+    # We are confident in memory_profiler measures above 100MiB.
+    # We raise an error if the measure is below the limit of 50MiB to avoid
+    # false positive.
+    if mem_used < 50:
+        raise ValueError("Memory profiler measured an untrustable memory "
+                         "consumption ({0:.2f} MiB). The expected memory "
+                         "limit was {1:.2f} MiB. Try to bench with larger "
+                         "objects (at least 100MiB in memory).".
+                         format(mem_used, memory_limit))
 
 
 class MockRequest(object):

--- a/nilearn/tests/test_niimg_conversions.py
+++ b/nilearn/tests/test_niimg_conversions.py
@@ -346,8 +346,9 @@ def test_iter_check_niimgs():
 def _check_memory(list_img_3d):
     # We intentionally add an offset of memory usage to avoid non trustable
     # measures with memory_profiler.
-    b'a' * 100 * 1024 ** 2
+    mem_offset = b'a' * 100 * 1024 ** 2
     list(_iter_check_niimg(list_img_3d))
+    del mem_offset
 
 
 @with_memory_profiler

--- a/nilearn/tests/test_niimg_conversions.py
+++ b/nilearn/tests/test_niimg_conversions.py
@@ -348,7 +348,7 @@ def _check_memory(list_img_3d):
     # measures with memory_profiler.
     mem_offset = b'a' * 100 * 1024 ** 2
     list(_iter_check_niimg(list_img_3d))
-    del mem_offset
+    return mem_offset
 
 
 @with_memory_profiler

--- a/nilearn/tests/test_niimg_conversions.py
+++ b/nilearn/tests/test_niimg_conversions.py
@@ -24,6 +24,8 @@ from nilearn import _utils, image
 from nilearn._utils.exceptions import DimensionError
 from nilearn._utils import testing, niimg_conversions
 from nilearn._utils.testing import assert_raises_regex
+from nilearn._utils.testing import with_memory_profiler
+from nilearn._utils.testing import assert_memory_less_than
 from nilearn._utils.niimg_conversions import _iter_check_niimg
 
 
@@ -339,6 +341,22 @@ def test_iter_check_niimgs():
     niimgs = list(_iter_check_niimg(img_2_4d))
     assert_array_equal(niimgs[0].get_data(),
                        _utils.check_niimg(img_2_4d).get_data())
+
+
+def _check_memory(list_img_3d):
+    # We intentionally add an offset of memory usage to avoid non trustable
+    # measures with memory_profiler.
+    b'a' * 100 * 1024 ** 2
+    list(_iter_check_niimg(list_img_3d))
+
+
+@with_memory_profiler
+def test_iter_check_niimgs_memory():
+    # Verify that iterating over a list of images doesn't consume extra
+    # memory.
+    assert_memory_less_than(100, 0.1, _check_memory,
+                            [Nifti1Image(np.ones((100, 100, 200)), np.eye(4))
+                             for i in range(10)])
 
 
 def test_repr_niimgs():

--- a/nilearn/tests/test_testing.py
+++ b/nilearn/tests/test_testing.py
@@ -1,10 +1,36 @@
 import itertools
-
 import numpy as np
 
 from nose.tools import assert_equal, assert_raises
 
-from nilearn._utils.testing import generate_fake_fmri
+from nilearn._utils.testing import generate_fake_fmri, with_memory_profiler
+from nilearn._utils.testing import assert_memory_less_than, assert_raises_regex
+
+
+def create_object(size):
+    """Just create and return an object containing `size` bytes."""
+    b'a' * size
+
+
+@with_memory_profiler
+def test_memory_usage():
+    # Valid measures
+    for mem in (500, 200, 100):
+        assert_memory_less_than(mem, 0.1, create_object, mem * 1024 ** 2)
+
+    # Ensure an exception is raised with too small objects as
+    # memory_profiler can return non trustable memory measure in this case.
+    assert_raises_regex(ValueError,
+                        "Memory profiler measured an untrustable memory",
+                        assert_memory_less_than, 50, 0.1,
+                        create_object, 25 * 1024 ** 2)
+
+    # Ensure ValueError is raised if memory used is above expected memory
+    # limit.
+    assert_raises_regex(ValueError,
+                        "Memory consumption measured",
+                        assert_memory_less_than, 50, 0.1,
+                        create_object, 100 * 1024 ** 2)
 
 
 def test_generate_fake_fmri():

--- a/nilearn/tests/test_testing.py
+++ b/nilearn/tests/test_testing.py
@@ -10,6 +10,7 @@ from nilearn._utils.testing import assert_memory_less_than, assert_raises_regex
 def create_object(size):
     """Just create and return an object containing `size` bytes."""
     mem_use = b'a' * size
+    return mem_use
 
 
 @with_memory_profiler

--- a/nilearn/tests/test_testing.py
+++ b/nilearn/tests/test_testing.py
@@ -9,8 +9,7 @@ from nilearn._utils.testing import assert_memory_less_than, assert_raises_regex
 
 def create_object(size):
     """Just create and return an object containing `size` bytes."""
-    mem_size = b'a' * size
-    return mem_size
+    mem_use = b'a' * size
 
 
 @with_memory_profiler

--- a/nilearn/tests/test_testing.py
+++ b/nilearn/tests/test_testing.py
@@ -9,7 +9,8 @@ from nilearn._utils.testing import assert_memory_less_than, assert_raises_regex
 
 def create_object(size):
     """Just create and return an object containing `size` bytes."""
-    b'a' * size
+    mem_size = b'a' * size
+    return mem_size
 
 
 @with_memory_profiler


### PR DESCRIPTION
This should fix #736 but it's not fully functional. The problem is memory_profiler cannot be really trusted when a function increase the memory less than 1MiB. I also couldn't apply it on a real test.

Here is an example (but it doesn't work) with it `test_masking.py`:
```python

from nilearn._utils.testing import with_memory_usage, assert_memory_less_than

@with_memory_usage
def test_memory_usage_with_multi_epi_mask():
    # As it calls intersect_masks, we only test resampling here.
    # Same masks as test_intersect_masks
    mask_a = np.zeros((400, 400, 1), dtype=np.bool)
    mask_a[200:400, 200:400] = 1
    mask_a_img = Nifti1Image(mask_a.astype(int), np.eye(4))

    mask_b = np.zeros((800, 800, 1), dtype=np.bool)
    mask_b[200:600, 200:600] = 1
    mask_b_img = Nifti1Image(mask_b.astype(int), np.eye(4) / 2.)

    mask_ab = np.zeros((400, 400, 1), dtype=np.bool)
    mask_ab[200, 200] = 1

   # arbitrary ground truth value...
    test_mem = 2 * (mask_b_img.get_data().nbytes +
                    mask_b_img.get_data().nbytes +
                    mask_a_img.get_data().nbytes) / (1024 ** 2)
    assert_memory_less_than(test_mem, 0.1,
                            compute_multi_epi_mask,
                            [mask_a_img, mask_b_img], threshold=1., opening=0,
                            target_affine=np.eye(4),
                            target_shape=(400, 400, 1))
```

Maybe an expert such as @AlexandreAbraham will have a better idea :)