### PR TITLE
MRG: limit download status output displayed on circle ci

### DIFF
--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -158,8 +158,10 @@ def _chunk_read_(response, local_file, chunk_size=8192, report_hook=None,
         chunk = response.read(chunk_size)
         bytes_so_far += len(chunk)
         time_last_read = time.time()
-        # Refresh report every half second.
-        if report_hook and time_last_read > time_last_display + 0.5:
+        if (report_hook and
+                # Refresh report every half second or when download is
+                # finished.
+                (time_last_read > time_last_display + 0.5 or not chunk)):
             _chunk_report_(len(chunk), bytes_so_far,
                            total_size, initial_size, t0)
             time_last_display = time_last_read
@@ -167,10 +169,7 @@ def _chunk_read_(response, local_file, chunk_size=8192, report_hook=None,
             local_file.write(chunk)
         else:
             break
-    # Show final report (with 100% downloaded).
-    if report_hook:
-        _chunk_report_(len(chunk), bytes_so_far,
-                       total_size, initial_size, t0)
+
     return
 
 

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -153,17 +153,16 @@ def _chunk_read_(response, local_file, chunk_size=8192, report_hook=None,
         total_size = None
     bytes_so_far = initial_size
 
-    t0 = time.time()
-    t_display = t0
+    t0 = time_last_display = time.time()
     while True:
         chunk = response.read(chunk_size)
         bytes_so_far += len(chunk)
-        t_read = time.time()
+        time_last_read = time.time()
         # Refresh report every half second.
-        if report_hook and t_read > t_display + 0.5:
+        if report_hook and time_last_read > time_last_display + 0.5:
             _chunk_report_(len(chunk), bytes_so_far,
                            total_size, initial_size, t0)
-            t_display = time.time()
+            time_last_display = time_last_read
         if chunk:
             local_file.write(chunk)
         else:

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -162,7 +162,7 @@ def _chunk_read_(response, local_file, chunk_size=8192, report_hook=None,
         chunk = response.read(chunk_size)
         bytes_so_far += len(chunk)
         # Reporting download progress by block (one block is 1% of the
-        # total size of the full size if _block_size == 1).
+        # total size or the full size if _block_size == 1).
         if report_hook and bytes_so_far % _block_size < chunk_size:
             _chunk_report_(len(chunk), bytes_so_far,
                            total_size, initial_size, t0)

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -538,10 +538,8 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
         dt = time.time() - t0
         if verbose > 0:
             # Complete the reporting hook
-            sys.stderr.write(' ...done. ({0:.4f} MB, {1} seconds, '
-                             '{2} min)\n'
-                             .format(os.path.getsize(full_name) / float(1e6),
-                                     int(dt), int(dt // 60)))
+            sys.stderr.write(' ...done. ({0:.0f} seconds, {1:.0f} min)\n'
+                             .format(dt, dt // 60))
     except (_urllib.error.HTTPError, _urllib.error.URLError) as e:
         if 'Error while fetching' not in str(e):
             # For some odd reason, the error message gets doubled up


### PR DESCRIPTION
This should fix #972 

The general idea is to use the CIRCLECI environment variable available when building on circle ci along with `functools.partial` to override a parameter of the fetch functions.
I choose to add a `report_frequency` named parameter (I couldn't find a better one, suggestions greatly appreciated) in `_chunk_read` with is set so that it keeps the current behaviour by default. Setting it to 5, will reduce the number of report displayed.
It seems that the output on circle ci is pretty weird: on my local computer I have 5 distinct output but this is not always the case on the ci.