### PR TITLE
DOC: Fix broken links in the documentation

### DIFF
--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -80,7 +80,7 @@ def load_niimg(niimg, dtype=None):
     -----------
 
     niimg: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Image to load.
 
     dtype: {dtype, "auto"}

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -178,7 +178,7 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False, dtype=None,
     Parameters
     ----------
     niimg: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         If niimg is a string, consider it as a path to Nifti image and
         call nibabel.load on it. The '~' symbol is expanded to the user home
         folder.
@@ -288,7 +288,7 @@ def check_niimg_3d(niimg, dtype=None):
     Parameters
     ----------
     niimg: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         If niimg is a string, consider it as a path to Nifti image and
         call nibabel.load on it. If it is an object, check if get_data()
         and get_affine() methods are present, raise TypeError otherwise.
@@ -322,7 +322,7 @@ def check_niimg_4d(niimg, return_iterator=False, dtype=None):
     Parameters
     ----------
     niimg: 4D Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         If niimgs is an iterable, checks if data is really 4D. Then,
         considering that it is a list of niimg and load them one by one.
         If niimg is a string, consider it as a path to Nifti image and
@@ -367,7 +367,7 @@ def concat_niimgs(niimgs, dtype=np.float32, ensure_ndim=None,
     Parameters
     ----------
     niimgs: iterable of Niimg-like objects
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Niimgs to concatenate.
 
     dtype: numpy dtype, optional

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -196,11 +196,11 @@ class SearchLight(BaseEstimator):
     Parameters
     -----------
     mask_img : Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         boolean image giving location of voxels containing usable signals.
 
     process_mask_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         boolean image giving voxels on which searchlight should be
         computed.
 
@@ -266,7 +266,7 @@ class SearchLight(BaseEstimator):
         Parameters
         ----------
         imgs : Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             4D image.
 
         y : 1D array-like

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -739,7 +739,7 @@ class BaseSpaceNet(LinearModel, RegressorMixin, CacheMixin):
         Parameters
         ----------
         X : list of Niimg-like objects
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg
             Data on which model is to be fitted. If this is a list,
             the affine is considered the same for all.
 
@@ -931,7 +931,7 @@ class BaseSpaceNet(LinearModel, RegressorMixin, CacheMixin):
         Parameters
         ----------
         X : list of Niimg-like objects
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg
             Data on prediction is to be made. If this is a list,
             the affine is considered the same for all.
 
@@ -1135,7 +1135,7 @@ class SpaceNetClassifier(BaseSpaceNet):
         Parameters
         ----------
         X : list of Niimg-like objects
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg
             Data on which model is to be fitted. If this is a list,
             the affine is considered the same for all.
 

--- a/nilearn/decomposition/base.py
+++ b/nilearn/decomposition/base.py
@@ -39,7 +39,7 @@ def mask_and_reduce(masker, imgs,
         Instance used to mask provided data.
 
     imgs: list of 4D Niimg-like objects
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         List of subject data to mask, reduce and stack.
 
     confounds: CSV file path or 2D matrix, optional
@@ -253,7 +253,7 @@ class BaseDecomposition(BaseEstimator, CacheMixin):
     Attributes
     ----------
     `mask_img_` : Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         The mask of the data. If no mask was given at masker creation, contains
         the automatically computed mask.
 
@@ -294,7 +294,7 @@ class BaseDecomposition(BaseEstimator, CacheMixin):
         Parameters
         ----------
         imgs: list of Niimg-like objects
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             Data on which the mask is calculated. If this is a list,
             the affine is considered the same for all.
 
@@ -335,7 +335,7 @@ class BaseDecomposition(BaseEstimator, CacheMixin):
         Parameters
         ----------
         imgs: iterable of Niimg-like objects
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             Data to be projected
 
         confounds: CSV file path or 2D matrix
@@ -412,7 +412,7 @@ class BaseDecomposition(BaseEstimator, CacheMixin):
         Parameters
         ----------
         imgs: iterable of Niimg-like objects
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             Data to be scored
 
         confounds: CSV file path or 2D matrix

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -199,7 +199,7 @@ class DictLearning(BaseDecomposition, TransformerMixin):
         Parameters
         ----------
         imgs: list of Niimg-like objects
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             Data on which PCA must be calculated. If this is a list,
             the affine is considered the same for all.
 

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -88,7 +88,7 @@ class MultiPCA(BaseDecomposition, TransformerMixin):
         of `mask` and other NiftiMasker related parameters as initialization.
 
     `mask_img_` : Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         The mask of the data. If no mask was given at masker creation, contains
         the automatically computed mask.
 
@@ -137,7 +137,7 @@ class MultiPCA(BaseDecomposition, TransformerMixin):
         Parameters
         ----------
         imgs: list of Niimg-like objects
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             Data on which the PCA must be calculated. If this is a list,
             the affine is considered the same for all.
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -33,11 +33,11 @@ def high_variance_confounds(imgs, n_confounds=5, percentile=2.,
         Parameters
         ==========
         imgs: Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             4D image.
 
         mask_img: Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             If provided, confounds are extracted from voxels inside the mask.
             If not provided, all voxels are used.
 
@@ -223,7 +223,7 @@ def smooth_img(imgs, fwhm):
     Parameters
     ==========
     imgs: Niimg-like object or iterable of Niimg-like objects
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Image(s) to smooth.
 
     fwhm: scalar, numpy.ndarray, 'fast' or None
@@ -275,7 +275,7 @@ def _crop_img_to(img, slices, copy=True):
     Parameters
     ==========
     img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Img to be cropped. If slices has less entries than img
         has dimensions, the slices will be applied to the first len(slices)
         dimensions
@@ -292,7 +292,7 @@ def _crop_img_to(img, slices, copy=True):
     Returns
     =======
     cropped_img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Cropped version of the input image
     """
 
@@ -328,7 +328,7 @@ def crop_img(img, rtol=1e-8, copy=True):
     Parameters
     ==========
     img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         img to be cropped.
 
     rtol: float
@@ -411,7 +411,7 @@ def mean_img(imgs, target_affine=None, target_shape=None,
     ==========
 
     imgs: Niimg-like object or iterable of Niimg-like objects
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Images to mean.
 
     target_affine: numpy.ndarray, optional
@@ -480,7 +480,7 @@ def swap_img_hemispheres(img):
     Parameters
     ----------
     img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Images to swap.
 
     Returns
@@ -521,7 +521,7 @@ def index_img(imgs, index):
     Parameters
     ----------
     imgs: 4D Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
 
     index: Any type compatible with numpy array indexing
         Used for indexing the 4D data array in the fourth dimension.
@@ -562,7 +562,7 @@ def iter_img(imgs):
     Parameters
     ----------
     imgs: 4D Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
 
     Returns
     -------

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -1,6 +1,6 @@
 """
 Utilities to resample a Niimg-like object
-See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
 """
 # Author: Gael Varoquaux, Alexandre Abraham, Michael Eickenberg
 # License: simplified BSD
@@ -164,7 +164,7 @@ def get_mask_bounds(img):
         Parameters
         ----------
         img: Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             The image to inspect. Zero values are considered as
             background.
 
@@ -275,7 +275,7 @@ def resample_img(img, target_affine=None, target_shape=None,
     Parameters
     ----------
     img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Image(s) to resample.
 
     target_affine: numpy.ndarray, optional
@@ -499,11 +499,11 @@ def resample_to_img(source_img, target_img,
     Parameters
     ----------
     source_img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Image(s) to resample.
 
     target_img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Reference image taken for resampling.
 
     interpolation: str, optional
@@ -553,7 +553,7 @@ def reorder_img(img, resample=None):
         Parameters
         -----------
         img: Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             Image to reorder.
 
         resample: None or string in {'continuous', 'nearest'}, optional

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -133,7 +133,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         Parameters
         ----------
         imgs: 3D/4D Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             Images to process. It must boil down to a 4D image with scans
             number as last dimension.
 
@@ -156,7 +156,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         Parameters
         ----------
         imgs: 3D/4D Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             Images to process. It must boil down to a 4D image with scans
             number as last dimension.
 
@@ -181,7 +181,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         Parameters
         ----------
         X : Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
 
         y : numpy array of shape [n_samples]
             Target values.

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -30,7 +30,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
     Parameters
     ----------
     mask_img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Mask of the data. If not given, a mask is computed in the fit step.
         Optional parameters can be set using mask_args and mask_strategy to
         fine tune the mask extraction.
@@ -145,7 +145,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         Parameters
         ----------
         imgs: list of Niimg-like objects
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             Data on which the mask must be calculated. If this is a list,
             the affine is considered the same for all.
         """
@@ -218,7 +218,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         ----------
 
         imgs_list: list of Niimg-like objects
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             List of imgs file to prepare. One item per subject.
 
         confounds: list of confounds, optional
@@ -284,7 +284,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         Parameters
         ----------
         imgs: list of Niimg-like objects
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             Data to be preprocessed
 
         confounds: CSV file path or 2D matrix

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -42,14 +42,14 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
     Parameters
     ==========
     labels_img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Region definitions, as one image of labels.
 
     background_label: number, optional
         Label used in labels_img to represent background.
 
     mask_img: Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Mask to apply to regions before extracting signals.
 
     smoothing_fwhm: float, optional
@@ -202,7 +202,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         Parameters
         ----------
         imgs: 3D/4D Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             Images to process. It must boil down to a 4D image with scans
             number as last dimension.
 

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -40,12 +40,12 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
     Parameters
     ==========
     maps_img: 4D niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Set of continuous maps. One representative time course per map is
         extracted using least square regression.
 
     mask_img: 3D niimg-like object, optional
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Mask to apply to regions before extracting signals.
 
     allow_overlap: boolean, optional
@@ -213,7 +213,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         Parameters
         ----------
         imgs: 3D/4D Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             Images to process. It must boil down to a 4D image with scans
             number as last dimension.
 

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -71,7 +71,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
     Parameters
     ----------
     mask_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Mask for the data. If not given, a mask is computed in the fit step.
         Optional parameters (mask_args and mask_strategy) can be set to
         fine tune the mask extraction.
@@ -201,7 +201,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
         Parameters
         ----------
         imgs: list of Niimg-like objects
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             Data on which the mask must be calculated. If this is a list,
             the affine is considered the same for all.
         """
@@ -257,7 +257,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
         Parameters
         ----------
         imgs: 3D/4D Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             Images to process. It must boil down to a 4D image with scans
             number as last dimension.
 

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -93,7 +93,7 @@ def _iter_signals_from_spheres(seeds, niimg, radius, allow_overlap,
         Seed definitions. List of coordinates of the seeds in the same space
         as the images (typically MNI or TAL).
     imgs: 3D/4D Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Images to process. It must boil down to a 4D image with scans
         number as last dimension.
     radius: float, optional
@@ -103,7 +103,7 @@ def _iter_signals_from_spheres(seeds, niimg, radius, allow_overlap,
         If False, an error is raised if the maps overlaps (ie at least two
         maps have a non-zero value for the same voxel). Default is False.
     mask_img: Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Mask to apply to regions before extracting signals.
     """
     X, A = _apply_mask_and_get_affinity(seeds, niimg, radius,
@@ -156,7 +156,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         Default is None (signal is extracted on a single voxel).
 
     mask_img: Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Mask to apply to regions before extracting signals.
 
     allow_overlap: boolean, optional
@@ -286,7 +286,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         Parameters
         ----------
         imgs: 3D/4D Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             Images to process. It must boil down to a 4D image with scans
             number as last dimension.
 

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -29,7 +29,7 @@ def _load_mask_img(mask_img, allow_empty=False):
     Parameters
     ----------
     mask_img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         The mask to check
 
     allow_empty: boolean, optional
@@ -111,7 +111,7 @@ def intersect_masks(mask_imgs, threshold=0.5, connected=True):
     Parameters
     ----------
     mask_imgs: list of Niimg-like objects
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         3D individual masks with same shape and affine.
 
     threshold: float, optional
@@ -196,7 +196,7 @@ def compute_epi_mask(epi_img, lower_cutoff=0.2, upper_cutoff=0.85,
     Parameters
     ----------
     epi_img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         EPI image, used to compute the mask. 3D and 4D images are accepted.
         If a 3D image is given, we suggest to use the mean image
 
@@ -301,7 +301,7 @@ def compute_multi_epi_mask(epi_imgs, lower_cutoff=0.2, upper_cutoff=0.85,
     Parameters
     ----------
     epi_imgs: list of Niimg-like objects
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         A list of arrays, each item being a subject or a session.
         3D and 4D images are accepted.
         If 3D images is given, we suggest to use the mean image of each
@@ -377,7 +377,7 @@ def compute_background_mask(data_imgs, border_size=2,
     Parameters
     ----------
     data_imgs: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Images used to compute the mask. 3D and 4D images are accepted.
         If a 3D image is given, we suggest to use the mean image
 
@@ -455,7 +455,7 @@ def compute_multi_background_mask(data_imgs, border_size=2, upper_cutoff=0.85,
     Parameters
     ----------
     data_imgs: list of Niimg-like objects
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         A list of arrays, each item being a subject or a session.
         3D and 4D images are accepted.
         If 3D images is given, we suggest to use the mean image of each
@@ -525,11 +525,11 @@ def apply_mask(imgs, mask_img, dtype='f',
     Parameters
     -----------
     imgs: list of 4D Niimg-like objects
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Images to be masked. list of lists of 3D images are also accepted.
 
     mask_img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         3D mask array: True where a voxel should be used.
 
     dtype: numpy dtype or 'f'
@@ -622,7 +622,7 @@ def _unmask_3d(X, mask, order="C"):
         Masked data. shape: (features,)
 
     mask: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Mask. mask.ndim must be equal to 3, and dtype *must* be bool.
     """
 
@@ -683,7 +683,7 @@ def unmask(X, mask_img, order="F"):
         Masked data. shape: (samples #, features #).
         If X is one-dimensional, it is assumed that samples# == 1.
     mask_img: niimg: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Must be 3-dimensional.
 
     Returns

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -500,7 +500,7 @@ class BaseSlicer(object):
             Parameters
             -----------
             img: Niimg-like object
-                See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+                See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
                 If it is a masked array, only the non-masked part will be
                 plotted.
             threshold : a number, None
@@ -537,7 +537,7 @@ class BaseSlicer(object):
             Parameters
             -----------
             img: Niimg-like object
-                See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+                See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
                 Provides image to plot.
             filled: boolean, optional
                 If filled=True, contours are displayed with color fillings.

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -1,6 +1,6 @@
 """
 Functions to do automatic visualization of Niimg-like objects
-See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
 
 Only matplotlib is required.
 """
@@ -220,7 +220,7 @@ def plot_img(img, cut_coords=None, output_file=None, display_mode='ortho',
         Parameters
         ----------
         img: Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         cut_coords: None, a tuple of floats, or an integer
             The MNI coordinates of the point where the cut is performed
             If display_mode is 'ortho', this should be a 3-tuple: (x, y, z)
@@ -399,7 +399,7 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
         Parameters
         ----------
         anat_img : Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             The anatomical image to be used as a background. If None is
             given, nilearn tries to find a T1 template.
         cut_coords : None, a tuple of floats, or an integer
@@ -565,11 +565,11 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         Parameters
         ----------
         roi_img : Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             The ROI/mask image, it could be binary mask or an atlas or ROIs
             with integer values.
         bg_img : Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             The background image that the ROI/mask will be plotted on top of.
             If nothing is specified, the MNI152 template will be used.
             To turn off background image, just pass "bg_img=False".
@@ -667,7 +667,7 @@ def plot_prob_atlas(maps_img, anat_img=MNI152TEMPLATE, view_type='auto',
         maps_img : Niimg-like object or the filename
             4D image of the probabilistic atlas maps
         anat_img : Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             The anatomical image to be used as a background.
             If nothing is specified, the MNI152 template will be used.
             To turn off background image, just pass "anat_img=False".
@@ -839,10 +839,10 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         Parameters
         ----------
         stat_map_img : Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             The statistical map image
         bg_img : Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             The background image that the ROI/mask will be plotted on top of.
             If nothing is specified, the MNI152 template will be used.
             To turn off background image, just pass "bg_img=False".
@@ -960,7 +960,7 @@ def plot_glass_brain(stat_map_img,
         Parameters
         ----------
         stat_map_img : Niimg-like object
-            See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+            See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
             The statistical map image. It needs to be in MNI space
             in order to align with the brain schematics.
         output_file : string, or None, optional

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -1007,7 +1007,7 @@ def plot_glass_brain(stat_map_img,
             absolute value will be used (rendering positive and negative
             values in the same manner). If set to false the sign of the
             maximum intensity will be represented with different colors.
-            See http://nilearn.github.io/auto_examples/manipulating_visualizing/plot_demo_glass_brain_extensive.html
+            See http://nilearn.github.io/auto_examples/01_plotting/plot_demo_glass_brain_extensive.html
             for examples.
         symmetric_cbar : boolean or 'auto', optional, default 'auto'
             Specifies whether the colorbar should range from -vmax to vmax

--- a/nilearn/regions/signal_extraction.py
+++ b/nilearn/regions/signal_extraction.py
@@ -28,16 +28,16 @@ def img_to_signals_labels(imgs, labels_img, mask_img=None,
     Parameters
     ==========
     imgs: 4D Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         input images.
 
     labels_img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         regions definition as labels. By default, the label zero is used to
         denote an absence of region. Use background_label to change it.
 
     mask_img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Mask to apply to labels before extracting signals. Every point
         outside the mask is considered as background (i.e. no region).
 
@@ -126,7 +126,7 @@ def signals_to_img_labels(signals, labels_img, mask_img=None,
         2D array with shape: (scan number, number of regions in labels_img)
 
     labels_img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Region definitions using labels.
 
     mask_img: Niimg-like object, optional
@@ -203,16 +203,16 @@ def img_to_signals_maps(imgs, maps_img, mask_img=None):
     Parameters
     ==========
     imgs: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Input images.
 
     maps_img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         regions definition as maps (array of weights).
         shape: imgs.shape + (region number, )
 
     mask_img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         mask to apply to regions before extracting signals. Every point
         outside the mask is considered as background (i.e. outside of any
         region).
@@ -282,11 +282,11 @@ def signals_to_img_maps(region_signals, maps_img, mask_img=None):
         In pseudo-code: region_signals.shape[1] == maps_img.shape[-1]
 
     maps_img: Niimg-like object
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Region definitions using maps.
 
     mask_img: Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_visualizing/manipulating_images.html#niimg.
+        See http://nilearn.github.io/manipulating_images/manipulating_images.html#niimg.
         Boolean array giving voxels to process. integer arrays also accepted,
         zero meaning False.
 


### PR DESCRIPTION
Links to `http://nilearn.github.io/manipulating_visualizing/*` are broken in part of the documentation.