### PR TITLE
Fix the find_xyz_cut_coord function

### DIFF
--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -61,7 +61,7 @@ def find_xyz_cut_coords(img, mask_img=None, activation_threshold='auto'):
 
     mask_imgs = []
     if mask_img is not None:
-        mask_imgs.append[mask_img]
+        mask_imgs.append(mask_img)
 
     # Account for numerical noise
     if activation_threshold is None:
@@ -78,7 +78,10 @@ def find_xyz_cut_coords(img, mask_img=None, activation_threshold='auto'):
 
     if len(mask_imgs) > 0:
         mask = intersect_masks(mask_imgs, threshold=1)
-        data = unmask(apply_mask([img], mask)[0], mask)
+        if mask.get_data().max() == 0:
+            raise ValueError('Masking or thresholding masks all data: '
+                             'Center of mass cannot be determined.')
+        data = unmask(apply_mask([img], mask)[0], mask).get_data()
     else:
         # Get rid of potential memmapping
         data = as_ndarray(data)

--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -26,15 +26,15 @@ from ..masking import apply_mask, unmask, intersect_masks
 ################################################################################
 
 
-def find_xyz_cut_coords(img, mask=None, activation_threshold='auto'):
+def find_xyz_cut_coords(img, mask_img=None, activation_threshold='auto'):
     """ Find the center of mass of the largest activation connected component.
 
         Parameters
         -----------
         img : 3D Nifti1Image
             The brain map.
-        mask : 3D Nifti1Image
-            An optional brain mask. The mask must not be empty.
+        mask_img : 3D Nifti1Image, optional
+            An optional brain mask. If provided, it must not be empty.
         activation_threshold : 'auto' or float, optional (default 'auto')
             The lower threshold to the positive activation. If 'auto', the
             activation threshold is computed using the 80% percentile of
@@ -59,9 +59,9 @@ def find_xyz_cut_coords(img, mask=None, activation_threshold='auto'):
     # - the activation threshold
     # - if data is a masked_array, the associated mask
 
-    masks = []
-    if mask is not None:
-        masks.append[mask]
+    mask_imgs = []
+    if mask_img is not None:
+        mask_imgs.append[mask_img]
 
     # Account for numerical noise
     if activation_threshold is None:
@@ -69,13 +69,15 @@ def find_xyz_cut_coords(img, mask=None, activation_threshold='auto'):
 
     # If threshold is auto, it is computed later on masked data
     if activation_threshold is not None and activation_threshold != 'auto':
-        masks.append(new_img_like(img, np.abs(data) >= activation_threshold))
+        mask_imgs.append(new_img_like(img, np.abs(data) >=
+                                      activation_threshold))
 
     if hasattr(data, 'mask'):
-        masks.append(new_img_like(np.logical_not(data.mask.astype(np.int8))))
+        mask_imgs.append(new_img_like(
+            np.logical_not(data.mask.astype(np.int8))))
 
-    if len(masks) > 0:
-        mask = intersect_masks(masks, threshold=1)
+    if len(mask_imgs) > 0:
+        mask = intersect_masks(mask_imgs, threshold=1)
         data = unmask(apply_mask([img], mask)[0], mask)
     else:
         # Get rid of potential memmapping

--- a/nilearn/plotting/tests/test_find_cuts.py
+++ b/nilearn/plotting/tests/test_find_cuts.py
@@ -38,10 +38,9 @@ def test_find_cut_coords():
     data = np.ones((36, 43, 36))
     affine = np.eye(4)
     img = nibabel.Nifti1Image(data, affine)
-    np.testing.assert_raises_regex(
-        ValueError, 'Masking or thresholding masks all data',
-        find_xyz_cut_coords, img, activation_threshold=1.1
-    )
+    x, y, z = find_xyz_cut_coords(img, activation_threshold=1.1)
+    np.testing.assert_array_equal(
+        np.array([x, y, z]), 0.5 * np.array(data.shape).astype(np.float))
 
     # regression test (cf. #922)
     # pseudo-4D images as input (i.e., X, Y, Z, 1)
@@ -144,10 +143,9 @@ def test_find_cuts_empty_mask_no_crash():
     img = nibabel.Nifti1Image(np.ones((2, 2, 2)), np.eye(4))
     mask_img = nibabel.Nifti1Image(np.zeros((2, 2, 2), dtype=np.int8),
                                    np.eye(4))
-    np.testing.assert_raises_regex(
-        ValueError, 'Masking or thresholding masks all data',
-        find_xyz_cut_coords, img, mask_img=mask_img,
-    )
+    cut_coords = assert_warns(UserWarning, find_xyz_cut_coords, img,
+                              mask_img=mask_img)
+    np.testing.assert_array_equal(cut_coords, [1., 1., 1.])
 
 
 def test_fast_abs_percentile_no_index_error_find_cuts():

--- a/nilearn/plotting/tests/test_find_cuts.py
+++ b/nilearn/plotting/tests/test_find_cuts.py
@@ -14,7 +14,8 @@ def test_find_cut_coords():
     # identity affine
     affine = np.eye(4)
     img = nibabel.Nifti1Image(data, affine)
-    x, y, z = find_xyz_cut_coords(img, mask=np.ones(data.shape, np.bool))
+    mask_img = nibabel.Nifti1Image(np.ones(data.shape, dtype=np.int8), affine)
+    x, y, z = find_xyz_cut_coords(img, mask_img=mask_img)
     np.testing.assert_allclose((x, y, z),
                                (x_map, y_map, z_map),
                                # Need such a high tolerance for the test to
@@ -24,7 +25,8 @@ def test_find_cut_coords():
     # non-trivial affine
     affine = np.diag([1. / 2, 1 / 3., 1 / 4., 1.])
     img = nibabel.Nifti1Image(data, affine)
-    x, y, z = find_xyz_cut_coords(img, mask=np.ones(data.shape, np.bool))
+    mask_img = nibabel.Nifti1Image(np.ones(data.shape, dtype=np.int8), affine)
+    x, y, z = find_xyz_cut_coords(img, mask_img=mask_img)
     np.testing.assert_allclose((x, y, z),
                                (x_map / 2., y_map / 3., z_map / 4.),
                                # Need such a high tolerance for the test to
@@ -36,10 +38,10 @@ def test_find_cut_coords():
     data = np.ones((36, 43, 36))
     affine = np.eye(4)
     img = nibabel.Nifti1Image(data, affine)
-    x, y, z = find_xyz_cut_coords(img, activation_threshold=1.1)
-    np.testing.assert_array_equal(
-        np.array([x, y, z]),
-        0.5 * np.array(data.shape).astype(np.float))
+    np.testing.assert_raises_regex(
+        ValueError, 'Masking or thresholding masks all data',
+        find_xyz_cut_coords, img, activation_threshold=1.1
+    )
 
     # regression test (cf. #922)
     # pseudo-4D images as input (i.e., X, Y, Z, 1)
@@ -140,10 +142,12 @@ def test_tranform_cut_coords():
 
 def test_find_cuts_empty_mask_no_crash():
     img = nibabel.Nifti1Image(np.ones((2, 2, 2)), np.eye(4))
-    mask = np.zeros((2, 2, 2)).astype(np.bool)
-    cut_coords = assert_warns(UserWarning, find_xyz_cut_coords, img,
-                              mask=mask)
-    np.testing.assert_array_equal(cut_coords, [.5, .5, .5])
+    mask_img = nibabel.Nifti1Image(np.zeros((2, 2, 2), dtype=np.int8),
+                                   np.eye(4))
+    np.testing.assert_raises_regex(
+        ValueError, 'Masking or thresholding masks all data',
+        find_xyz_cut_coords, img, mask_img=mask_img,
+    )
 
 
 def test_fast_abs_percentile_no_index_error_find_cuts():


### PR DESCRIPTION
Fixes:
- #1189: always returns a list
- #1190: always returns a point in real world coordinate or raise a meaningful error
- #1191: internally converts to float during masking (can be discussed later)
- #1193: force mask to be a niimg (I did not change the parameter name but maybe I should?)
- #1194: now works for binary images

I am still a bit doubtful about the "second threshold" and all the magic it does. Do we have a reference about that somewhere?
