### PR TITLE
[MRG] Discard diagonal in sym_to_vec and refactor scaling

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -9,6 +9,10 @@ The new minimum required version of scikit-learn is 0.14.1
 New features
 ............
 
+    - Add an option to select only off-diagonal elements in sym_to_vec. Also,
+      the scaling of matrices is modified: we divide the diagonal by sqrt(2)
+      instead of multiplying the off-diagonal elements.
+
 0.2.5
 =====
 

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -196,7 +196,8 @@ def _geometric_mean(matrices, init=None, max_iter=10, tol=1e-7):
 def sym_to_vec(symmetric, discard_diagonal=False, isometric=True):
     """Return the flattened lower triangular part of an array.
 
-    If diagonal is kept, off-diagonal elements are multiplied by sqrt(2).
+    If diagonal is kept, diagonal elements are divided by sqrt(2) to conserve
+    the norm.
 
     Acts on the last two dimensions of the array if not 2-dimensional.
 
@@ -209,7 +210,7 @@ def sym_to_vec(symmetric, discard_diagonal=False, isometric=True):
 
     discard_diagonal : boolean, optional
         If True, the values of the diagonal are not returned.
-        Default is True.
+        Default is False.
 
     Returns
     -------

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -193,9 +193,10 @@ def _geometric_mean(matrices, init=None, max_iter=10, tol=1e-7):
     return gmean
 
 
-def sym_to_vec(symmetric):
-    """Return the flattened lower triangular part of an array, after
-    multiplying above the diagonal elements by sqrt(2).
+def sym_to_vec(symmetric, keep_diagonal=True):
+    """Return the flattened lower triangular part of an array.
+
+    If diagonal is kept, off-diagonal elements are multiplied by sqrt(2).
 
     Acts on the last two dimensions of the array if not 2-dimensional.
 
@@ -206,15 +207,26 @@ def sym_to_vec(symmetric):
     symmetric : numpy.ndarray, shape (..., n_features, n_features)
         Input array.
 
+    keep_diagonal : boolean, optional
+        Whether to keep or not the coefficient in the diagonal of the matrix.
+        Default is True.
+
     Returns
     -------
-    output : numpy.ndarray, shape (..., n_features * (n_features + 1) / 2)
-        The output flattened lower triangular part of symmetric.
+    output : numpy.ndarray
+        The output flattened lower triangular part of symmetric. Shape is
+        (..., n_features * (n_features + 1) / 2) if keep_diagonal is True and
+        (..., (n_features - 1) * n_features / 2) if it is False.
+
+
     """
-    scaling = sqrt(2) * np.ones(symmetric.shape[-2:])
-    np.fill_diagonal(scaling, 1.)
-    tril_mask = np.tril(np.ones(symmetric.shape[-2:])).astype(np.bool)
-    return symmetric[..., tril_mask] * scaling[tril_mask]
+    if keep_diagonal:
+        scaling = sqrt(2) * np.ones(symmetric.shape[-2:])
+        np.fill_diagonal(scaling, 1.)
+        tril_mask = np.tril(np.ones(symmetric.shape[-2:])).astype(np.bool)
+        return symmetric[..., tril_mask] * scaling[tril_mask]
+    tril_mask = np.tril(np.ones(symmetric.shape[-2:]), k=-1).astype(np.bool)
+    return symmetric[..., tril_mask]
 
 
 def _cov_to_corr(covariance):

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -193,7 +193,7 @@ def _geometric_mean(matrices, init=None, max_iter=10, tol=1e-7):
     return gmean
 
 
-def sym_to_vec(symmetric, discard_diagonal=False, isometric=True):
+def sym_to_vec(symmetric, discard_diagonal=False):
     """Return the flattened lower triangular part of an array.
 
     If diagonal is kept, diagonal elements are divided by sqrt(2) to conserve

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -193,7 +193,7 @@ def _geometric_mean(matrices, init=None, max_iter=10, tol=1e-7):
     return gmean
 
 
-def sym_to_vec(symmetric, keep_diagonal=True):
+def sym_to_vec(symmetric, discard_diagonal=False, isometric=True):
     """Return the flattened lower triangular part of an array.
 
     If diagonal is kept, off-diagonal elements are multiplied by sqrt(2).
