### PR TITLE
Added a example for seed-based correlation and fixed a typo in add_marker

### DIFF
--- a/examples/03_connectivity/plot_seed_based_correlation.py
+++ b/examples/03_connectivity/plot_seed_based_correlation.py
@@ -1,0 +1,145 @@
+"""
+Producing single subject maps of seed-based correlation
+========================================================
+
+This example shows how to produce seed-based correlation maps for a single subject based on resting-state fMRI scans.
+These maps depict the temporal correlation of a **seed region** with the **rest of the brain**.
+"""
+
+
+
+################################################
+# Getting the data
+# ----------------------------------------------
+
+# We will work with the first subject of the adhd data set.
+# adhd_dataset.func is a list of filenames. We select the 1st (0-based) subject by indexing with [0]).
+from nilearn import datasets
+adhd_dataset = datasets.fetch_adhd(n_subjects=1)
+func_filename = adhd_dataset.func[0]
+confound_filename = adhd_dataset.confounds[0]
+
+##########################################################################
+# Note that func_filename and confound_filename are strings pointing to files on your hard drive.
+print(func_filename)
+print(confound_filename)
+
+
+#############################
+# Time series extraction
+# ----------------------
+#
+# We are going to extract signals from the functional time series in two steps. First we will extract the mean signal within
+# the **seed region of interest**. Second, we will extract the **brain-wide voxel-wise time series**.
+#
+# We will be working with one seed sphere in the Posterior Cingulate Cortex, considered part of the Default Mode Network.
+dmn_coords = [(0, -52, 18)]
+
+##########################################################################
+# We use :class:`nilearn.input_data.NiftiSpheresMasker` to extract the **time series from the functional
+# imaging within the sphere**. The sphere is centered at dmn_coords and will have the radius we pass the
+# NiftiSpheresMasker function (here 8 mm).
+#
+# The extraction will also detrend, standardize, and bandpass filter the data.
+# This will create a NiftiSpheresMasker object.
+from nilearn import input_data
+seed_masker = input_data.NiftiSpheresMasker(
+    dmn_coords, radius=8,
+    detrend=True, standardize=True,
+    low_pass=0.1, high_pass=0.01, t_r=2.,
+    memory='nilearn_cache', memory_level=1, verbose=0)
+
+##########################################################################
+# Then we extract the mean time series within the seed region while regressing out the confounds that
+# can be found in the dataset's csv file
+seed_time_series = seed_masker.fit_transform(func_filename, confounds=[confound_filename])
+
+##########################################################################
+# Next, we can proceed similarly for the **brain-wide voxel-wise time series**, using :class:`nilearn.in_data.NiftiMasker`
+# with the same input arguments as in the seed_masker in addition to smoothing with a 6 mm kernel
+brain_masker = input_data.NiftiMasker(
+    smoothing_fwhm=6,
+    detrend=True, standardize=True,
+    low_pass=0.1, high_pass=0.01, t_r=2.,
+    memory='nilearn_cache', memory_level=1, verbose=0)
+
+##########################################################################
+# Then we extract the brain-wide voxel-wise time series while regressing out the confounds as before
+brain_time_series = brain_masker.fit_transform(func_filename, confounds=[confound_filename])
+
+
+#############################
+# Inspecting the extracted time series
+# ----------------------
+
+##########################################################################
+# Note that the **seed time series** is an array with shape (n_volumes, 1), while the **brain time series** is an array
+# with shape (n_volumes, n_voxels).
+
+print("seed time series shape: (%s, %s)" % seed_time_series.shape)
+print("brain time series shape: (%s, %s)" % brain_time_series.shape)
+
+##########################################################################
+# We can plot the **seed time series**.
+
+import matplotlib.pyplot as plt
+plt.plot(seed_time_series)
+plt.title('Seed time series (Posterior cingulate cortex)')
+plt.xlabel('Scan number')
+plt.ylabel('Normalized signal')
+plt.tight_layout()
+
+##########################################################################
+# Exemplarily, we can also select 5 random voxels from the **brain-wide data** and plot the time series from.
+
+plt.plot(brain_time_series[:, [10, 45, 100, 5000, 10000]])
+plt.title('Time series from 5 random voxels')
+plt.xlabel('Scan number')
+plt.ylabel('Normalized signal')
+plt.tight_layout()
+
+
+
+################################################
+# Performing the seed-based correlation analysis
+# ----------------------------------------------
+#
+# Now that we have two arrays (**sphere signal**: (n_volumes, 1), **brain-wide voxel-wise signal** (n_volumes, n_voxels)), we
+# can correlate the **seed signal** with the **signal of each voxel**. The dot product of the two arrays will give us this
+# correlation. Note that the signals have been variance-standardized during extraction. To have them standardized to
+# norm unit, we further have to divide the result by the length of the time series.
+import numpy as np
+seed_based_correlations = np.dot(brain_time_series.T, seed_time_series) / seed_time_series.shape[0]
+
+################################################
+# The resulting array will contain a value representing the correlation values between the signal in the **seed region** of
+# interest and **each voxel's signal**, and will be of shape (n_voxels, 1). The correlation values can potentially range
+# between -1 and 1.
+print("seed-based correlation shape: (%s, %s)" % seed_based_correlations.shape)
+print("seed-based correlation: min = %.3f; max = %.3f" % (seed_based_correlations.min(), seed_based_correlations.max()))
+
+
+################################################
+# Fisher-z transformation and save nifti
+# ----------------------------------------------
+# Now we can Fisher-z transform the data to achieve a normal distribution. The transformed array can now have values
+# more extreme than +/- 1.
+seed_based_correlations_fisher_z = np.arctanh(seed_based_correlations)
+print("seed-based correlation Fisher-z transformed: min = %.3f; max = %.3f" % (
+    seed_based_correlations_fisher_z.min(), seed_based_correlations_fisher_z.max()))
+
+# Finally, we can tranform the correlation array back to a Nifti image object, that we can save.
+seed_based_correlation_img = brain_masker.inverse_transform(seed_based_correlations.T)
+seed_based_correlation_img.to_filename('sbc_z.nii.gz')
+
+
+################################################
+# Plotting the seed-based correlation map
+# ----------------------------------------------
+# We can also plot this image and perform thresholding to only show values more extreme than +/- 0.3.
+# The cross has been set to the center of the seed region of interest.
+from nilearn import plotting
+display = plotting.plot_stat_map(seed_based_correlation_img, threshold=0.3, cut_coords=dmn_coords[0])
+
+# At last, we save the plot as pdf.
+display.savefig('sbc_z.pdf')

