### PR TITLE
Check memory

### DIFF
--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -31,6 +31,8 @@ __CACHE_CHECKED = dict()
 
 
 def _check_memory(memory, verbose=False):
+    if memory is None:
+        memory = Memory(cachedir=None, verbose=verbose)
     if isinstance(memory, _basestring):
         cache_dir = memory
         if nilearn.EXPAND_PATH_WILDCARDS:

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -35,7 +35,7 @@ def _check_memory(memory, verbose=0):
 
     Parameters
     ----------
-    memory: instance of joblib.Memory or string
+    memory: None or instance of joblib.Memory or string
         Used to cache the masking process.
         If a string is given, it is the
         path to the caching directory.

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -30,6 +30,44 @@ from .compat import _basestring
 __CACHE_CHECKED = dict()
 
 
+def _check_memory(memory, verbose=False):
+    if isinstance(memory, _basestring):
+        cache_dir = memory
+        if nilearn.EXPAND_PATH_WILDCARDS:
+            cache_dir = os.path.expanduser(cache_dir)
+
+        # Perform some verifications on given path.
+        split_cache_dir = os.path.split(cache_dir)
+        if (len(split_cache_dir) > 1 and
+                (not os.path.exists(split_cache_dir[0]) and
+                    split_cache_dir[0] != '')):
+            if (not nilearn.EXPAND_PATH_WILDCARDS and
+                    cache_dir.startswith("~")):
+                # Maybe the user want to enable expanded user path.
+                error_msg = ("Given cache path parent directory doesn't "
+                             "exists, you gave '{0}'. Enabling "
+                             "nilearn.EXPAND_PATH_WILDCARDS could solve "
+                             "this issue.".format(split_cache_dir[0]))
+            elif memory.startswith("~"):
+                # Path built on top of expanded user path doesn't exist.
+                error_msg = ("Given cache path parent directory doesn't "
+                             "exists, you gave '{0}' which was expanded "
+                             "as '{1}' but doesn't exist either. Use "
+                             "nilearn.EXPAND_PATH_WILDCARDS to deactivate "
+                             "auto expand user path (~) behavior."
+                             .format(split_cache_dir[0],
+                                     os.path.dirname(memory)))
+            else:
+                # The given cache base path doesn't exist.
+                error_msg = ("Given cache path parent directory doesn't "
+                             "exists, you gave '{0}'."
+                             .format(split_cache_dir[0]))
+            raise ValueError(error_msg)
+
+        memory = Memory(cachedir=cache_dir, verbose=verbose)
+    return memory
+
+
 def _safe_cache(memory, func, **kwargs):
     """ A wrapper for mem.cache that flushes the cache if the version
         number of nibabel has changed.
@@ -231,40 +269,7 @@ class CacheMixin(object):
             self.memory_level = 0
         if not hasattr(self, "memory"):
             self.memory = Memory(cachedir=None, verbose=verbose)
-        if isinstance(self.memory, _basestring):
-            cache_dir = self.memory
-            if nilearn.EXPAND_PATH_WILDCARDS:
-                cache_dir = os.path.expanduser(cache_dir)
-
-            # Perform some verifications on given path.
-            split_cache_dir = os.path.split(cache_dir)
-            if (len(split_cache_dir) > 1 and
-                    (not os.path.exists(split_cache_dir[0]) and
-                     split_cache_dir[0] != '')):
-                if (not nilearn.EXPAND_PATH_WILDCARDS and
-                        cache_dir.startswith("~")):
-                    # Maybe the user want to enable expanded user path.
-                    error_msg = ("Given cache path parent directory doesn't "
-                                 "exists, you gave '{0}'. Enabling "
-                                 "nilearn.EXPAND_PATH_WILDCARDS could solve "
-                                 "this issue.".format(split_cache_dir[0]))
-                elif self.memory.startswith("~"):
-                    # Path built on top of expanded user path doesn't exist.
-                    error_msg = ("Given cache path parent directory doesn't "
-                                 "exists, you gave '{0}' which was expanded "
-                                 "as '{1}' but doesn't exist either. Use "
-                                 "nilearn.EXPAND_PATH_WILDCARDS to deactivate "
-                                 "auto expand user path (~) behavior."
-                                 .format(split_cache_dir[0],
-                                         os.path.dirname(self.memory)))
-                else:
-                    # The given cache base path doesn't exist.
-                    error_msg = ("Given cache path parent directory doesn't "
-                                 "exists, you gave '{0}'."
-                                 .format(split_cache_dir[0]))
-                raise ValueError(error_msg)
-
-            self.memory = Memory(cachedir=cache_dir, verbose=verbose)
+        self.memory = _check_memory(self.memory, verbose=verbose)
 
         # If cache level is 0 but a memory object has been provided, set
         # memory_level to 1 with a warning.

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -30,7 +30,23 @@ from .compat import _basestring
 __CACHE_CHECKED = dict()
 
 
-def _check_memory(memory, verbose=False):
+def _check_memory(memory, verbose=0):
+    """Function to make ensure a memory object.
+
+    Parameters
+    ----------
+    memory: instance of joblib.Memory or string
+        Used to cache the masking process.
+        If a string is given, it is the
+        path to the caching directory.
+
+    verbose : int, optional (default 1)
+        Verbosity level.
+
+    Returns
+    -------
+    instance of joblib.Memory.
+    """
     if memory is None:
         memory = Memory(cachedir=None, verbose=verbose)
     if isinstance(memory, _basestring):

--- a/nilearn/input_data/masker_validation.py
+++ b/nilearn/input_data/masker_validation.py
@@ -3,6 +3,7 @@ import warnings
 import numpy as np
 
 from .._utils.class_inspect import get_params
+from .._utils.cache_mixin import _check_memory
 from .multi_nifti_masker import MultiNiftiMasker
 from .nifti_masker import NiftiMasker
 
@@ -51,7 +52,7 @@ def check_embedded_nifti_masker(estimator, multi_subject=True):
     if multi_subject and hasattr(estimator, 'n_jobs'):
         # For MultiNiftiMasker only
         new_masker_params['n_jobs'] = estimator.n_jobs
-    new_masker_params['memory'] = estimator.memory
+    new_masker_params['memory'] = _check_memory(estimator.memory)
     new_masker_params['memory_level'] = max(0, estimator.memory_level - 1)
     new_masker_params['verbose'] = estimator.verbose
 

--- a/nilearn/tests/test_cache_mixin.py
+++ b/nilearn/tests/test_cache_mixin.py
@@ -17,9 +17,33 @@ from nilearn._utils import cache_mixin, CacheMixin
 from nilearn._utils.testing import assert_raises_regex
 
 
+
 def f(x):
     # A simple test function
     return x
+
+
+def test_check_memory():
+    try:
+        temp_dir = tempfile.mkdtemp()
+
+        mem_none = Memory(cachedir=None)
+        mem_temp = Memory(cachedir=temp_dir)
+
+        for mem in [None, mem_none]:
+            memory = cache_mixin._check_memory(mem, verbose=False)
+            assert_true(memory, Memory)
+            assert_equal(memory.cachedir, mem_none.cachedir)
+
+        for mem in [temp_dir, mem_temp]:
+            memory = cache_mixin._check_memory(mem, verbose=False)
+            assert_equal(memory.cachedir, mem_temp.cachedir)
+            assert_true(memory, Memory)
+
+    finally:
+        if os.path.exists(temp_dir):
+            shutil.rmtree(temp_dir)
+
 
 
 def test__safe_cache_dir_creation():

--- a/nilearn/tests/test_cache_mixin.py
+++ b/nilearn/tests/test_cache_mixin.py
@@ -24,6 +24,8 @@ def f(x):
 
 
 def test_check_memory():
+    # Test if _check_memory returns a memory object with the cachedir equal to
+    # input path
     try:
         temp_dir = tempfile.mkdtemp()
 


### PR DESCRIPTION
With this PR we solve the issue #1365.
We separate the function that checks the memory in _utils/chache_mixin.py, and use it use it in check_embedded_nifti_masker.

Basically this functions returns a memory object with the predefine cachedir.

Ping @GaelVaroquaux  @KamalakerDadi 