### PR TITLE
Dropping scikit learn dependency < 0.14.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       # still having the package version available through conda
     - env: DISTRIB="conda" PYTHON_VERSION="2.6"
            NUMPY_VERSION="1.6.2" SCIPY_VERSION="0.11.0"
-           SCIKIT_LEARN_VERSION="0.13" MATPLOTLIB_VERSION="1.1.1"
+           SCIKIT_LEARN_VERSION="0.14.1" MATPLOTLIB_VERSION="1.1.1"
            NIBABEL_VERSION="1.1.0"
     # Python 3.4 with intermediary versions
     - env: DISTRIB="conda" PYTHON_VERSION="3.4"

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ The required dependencies to use the software are:
 * setuptools
 * Numpy >= 1.6.1
 * SciPy >= 0.9
-* Scikit-learn >= 0.13 (Some examples require 0.14 to run)
+* Scikit-learn >= 0.14.1
 * Nibabel >= 1.1.0
 
 If you are using nilearn plotting functionalities or running the

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -4,7 +4,7 @@
 Changelog
 ---------
 
-XXX
+The new minimum required version of scikit-learn is 0.14.1
 
 New features
 ............

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -5,11 +5,6 @@
     directory. If you install nilearn manually, make sure you have followed
     :ref:`the instructions <installation>`.
 
-.. note::
-
-    A few examples may not run with scikit-learn versions older than
-    0.14.1.
-
 
 .. contents:: **Contents**
     :local:

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -39,7 +39,7 @@ REQUIRED_MODULE_METADATA = (
         'required_at_installation': True,
         'install_info': _NILEARN_INSTALL_MSG}),
     ('sklearn', {
-        'min_version': '0.13',
+        'min_version': '0.14.1',
         'required_at_installation': True,
         'install_info': _NILEARN_INSTALL_MSG}),
     ('nibabel', {


### PR DESCRIPTION
- Minimum version required will be now 0.14.1

Attempts to fix #1160 