### PR TITLE
[MRG] MAINT: switching from coveralls to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="2.7"
            NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.13.3"
            SCIKIT_LEARN_VERSION="0.15.1" MATPLOTLIB_VERSION="1.3.1"
-           NIBABEL_VERSION="1.1.0"
+           NIBABEL_VERSION="1.1.0" COVERAGE="true"
     # Ubuntu 14.04 versions without matplotlib
     - env: DISTRIB="conda" PYTHON_VERSION="2.7"
            NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.13.3"
@@ -45,4 +45,4 @@ before_script: make clean
 
 script: source continuous_integration/test_script.sh
 
-after_success: source continuous_integration/after_success.sh  
+after_success: source continuous_integration/after_success.sh

--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@
    :target: https://ci.appveyor.com/project/nilearn-ci/nilearn
    :alt: AppVeyor Build Status
 
-.. image:: https://coveralls.io/repos/nilearn/nilearn/badge.svg?branch=master
-   :target: https://coveralls.io/r/nilearn/nilearn
+.. image:: https://codecov.io/gh/nilearn/nilearn/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/nilearn/nilearn
 
 nilearn
 =======

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,0 @@
-comment: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/continuous_integration/after_success.sh
+++ b/continuous_integration/after_success.sh
@@ -2,12 +2,11 @@
 
 set -e
 
-# Ignore coveralls failures as the coveralls server is not very reliable
-# but we don't want travis to report a failure in the github UI just
-# because the coverage report failed to be published.
-# coveralls need to be run from the git checkout
+# Ignore codecov failures because we don't want travis to report a failure
+# in the github UI just because the coverage report failed to be published.
+# codecov needs to be run from the git checkout
 # so we need to copy the coverage results from TEST_RUN_FOLDER
 if [[ "$SKIP_TESTS" != "true" && "$COVERAGE" == "true" ]]; then
     cp "$TEST_RUN_FOLDER/.coverage" .
-    coveralls || echo "Coveralls upload failed"
+    codecov || echo "Codecov upload failed"
 fi

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -111,7 +111,7 @@ fi
 pip install psutil memory_profiler
 
 if [[ "$COVERAGE" == "true" ]]; then
-    pip install coverage coveralls
+    pip install codecov
 fi
 
 # numpy not installed when skipping the tests so we do not want to run


### PR DESCRIPTION
It's all in the title and is similar to what was done in [joblib](https://github.com/joblib/joblib/pull/492).

Codecov merges results from different builds that's why coverage is activated in python 2.7.