### PR TITLE
fix: warn 3D normalization only if normalize==True

### DIFF
--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -47,12 +47,13 @@ def _standardize(signals, detrend=False, normalize=True):
         signals = _detrend(signals, inplace=False)
     else:
         signals = signals.copy()
-    if signals.shape[0] == 1:
-        warnings.warn('Standardization of 3D signal has been requested but '
-            'would lead to zero values. Skipping.')
-        return signals
 
     if normalize:
+        if signals.shape[0] == 1:
+            warnings.warn('Standardization of 3D signal has been requested but '
+                'would lead to zero values. Skipping.')
+            return signals
+
         if not detrend:
             # remove mean if not already detrended
             signals = signals - signals.mean(axis=0)


### PR DESCRIPTION
in the case of masking 3D images with detrend and standardize = False, _standardize would give the 'Standardization of 3D signal has been requested' warning, since the warning was not located within if normalize.
I have moved the warning.


