### PR TITLE
Robustify csv_to_array

### DIFF
--- a/nilearn/_utils/numpy_conversions.py
+++ b/nilearn/_utils/numpy_conversions.py
@@ -152,12 +152,14 @@ def csv_to_array(csv_path, delimiters=' \t,;', **kwargs):
     if not isinstance(csv_path, _basestring):
         raise TypeError('CSV must be a file path. Got a CSV of type: %s' %
                         type(csv_path))
-    # First, we try genfromtxt which works in most cases.
-    array = np.genfromtxt(csv_path, **kwargs)
 
-    if array.ndim <= 1 and np.all(np.isnan(array)):
-        # If the delimiter is not known genfromtxt generates an array full of
-        # nan. In that case, we try to guess the delimiter
+    try:
+        # First, we try genfromtxt which works in most cases.
+        array = np.genfromtxt(csv_path, loose=False, **kwargs)
+    except ValueError:
+        # There was an error during the conversion to numpy array, probably
+        # because the delimiter is wrong.
+        # In that case, we try to guess the delimiter.
         try:
             with open(csv_path, 'r') as csv_file:
                 dialect = csv.Sniffer().sniff(csv_file.readline(), delimiters)


### PR DESCRIPTION
In order to check if `genfromtxt` failed in `csv_to_array`, we checked that the resulting array is full of nan values. This may fail even when the resulting array is OK. This PR makes this check rely on the `loose=False` option of `genfromtxt` that raises a `ValueError` in case of a problem.