### PR TITLE
Re-invert the axis after bounding box update if needed.

### DIFF
--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -67,7 +67,13 @@ class BaseAxes(object):
         new_object_bounds = self.get_object_bounds()
 
         if new_object_bounds != old_object_bounds:
+            # The bounds of the object do not take into account a possible
+            # inversion of the axis. As such, we check if the axis was inverted
+            # before resetting the bounds and re-invert it after if needed.
+            inverted = self.ax.get_xlim()[0] > self.ax.get_xlim()[1]
             self.ax.axis(self.get_object_bounds())
+            if inverted:
+                self.ax.invert_xaxis()
 
     def draw_2d(self, data_2d, data_bounds, bounding_box,
                 type='imshow', **kwargs):


### PR DESCRIPTION
OK, here is how the bug happens.

Here is what happens in the code (I'm sorry, I'll dig a bit into how matplotlib works because you can't understand the bug if you don't know it):
* First, we create the base layer of the glass brain (ie the brain outline). In the case of left-side brain, we call `invert_xaxis` to flip it horizontally. Behind the scenes, matplotlib simply takes `x_min`, `x_max` and invert them (this is not just a flag, this is important). So we have `x_min` > `x_max`.
* Then, we want to plot the "data" layer over this background. When we do it, we compute the bounds of the data to plot in order to readjust the limits of the axis if needed. Two cases:
  1. the data fits in the glass brain: we do nothing. Everything is fine.
  1. there is a voxel outside of the canvas of the axis. The canvas is then readjusted to display this voxel. During this adjustment, the limits of the axis are modified. So, if the limits were flipped before by `invert_xaxis`, they are now resetted in the correct order (`x_min` < `x_max`). This happens because we do not take into account the direction of the plot when computing the bounds.

The patch may seems a bit "quick and dirty" but it is actually the safest way I've found to fix the bug with my limited knowledge of the plotting framework. In particular:
* I don't want to change the way the bounds are computed because the `x_min` > `x_max` thing is matplotlib dependant and I don't know if some other code relies on these values
* I don't want to call `invert_xaxis` each time something is plotting, I'm a bit afraid that adding more layers may flip the image again
* If tomorrow the matplotlib API changes and the inversion is represented as a flag, the code should still work.

Comments welcome of course.