### PR TITLE
Removing accentuated characters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ This work is made available by a community of people, amongst which
 the INRIA Parietal Project Team and the scikit-learn folks, in particular
 P. Gervais, A. Abraham, V. Michel, A.
 Gramfort, G. Varoquaux, F. Pedregosa, B. Thirion, M. Eickenberg, C. F. Gorgolewski,
-D. Bzdok, L. Estève and B. Cipollini.
+D. Bzdok, L. Esteve and B. Cipollini.
 
 Important links
 ===============

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -2,7 +2,7 @@
 """
 nilearn version, required package versions, and utilities for checking
 """
-# Author: Loïc Estève, Ben Cipollini
+# Author: Loic Esteve, Ben Cipollini
 # License: simplified BSD
 
 # PEP0440 compatible formatted version, see:


### PR DESCRIPTION
Accentuated characters are creating build failures with python3 (during rpmbuild)
