### PR TITLE
[MRG +1] Fixing small typos on data_preparation.rst

### DIFF
--- a/doc/manipulating_images/data_preparation.rst
+++ b/doc/manipulating_images/data_preparation.rst
@@ -1,8 +1,8 @@
 .. _extracting_data:
 
-=========================================================
+=====================================================
 Data preparation: loading and basic signal extraction
-=========================================================
+=====================================================
 
 .. contents:: **Contents**
     :local:
@@ -15,30 +15,30 @@ Data preparation: loading and basic signal extraction
    Nilearn functions and objects accept file names as arguments::
 
     >>> from nilearn import image
-    >>> smoothed_img = image.smooth_img('/home/user/t_map001.nii') # doctest: +SKIP
+    >>> smoothed_img = image.smooth_img('/home/user/t_map001.nii')  # doctest: +SKIP
 
    Nilearn can operate on either file names or `NiftiImage objects
    <http://nipy.org/nibabel/nibabel_images.html>`_. The later represent
    the specified nifti files loaded in memory.
 
-   In nilearn, we often use the term 'niimg' as abbreviation that denotes
+   In nilearn, we often use the term *"niimg"* as abbreviation that denotes
    either a file name or a NiftiImage object. In the example above, the
    function smooth_img returns a NiftiImage object, which can then be
    readily passed to any other nilearn function that accepts niimg
    arguments.
 
    Niimgs can be 3D or 4D, and a 4D niimg can be a list of file names, or
-   even a *wildcard* matching patterns. The '~' symbol is also expanded to the
-   user home folder.For instance, to retrieve a 4D volume of
+   even a *wildcard* matching patterns. The ``~`` symbol is also expanded to the
+   user home folder. For instance, to retrieve a 4D volume of
    all t maps smoothed::
 
-    >>> smoothed_imgs = image.smooth_img('~/t_map*.nii') # doctest: +SKIP
+    >>> smoothed_imgs = image.smooth_img('~/t_map*.nii')  # doctest: +SKIP
 
 
 |
 
 The concept of "masker" objects
-=================================
+===============================
 
 In any analysis, the first step is to load the data.
 It is often convenient to apply some basic data
@@ -46,7 +46,7 @@ transformations and to turn the data in a 2D (samples x features) matrix,
 where the samples could be different time points, and the features derived
 from different voxels (e.g., restrict analysis to the ventral visual stream),
 regions of interest (e.g., extract local signals from spheres/cubes), or
