### PR TITLE
[MRG] Register colormaps in matplotlib

### DIFF
--- a/nilearn/plotting/cm.py
+++ b/nilearn/plotting/cm.py
@@ -175,7 +175,11 @@ for color, name in (((1, 0, 0), 'red'),
         alpha_max=1, name=name)
 
 
+# Save colormaps in the scope of the module
 locals().update(_cmap_d)
+# Register cmaps in matplotlib too
+for k, v in _cmap_d.items():
+    _cm.register_cmap(name=k, cmap=v)
 
 
 ################################################################################

--- a/nilearn/plotting/tests/test_cm.py
+++ b/nilearn/plotting/tests/test_cm.py
@@ -19,3 +19,7 @@ def test_replace_inside():
     if hasattr(plt.cm, 'gnuplot'):
         # gnuplot is only in recent version of MPL
         replace_inside(plt.cm.gnuplot, plt.cm.gnuplot2, .2, .8)
+
+
+def test_cm_preload():
+    plt.imshow([list(range(10))], cmap="cold_hot")


### PR DESCRIPTION
Fix #1151

Problem: ATM, you need to import nilearn.plotting.cm for them to be registered. It would be nice to register them directly when nilearn is imported but that implies loading the whole plotting module, which is a but heavy.

What should we do?