### PR TITLE
[MRG+1] A canonical brain mask

### DIFF
--- a/doc/modules/reference.rst
+++ b/doc/modules/reference.rst
@@ -85,6 +85,8 @@ uses.
    fetch_megatrawls_netmats
    fetch_cobre
    load_mni152_template
+   load_mni152_brain_mask
+   fetch_brain_gm_mask
 
 .. _decoding_ref:
 

--- a/doc/modules/reference.rst
+++ b/doc/modules/reference.rst
@@ -77,6 +77,7 @@ uses.
    fetch_haxby
    fetch_haxby_simple
    fetch_icbm152_2009
+   fetch_icbm152_brain_gm_mask
    fetch_localizer_contrasts
    fetch_localizer_calculation_task
    fetch_miyawaki2008
@@ -86,7 +87,6 @@ uses.
    fetch_cobre
    load_mni152_template
    load_mni152_brain_mask
-   fetch_brain_gm_mask
 
 .. _decoding_ref:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -9,6 +9,12 @@ New features
     - New display_mode options in plot_glass_brain and plot_connectome. It
       is possible to plot right and left hemisphere projections separately.
 
+    - A function to load canonical brain mask image in MNI template space,
+      :func:`nilearn.datasets.load_mni152_brain_mask`
+
+    - A function to load brain grey matter mask image,
+      :func:`nilearn.datasets.fetch_brain_gm_mask`
+
 0.2.4
 =====
 

--- a/nilearn/datasets/__init__.py
+++ b/nilearn/datasets/__init__.py
@@ -2,7 +2,8 @@
 Helper functions to download NeuroImaging datasets
 """
 
-from .struct import (fetch_icbm152_2009, load_mni152_template, fetch_oasis_vbm)
+from .struct import (fetch_icbm152_2009, load_mni152_template,
+                     load_brain_mask, fetch_oasis_vbm)
 from .func import (fetch_haxby_simple, fetch_haxby, fetch_nyu_rest,
                    fetch_adhd, fetch_miyawaki2008,
                    fetch_localizer_contrasts, fetch_abide_pcp,
@@ -26,4 +27,5 @@ __all__ = ['fetch_icbm152_2009', 'load_mni152_template', 'fetch_oasis_vbm',
            'fetch_atlas_smith_2009',
            'fetch_atlas_yeo_2011', 'fetch_mixed_gambles', 'fetch_atlas_aal',
            'fetch_megatrawls_netmats', 'fetch_cobre',
-           'fetch_atlas_basc_multiscale_2015', 'fetch_coords_dosenbach_2010']
+           'fetch_atlas_basc_multiscale_2015', 'fetch_coords_dosenbach_2010',
+           'load_brain_mask']

--- a/nilearn/datasets/__init__.py
+++ b/nilearn/datasets/__init__.py
@@ -3,7 +3,7 @@ Helper functions to download NeuroImaging datasets
 """
 
 from .struct import (fetch_icbm152_2009, load_mni152_template,
-                     load_brain_mask, fetch_oasis_vbm)
+                     load_mni152_brain_mask, fetch_oasis_vbm)
 from .func import (fetch_haxby_simple, fetch_haxby, fetch_nyu_rest,
                    fetch_adhd, fetch_miyawaki2008,
                    fetch_localizer_contrasts, fetch_abide_pcp,
@@ -28,4 +28,4 @@ __all__ = ['fetch_icbm152_2009', 'load_mni152_template', 'fetch_oasis_vbm',
            'fetch_atlas_yeo_2011', 'fetch_mixed_gambles', 'fetch_atlas_aal',
            'fetch_megatrawls_netmats', 'fetch_cobre',
            'fetch_atlas_basc_multiscale_2015', 'fetch_coords_dosenbach_2010',
-           'load_brain_mask']
+           'load_mni152_brain_mask']

