### PR TITLE
displays.add_overlay: Add check if ims is empty

### DIFF
--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -584,6 +584,7 @@ class BaseSlicer(object):
         kwargs.setdefault('interpolation', 'nearest')
         ims = self._map_show(img, type='imshow', threshold=threshold, **kwargs)
 
+        # `ims` can be empty in some corner cases, look at test_img_plotting.test_outlier_cut_coords.
         if colorbar and ims:
             self._show_colorbar(ims[0].cmap, ims[0].norm, threshold)
 

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -584,7 +584,7 @@ class BaseSlicer(object):
         kwargs.setdefault('interpolation', 'nearest')
         ims = self._map_show(img, type='imshow', threshold=threshold, **kwargs)
 
-        if colorbar:
+        if colorbar and ims:
             self._show_colorbar(ims[0].cmap, ims[0].norm, threshold)
 
         plt.draw_if_interactive()

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -859,7 +859,7 @@ def test_invalid_in_display_mode_cut_coords_all_plots():
 
 
 def test_outlier_cut_coords():
-    """ Test to plot a few cuts that are out of the """
+    """ Test to plot a subset of a large set of cuts found for a small area."""
     bg_img = load_mni152_template()
 
     data = np.zeros((79, 95, 79))

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -13,6 +13,8 @@ from scipy import sparse
 
 from nilearn._utils.testing import assert_raises_regex
 from nilearn.image.resampling import coord_transform
+from nilearn.datasets import load_mni152_template
+from nilearn.plotting.find_cuts import find_cut_slices
 from nilearn.plotting.img_plotting import (MNI152TEMPLATE, plot_anat, plot_img,
                                            plot_roi, plot_stat_map, plot_epi,
                                            plot_glass_brain, plot_connectome,
@@ -854,3 +856,28 @@ def test_invalid_in_display_mode_cut_coords_all_plots():
                             "be a list of 3d world coordinates.",
                             plot_func,
                             img, display_mode='ortho', cut_coords=2)
+
+
+def test_outlier_cut_coords():
+    """ Test to plot a few cuts that are out of the """
+    bg_img = load_mni152_template()
+
+    data = np.zeros((79, 95, 79))
+    affine = np.array([[  -2.,    0.,    0.,   78.],
+                       [   0.,    2.,    0., -112.],
+                       [   0.,    0.,    2.,  -70.],
+                       [   0.,    0.,    0.,    1.]])
+
+    # Color a cube around a corner area:
+    x, y, z = 20, 22, 60
+    x_map, y_map, z_map = coord_transform(x, y, z,
+                                          np.linalg.inv(affine))
+
+    data[int(x_map) - 1:int(x_map) + 1,
+         int(y_map) - 1:int(y_map) + 1,
+         int(z_map) - 1:int(z_map) + 1] = 1
+    img = nibabel.Nifti1Image(data, affine)
+    cuts = find_cut_slices(img, n_cuts=20, direction='z')
+
+    p = plot_stat_map(img, display_mode='z', cut_coords=cuts[-4:],
+                      bg_img=bg_img)


### PR DESCRIPTION
Hi,

This fix I think it makes sense since BaseSlices._map_show can actually return an empty list.