--- a/examples/03_connectivity/plot_seed_based_correlation.py
+++ b/examples/03_connectivity/plot_seed_based_correlation.py
@@ -169,7 +169,7 @@ from nilearn import plotting
 
 display = plotting.plot_stat_map(seed_based_correlation_img, threshold=0.3,
                                  cut_coords=dmn_coords[0])
-display.add_markers(marker_coords=np.array(dmn_coords), marker_color='g',
+display.add_markers(marker_coords=dmn_coords, marker_color='g',
                     marker_size=300)
 # At last, we save the plot as pdf.
 display.savefig('sbc_z.pdf')

--- a/examples/03_connectivity/plot_seed_based_correlation.py
+++ b/examples/03_connectivity/plot_seed_based_correlation.py
@@ -43,12 +43,12 @@ print(confound_filename)
 #
 # We will be working with one seed sphere in the Posterior Cingulate Cortex,
 # considered part of the Default Mode Network.
-dmn_coords = [(0, -52, 18)]
+pcc_coords = [(0, -52, 18)]
 
 ##########################################################################
 # We use :class:`nilearn.input_data.NiftiSpheresMasker` to extract the
 # **time series from the functional imaging within the sphere**. The
-# sphere is centered at dmn_coords and will have the radius we pass the
+# sphere is centered at pcc_coords and will have the radius we pass the
 # NiftiSpheresMasker function (here 8 mm).
 #
 # The extraction will also detrend, standardize, and bandpass filter the data.
@@ -56,7 +56,7 @@ dmn_coords = [(0, -52, 18)]
 from nilearn import input_data
 
 seed_masker = input_data.NiftiSpheresMasker(
-    dmn_coords, radius=8,
+    pcc_coords, radius=8,
     detrend=True, standardize=True,
     low_pass=0.1, high_pass=0.01, t_r=2.,
     memory='nilearn_cache', memory_level=1, verbose=0)
@@ -172,8 +172,8 @@ seed_based_correlation_img.to_filename('sbc_z.nii.gz')
 from nilearn import plotting
 
 display = plotting.plot_stat_map(seed_based_correlation_img, threshold=0.3,
-                                 cut_coords=dmn_coords[0])
-display.add_markers(marker_coords=dmn_coords, marker_color='g',
+                                 cut_coords=pcc_coords[0])
+display.add_markers(marker_coords=pcc_coords, marker_color='g',
                     marker_size=300)
 # At last, we save the plot as pdf.
 display.savefig('sbc_z.pdf')

--- a/examples/03_connectivity/plot_seed_based_correlation.py
+++ b/examples/03_connectivity/plot_seed_based_correlation.py
@@ -139,7 +139,7 @@ seed_based_correlations = np.dot(brain_time_series.T, seed_time_series) / \
 # values can potentially range between -1 and 1.
 print("seed-based correlation shape: (%s, %s)" % seed_based_correlations.shape)
 print("seed-based correlation: min = %.3f; max = %.3f" % (
-seed_based_correlations.min(), seed_based_correlations.max()))
+    seed_based_correlations.min(), seed_based_correlations.max()))
 
 
 ##########################################################################