-prespecified networks (e.g., look at data from all voxels of a set of
+pre-specified networks (e.g., look at data from all voxels of a set of
 network nodes). Think of masker objects as swiss army knifes for shaping
 the raw neuroimaging data in 3D space into the units of observation
 relevant for the research questions at hand.
@@ -70,36 +70,35 @@ relevant for the research questions at hand.
 simplifying these "data folding" steps that often preceed the actual
 statistical analysis.
 
-On an advanced note,
-the underlying philosophy of these classes is similar to `scikit-learn
-<http://scikit-learn.org>`_\ 's
-transformers. First, objects are initialized with some parameters guiding
-the transformation (unrelated to the data). Then the fit() method
+On an advanced note, the underlying philosophy of these classes is similar
+to `scikit-learn <http://scikit-learn.org>`_\ 's transformers.
+First, objects are initialized with some parameters guiding
+the transformation (unrelated to the data). Then the `fit()` method
 should be called, possibly specifying some data-related
 information (such as number of images to process), to perform some
 initial computation (e.g., fitting a mask based on the data). Finally,
-transform() can be called, with the data as argument, to perform some
-computation on data themselves (e.g. extracting time series from images).
+`transform()` can be called, with the data as argument, to perform some
+computation on data themselves (e.g., extracting time series from images).
 
 Note that the masker objects may not cover all the image transformations
-for specific tasks. Users who want to make some specific processing may
-have to call low-level functions (see e.g. :mod:`nilearn.signal`,
-:mod:`nilearn.masking`).
+for specific tasks. Users who want to make some specific processing
+may have to call low-level functions
+(see e.g., :mod:`nilearn.signal`, :mod:`nilearn.masking`).
 
 .. currentmodule:: nilearn.input_data
 
 .. _nifti_masker:
 
 :class:`NiftiMasker`: loading, masking and filtering
-=========================================================
+====================================================
 
 This section details how to use the :class:`NiftiMasker` class.
-:class:`NiftiMasker` is a
-powerful tool to load images and extract voxel signals in the area
-defined by the mask. It is designed to apply some basic preprocessing
-steps by default with commonly used parameters as defaults. But it is
-*very important* to look at your data to see the effects of the
-preprocessings and validate them.
+:class:`NiftiMasker` is a powerful tool to load images and
+extract voxel signals in the area defined by the mask.
+It is designed to apply some basic preprocessing
+steps by default with commonly used parameters as defaults.
+But it is *very important* to look at your data to see the effects
+of the preprocessings and validate them.
 
 In particular, :class:`NiftiMasker` is a `scikit-learn
 <http://scikit-learn.org>`_ compliant
@@ -107,7 +106,7 @@ transformer so that you can directly plug it into a `scikit-learn
 pipeline <http://scikit-learn.org/stable/modules/pipeline.html>`_.
 
 Custom data loading
---------------------
+-------------------
 
 Sometimes, some custom preprocessing of data is necessary. For instance
 we can restrict a dataset to the first 100 frames. Below, we load
@@ -125,7 +124,7 @@ in memory:
     :end-before: # To display the background
 
 Controlling how the mask is computed from the data
------------------------------------------------------
+--------------------------------------------------
 
 In this tutorial, we show how the masker object can compute a mask
 automatically for subsequent statistical analysis.
@@ -135,7 +134,7 @@ This is why it is very important to
 engineering using masker objects.
 
 Computing the mask
-...................
+..................
 
 .. note::
 
@@ -144,15 +143,14 @@ Computing the mask
     It is also related to this example:
     :doc:`plot_nifti_simple.py <../auto_examples/04_manipulating_images/plot_nifti_simple>`.
 
-If a mask is not specified as an argument,
-:class:`NiftiMasker` will try to compute
-one from the provided neuroimaging data.
-It is *very important* to verify the quality of the generated mask by
-visualization. This allows to see whether it
-is suitable for your data and intended analyses.
-Alternatively, the mask computation parameters can still be modified. See the
-:class:`NiftiMasker` documentation for a complete list of mask computation
-parameters.
+
+If a mask is not specified as an argument, :class:`NiftiMasker` will try to
+compute one from the provided neuroimaging data.
+It is *very important* to verify the quality of the generated mask by visualization.
+This allows to see whether it is suitable for your data and intended analyses.
+Alternatively, the mask computation parameters can still be modified.
+See the :class:`NiftiMasker` documentation for a complete list of
+mask computation parameters.
 
 As a first example, we will now automatically build a mask from a dataset.
 We will here use the Haxby dataset because it provides the original mask that
@@ -171,7 +169,7 @@ The first step is to generate a mask with default parameters and visualize it.
 
 
 We can then fine-tune the outline of the mask by increasing the number of
-opening steps (*opening=10*) using the `mask_args` argument of the
+opening steps (`opening=10`) using the `mask_args` argument of the
 :class:`NiftiMasker`. This effectively performs erosion and dilation operations
 on the outer voxel layers of the mask, which can for example remove remaining
 skull parts in the image.
@@ -188,7 +186,7 @@ skull parts in the image.
 
 Looking at the :func:`nilearn.masking.compute_epi_mask` called by the
 :class:`NiftiMasker` object, we see two interesting parameters:
-*lower_cutoff* and *upper_cutoff*. These set the grey-value bounds in
+`lower_cutoff` and `upper_cutoff`. These set the grey-value bounds in
 which the masking algorithm will search for its threshold
 (0 being the minimum of the image and 1 the maximum). We will here increase
 the lower cutoff to enforce selection of those
@@ -206,9 +204,8 @@ voxels that appear as bright in the EPI image.
 
 
 
-
 Common data preparation steps: resampling, smoothing, filtering
------------------------------------------------------------------
+---------------------------------------------------------------
 
 .. seealso::
 
@@ -225,12 +222,13 @@ Resampling
 :class:`NiftiMasker` and many similar classes enable resampling
 (recasting of images into different resolutions and transformations of
 brain voxel data). The resampling procedure takes as input the
-*target_affine* to resample (resize, rotate...) images in order to match
+`target_affine` to resample (resize, rotate...) images in order to match
 the spatial configuration defined by the new affine (i.e., matrix
-transforming from voxel space into world space). Additionally, a
-*target_shape* can be used to resize images (i.e., cropping or padding
-with zeros) to match an expected data image dimensions (shape composed of
-x, y, and z).
+transforming from voxel space into world space).
+
+Additionally, a `target_shape` can be used to resize images
+(i.e., cropping or padding with zeros) to match an expected data
+image dimensions (shape composed of x, y, and z).
 
 As a common use case, resampling can be a viable means to
 downsample image quality on purpose to increase processing speed
@@ -238,12 +236,10 @@ and lower memory consumption of an analysis pipeline.
 In fact, certain image viewers (e.g., FSLView) also require images to be
 resampled to display overlays.
 
