### PR TITLE
BUG: don't ignore constant part of confounds

### DIFF
--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -473,7 +473,16 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
     # Remove confounds
     if confounds is not None:
         confounds = _ensure_float(confounds)
-        confounds = _standardize(confounds, normalize=True, detrend=detrend)
+        confounds = _standardize(confounds, normalize=standardize,
+                                 detrend=detrend)
+        if not standardize:
+            # Improve numerical stability by controlling the range of
+            # confounds. We don't rely on _standardize as it removes any
+            # constant contribution to confounds
+            confound_max = np.maximum(confounds.max(axis=0),
+                                      -confounds.min(axis=0))
+            confound_max[confound_max == 0] = 1
+            confounds /= confound_max
 
         if (LooseVersion(scipy.__version__) > LooseVersion('0.9.0')):
             # Pivoting in qr decomposition was added in scipy 0.10

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -478,9 +478,8 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
         if not standardize:
             # Improve numerical stability by controlling the range of
             # confounds. We don't rely on _standardize as it removes any
-            # constant contribution to confounds
-            confound_max = np.maximum(confounds.max(axis=0),
-                                      -confounds.min(axis=0))
+            # constant contribution to confounds.
+            confound_max = np.max(np.abs(confounds), axis=0)
             confound_max[confound_max == 0] = 1
             confounds /= confound_max
 

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -363,7 +363,7 @@ def test_clean_confounds():
                                                   confounds=np.ones(20),
                                                   detrend=False,
                                                   ).mean(),
-                                   0)
+                                   np.zeros((20, 2)))
 
 
 def test_high_variance_confounds():

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -356,6 +356,15 @@ def test_clean_confounds():
     assert_raises(TypeError, nisignal.clean, signals,
                   confounds=[None])
 
+    # Test without standardizing that constant parts of confounds are
+    # accounted for
+    np.testing.assert_almost_equal(nisignal.clean(np.ones((20, 2)),
+                                                  standardize=False,
+                                                  confounds=np.ones(20),
+                                                  detrend=False,
+                                                  ).mean(),
+                                   0)
+
 
 def test_high_variance_confounds():
     # C and F order might take different paths in the function. Check that the


### PR DESCRIPTION
When the signal is not detrended or normalized, we need to account for
constant confounds
