### PR TITLE
[MRG] fixing overlapping text in documentation

### DIFF
--- a/doc/building_blocks/manual_pipeline.rst
+++ b/doc/building_blocks/manual_pipeline.rst
@@ -39,8 +39,9 @@ example, we can download the data from the
 
 `dataset.func` contains filenames referring to dataset files on the disk::
 
-  >>> list(sorted(dataset.keys())) # doctest: +SKIP
-  ['anat', 'description', 'func', 'mask_face', 'mask_face_little', 'mask_house', 'mask_house_little', 'mask_vt', 'session_target']
+  >>> list(sorted(dataset.keys())) # doctest: +SKIP +NORMALIZE_WHITE
+  ['anat', 'description', 'func', 'mask_face', 'mask_face_little',
+   'mask_house', 'mask_house_little', 'mask_vt', 'session_target']
   >>> dataset.func # doctest: +ELLIPSIS +SKIP
   ['.../haxby2001/subj1/bold.nii.gz']
 


### PR DESCRIPTION
While having a look at #1071, I found text that overlaps the sidebar in section [6.1.1.1](http://nilearn.github.io/building_blocks/manual_pipeline.html#downloading-the-data)

Using the doctest `NORMALIZE_WHITESPACE` option fixes this issue.