-On an advanced note,
-automatic computation of offset and bounding box can be performed by
-specifying a 3x3 matrix instead of the 4x4 affine.
-In this case, nilearn
-computes automatically the translation part of the transformation
-matrix (i.e., affine).
+On an advanced note, automatic computation of offset and bounding box
+can be performed by specifying a 3x3 matrix instead of the 4x4 affine.
+In this case, nilearn computes automatically the translation part
+of the transformation matrix (i.e., affine).
 
 .. image:: ../auto_examples/04_manipulating_images/images/sphx_glr_plot_affine_transformation_002.png
     :target: ../auto_examples/04_manipulating_images/plot_affine_transformation.html
@@ -284,12 +280,11 @@ Smoothing
 :class:`NiftiMasker` can further be used for local spatial filtering of
 the neuroimaging data to make the data more homogeneous and thus account
 for inter-individual differences in neuroanatomy.
-It is achieved by passing the full-width
-half maximum (FWHM; in millimeter scale)
+It is achieved by passing the full-width half maximum (FWHM; in millimeter scale)
 along the x, y, and z image axes by specifying the `smoothing_fwhm` parameter.
-For an isotropic filtering, passing a scalar is also possible. The underlying
-function handles properly the tricky case of non-cubic voxels by scaling the
-given widths appropriately.
+For an isotropic filtering, passing a scalar is also possible.
+The underlying function handles properly the tricky case of non-cubic
+voxels by scaling the given widths appropriately.
 
 .. seealso::
 
@@ -302,25 +297,23 @@ Temporal Filtering
 ..................
 
 Rather than optimizing spatial properties of the neuroimaging data,
-the user may want to improve aspects of temporal data properties,
-before conversion to voxel signals.
-:class:`NiftiMasker` can also process voxel signals. Here are the possibilities:
+the user may want to improve aspects of temporal data properties, before
+conversion to voxel signals. :class:`NiftiMasker` can also process voxel signals.
+Here are the possibilities:
 
 - Confound removal. Two ways of removing confounds are provided. Any linear
   trend can be removed by activating the `detrend` option.
   This accounts for slow (as opposed to abrupt or transient) changes
   in voxel values along a series of brain images that are unrelated to the
   signal of interest (e.g., the neural correlates of cognitive tasks).
-  It is not activated
-  by default in :class:`NiftiMasker` but is recommended in almost all scenarios.
-  More complex confounds can
+  It is not activated by default in :class:`NiftiMasker` but is recommended
+  in almost all scenarios. More complex confounds can
   be removed by passing them to :meth:`NiftiMasker.transform`. If the
   dataset provides a confounds file, just pass its path to the masker.
 
 - Linear filtering. Low-pass and high-pass filters can be used to remove artifacts.
   It simply removes all voxel values lower or higher than the specified
-  parameters, respectively.
-  Care has been taken to automatically
+  parameters, respectively. Care has been taken to automatically
   apply this processing to confounds if it appears necessary.
 
 - Normalization. Signals can be normalized (scaled to unit variance) before
@@ -329,8 +322,9 @@ before conversion to voxel signals.
 .. topic:: **Exercise**
 
    You can, more as a training than as an exercise, try to play with
-   the parameters in :ref:`sphx_glr_auto_examples_plot_haxby_simple.py`. Try to enable detrending
-   and run the script: does it have a big impact on the result?
+   the parameters in :ref:`sphx_glr_auto_examples_plot_haxby_simple.py`.
+   Try to enable detrending and run the script:
+   does it have a big impact on the result?
 
 
 .. seealso::
@@ -339,7 +333,7 @@ before conversion to voxel signals.
 
 
 Inverse transform: unmasking data
