### PR TITLE
FIX: correct left and right hemisphere mix-up in glass brain visualization

### DIFF
--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -255,11 +255,11 @@ class GlassBrainAxes(BaseAxes):
         if self.direction == 'l':
             x_center, _, _, _ = np.dot(np.linalg.inv(affine),
                                        np.array([0, 0, 0, 1]))
-            data_selection = data[int(x_center):, :, :]
+            data_selection = data[:int(x_center), :, :]
         elif self.direction == 'r':
             x_center, _, _, _ = np.dot(np.linalg.inv(affine),
                                        np.array([0, 0, 0, 1]))
-            data_selection = data[:int(x_center), :, :]
+            data_selection = data[int(x_center):, :, :]
         else:
             data_selection = data
 


### PR DESCRIPTION
Small correction for the glass brain visualization where display_mode includes 'l' or 'r'. It seems that the data from the left side was displayed in the right hemisphere and vice versa.

In my example, this was obvious, as I have two clusters on the right and one on the left. This is with the old code:
![lyrz_before](https://cloud.githubusercontent.com/assets/950321/17038436/00f21dd6-4f96-11e6-9a56-30774442466e.png)

And this is with the correction from this pull request:
![lyrz_after](https://cloud.githubusercontent.com/assets/950321/17038437/00f265f2-4f96-11e6-9216-c16c267df117.png)