### PR TITLE
[MRG+1] Use expandpath when memory attribute is a basestring in CacheMixin 

### DIFF
--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -47,8 +47,8 @@ if hasattr(gzip.GzipFile, 'max_read_chunk'):
 # module
 EXPAND_PATH_WILDCARDS = True
 
-# Boolean controlling whether os.path.expanduser should be applied on input path
-# parameters.
+# Boolean controlling whether os.path.expanduser should be applied on input
+# path parameters.
 # Default value is True. Set this to False to completely deactivate this
 # behavior.
 EXPAND_PATH_USER = True

--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -47,6 +47,12 @@ if hasattr(gzip.GzipFile, 'max_read_chunk'):
 # module
 EXPAND_PATH_WILDCARDS = True
 
+# Boolean controlling whether os.path.expanduser should be applied on input path
+# parameters.
+# Default value is True. Set this to False to completely deactivate this
+# behavior.
+EXPAND_PATH_USER = True
+
 # Boolean controlling whether the joblib caches should be
 # flushed if the version of certain modules changes (eg nibabel, as it
 # does not respect the backward compatibility in some of its internal

--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -43,15 +43,10 @@ if hasattr(gzip.GzipFile, 'max_read_chunk'):
     gzip.GzipFile.max_read_chunk = 100 * 1024 * 1024  # 100Mb
 
 # Boolean controlling the default globbing technique when using check_niimg
-# Default value it True, set it to False to completely deactivate use of glob
-# module
-EXPAND_PATH_WILDCARDS = True
-
-# Boolean controlling whether os.path.expanduser should be applied on input
-# path parameters.
-# Default value is True. Set this to False to completely deactivate this
+# and the os.path.expanduser usage in CacheMixin.
+# Default value it True, set it to False to completely deactivate this
 # behavior.
-EXPAND_PATH_USER = True
+EXPAND_PATH_WILDCARDS = True
 
 # Boolean controlling whether the joblib caches should be
 # flushed if the version of certain modules changes (eg nibabel, as it

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -208,8 +208,19 @@ class CacheMixin(object):
         if not hasattr(self, "memory"):
             self.memory = Memory(cachedir=None, verbose=verbose)
         if isinstance(self.memory, _basestring):
-            self.memory = Memory(cachedir=os.path.expanduser(self.memory),
-                                 verbose=verbose)
+            cache_dir = self.memory
+            if nilearn.EXPAND_PATH_USER:
+                cache_dir = os.path.expanduser(cache_dir)
+
+            # Perform some verifications on given path.
+            split_cache_dir = os.path.split(cache_dir)
+            if (len(split_cache_dir) > 1 and
+                    not os.path.exists(split_cache_dir[0])):
+                raise ValueError("Given cache path base directory doesn't "
+                                 "exists, you gave '{0}'."
+                                 .format(split_cache_dir[0]))
+
+            self.memory = Memory(cachedir=cache_dir, verbose=verbose)
 
         # If cache level is 0 but a memory object has been provided, set
         # memory_level to 1 with a warning.

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -214,11 +214,27 @@ class CacheMixin(object):
 
             # Perform some verifications on given path.
             split_cache_dir = os.path.split(cache_dir)
-            if (len(split_cache_dir) > 1 and
-                    not os.path.exists(split_cache_dir[0])):
-                raise ValueError("Given cache path base directory doesn't "
+            if not os.path.exists(split_cache_dir[0]):
+                if (not nilearn.EXPAND_PATH_WILDCARDS and
+                        cache_dir.startswith("~")):
+                    # Maybe the user want to enable expanded user path.
+                    error_msg = ("Given cache path base directory doesn't "
+                                 "exists, you gave '{0}'. Enabling "
+                                 "nilearn.EXPAND_PATH_WILDCARDS could solve "
+                                 "this issue.".format(split_cache_dir[0]))
+                elif self.memory.startswith("~"):
+                    # Path built on top of expanded user path doesn't exist.
+                    error_msg = ("Given cache path base directory doesn't "
+                                 "exists, you gave '{0}' which has expanded "
+                                 "as '{1}' and doesn't exist either."
+                                 .format(split_cache_dir[0],
+                                         os.path.dirname(self.memory)))
+                else:
+                    # The given cache base path doesn't exist.
+                    error_msg = ("Given cache path base directory doesn't "
                                  "exists, you gave '{0}'."
                                  .format(split_cache_dir[0]))
+                raise ValueError(error_msg)
 
             self.memory = Memory(cachedir=cache_dir, verbose=verbose)
 

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -208,17 +208,16 @@ class CacheMixin(object):
         if not hasattr(self, "memory"):
             self.memory = Memory(cachedir=None, verbose=verbose)
         if isinstance(self.memory, _basestring):
-            self.memory = Memory(cachedir=self.memory, verbose=verbose)
+            self.memory = Memory(cachedir=os.path.expanduser(self.memory),
+                                 verbose=verbose)
 
         # If cache level is 0 but a memory object has been provided, set
         # memory_level to 1 with a warning.
-        if self.memory_level == 0:
-            if (isinstance(self.memory, _basestring)
-                    or self.memory.cachedir is not None):
-                warnings.warn("memory_level is currently set to 0 but "
-                              "a Memory object has been provided. "
-                              "Setting memory_level to 1.")
-                self.memory_level = 1
+        if self.memory_level == 0 and self.memory.cachedir is not None:
+            warnings.warn("memory_level is currently set to 0 but "
+                          "a Memory object has been provided. "
+                          "Setting memory_level to 1.")
+            self.memory_level = 1
 
         return cache(func, self.memory, func_memory_level=func_memory_level,
                      memory_level=self.memory_level, **kwargs)

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -215,7 +215,8 @@ class CacheMixin(object):
             # Perform some verifications on given path.
             split_cache_dir = os.path.split(cache_dir)
             if (len(split_cache_dir) > 1 and
-                    not os.path.exists(split_cache_dir[0])):
+                    (not os.path.exists(split_cache_dir[0]) and
+                     split_cache_dir[0] != '')):
                 if (not nilearn.EXPAND_PATH_WILDCARDS and
                         cache_dir.startswith("~")):
                     # Maybe the user want to enable expanded user path.

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -209,7 +209,7 @@ class CacheMixin(object):
             self.memory = Memory(cachedir=None, verbose=verbose)
         if isinstance(self.memory, _basestring):
             cache_dir = self.memory
