### PR TITLE
use ConnectivityMeasure for GraphLasso

### DIFF
--- a/examples/03_connectivity/plot_inverse_covariance_connectome.py
+++ b/examples/03_connectivity/plot_inverse_covariance_connectome.py
@@ -49,9 +49,14 @@ time_series = masker.fit_transform(data.func[0],
 ##############################################################################
 # Compute the sparse inverse covariance
 from sklearn.covariance import GraphLassoCV
-estimator = GraphLassoCV()
+from nilearn.connectome import ConnectivityMeasure
+covariance_measure = ConnectivityMeasure(cov_estimator=GraphLassoCV(),
+                                         kind='covariance')
+covariance_matrix = covariance_measure.fit_transform([time_series])[0]
 
-estimator.fit(time_series)
+precision_measure = ConnectivityMeasure(cov_estimator=GraphLassoCV(),
+                                        kind='precision')
+precision_matrix = covariance_measure.fit_transform([time_series])[0]
 
 ##############################################################################
 # Display the connectome matrix
@@ -61,7 +66,7 @@ from matplotlib import pyplot as plt
 plt.figure(figsize=(10, 10))
 
 # The covariance can be found at estimator.covariance_
-plt.imshow(estimator.covariance_, interpolation="nearest",
+plt.imshow(covariance_matrix, interpolation="nearest",
            vmax=1, vmin=-1, cmap=plt.cm.RdBu_r)
 # And display the labels
 x_ticks = plt.xticks(range(len(labels)), labels, rotation=90)
@@ -73,7 +78,7 @@ plt.title('Covariance')
 from nilearn import plotting
 coords = atlas.region_coords
 
-plotting.plot_connectome(estimator.covariance_, coords,
+plotting.plot_connectome(covariance_matrix, coords,
                          title='Covariance')
 
 
@@ -81,7 +86,7 @@ plotting.plot_connectome(estimator.covariance_, coords,
 # Display the sparse inverse covariance (we negate it to get partial
 # correlations)
 plt.figure(figsize=(10, 10))
-plt.imshow(-estimator.precision_, interpolation="nearest",
+plt.imshow(-precision_matrix, interpolation="nearest",
            vmax=1, vmin=-1, cmap=plt.cm.RdBu_r)
 # And display the labels
 x_ticks = plt.xticks(range(len(labels)), labels, rotation=90)
@@ -90,7 +95,7 @@ plt.title('Sparse inverse covariance')
 
 ##############################################################################
 # And now display the corresponding graph
-plotting.plot_connectome(-estimator.precision_, coords,
+plotting.plot_connectome(-precision_matrix, coords,
                          title='Sparse inverse covariance')
 
 plotting.show()

--- a/examples/03_connectivity/plot_multi_subject_connectome.py
+++ b/examples/03_connectivity/plot_multi_subject_connectome.py
@@ -89,26 +89,33 @@ from nilearn.connectome import GroupSparseCovarianceCV
 gsc = GroupSparseCovarianceCV(verbose=2)
 gsc.fit(subject_time_series)
 
-from sklearn import covariance
-gl = covariance.GraphLassoCV(verbose=2)
-gl.fit(np.concatenate(subject_time_series))
+from nilearn.connectome import ConnectivityMeasure
+from sklearn.covariance import GraphLassoCV
+gl_covariance_measure = ConnectivityMeasure(GraphLassoCV(verbose=2),
+                                            kind='covariance')
+gl_covariance = gl_covariance_measure.fit_transform(
+    [np.concatenate(subject_time_series)])[0]
 
+gl_precision_measure = ConnectivityMeasure(GraphLassoCV(verbose=2),
+                                           kind='precision')
+gl_precision = gl_covariance_measure.fit_transform(
+    [np.concatenate(subject_time_series)])[0]
 
 ##############################################################################
 # Displaying results
 atlas_imgs = image.iter_img(msdl_atlas_dataset.maps)
 atlas_region_coords = [plotting.find_xyz_cut_coords(img) for img in atlas_imgs]
 
-plotting.plot_connectome(gl.covariance_,
+plotting.plot_connectome(gl_covariance,
                          atlas_region_coords, edge_threshold='90%',
                          title="Covariance",
                          display_mode="lzr")
-plotting.plot_connectome(-gl.precision_, atlas_region_coords,
+plotting.plot_connectome(-gl_precision, atlas_region_coords,
                          edge_threshold='90%',
                          title="Sparse inverse covariance (GraphLasso)",
                          display_mode="lzr",
                          edge_vmax=.5, edge_vmin=-.5)
-plot_matrices(gl.covariance_, gl.precision_, "GraphLasso")
+plot_matrices(gl_covariance, gl_precision, "GraphLasso")
 
 title = "GroupSparseCovariance"
 plotting.plot_connectome(-gsc.precisions_[..., 0],


### PR DESCRIPTION
fixes #1213.
For the moment I am keeping direct fitting of sklearn GraphLasso in `plot_simulated_connectome` because of `alpha_` parameter use, and will do another PR for this example.