-----------------------------------
+---------------------------------
 
 Once voxel signals have been processed, the result can be visualized as
 images after unmasking (masked-reduced data transformed back into
@@ -363,8 +357,8 @@ an excerpt of :ref:`the example performing Anova-SVM on the Haxby data
 
 .. _region:
 
-Extraction of signals from regions:\  :class:`NiftiLabelsMasker`, :class:`NiftiMapsMasker`.
-===========================================================================================
+Extraction of signals from regions:\  :class:`NiftiLabelsMasker`, :class:`NiftiMapsMasker`
+==========================================================================================
 
 The purpose of :class:`NiftiLabelsMasker` and :class:`NiftiMapsMasker` is to
 compute signals from regions containing many voxels. They make it easy to get
@@ -386,7 +380,8 @@ labels and maps, handled by :class:`NiftiLabelsMasker` and
   required memory load is independent of the number of regions, allowing
   for a large number of regions. On the other hand, there are
   several disadvantages: regions cannot spatially overlap
-  and are represented in a binary present-nonpresent coding (no weighting).
+  and are represented in a binary present/nonpresent coding (no weighting).
+
 - maps: a single region is defined as the set of all the voxels that have a
   non-zero weight. A set of regions is thus defined by a set of 3D images (or a
   single 4D image), one 3D image per region (as opposed to all regions in a
@@ -394,16 +389,15 @@ labels and maps, handled by :class:`NiftiLabelsMasker` and
   While these defined weighted regions can exhibit spatial
   overlap (as opposed to labels), storage cost scales linearly with the
   number of regions. Handling a large number (e.g., thousands)
-  of regions will prove
-  difficult with this data transformation of whole-brain voxel data
-  into weighted region-wise data.
+  of regions will prove difficult with this data transformation of
+  whole-brain voxel data into weighted region-wise data.
 
 .. note::
 
-   These usage are illustrated in the section :ref:`functional_connectomes`
+   These usage are illustrated in the section :ref:`functional_connectomes`.
 
 :class:`NiftiLabelsMasker` Usage
----------------------------------
+--------------------------------
 
 Usage of :class:`NiftiLabelsMasker` is similar to that of
 :class:`NiftiMapsMasker`. The main difference is that it requires a labels image
@@ -411,14 +405,12 @@ instead of a set of maps as input.
 
 The `background_label` keyword of :class:`NiftiLabelsMasker` deserves
 some explanation. The voxels that correspond to the brain or a region
-of interest in an fMRI image do not fill the entire
-image. Consequently, in the labels image, there must be a label value that
-corresponds to "outside" the brain (for which no signal should be
-extracted). By default, this label is set to zero in nilearn
-(refered to as "background").
-Should some non-zero value encoding be necessary, it is
-possible to change the background value with the `background_label`
-keyword.
+of interest in an fMRI image do not fill the entire image.
+Consequently, in the labels image, there must be a label value that corresponds
+to "outside" the brain (for which no signal should be extracted).
+By default, this label is set to zero in nilearn (refered to as "background").
+Should some non-zero value encoding be necessary, it is possible
+to change the background value with the `background_label` keyword.
 
 .. topic:: **Examples**
 
@@ -428,14 +420,14 @@ keyword.
 ------------------------------
 
 This atlas defines its regions using maps. The path to the corresponding
-file is given in the "maps_img" argument.
+file is given in the `maps_img` argument.
 
 One important thing that happens transparently during the execution of
 :meth:`NiftiMasker.fit_transform` is resampling. Initially, the images
-and the atlas do typically not have the same shape nor the same affine. Casting
-them into the same format is required for successful signal extraction
-The keyword argument `resampling_target` specifies which format (i.e.,
-dimensions and affine) the data should be resampled to.
+and the atlas do typically not have the same shape nor the same affine.
+Casting them into the same format is required for successful signal extraction
+The keyword argument `resampling_target` specifies which format
+(i.e., dimensions and affine) the data should be resampled to.
 See the reference documentation for :class:`NiftiMapsMasker` for every
 possible option.
 
@@ -443,8 +435,8 @@ possible option.
 
    * :ref:`sphx_glr_auto_examples_03_connectivity_plot_probabilistic_atlas_extraction.py`
 
-Extraction of signals from seeds:\  :class:`NiftiSpheresMasker`.
-==================================================================
+Extraction of signals from seeds:\  :class:`NiftiSpheresMasker`
+===============================================================
 
 The purpose of :class:`NiftiSpheresMasker` is to compute signals from
 seeds containing voxels in spheres. It makes it easy to get these signals once
@@ -453,16 +445,16 @@ A single seed is a sphere defined by the radius (in millimeters) and the
 coordinates (typically MNI or TAL) of its center.
 
 Using :class:`NiftiSpheresMasker` needs to define a list of coordinates.
-"seeds" argument takes a list of 3D coordinates (tuples) of the spheres centers,
+`seeds` argument takes a list of 3D coordinates (tuples) of the spheres centers,
 they should be in the same space as the images.
-Seeds can overlap spatially and are represented in a binary present-nonpresent
+Seeds can overlap spatially and are represented in a binary present/nonpresent
 coding (no weighting).
 Below is an example of a coordinates list of four seeds from the default mode network::
 
   >>> dmn_coords = [(0, -52, 18), (-46, -68, 32), (46, -68, 32), (0, 50, -5)]
 
-"radius" is an optional argument that takes a real value in millimeters.
-If no value is given for the "radius" argument, the single voxel at the given
+`radius` is an optional argument that takes a real value in millimeters.
+If no value is given for the `radius` argument, the single voxel at the given
 seed position is used.
 
 .. topic:: **Examples**


### PR DESCRIPTION
Fixing small typos on [doc/manipulating_images/data_preparation.rst](https://nilearn.github.io/manipulating_images/data_preparation.html).