### PR TITLE
Line correction; if vmax was None, no point on assigning

### DIFF
--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -366,7 +366,7 @@ class GlassBrainAxes(BaseAxes):
                 )
         elif vmax is None:
             if vmin < 0:
-                vmin = -vmax
+                vmax = -vmin
             else:
                 raise ValueError(
                     "If vmin is set to a non-negative number "


### PR DESCRIPTION
Hi!

I was trying to plot a statmap using`plt.plot_glass_brain()`and using `vmin` and `vmax` parameters to force range the colorbar between 2 given values. `vmax` works fine, but I could not make the colorbar's lower values to adapt to `vmin` 's values (should I open an issue?). I came to the source and spotted this small bug, which has no relation with my first problem, but I think it was fine to solve. 

thanks!