-            if nilearn.EXPAND_PATH_USER:
+            if nilearn.EXPAND_PATH_WILDCARDS:
                 cache_dir = os.path.expanduser(cache_dir)
 
             # Perform some verifications on given path.

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -220,20 +220,22 @@ class CacheMixin(object):
                 if (not nilearn.EXPAND_PATH_WILDCARDS and
                         cache_dir.startswith("~")):
                     # Maybe the user want to enable expanded user path.
-                    error_msg = ("Given cache path base directory doesn't "
+                    error_msg = ("Given cache path parent directory doesn't "
                                  "exists, you gave '{0}'. Enabling "
                                  "nilearn.EXPAND_PATH_WILDCARDS could solve "
                                  "this issue.".format(split_cache_dir[0]))
                 elif self.memory.startswith("~"):
                     # Path built on top of expanded user path doesn't exist.
-                    error_msg = ("Given cache path base directory doesn't "
-                                 "exists, you gave '{0}' which has expanded "
-                                 "as '{1}' and doesn't exist either."
+                    error_msg = ("Given cache path parent directory doesn't "
+                                 "exists, you gave '{0}' which was expanded "
+                                 "as '{1}' but doesn't exist either. Use "
+                                 "nilearn.EXPAND_PATH_WILDCARDS to deactivate "
+                                 "auto expand user path (~) behavior."
                                  .format(split_cache_dir[0],
                                          os.path.dirname(self.memory)))
                 else:
                     # The given cache base path doesn't exist.
-                    error_msg = ("Given cache path base directory doesn't "
+                    error_msg = ("Given cache path parent directory doesn't "
                                  "exists, you gave '{0}'."
                                  .format(split_cache_dir[0]))
                 raise ValueError(error_msg)

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -214,7 +214,8 @@ class CacheMixin(object):
 
             # Perform some verifications on given path.
             split_cache_dir = os.path.split(cache_dir)
-            if not os.path.exists(split_cache_dir[0]):
+            if (len(split_cache_dir) > 1 and
+                    not os.path.exists(split_cache_dir[0])):
                 if (not nilearn.EXPAND_PATH_WILDCARDS and
                         cache_dir.startswith("~")):
                     # Maybe the user want to enable expanded user path.

--- a/nilearn/tests/test_cache_mixin.py
+++ b/nilearn/tests/test_cache_mixin.py
@@ -90,7 +90,7 @@ def test_cache_memory_level():
     assert_equal(len(glob.glob(job_glob)), 3)
 
 
-class CacheMixinMock(CacheMixin):
+class CacheMixinTest(CacheMixin):
     """Dummy mock object that wraps a CacheMixin."""
 
     def __init__(self, memory=None, memory_level=1):
@@ -105,7 +105,7 @@ def test_cache_mixin_with_expand_user():
     # Test the memory cache is correctly created when using ~.
     cache_dir = "~/nilearn_data/test_cache"
     expand_cache_dir = os.path.expanduser(cache_dir)
-    mixin_mock = CacheMixinMock(cache_dir)
+    mixin_mock = CacheMixinTest(cache_dir)
 
     try:
         assert_false(os.path.exists(expand_cache_dir))
@@ -120,7 +120,7 @@ def test_cache_mixin_without_expand_user():
     # Test the memory cache is correctly created when using ~.
     cache_dir = "~/nilearn_data/test_cache"
     expand_cache_dir = os.path.expanduser(cache_dir)
-    mixin_mock = CacheMixinMock(cache_dir)
+    mixin_mock = CacheMixinTest(cache_dir)
 
     try:
         assert_false(os.path.exists(expand_cache_dir))
@@ -142,7 +142,7 @@ def test_cache_mixin_wrong_dirs():
     for cache_dir in ("/bad_dir/cache",
                       "~/nilearn_data/tmp/test_cache"):
         expand_cache_dir = os.path.expanduser(cache_dir)
-        mixin_mock = CacheMixinMock(cache_dir)
+        mixin_mock = CacheMixinTest(cache_dir)
 
         try:
             assert_raises_regex(ValueError,

--- a/nilearn/tests/test_cache_mixin.py
+++ b/nilearn/tests/test_cache_mixin.py
@@ -103,7 +103,7 @@ class CacheMixinMock(CacheMixin):
 
 def test_cache_mixin_with_expand_user():
     # Test the memory cache is correctly created when using ~.
-    cache_dir = "~/nilearn_data/cache"
+    cache_dir = "~/nilearn_test_cache"
     expand_cache_dir = os.path.expanduser(cache_dir)
     mixin_mock = CacheMixinMock(cache_dir)
 
@@ -118,7 +118,7 @@ def test_cache_mixin_with_expand_user():
 
 def test_cache_mixin_without_expand_user():
     # Test the memory cache is correctly created when using ~.
-    cache_dir = "~/nilearn_data/cache"
+    cache_dir = "~/nilearn_test_cache"
     expand_cache_dir = os.path.expanduser(cache_dir)
     mixin_mock = CacheMixinMock(cache_dir)
 

--- a/nilearn/tests/test_cache_mixin.py
+++ b/nilearn/tests/test_cache_mixin.py
@@ -103,7 +103,7 @@ class CacheMixinMock(CacheMixin):
 
 def test_cache_mixin_with_expand_user():
     # Test the memory cache is correctly created when using ~.
-    cache_dir = "~/nilearn_test_cache"
+    cache_dir = "~/nilearn_data/test_cache"
     expand_cache_dir = os.path.expanduser(cache_dir)
     mixin_mock = CacheMixinMock(cache_dir)
 
@@ -118,34 +118,37 @@ def test_cache_mixin_with_expand_user():
 
 def test_cache_mixin_without_expand_user():
     # Test the memory cache is correctly created when using ~.
-    cache_dir = "~/nilearn_test_cache"
+    cache_dir = "~/nilearn_data/test_cache"
     expand_cache_dir = os.path.expanduser(cache_dir)
     mixin_mock = CacheMixinMock(cache_dir)
 
     try:
         assert_false(os.path.exists(expand_cache_dir))
-        nilearn.EXPAND_PATH_USER = False
-        mixin_mock.run()
-        # Memory fails to create a cache whose path starts with ~.
+        nilearn.EXPAND_PATH_WILDCARDS = False
+        assert_raises_regex(ValueError,
+                            "Given cache path base directory doesn't",
+                            mixin_mock.run)
         assert_false(os.path.exists(expand_cache_dir))
-        nilearn.EXPAND_PATH_USER = True
+        nilearn.EXPAND_PATH_WILDCARDS = True
     finally:
         if os.path.exists(expand_cache_dir):
             shutil.rmtree(expand_cache_dir)
 
 
-def test_cache_mixin_wrong_expand_user():
+def test_cache_mixin_wrong_dirs():
     # Test the memory cache raises a ValueError when input base path doesn't
     # exist.
 
-    cache_dir = "/bad_dir/cache"
-    mixin_mock = CacheMixinMock(cache_dir)
+    for cache_dir in ("/bad_dir/cache",
+                      "~/nilearn_data/tmp/test_cache"):
+        expand_cache_dir = os.path.expanduser(cache_dir)
+        mixin_mock = CacheMixinMock(cache_dir)
 
-    try:
-        assert_raises_regex(ValueError,
-                            "Given cache path base directory doesn't exists",
-                            mixin_mock.run)
-        assert_false(os.path.exists(cache_dir))
-    finally:
-        if os.path.exists(cache_dir):
-            shutil.rmtree(cache_dir)
+        try:
+            assert_raises_regex(ValueError,
+                                "Given cache path base directory doesn't",
+                                mixin_mock.run)
+            assert_false(os.path.exists(expand_cache_dir))
+        finally:
+            if os.path.exists(expand_cache_dir):
+                shutil.rmtree(expand_cache_dir)

--- a/nilearn/tests/test_cache_mixin.py
+++ b/nilearn/tests/test_cache_mixin.py
@@ -126,7 +126,7 @@ def test_cache_mixin_without_expand_user():
         assert_false(os.path.exists(expand_cache_dir))
         nilearn.EXPAND_PATH_WILDCARDS = False
         assert_raises_regex(ValueError,
-                            "Given cache path base directory doesn't",
+                            "Given cache path parent directory doesn't",
                             mixin_mock.run)
         assert_false(os.path.exists(expand_cache_dir))
         nilearn.EXPAND_PATH_WILDCARDS = True
@@ -146,7 +146,7 @@ def test_cache_mixin_wrong_dirs():
 
         try:
             assert_raises_regex(ValueError,
-                                "Given cache path base directory doesn't",
+                                "Given cache path parent directory doesn't",
                                 mixin_mock.run)
             assert_false(os.path.exists(expand_cache_dir))
         finally:


### PR DESCRIPTION
Fix #1051 + non regression test