### PR TITLE
fixed doc in all maskers, changed False possibility for None. Moreove…

### DIFF
--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -553,13 +553,13 @@ class BaseSpaceNet(LinearModel, RegressorMixin, CacheMixin):
         This parameter is passed to image.resample_img. Please see the
         related documentation for details.
 
-    low_pass : False or float, optional, (default None)
+    low_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
-        documentation for details.
+        documentation for details
 
-    high_pass : False or float, optional (default None)
-        This parameter is passed to signal. Clean. Please see the related
-        documentation for details.
+    high_pass: None or float, optional
+        This parameter is passed to signal.clean. Please see the related
+        documentation for details
 
     t_r : float, optional (default None)
         This parameter is passed to signal.clean. Please see the related
@@ -1009,13 +1009,13 @@ class SpaceNetClassifier(BaseSpaceNet):
         This parameter is passed to image.resample_img. Please see the
         related documentation for details.
 
-    low_pass : False or float, optional, (default None)
+    low_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
-        documentation for details.
+        documentation for details
 
-    high_pass : False or float, optional (default None)
-        This parameter is passed to signal. Clean. Please see the related
-        documentation for details.
+    high_pass: None or float, optional
+        This parameter is passed to signal.clean. Please see the related
+        documentation for details
 
     t_r : float, optional (default None)
         This parameter is passed to signal.clean. Please see the related
@@ -1197,12 +1197,12 @@ class SpaceNetRegressor(BaseSpaceNet):
         This parameter is passed to image.resample_img. Please see the
         related documentation for details.
 
-    low_pass : False or float, optional, (default None)
+    low_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    high_pass : False or float, optional (default None)
-        This parameter is passed to signal. Clean. Please see the related
+    high_pass: None or float, optional
+        This parameter is passed to signal.clean. Please see the related
         documentation for details
 
     t_r : float, optional (default None)

--- a/nilearn/decomposition/base.py
+++ b/nilearn/decomposition/base.py
@@ -202,11 +202,11 @@ class BaseDecomposition(BaseEstimator, CacheMixin):
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    low_pass: False or float, optional
+    low_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    high_pass: False or float, optional
+    high_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -51,11 +51,11 @@ class MultiPCA(BaseDecomposition, TransformerMixin):
         This parameter is passed to image.resample_img. Please see the
         related documentation for details.
 
-    low_pass: False or float, optional
+    low_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    high_pass: False or float, optional
+    high_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -47,11 +47,11 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    low_pass: False or float, optional
+    low_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    high_pass: False or float, optional
+    high_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -64,11 +64,11 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    low_pass: False or float, optional
+    low_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    high_pass: False or float, optional
+    high_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -64,11 +64,11 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    low_pass: False or float, optional
+    low_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    high_pass: False or float, optional
+    high_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -92,11 +92,11 @@ class NiftiMasker(BaseMasker, CacheMixin):
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    low_pass : False or float, optional
+    low_pass : None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    high_pass : False or float, optional
+    high_pass : None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -92,11 +92,11 @@ class NiftiMasker(BaseMasker, CacheMixin):
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    low_pass : None or float, optional
+    low_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    high_pass : None or float, optional
+    high_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -176,11 +176,11 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         This parameter is passed to signal.clean. Please see the related
         documentation for details.
 
-    low_pass: False or float, optional
+    low_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details.
 
-    high_pass: False or float, optional
+    high_pass: None or float, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details.
 

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -417,6 +417,9 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
         nilearn.image.clean_img
     """
 
+    if isinstance(low_pass, bool) or isinstance(high_pass, bool):
+        raise TypeError("high pass and low pass must be float or None")
+
     if not isinstance(confounds,
                       (list, tuple, _basestring, np.ndarray, type(None))):
         raise TypeError("confounds keyword has an unhandled type: %s"

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -417,8 +417,12 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
         nilearn.image.clean_img
     """
 
-    if isinstance(low_pass, bool) or isinstance(high_pass, bool):
-        raise TypeError("high pass and low pass must be float or None")
+    if isinstance(low_pass, bool):
+        raise TypeError("low pass must be float or None but you provided "
+                        "low_pass='{0}'".format(low_pass))
+    if isinstance(high_pass, bool):
+        raise TypeError("high pass must be float or None but you provided "
+                        "high_pass='{0}'".format(high_pass))
 
     if not isinstance(confounds,
                       (list, tuple, _basestring, np.ndarray, type(None))):

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -250,6 +250,10 @@ def test_clean_detrending():
                              length=n_samples)
     x = signals + trends
 
+    # test boolean is not given to signal.clean
+    assert_raises(TypeError, nisignal.clean(x, low_pass=False))
+    assert_raises(TypeError, nisignal.clean(x, high_pass=False))
+
     # This should remove trends
     x_detrended = nisignal.clean(x, standardize=False, detrend=True,
                                  low_pass=None, high_pass=None)

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -251,8 +251,8 @@ def test_clean_detrending():
     x = signals + trends
 
     # test boolean is not given to signal.clean
-    assert_raises(TypeError, nisignal.clean(x, low_pass=False))
-    assert_raises(TypeError, nisignal.clean(x, high_pass=False))
+    assert_raises(TypeError, nisignal.clean, x, low_pass=False)
+    assert_raises(TypeError, nisignal.clean, x, high_pass=False)
 
     # This should remove trends
     x_detrended = nisignal.clean(x, standardize=False, detrend=True,


### PR DESCRIPTION
As explained in #1118 all maskers had the option of passing False in the documentation for high pass and low pass, but this would create an error in signal.py under some circumstances. So updated documentation and raised a typeerror in signal.py to avoid future problems. Moreover in signal.py is clearly stated that high pass and low pass should be float or None.