### PR TITLE
DOC: fix warning when creating an already existing nilearn_cache

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -41,7 +41,7 @@ clean:
 sym_links:
 	# Make sym-links to share the cache across various example
 	# directories
-	-cd ../examples/ && mkdir nilearn_cache
+	-cd ../examples/ && mkdir -p nilearn_cache
 	-cd ../examples/01_plotting/ && ln -sf ../nilearn_cache
 	-cd ../examples/02_decoding/ && ln -sf ../nilearn_cache
 	-cd ../examples/03_connectivity/ && ln -sf ../nilearn_cache


### PR DESCRIPTION
Follow-up of #1266 : I missed the fix of the warning generated when creating nilearn_cache if it exists already.
I use the simplest way use `-p` option of `mkdir` to silent it.