--- a/examples/03_connectivity/plot_seed_based_correlation.py
+++ b/examples/03_connectivity/plot_seed_based_correlation.py
@@ -71,7 +71,7 @@ seed_time_series = seed_masker.fit_transform(func_filename,
 ##########################################################################
 # Next, we can proceed similarly for the **brain-wide voxel-wise time
 # series**, using :class:`nilearn.in_data.NiftiMasker` with the same input
-#  arguments as in the seed_masker in addition to smoothing with a 6 mm kernel
+# arguments as in the seed_masker in addition to smoothing with a 6 mm kernel
 brain_masker = input_data.NiftiMasker(
     smoothing_fwhm=6,
     detrend=True, standardize=True,

--- a/examples/03_connectivity/plot_seed_based_correlation.py
+++ b/examples/03_connectivity/plot_seed_based_correlation.py
@@ -15,6 +15,7 @@ These maps depict the temporal correlation of a **seed region** with the **rest 
 # We will work with the first subject of the adhd data set.
 # adhd_dataset.func is a list of filenames. We select the 1st (0-based) subject by indexing with [0]).
 from nilearn import datasets
+
 adhd_dataset = datasets.fetch_adhd(n_subjects=1)
 func_filename = adhd_dataset.func[0]
 confound_filename = adhd_dataset.confounds[0]
@@ -43,6 +44,7 @@ dmn_coords = [(0, -52, 18)]
 # The extraction will also detrend, standardize, and bandpass filter the data.
 # This will create a NiftiSpheresMasker object.
 from nilearn import input_data
+
 seed_masker = input_data.NiftiSpheresMasker(
     dmn_coords, radius=8,
     detrend=True, standardize=True,
@@ -83,6 +85,7 @@ print("brain time series shape: (%s, %s)" % brain_time_series.shape)
 # We can plot the **seed time series**.
 
 import matplotlib.pyplot as plt
+
 plt.plot(seed_time_series)
 plt.title('Seed time series (Posterior cingulate cortex)')
 plt.xlabel('Scan number')
@@ -109,6 +112,7 @@ plt.tight_layout()
 # correlation. Note that the signals have been variance-standardized during extraction. To have them standardized to
 # norm unit, we further have to divide the result by the length of the time series.
 import numpy as np
+
 seed_based_correlations = np.dot(brain_time_series.T, seed_time_series) / seed_time_series.shape[0]
 
 ################################################
@@ -137,9 +141,11 @@ seed_based_correlation_img.to_filename('sbc_z.nii.gz')
 # Plotting the seed-based correlation map
 # ----------------------------------------------
 # We can also plot this image and perform thresholding to only show values more extreme than +/- 0.3.
-# The cross has been set to the center of the seed region of interest.
+# Furthermore, we can display the location of the seed with a sphere and set the cross to the center
+# of the seed region of interest.
 from nilearn import plotting
-display = plotting.plot_stat_map(seed_based_correlation_img, threshold=0.3, cut_coords=dmn_coords[0])
 
+display = plotting.plot_stat_map(seed_based_correlation_img, threshold=0.3, cut_coords=dmn_coords[0])
+display.add_markers(marker_coords=np.array(dmn_coords), marker_color='g', marker_size=300)
 # At last, we save the plot as pdf.
 display.savefig('sbc_z.pdf')

--- a/examples/03_connectivity/plot_seed_based_correlation.py
+++ b/examples/03_connectivity/plot_seed_based_correlation.py
@@ -2,18 +2,20 @@
 Producing single subject maps of seed-based correlation
 ========================================================
 
-This example shows how to produce seed-based correlation maps for a single subject based on resting-state fMRI scans.
-These maps depict the temporal correlation of a **seed region** with the **rest of the brain**.
+This example shows how to produce seed-based correlation maps for a single
+subject based on resting-state fMRI scans. These maps depict the temporal
+correlation of a **seed region** with the **rest of the brain**.
 """
 
 
 
-################################################
+##########################################################################
 # Getting the data
-# ----------------------------------------------
+# ----------------
 
 # We will work with the first subject of the adhd data set.
-# adhd_dataset.func is a list of filenames. We select the 1st (0-based) subject by indexing with [0]).
+# adhd_dataset.func is a list of filenames. We select the 1st (0-based)
+# subject by indexing with [0]).
 from nilearn import datasets
 
 adhd_dataset = datasets.fetch_adhd(n_subjects=1)
@@ -21,24 +23,28 @@ func_filename = adhd_dataset.func[0]
 confound_filename = adhd_dataset.confounds[0]
 
 ##########################################################################
-# Note that func_filename and confound_filename are strings pointing to files on your hard drive.
+# Note that func_filename and confound_filename are strings pointing to
+# files on your hard drive.
 print(func_filename)
 print(confound_filename)
 
 
-#############################
+##########################################################################
 # Time series extraction
 # ----------------------
 #
-# We are going to extract signals from the functional time series in two steps. First we will extract the mean signal within
-# the **seed region of interest**. Second, we will extract the **brain-wide voxel-wise time series**.
+# We are going to extract signals from the functional time series in two
+# steps. First we will extract the mean signal within the **seed region of
+# interest**. Second, we will extract the **brain-wide voxel-wise time series**.
 #
-# We will be working with one seed sphere in the Posterior Cingulate Cortex, considered part of the Default Mode Network.
+# We will be working with one seed sphere in the Posterior Cingulate Cortex,
+# considered part of the Default Mode Network.
 dmn_coords = [(0, -52, 18)]
 
 ##########################################################################
-# We use :class:`nilearn.input_data.NiftiSpheresMasker` to extract the **time series from the functional
-# imaging within the sphere**. The sphere is centered at dmn_coords and will have the radius we pass the
+# We use :class:`nilearn.input_data.NiftiSpheresMasker` to extract the
+# **time series from the functional imaging within the sphere**. The
+# sphere is centered at dmn_coords and will have the radius we pass the
 # NiftiSpheresMasker function (here 8 mm).
 #
 # The extraction will also detrend, standardize, and bandpass filter the data.
@@ -52,13 +58,16 @@ seed_masker = input_data.NiftiSpheresMasker(
     memory='nilearn_cache', memory_level=1, verbose=0)
 
 ##########################################################################
-# Then we extract the mean time series within the seed region while regressing out the confounds that
+# Then we extract the mean time series within the seed region while
+# regressing out the confounds that
 # can be found in the dataset's csv file
-seed_time_series = seed_masker.fit_transform(func_filename, confounds=[confound_filename])
+seed_time_series = seed_masker.fit_transform(func_filename,
+                                             confounds=[confound_filename])
 
 ##########################################################################
-# Next, we can proceed similarly for the **brain-wide voxel-wise time series**, using :class:`nilearn.in_data.NiftiMasker`
-# with the same input arguments as in the seed_masker in addition to smoothing with a 6 mm kernel
+# Next, we can proceed similarly for the **brain-wide voxel-wise time
+# series**, using :class:`nilearn.in_data.NiftiMasker` with the same input
+#  arguments as in the seed_masker in addition to smoothing with a 6 mm kernel
 brain_masker = input_data.NiftiMasker(
     smoothing_fwhm=6,
     detrend=True, standardize=True,
@@ -66,17 +75,19 @@ brain_masker = input_data.NiftiMasker(
     memory='nilearn_cache', memory_level=1, verbose=0)
 
 ##########################################################################
-# Then we extract the brain-wide voxel-wise time series while regressing out the confounds as before
-brain_time_series = brain_masker.fit_transform(func_filename, confounds=[confound_filename])
+# Then we extract the brain-wide voxel-wise time series while regressing
+# out the confounds as before
+brain_time_series = brain_masker.fit_transform(func_filename,
+                                               confounds=[confound_filename])
 
-
-#############################
-# Inspecting the extracted time series
-# ----------------------
 
 ##########################################################################
-# Note that the **seed time series** is an array with shape (n_volumes, 1), while the **brain time series** is an array
-# with shape (n_volumes, n_voxels).
+# Inspecting the extracted time series
+# ------------------------------------
+
+##########################################################################
+# Note that the **seed time series** is an array with shape (n_volumes, 1),
+# while the **brain time series** is an array with shape (n_volumes, n_voxels).
 
 print("seed time series shape: (%s, %s)" % seed_time_series.shape)
 print("brain time series shape: (%s, %s)" % brain_time_series.shape)
@@ -93,7 +104,8 @@ plt.ylabel('Normalized signal')
 plt.tight_layout()
 
 ##########################################################################
-# Exemplarily, we can also select 5 random voxels from the **brain-wide data** and plot the time series from.
+# Exemplarily, we can also select 5 random voxels from the **brain-wide
+# data** and plot the time series from.
 
 plt.plot(brain_time_series[:, [10, 45, 100, 5000, 10000]])
 plt.title('Time series from 5 random voxels')
@@ -103,49 +115,61 @@ plt.tight_layout()
 
 
 
-################################################
+##########################################################################
 # Performing the seed-based correlation analysis
 # ----------------------------------------------
 #
-# Now that we have two arrays (**sphere signal**: (n_volumes, 1), **brain-wide voxel-wise signal** (n_volumes, n_voxels)), we
-# can correlate the **seed signal** with the **signal of each voxel**. The dot product of the two arrays will give us this
-# correlation. Note that the signals have been variance-standardized during extraction. To have them standardized to
-# norm unit, we further have to divide the result by the length of the time series.
+# Now that we have two arrays (**sphere signal**: (n_volumes, 1),
+# **brain-wide voxel-wise signal** (n_volumes, n_voxels)), we can correlate
+# the **seed signal** with the **signal of each voxel**. The dot product of
+# the two arrays will give us this correlation. Note that the signals have
+# been variance-standardized during extraction. To have them standardized to
+# norm unit, we further have to divide the result by the length of the time
+# series.
 import numpy as np
 
-seed_based_correlations = np.dot(brain_time_series.T, seed_time_series) / seed_time_series.shape[0]
+seed_based_correlations = np.dot(brain_time_series.T, seed_time_series) / \
+                          seed_time_series.shape[0]
 
 ################################################
-# The resulting array will contain a value representing the correlation values between the signal in the **seed region** of
-# interest and **each voxel's signal**, and will be of shape (n_voxels, 1). The correlation values can potentially range
-# between -1 and 1.
+# The resulting array will contain a value representing the correlation
+# values between the signal in the **seed region** of interest and **each
+# voxel's signal**, and will be of shape (n_voxels, 1). The correlation
+# values can potentially range between -1 and 1.
 print("seed-based correlation shape: (%s, %s)" % seed_based_correlations.shape)
-print("seed-based correlation: min = %.3f; max = %.3f" % (seed_based_correlations.min(), seed_based_correlations.max()))
+print("seed-based correlation: min = %.3f; max = %.3f" % (
+seed_based_correlations.min(), seed_based_correlations.max()))
 
 
-################################################
+##########################################################################
 # Fisher-z transformation and save nifti
-# ----------------------------------------------
-# Now we can Fisher-z transform the data to achieve a normal distribution. The transformed array can now have values
-# more extreme than +/- 1.
+# --------------------------------------
+# Now we can Fisher-z transform the data to achieve a normal distribution.
+# The transformed array can now have values more extreme than +/- 1.
 seed_based_correlations_fisher_z = np.arctanh(seed_based_correlations)
 print("seed-based correlation Fisher-z transformed: min = %.3f; max = %.3f" % (
-    seed_based_correlations_fisher_z.min(), seed_based_correlations_fisher_z.max()))
+    seed_based_correlations_fisher_z.min(),
+    seed_based_correlations_fisher_z.max()))
 
-# Finally, we can tranform the correlation array back to a Nifti image object, that we can save.
-seed_based_correlation_img = brain_masker.inverse_transform(seed_based_correlations.T)
+# Finally, we can tranform the correlation array back to a Nifti image
+# object, that we can save.
+seed_based_correlation_img = brain_masker.inverse_transform(
+    seed_based_correlations.T)
 seed_based_correlation_img.to_filename('sbc_z.nii.gz')
 
 
-################################################
+##########################################################################
 # Plotting the seed-based correlation map
-# ----------------------------------------------
-# We can also plot this image and perform thresholding to only show values more extreme than +/- 0.3.
-# Furthermore, we can display the location of the seed with a sphere and set the cross to the center
-# of the seed region of interest.
+# ---------------------------------------
+# We can also plot this image and perform thresholding to only show values
+# more extreme than +/- 0.3. Furthermore, we can display the location of the
+# seed with a sphere and set the cross to the center of the seed region of
+# interest.
 from nilearn import plotting
 
-display = plotting.plot_stat_map(seed_based_correlation_img, threshold=0.3, cut_coords=dmn_coords[0])
-display.add_markers(marker_coords=np.array(dmn_coords), marker_color='g', marker_size=300)
+display = plotting.plot_stat_map(seed_based_correlation_img, threshold=0.3,
+                                 cut_coords=dmn_coords[0])
+display.add_markers(marker_coords=np.array(dmn_coords), marker_color='g',
+                    marker_size=300)
 # At last, we save the plot as pdf.
 display.savefig('sbc_z.pdf')

--- a/examples/03_connectivity/plot_seed_based_correlation.py
+++ b/examples/03_connectivity/plot_seed_based_correlation.py
@@ -86,12 +86,9 @@ brain_time_series = brain_masker.fit_transform(func_filename,
 
 
 ##########################################################################
-# Inspecting the extracted time series
-# ------------------------------------
-
-##########################################################################
-# Note that the **seed time series** is an array with shape (n_volumes, 1),
-# while the **brain time series** is an array with shape (n_volumes, n_voxels).
+# We can now inspect the extracted time series. Note that the **seed time
+# series** is an array with shape n_volumes, 1), while the
+# **brain time series** is an array with shape (n_volumes, n_voxels).
 
 print("seed time series shape: (%s, %s)" % seed_time_series.shape)
 print("brain time series shape: (%s, %s)" % brain_time_series.shape)

--- a/examples/03_connectivity/plot_seed_based_correlation.py
+++ b/examples/03_connectivity/plot_seed_based_correlation.py
@@ -5,6 +5,10 @@ Producing single subject maps of seed-based correlation
 This example shows how to produce seed-based correlation maps for a single
 subject based on resting-state fMRI scans. These maps depict the temporal
 correlation of a **seed region** with the **rest of the brain**.
+
+This example is an advanced one that requires manipulating the data with numpy.
+Note the difference between images, that lie in brain space, and the
+numpy array, corresponding to the data inside the mask.
 """
 
 

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -730,6 +730,7 @@ class BaseSlicer(object):
         """
         defaults = {'marker': 'o',
                     'zorder': 1000}
+        marker_coords = np.asanyarray(marker_coords)
         for k, v in defaults.items():
             kwargs.setdefault(k, v)
 

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -719,7 +719,7 @@ class BaseSlicer(object):
 
         Parameters
         ----------
-        markers_coords: array of size (n_markers, 3)
+        marker_coords: array of size (n_markers, 3)
             Coordinates of the markers to plot. For each slice, only markers
             that are 2 millimeters away from the slice are plotted.
         marker_color: pyplot compatible color or list of shape (n_markers,)


### PR DESCRIPTION
A thing that's not too pretty yet, is that add_marker takes marker_size in points. Is there a way to give this in mm (as the MaskerSphere is also defined in mm) 
See #1019 