--- a/nilearn/datasets/__init__.py
+++ b/nilearn/datasets/__init__.py
@@ -4,7 +4,7 @@ Helper functions to download NeuroImaging datasets
 
 from .struct import (fetch_icbm152_2009, load_mni152_template,
                      load_mni152_brain_mask, fetch_oasis_vbm,
-                     fetch_brain_gm_mask)
+                     fetch_icbm152_brain_gm_mask)
 from .func import (fetch_haxby_simple, fetch_haxby, fetch_nyu_rest,
                    fetch_adhd, fetch_miyawaki2008,
                    fetch_localizer_contrasts, fetch_abide_pcp,
@@ -29,4 +29,4 @@ __all__ = ['fetch_icbm152_2009', 'load_mni152_template', 'fetch_oasis_vbm',
            'fetch_atlas_yeo_2011', 'fetch_mixed_gambles', 'fetch_atlas_aal',
            'fetch_megatrawls_netmats', 'fetch_cobre',
            'fetch_atlas_basc_multiscale_2015', 'fetch_coords_dosenbach_2010',
-           'load_mni152_brain_mask', 'fetch_brain_gm_mask']
+           'load_mni152_brain_mask', 'fetch_icbm152_brain_gm_mask']

--- a/nilearn/datasets/__init__.py
+++ b/nilearn/datasets/__init__.py
@@ -4,7 +4,7 @@ Helper functions to download NeuroImaging datasets
 
 from .struct import (fetch_icbm152_2009, load_mni152_template,
                      load_mni152_brain_mask, fetch_oasis_vbm,
-                     fetch_mni152_grey_matter_mask)
+                     fetch_brain_gm_mask)
 from .func import (fetch_haxby_simple, fetch_haxby, fetch_nyu_rest,
                    fetch_adhd, fetch_miyawaki2008,
                    fetch_localizer_contrasts, fetch_abide_pcp,
@@ -29,4 +29,4 @@ __all__ = ['fetch_icbm152_2009', 'load_mni152_template', 'fetch_oasis_vbm',
            'fetch_atlas_yeo_2011', 'fetch_mixed_gambles', 'fetch_atlas_aal',
            'fetch_megatrawls_netmats', 'fetch_cobre',
            'fetch_atlas_basc_multiscale_2015', 'fetch_coords_dosenbach_2010',
-           'load_mni152_brain_mask', 'fetch_mni152_grey_matter_mask']
+           'load_mni152_brain_mask', 'fetch_brain_gm_mask']

