### PR TITLE
#1029 Ignore unit tests in circleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,8 @@ dependencies:
 
 test:
   override:
-    - make clean test test-coverage
+    - echo "ignore unit tests in circleCI"
+    # - make clean test test-coverage
     # workaround - make html returns 0 even if examples fail to build
     # (see https://github.com/sphinx-gallery/sphinx-gallery/issues/45)
     - cat ~/log.txt && if grep -q "Traceback (most recent call last):" ~/log.txt; then false; else true; fi


### PR DESCRIPTION
@GaelVaroquaux I changed the .yml for circleCI to ignore the unit tests as you pointed out in #1029 by overriding the test section with just an 'echo' statement. [link](https://github.com/sahmed95/nilearn/commit/b9dd4a69ac252bb2d07b34bfbb9e4af9a979cfec) It is passing circleCI test but failing with appveyor even though I haven't changed any setting for appveyor. Any suggestions?