### PR TITLE
DOC: add a link to download the user guide

### DIFF
--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -4,6 +4,10 @@
 User guide: table of contents
 ==============================
 
+.. sidebar:: **Download for offline viewing**
+
+   Download the `user guide and examples
+   <https://github.com/nilearn/nilearn.github.io/archive/master.zip>`_.
 
 .. include:: includes/big_toc_css.rst
 


### PR DESCRIPTION
Downloads the latest version of the user guide for offline viewing.

This is what it looks like:

![image](https://cloud.githubusercontent.com/assets/208217/16006791/3ab6e028-316f-11e6-891c-8a2a46478512.png)
