### PR TITLE
[MRG] SearchLight cannot handle one-voxel mask

### DIFF
--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -291,7 +291,7 @@ class SearchLight(BaseEstimator):
 
         X, A = _apply_mask_and_get_affinity(
             process_mask_coords, imgs, self.radius, True,
-            mask_img=process_mask_img)
+            mask_img=self.mask_img)
 
         estimator = self.estimator
         if isinstance(estimator, _basestring):

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -287,7 +287,6 @@ class SearchLight(BaseEstimator):
         process_mask_coords = coord_transform(
             process_mask_coords[0], process_mask_coords[1],
             process_mask_coords[2], process_mask_affine, squeeze=False)
-        print(process_mask_coords)
         process_mask_coords = np.asarray(process_mask_coords).T
 
         X, A = _apply_mask_and_get_affinity(

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -286,7 +286,8 @@ class SearchLight(BaseEstimator):
         process_mask_coords = np.where(process_mask != 0)
         process_mask_coords = coord_transform(
             process_mask_coords[0], process_mask_coords[1],
-            process_mask_coords[2], process_mask_affine)
+            process_mask_coords[2], process_mask_affine, squeeze=False)
+        print(process_mask_coords)
         process_mask_coords = np.asarray(process_mask_coords).T
 
         X, A = _apply_mask_and_get_affinity(

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -286,7 +286,7 @@ class SearchLight(BaseEstimator):
         process_mask_coords = np.where(process_mask != 0)
         process_mask_coords = coord_transform(
             process_mask_coords[0], process_mask_coords[1],
-            process_mask_coords[2], process_mask_affine, squeeze=False)
+            process_mask_coords[2], process_mask_affine)
         process_mask_coords = np.asarray(process_mask_coords).T
 
         X, A = _apply_mask_and_get_affinity(

--- a/nilearn/decoding/tests/test_searchlight.py
+++ b/nilearn/decoding/tests/test_searchlight.py
@@ -67,7 +67,6 @@ def test_searchlight():
     # applied instead of using mask_img
     mask = np.zeros((5, 5, 5), np.bool)
     mask[0, 0, 0] = True
-    mask[0, 0, 1] = True
     mask_img = nibabel.Nifti1Image(mask.astype(np.int), np.eye(4))
 
     sl = searchlight.SearchLight(mask_img, radius=4,

--- a/nilearn/decoding/tests/test_searchlight.py
+++ b/nilearn/decoding/tests/test_searchlight.py
@@ -42,8 +42,18 @@ def test_searchlight():
     assert_equal(np.where(sl.scores_ == 1)[0].size, 1)
     assert_equal(sl.scores_[2, 2, 2], 1.)
 
-    # Medium radius : little ball selected
+    # The voxel selected in process_mask_img is too far from the signal
+    process_mask = np.zeros((5, 5, 5), np.bool)
+    process_mask[0, 0, 0] = True
+    process_mask_img = nibabel.Nifti1Image(process_mask.astype(np.int),
+                                           np.eye(4))
+    sl = searchlight.SearchLight(mask_img, process_mask_img=process_mask_img,
+                                 radius=0.5, n_jobs=n_jobs,
+                                 scoring='accuracy', cv=cv)
+    sl.fit(data_img, cond)
+    assert_equal(np.where(sl.scores_ == 1)[0].size, 0)
 
+    # Medium radius : little ball selected
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img, radius=1,
                                  n_jobs=n_jobs, scoring='accuracy', cv=cv)
     sl.fit(data_img, cond)
@@ -62,14 +72,3 @@ def test_searchlight():
     sl.fit(data_img, cond)
     assert_equal(np.where(sl.scores_ == 1)[0].size, 33)
     assert_equal(sl.scores_[2, 2, 2], 1.)
-
-    # Regression test for #1216: if process_mask_img is not given, no masking is
-    # applied instead of using mask_img
-    mask = np.zeros((5, 5, 5), np.bool)
-    mask[0, 0, 0] = True
-    mask_img = nibabel.Nifti1Image(mask.astype(np.int), np.eye(4))
-
-    sl = searchlight.SearchLight(mask_img, radius=4,
-                                 n_jobs=n_jobs, scoring='accuracy', cv=cv)
-    sl.fit(data_img, cond)
-    assert_equal(np.where(sl.scores_ == 1)[0].size, 0)

--- a/nilearn/decoding/tests/test_searchlight.py
+++ b/nilearn/decoding/tests/test_searchlight.py
@@ -62,3 +62,15 @@ def test_searchlight():
     sl.fit(data_img, cond)
     assert_equal(np.where(sl.scores_ == 1)[0].size, 33)
     assert_equal(sl.scores_[2, 2, 2], 1.)
+
+    # Regression test for #1216: if process_mask_img is not given, no masking is
+    # applied instead of using mask_img
+    mask = np.zeros((5, 5, 5), np.bool)
+    mask[0, 0, 0] = True
+    mask[0, 0, 1] = True
+    mask_img = nibabel.Nifti1Image(mask.astype(np.int), np.eye(4))
+
+    sl = searchlight.SearchLight(mask_img, radius=4,
+                                 n_jobs=n_jobs, scoring='accuracy', cv=cv)
+    sl.fit(data_img, cond)
+    assert_equal(np.where(sl.scores_ == 1)[0].size, 0)

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -86,7 +86,7 @@ def from_matrix_vector(matrix, vector):
     return t
 
 
-def coord_transform(x, y, z, affine, squeeze=True):
+def coord_transform(x, y, z, affine):
     """ Convert the x, y, z coordinates from one image space to another
         space.
 
@@ -100,9 +100,6 @@ def coord_transform(x, y, z, affine, squeeze=True):
             The z coordinates in the input space
         affine : 2D 4x4 ndarray
             affine that maps from input to output space.
-        squeeze : boolean, optional (default True)
-            If True and only one point is given, a tuple of numbers is returned
-            instead of a tuple of nparrays.
 
         Returns
         -------
@@ -116,6 +113,7 @@ def coord_transform(x, y, z, affine, squeeze=True):
         Warning: The x, y and z have their Talairach ordering, not 3D
         numy image ordering.
     """
+    squeeze = (not hasattr(x, '__iter__'))
     coords = np.c_[np.atleast_1d(x).flat,
                    np.atleast_1d(y).flat,
                    np.atleast_1d(z).flat,

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -86,7 +86,7 @@ def from_matrix_vector(matrix, vector):
     return t
 
 
-def coord_transform(x, y, z, affine):
+def coord_transform(x, y, z, affine, squeeze=True):
     """ Convert the x, y, z coordinates from one image space to another
         space.
 
@@ -100,6 +100,9 @@ def coord_transform(x, y, z, affine):
             The z coordinates in the input space
         affine : 2D 4x4 ndarray
             affine that maps from input to output space.
+        squeeze : boolean, optional (default True)
+            If True and only one point is given, a tuple of numbers is returned
+            instead of a tuple of nparrays.
 
         Returns
         -------
@@ -118,7 +121,9 @@ def coord_transform(x, y, z, affine):
                    np.atleast_1d(z).flat,
                    np.ones_like(np.atleast_1d(z).flat)].T
     x, y, z, _ = np.dot(affine, coords)
-    return x.squeeze(), y.squeeze(), z.squeeze()
+    if squeeze:
+        return x.squeeze(), y.squeeze(), z.squeeze()
+    return x, y, z
 
 
 def get_bounds(shape, affine):

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -591,6 +591,20 @@ def test_coord_transform_trivial():
     np.testing.assert_array_equal(y + 1, y_)
     np.testing.assert_array_equal(z + 1, z_)
 
+    # Test the output in case of one item array
+    x, y, z = x[:1], y[:1], z[:1]
+    x_, y_, z_ = coord_transform(x, y, z, sform)
+    np.testing.assert_array_equal(x + 1, x_)
+    np.testing.assert_array_equal(y + 1, y_)
+    np.testing.assert_array_equal(z + 1, z_)
+
+    # Test the output in case of simple items
+    x, y, z = x[0], y[0], z[0]
+    x_, y_, z_ = coord_transform(x, y, z, sform)
+    np.testing.assert_array_equal(x + 1, x_)
+    np.testing.assert_array_equal(y + 1, y_)
+    np.testing.assert_array_equal(z + 1, z_)
+
 
 def test_resample_img_segmentation_fault():
     if os.environ.get('APPVEYOR') == 'True':

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -52,7 +52,7 @@ def _apply_mask_and_get_affinity(seeds, niimg, radius, allow_overlap,
 
     mask_coords = np.asarray(list(zip(*mask_coords)))
     mask_coords = coord_transform(mask_coords[0], mask_coords[1],
-                                  mask_coords[2], affine)
+                                  mask_coords[2], affine, squeeze=False)
     mask_coords = np.asarray(mask_coords).T
 
     if (radius is not None and

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -52,7 +52,7 @@ def _apply_mask_and_get_affinity(seeds, niimg, radius, allow_overlap,
 
     mask_coords = np.asarray(list(zip(*mask_coords)))
     mask_coords = coord_transform(mask_coords[0], mask_coords[1],
-                                  mask_coords[2], affine, squeeze=False)
+                                  mask_coords[2], affine)
     mask_coords = np.asarray(mask_coords).T
 
     if (radius is not None and


### PR DESCRIPTION
Because `coord_transform` returns either a list of arrays or a list of number, iterating on the return values fails if only one point is transformed. I decided to directly add an option in `coord_transform` instead of "catching" the problem in the searchlight because I think it may be useful for other usage.

Update:

For the bug fix: We have two masks in SearchLight: mask_img, that masks voxels outside of the brain and process_mask_img that "selects" the voxels to process. Before, mask_img was not used properly, process_mask_img was used instead. I fixed it.