### PR TITLE
FIX: Plotting functions works with NaNs in images

### DIFF
--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -643,7 +643,7 @@ class BaseSlicer(object):
         threshold = float(threshold) if threshold is not None else None
 
         if threshold is not None:
-            data = img.get_data()
+            data = _utils.niimg._safe_get_data(img, ensure_finite=True)
             if threshold == 0:
                 data = np.ma.masked_equal(data, 0, copy=False)
             else:
@@ -652,7 +652,7 @@ class BaseSlicer(object):
             img = new_img_like(img, data, _utils.compat.get_affine(img))
 
         affine = _utils.compat.get_affine(img)
-        data = img.get_data()
+        data = _utils.niimg._safe_get_data(img, ensure_finite=True)
         data_bounds = get_bounds(data.shape, affine)
         (xmin, xmax), (ymin, ymax), (zmin, zmax) = data_bounds
 

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -149,7 +149,7 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
 
     if img is not False and img is not None:
         img = _utils.check_niimg_3d(img, dtype='auto')
-        data = _safe_get_data(img)
+        data = _safe_get_data(img, ensure_finite=True)
         affine = _get_affine(img)
 
         if np.isnan(np.sum(data)):
@@ -967,7 +967,7 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
     stat_map_img = _utils.check_niimg_3d(stat_map_img, dtype='auto')
 
     cbar_vmin, cbar_vmax, vmin, vmax = _get_colorbar_and_data_ranges(
-        _safe_get_data(stat_map_img),
+        _safe_get_data(stat_map_img, ensure_finite=True),
         vmax,
         symmetric_cbar,
         kwargs)

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -881,3 +881,18 @@ def test_outlier_cut_coords():
 
     p = plot_stat_map(img, display_mode='z', cut_coords=cuts[-4:],
                       bg_img=bg_img)
+
+
+def test_plot_stat_map_with_nans():
+    img = _generate_img()
+    data = img.get_data()
+
+    data[6, 5, 1] = np.nan
+    data[1, 5, 2] = np.nan
+    data[1, 3, 2] = np.nan
+    data[6, 5, 2] = np.inf
+
+    img = nibabel.Nifti1Image(data, mni_affine)
+    plot_epi(img)
+    plot_stat_map(img)
+    plot_glass_brain(img)


### PR DESCRIPTION
Attempts to address issue #1333. By default plotting functions should work with images which contains NaN or Inf values. Also, added tests in test_img_plotting which tests this additions.

Any kind of reviews are welcome.