--- a/nilearn/datasets/__init__.py
+++ b/nilearn/datasets/__init__.py
@@ -3,7 +3,8 @@ Helper functions to download NeuroImaging datasets
 """
 
 from .struct import (fetch_icbm152_2009, load_mni152_template,
-                     load_mni152_brain_mask, fetch_oasis_vbm)
+                     load_mni152_brain_mask, fetch_oasis_vbm,
+                     fetch_mni152_grey_matter_mask)
 from .func import (fetch_haxby_simple, fetch_haxby, fetch_nyu_rest,
                    fetch_adhd, fetch_miyawaki2008,
                    fetch_localizer_contrasts, fetch_abide_pcp,
@@ -28,4 +29,4 @@ __all__ = ['fetch_icbm152_2009', 'load_mni152_template', 'fetch_oasis_vbm',
            'fetch_atlas_yeo_2011', 'fetch_mixed_gambles', 'fetch_atlas_aal',
            'fetch_megatrawls_netmats', 'fetch_cobre',
            'fetch_atlas_basc_multiscale_2015', 'fetch_coords_dosenbach_2010',
-           'load_mni152_brain_mask']
+           'load_mni152_brain_mask', 'fetch_mni152_grey_matter_mask']

--- a/nilearn/datasets/struct.py
+++ b/nilearn/datasets/struct.py
@@ -9,6 +9,7 @@ from sklearn.datasets.base import Bunch
 from .utils import _get_dataset_dir, _fetch_files, _get_dataset_descr
 
 from .._utils import check_niimg
+from ..image import new_img_like
 
 
 def fetch_icbm152_2009(data_dir=None, url=None, resume=True, verbose=1):
@@ -116,6 +117,25 @@ def load_mni152_template():
 
     # XXX Should we load the image here?
     return check_niimg(path)
+
+
+def load_brain_mask():
+    """Load grey matter mask from MNI template
+
+    Returns
+    -------
+    mask_img: Masked Nifti-like image corresponding to grey matter
+
+    References
+    ----------
+    Refer to load_mni152_template function for more information about MNI
+    template
+    """
+    # Load MNI template
+    target_img = load_mni152_template()
+    mask_voxels = (target_img.get_data() > 0).astype(int)
+    mask_img = new_img_like(target_img, mask_voxels)
+    return mask_img
 
 
 def fetch_oasis_vbm(n_subjects=None, dartel_version=True, data_dir=None,

--- a/nilearn/datasets/struct.py
+++ b/nilearn/datasets/struct.py
@@ -119,12 +119,12 @@ def load_mni152_template():
     return check_niimg(path)
 
 
-def load_brain_mask():
-    """Load grey matter mask from MNI template
+def load_mni152_brain_mask():
+    """Load brain mask from MNI152 template
 
     Returns
     -------
-    mask_img: Masked Nifti-like image corresponding to grey matter
+    mask_img: Nifti-like mask image corresponding to grey and white matter.
 
     References
     ----------

--- a/nilearn/datasets/struct.py
+++ b/nilearn/datasets/struct.py
@@ -121,7 +121,7 @@ def load_mni152_template():
 
 
 def load_mni152_brain_mask():
-    """Load brain mask from MNI152 template
+    """Load brain mask from MNI152 T1 template
 
     .. versionadded:: 0.2.5
 
@@ -131,13 +131,13 @@ def load_mni152_brain_mask():
 
     References
     ----------
-    Refer to load_mni152_template function for more information about MNI
-    template
+    Refer to load_mni152_template function for more information about the MNI152
+    T1 template
 
     See Also
     --------
-    nilearn.datasets.load_mni152_template for details about version of MNI152
-        template and related.
+    nilearn.datasets.load_mni152_template for details about version of the
+        MNI152 T1 template and related.
     """
     # Load MNI template
     target_img = load_mni152_template()
@@ -146,7 +146,8 @@ def load_mni152_brain_mask():
     return mask_img
 
 
