### PR TITLE
correct a bug in nilearn.image.clean_img

### DIFF
--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -861,10 +861,10 @@ def clean_img(imgs, sessions=None, detrend=True, standardize=True,
 
     imgs_ = check_niimg_4d(imgs)
     data = signal.clean(
-        imgs_.get_data().reshape(-1, imgs.shape[-1]).T, sessions=sessions,
+        imgs_.get_data().reshape(-1, imgs_.shape[-1]).T, sessions=sessions,
         detrend=detrend, standardize=standardize, confounds=confounds,
         low_pass=low_pass, high_pass=high_pass, t_r=2.5,
-        ensure_finite=ensure_finite).T.reshape(imgs.shape)
+        ensure_finite=ensure_finite).T.reshape(imgs_.shape)
     return new_img_like(imgs, data, copy_header=True)
 
 


### PR DESCRIPTION
In 0.2.6, when we pass a path to a 4D Nifti image to clean_img, we  get an error msg,
```
lib/python3.5/site-packages/nilearn/image/image.py", line 861, in clean_img
    imgs_.get_data().reshape(-1, imgs.shape[-1]).T, sessions=sessions,
AttributeError: 'str' object has no attribute 'shape'
```
The reason is ```imgs``` is a path string not nii object.
This commit corrects the problem by modfiy ```imgs``` to ```imgs_```.