### PR TITLE
[MRG+1] threshold=None implies keeping data as it is to be visualized in plot_prob_atlas function

### DIFF
--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -655,7 +655,7 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
 
 
 def plot_prob_atlas(maps_img, anat_img=MNI152TEMPLATE, view_type='auto',
-                    threshold=None, linewidths=2.5, cut_coords=None,
+                    threshold='auto', linewidths=2.5, cut_coords=None,
                     output_file=None, display_mode='ortho',
                     figure=None, axes=None, title=None, annotate=True,
                     draw_cross=True, black_bg='auto', dim=False,
@@ -683,19 +683,21 @@ def plot_prob_atlas(maps_img, anat_img=MNI152TEMPLATE, view_type='auto',
             along with color fillings inside the contours.
             If view_type == 'continuous', maps are overlayed as continous
             colors irrespective of the number maps.
-        threshold : None, a str or a number, list of either str or number, optional
-            If threshold is a string it must finish with a percent sign,
-            e.g. "25.3%", and it is a percentile. Or if it is a number,
-            it should be a real number, in which case it is the value
-            to threshold at.
-            This option is served for two purposes, for contours and contour
-            fillings threshold serves to select the level of the maps
-            to display and same threshold is applied for color fillings.
-            For continuous overlays this threshold value serves to select
-            the maps which are greater than a given value or list of given
-            values. If None is given, the maps are thresholded with default
-            value.
-        linewidths : float, optional
+        threshold : 'auto', None, a str or a number, str or numbers in list
+            Optional parameter is used to threshold the maps image and the
+            values which lies above the threshold level will be visualized.
+            By default 'auto', maps are thresholded automatically by finding
+            a value with the input maps data.
+            If None, maps are visualized as it is without any threshold.
+            If string, it must finish with a percent sign, e.g., "25.3%",
+            thresholding is the percentile of values in input data. If single
+            string is provided, same percentile will be applied to each 3D map.
+            Otherwise, if list of percentiles are provided then each map is
+            thresholded with each percentile sequentially. Length of percentiles
+            given should match with number of 3D map in time (4th) dimension.
+            If number or list of numbers, given value will be used directly
+            to threshold the maps image without any percentile calculation.
+       linewidths : float, optional
             This option can be used to set the boundary thickness of the
             contours.
         cut_coords : None, a tuple of floats, or an integer
@@ -785,6 +787,9 @@ def plot_prob_atlas(maps_img, anat_img=MNI152TEMPLATE, view_type='auto',
             view_type = 'continuous'
 
     if threshold is None:
+        # selecting level to use in all three display types
+        threshold = max(threshold, 1e-6)
+    elif threshold == 'auto':
         # it will use default percentage,
         # strategy is to avoid maximum overlaps as possible
         if view_type == 'contours':
@@ -814,6 +819,7 @@ def plot_prob_atlas(maps_img, anat_img=MNI152TEMPLATE, view_type='auto',
                               name='threshold')
         # Get rid of background values in all cases
         thr = max(thr, 1e-6)
+
         if view_type == 'continuous':
             display.add_overlay(map_img, threshold=thr,
                                 cmap=cm.alpha_cmap(color))

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -685,8 +685,8 @@ def plot_prob_atlas(maps_img, anat_img=MNI152TEMPLATE, view_type='auto',
             colors irrespective of the number maps.
         threshold : 'auto', a str or a number, list of str or numbers, None
             This parameter is optional and is used to threshold the maps image
-            using the given value or automized value. The values in the image
-            which lies above the threshold level will be visualized.
+            using the given value or automatically selected value. The values
+            in the image above the threshold level will be visualized.
             The default strategy, corresponding to 'auto', computes a threshold
             level that seeks to minimize (yet not eliminate completely) the
             overlap between several maps for a better visualization.
@@ -696,8 +696,8 @@ def plot_prob_atlas(maps_img, anat_img=MNI152TEMPLATE, view_type='auto',
             If a single string is provided, the same percentile will be applied
             over the whole atlas. Otherwise, if a list of percentiles is
             provided, each 3D map is thresholded with certain percentile
-            sequentially. Length of percentiles given should match with the
-            number of 3D map in time (4th) dimension.
+            sequentially. Length of percentiles given should match the number
+            of 3D map in time (4th) dimension.
             If a number or a list of numbers, the given value will be used
             directly to threshold the maps without any percentile calculation.
             If None, no threshold will be applied.

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -675,9 +675,9 @@ def plot_prob_atlas(maps_img, anat_img=MNI152TEMPLATE, view_type='auto',
             If nothing is specified, the MNI152 template will be used.
             To turn off background image, just pass "anat_img=False".
         view_type : {'auto', 'contours', 'filled_contours', 'continuous'}, optional
-            By default view_type == 'auto', which means maps are overlayed as
-            contours if number of maps to display are more or
-            overlayed as continuous colors if number of maps are less.
+            By default view_type == 'auto', means maps will be displayed
+            automatically using any one of the three view types. The automatic
+            selection of view type depends on the total number of maps.
             If view_type == 'contours', maps are overlayed as contours
             If view_type == 'filled_contours', maps are overlayed as contours
             along with color fillings inside the contours.
@@ -690,13 +690,14 @@ def plot_prob_atlas(maps_img, anat_img=MNI152TEMPLATE, view_type='auto',
             a value with the input maps data.
             If None, maps are visualized as it is without any threshold.
             If string, it must finish with a percent sign, e.g., "25.3%",
-            thresholding is the percentile of values in input data. If single
-            string is provided, same percentile will be applied to each 3D map.
-            Otherwise, if list of percentiles are provided then each map is
-            thresholded with each percentile sequentially. Length of percentiles
-            given should match with number of 3D map in time (4th) dimension.
-            If number or list of numbers, given value will be used directly
-            to threshold the maps image without any percentile calculation.
+            thresholding is the percentile of values in input data. If a
+            single string is provided, the same percentile will be applied to
+            each 3D map. Otherwise, if a list of percentiles is provided, each
+            map is thresholded with each percentile sequentially. Length of
+            percentiles given should match with the number of 3D map in time
+            (4th) dimension.
+            If a number or a list of numbers, the given value will be used
+            directly to threshold the maps without any percentile calculation.
         linewidths : float, optional
             This option can be used to set the boundary thickness of the
             contours.

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -683,21 +683,24 @@ def plot_prob_atlas(maps_img, anat_img=MNI152TEMPLATE, view_type='auto',
             along with color fillings inside the contours.
             If view_type == 'continuous', maps are overlayed as continous
             colors irrespective of the number maps.
-        threshold : 'auto', None, a str or a number, str or numbers in list
-            Optional parameter is used to threshold the maps image and the
-            values which lies above the threshold level will be visualized.
-            By default 'auto', maps are thresholded automatically by finding
-            a value with the input maps data.
-            If None, maps are visualized as it is without any threshold.
-            If string, it must finish with a percent sign, e.g., "25.3%",
-            thresholding is the percentile of values in input data. If a
-            single string is provided, the same percentile will be applied to
-            each 3D map. Otherwise, if a list of percentiles is provided, each
-            map is thresholded with each percentile sequentially. Length of
-            percentiles given should match with the number of 3D map in time
-            (4th) dimension.
+        threshold : 'auto', a str or a number, list of str or numbers, None
+            This parameter is optional and is used to threshold the maps image
+            using the given value or automized value. The values in the image
+            which lies above the threshold level will be visualized.
+            The default strategy, corresponding to 'auto', computes a threshold
+            level that seeks to minimize (yet not eliminate completely) the
+            overlap between several maps for a better visualization.
+            The threshold can also be expressed as a percentile over the values
+            of the whole atlas. In that case, the value must be specified as
+            string finishing with a percent sign, e.g., "25.3%".
+            If a single string is provided, the same percentile will be applied
+            over the whole atlas. Otherwise, if a list of percentiles is
+            provided, each 3D map is thresholded with certain percentile
+            sequentially. Length of percentiles given should match with the
+            number of 3D map in time (4th) dimension.
             If a number or a list of numbers, the given value will be used
             directly to threshold the maps without any percentile calculation.
+            If None, no threshold will be applied.
         linewidths : float, optional
             This option can be used to set the boundary thickness of the
             contours.

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -697,7 +697,7 @@ def plot_prob_atlas(maps_img, anat_img=MNI152TEMPLATE, view_type='auto',
             given should match with number of 3D map in time (4th) dimension.
             If number or list of numbers, given value will be used directly
             to threshold the maps image without any percentile calculation.
-       linewidths : float, optional
+        linewidths : float, optional
             This option can be used to set the boundary thickness of the
             contours.
         cut_coords : None, a tuple of floats, or an integer
@@ -788,7 +788,7 @@ def plot_prob_atlas(maps_img, anat_img=MNI152TEMPLATE, view_type='auto',
 
     if threshold is None:
         # selecting level to use in all three display types
-        threshold = max(threshold, 1e-6)
+        threshold = 1e-6
     elif threshold == 'auto':
         # it will use default percentage,
         # strategy is to avoid maximum overlaps as possible

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -683,13 +683,13 @@ def plot_prob_atlas(maps_img, anat_img=MNI152TEMPLATE, view_type='auto',
             along with color fillings inside the contours.
             If view_type == 'continuous', maps are overlayed as continous
             colors irrespective of the number maps.
-        threshold : 'auto', a str or a number, list of str or numbers, None
+        threshold : a str or a number, list of str or numbers, None
             This parameter is optional and is used to threshold the maps image
             using the given value or automatically selected value. The values
             in the image above the threshold level will be visualized.
-            The default strategy, corresponding to 'auto', computes a threshold
-            level that seeks to minimize (yet not eliminate completely) the
-            overlap between several maps for a better visualization.
+            The default strategy, computes a threshold level that seeks to
+            minimize (yet not eliminate completely) the overlap between several
+            maps for a better visualization.
             The threshold can also be expressed as a percentile over the values
             of the whole atlas. In that case, the value must be specified as
             string finishing with a percent sign, e.g., "25.3%".
@@ -700,7 +700,8 @@ def plot_prob_atlas(maps_img, anat_img=MNI152TEMPLATE, view_type='auto',
             of 3D map in time (4th) dimension.
             If a number or a list of numbers, the given value will be used
             directly to threshold the maps without any percentile calculation.
-            If None, no threshold will be applied.
+            If None, a very small threshold is applied to remove numerical
+            noise from the maps background.
         linewidths : float, optional
             This option can be used to set the boundary thickness of the
             contours.
@@ -791,7 +792,6 @@ def plot_prob_atlas(maps_img, anat_img=MNI152TEMPLATE, view_type='auto',
             view_type = 'continuous'
 
     if threshold is None:
-        # selecting level to use in all three display types
         threshold = 1e-6
     elif threshold == 'auto':
         # it will use default percentage,

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -562,6 +562,7 @@ def test_plot_prob_atlas():
     plt.close()
     # threshold=None
     plot_prob_atlas(img, threshold=None)
+    plt.close()
 
 
 def test_get_colorbar_and_data_ranges_with_vmin():

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -86,7 +86,7 @@ def test_plot_anat():
         ortho_slicer.savefig(filename)
     finally:
         os.remove(filename)
-    
+
     # Save execution time and memory
     plt.close()
 
@@ -560,6 +560,8 @@ def test_plot_prob_atlas():
     # Testing the 4D plot prob atlas with colormap
     plot_prob_atlas(img, view_type='filled_contours', colorbar=True)
     plt.close()
+    # threshold=None
+    plot_prob_atlas(img, threshold=None)
 
 
 def test_get_colorbar_and_data_ranges_with_vmin():


### PR DESCRIPTION
- documentation improvements accordingly in ```plot_prob_atlas``` plotting function
- tests added for threshold=None ```plot_prob_atlas```

Trying to Fix #1047 