-def fetch_brain_gm_mask(data_dir=None, threshold=0.2, resume=True, verbose=1):
+def fetch_icbm152_brain_gm_mask(data_dir=None, threshold=0.2, resume=True,
+                                verbose=1):
     """Downloads ICBM152 template first, then loads 'gm' mask image.
 
     .. versionadded:: 0.2.5
@@ -171,7 +172,7 @@ def fetch_brain_gm_mask(data_dir=None, threshold=0.2, resume=True, verbose=1):
     Returns
     -------
     gm_mask_img: Nifti image
-        Corresponding to brain grey matter resampled to MNI152 template space.
+        Corresponding to brain grey matter from ICBM152 template.
 
     Notes
     -----

--- a/nilearn/datasets/tests/test_struct.py
+++ b/nilearn/datasets/tests/test_struct.py
@@ -151,7 +151,7 @@ def test_load_mni152_brain_mask():
     assert_equal(brain_mask.shape, (91, 109, 91))
 
 
-def test_fetch_mni152_grey_matter_mask():
-    grey_matter_img = struct.fetch_mni152_grey_matter_mask()
+@with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
+def test_fetch_brain_gm_mask():
+    grey_matter_img = struct.fetch_brain_gm_mask(data_dir=tst.tmpdir, verbose=0)
     assert_true(isinstance(grey_matter_img, nibabel.Nifti1Image))
-    assert_equal(grey_matter_img.shape, (91, 109, 91))

--- a/nilearn/datasets/tests/test_struct.py
+++ b/nilearn/datasets/tests/test_struct.py
@@ -153,8 +153,9 @@ def test_load_mni152_brain_mask():
 
 @with_setup(setup_mock, teardown_mock)
 @with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
-def test_fetch_brain_gm_mask():
+def test_fetch_icbm152_brain_gm_mask():
     dataset = struct.fetch_icbm152_2009(data_dir=tst.tmpdir, verbose=0)
     struct.load_mni152_template().to_filename(dataset.gm)
-    grey_matter_img = struct.fetch_brain_gm_mask(data_dir=tst.tmpdir, verbose=0)
+    grey_matter_img = struct.fetch_icbm152_brain_gm_mask(data_dir=tst.tmpdir,
+                                                         verbose=0)
     assert_true(isinstance(grey_matter_img, nibabel.Nifti1Image))

--- a/nilearn/datasets/tests/test_struct.py
+++ b/nilearn/datasets/tests/test_struct.py
@@ -144,8 +144,8 @@ def test_load_mni152_template():
     assert_equal(template_nii.get_header().get_zooms(), (2.0, 2.0, 2.0))
 
 
-def test_load_brain_mask():
-    brain_mask = struct.load_brain_mask()
+def test_load_mni152_brain_mask():
+    brain_mask = struct.load_mni152_brain_mask()
     assert_true(isinstance(brain_mask, nibabel.Nifti1Image))
     # standard MNI template shape
     assert_equal(brain_mask.shape, (91, 109, 91))

--- a/nilearn/datasets/tests/test_struct.py
+++ b/nilearn/datasets/tests/test_struct.py
@@ -6,6 +6,7 @@ Test the datasets module
 
 import os
 import shutil
+import nibabel
 import numpy as np
 
 from nose import with_setup
@@ -141,3 +142,10 @@ def test_load_mni152_template():
     template_nii = struct.load_mni152_template()
     assert_equal(template_nii.shape, (91, 109, 91))
     assert_equal(template_nii.get_header().get_zooms(), (2.0, 2.0, 2.0))
+
+
+def test_load_brain_mask():
+    brain_mask = struct.load_brain_mask()
+    assert_true(isinstance(brain_mask, nibabel.Nifti1Image))
+    # standard MNI template shape
+    assert_equal(brain_mask.shape, (91, 109, 91))

--- a/nilearn/datasets/tests/test_struct.py
+++ b/nilearn/datasets/tests/test_struct.py
@@ -151,7 +151,10 @@ def test_load_mni152_brain_mask():
     assert_equal(brain_mask.shape, (91, 109, 91))
 
 
+@with_setup(setup_mock, teardown_mock)
 @with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_brain_gm_mask():
+    dataset = struct.fetch_icbm152_2009(data_dir=tst.tmpdir, verbose=0)
+    struct.load_mni152_template().to_filename(dataset.gm)
     grey_matter_img = struct.fetch_brain_gm_mask(data_dir=tst.tmpdir, verbose=0)
     assert_true(isinstance(grey_matter_img, nibabel.Nifti1Image))

--- a/nilearn/datasets/tests/test_struct.py
+++ b/nilearn/datasets/tests/test_struct.py
@@ -149,3 +149,9 @@ def test_load_mni152_brain_mask():
     assert_true(isinstance(brain_mask, nibabel.Nifti1Image))
     # standard MNI template shape
     assert_equal(brain_mask.shape, (91, 109, 91))
+
+
+def test_fetch_mni152_grey_matter_mask():
+    grey_matter_img = struct.fetch_mni152_grey_matter_mask()
+    assert_true(isinstance(grey_matter_img, nibabel.Nifti1Image))
+    assert_equal(grey_matter_img.shape, (91, 109, 91))


### PR DESCRIPTION
As imposed in issue #945 created using MNI template.

Output of the **brain mask** with selected coordinates:
![brain](https://cloud.githubusercontent.com/assets/11410385/15538932/9a86b37e-227f-11e6-8f39-73ed0c2ac612.png)
