### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include AUTHORS.rst
+include LICENSE
+include README.rst


### PR DESCRIPTION
Adds the `MANIFEST.in` file to include various non-code files in packages (e.g. `sdist`s) as needed.