@@ -207,26 +207,27 @@ def sym_to_vec(symmetric, keep_diagonal=True):
     symmetric : numpy.ndarray, shape (..., n_features, n_features)
         Input array.
 
-    keep_diagonal : boolean, optional
-        Whether to keep or not the coefficient in the diagonal of the matrix.
+    discard_diagonal : boolean, optional
+        If True, the values of the diagonal are not returned.
         Default is True.
 
     Returns
     -------
     output : numpy.ndarray
         The output flattened lower triangular part of symmetric. Shape is
-        (..., n_features * (n_features + 1) / 2) if keep_diagonal is True and
-        (..., (n_features - 1) * n_features / 2) if it is False.
+        (..., n_features * (n_features + 1) / 2) if discard_diagonal is False and
+        (..., (n_features - 1) * n_features / 2) otherwise.
 
 
     """
-    if keep_diagonal:
-        scaling = sqrt(2) * np.ones(symmetric.shape[-2:])
-        np.fill_diagonal(scaling, 1.)
-        tril_mask = np.tril(np.ones(symmetric.shape[-2:])).astype(np.bool)
-        return symmetric[..., tril_mask] * scaling[tril_mask]
-    tril_mask = np.tril(np.ones(symmetric.shape[-2:]), k=-1).astype(np.bool)
-    return symmetric[..., tril_mask]
+    if discard_diagonal:
+        # No scaling, we directly return the values
+        tril_mask = np.tril(np.ones(symmetric.shape[-2:]), k=-1).astype(np.bool)
+        return symmetric[..., tril_mask]
+    scaling = np.ones(symmetric.shape[-2:])
+    np.fill_diagonal(scaling, sqrt(2.))
+    tril_mask = np.tril(np.ones(symmetric.shape[-2:])).astype(np.bool)
+    return symmetric[..., tril_mask] / scaling[tril_mask]
 
 
 def _cov_to_corr(covariance):

--- a/nilearn/connectome/tests/test_connectivity_matrices.py
+++ b/nilearn/connectome/tests/test_connectivity_matrices.py
@@ -327,6 +327,10 @@ def test_sym_to_vec():
     vec = np.array([1., sqrt(2), 1., sqrt(2), sqrt(2), 1.])
     assert_array_almost_equal(sym_to_vec(sym), vec)
 
+    vec = np.array([1., 1., 1.])
+    assert_array_almost_equal(sym_to_vec(sym, keep_diagonal=False), vec)
+
+
 
 def test_prec_to_partial():
     prec = np.array([[2., -1., 1.], [-1., 2., -1.], [1., -1., 1.]])

--- a/nilearn/connectome/tests/test_connectivity_matrices.py
+++ b/nilearn/connectome/tests/test_connectivity_matrices.py
@@ -324,11 +324,12 @@ def test_geometric_mean_errors():
 
 def test_sym_to_vec():
     sym = np.ones((3, 3))
-    vec = np.array([1., sqrt(2), 1., sqrt(2), sqrt(2), 1.])
+    sqrt2 = 1. / sqrt(2.)
+    vec = np.array([sqrt2, 1., sqrt2, 1., 1., sqrt2])
     assert_array_almost_equal(sym_to_vec(sym), vec)
 
     vec = np.array([1., 1., 1.])
-    assert_array_almost_equal(sym_to_vec(sym, keep_diagonal=False), vec)
+    assert_array_almost_equal(sym_to_vec(sym, discard_diagonal=True), vec)
 
 
 


### PR DESCRIPTION
Depending on the type of connectivity matrix extracted, keeping diagonal elements can be pertinent or not. I suggest to add a parameter to be able to discard them.

One problem is that it makes the multiplication of off-diagonal elements by sqrt(2) useless so I removed it. But I don't know what is the best option here.