### PR TITLE
Issue with searchlight with no process mask?

### DIFF
--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -291,7 +291,7 @@ class SearchLight(BaseEstimator):
 
         X, A = _apply_mask_and_get_affinity(
             process_mask_coords, imgs, self.radius, True,
-            mask_img=self.process_mask_img)
+            mask_img=process_mask_img)
 
         estimator = self.estimator
         if isinstance(estimator, _basestring):


### PR DESCRIPTION
It appears that values from outside the brain mask are being included when SearchLight is run without the optional `process_mask_img`. Accordingly, omitting the `process_mask_img` argument produces different results than passing the same Niimg-like object image as both the `mask_img` and the `process_mask_img` (whereas, if I understand correctly, identical results would be the expected behavior).  I believe this change addresses the issue. 