### PR TITLE
ENH [Plotting] Accepting User defined levels in contour fillings

### DIFF
--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -539,8 +539,9 @@ class BaseSlicer(object):
         if filled:
             colors = kwargs['colors']
             levels = kwargs['levels']
-            # contour fillings levels should be given as (lower, upper).
-            levels.append(np.inf)
+            if len(levels) <= 1:
+                # contour fillings levels should be given as (lower, upper).
+                levels.append(np.inf)
             alpha = kwargs['alpha']
             self._map_show(img, type='contourf', levels=levels, alpha=alpha,
                            colors=colors[:3])

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -38,3 +38,17 @@ def test_demo_ortho_projector():
     with tempfile.TemporaryFile() as fp:
         oprojector.savefig(fp)
     oprojector.close()
+
+
+def test_contour_fillings_levels_in_add_contours():
+    oslicer = OrthoSlicer(cut_coords=(0, 0, 0))
+    img = load_mni152_template()
+    # levels should be atleast 2
+    # If single levels are passed then we force upper level to be inf
+    oslicer.add_contours(img, filled=True, colors='r',
+                         alpha=0.2, levels=[0.])
+
+    # If two levels are passed, it should be increasing from zero index
+    # In this case, we simply omit appending inf
+    oslicer.add_contours(img, filled=True, colors='b',
+                         alpha=0.1, levels=[0., 0.2])


### PR DESCRIPTION
This will gives us choosing levels depending on the statistical values. See work around example results.

Example:
```python
from nilearn import plotting
from nilearn import datasets

localizer_dataset = datasets.fetch_localizer_contrasts(
    ["left vs right button press"],
    n_subjects=2, get_tmaps=True)
localizer_tmap_filename = localizer_dataset.tmaps[1]
display = plotting.plot_glass_brain(None, title='Statistical results overlayed as contour fillings',
                                                        plot_abs=False)
display.add_contours(localizer_tmap_filename, filled=True, levels=[-4.7, -3], colors='b', alpha=0.9)
display.add_contours(localizer_tmap_filename, filled=True, levels=[3], colors='r', alpha=0.9)
```
![contours_enhancement](https://cloud.githubusercontent.com/assets/11410385/12912019/5955f840-cf16-11e5-9835-83f3d185c8d7.png)
