### PR TITLE
[MRG] Drop Nibabel 1.1.0 minimum dependency to 1.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="2.7"
            NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.13.3"
            SCIKIT_LEARN_VERSION="0.15.1" MATPLOTLIB_VERSION="1.3.1"
-           NIBABEL_VERSION="1.1.0" COVERAGE="true"
+           NIBABEL_VERSION="1.2.0" COVERAGE="true"
     # Ubuntu 14.04 versions without matplotlib
     - env: DISTRIB="conda" PYTHON_VERSION="2.7"
            NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.13.3"

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ The required dependencies to use the software are:
 * Numpy >= 1.6.1
 * SciPy >= 0.9
 * Scikit-learn >= 0.14.1
-* Nibabel >= 1.1.0
+* Nibabel >= 1.2.0
 
 If you are using nilearn plotting functionalities or running the
 examples, matplotlib >= 1.1.1 is required.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -10,6 +10,10 @@ now 0.15.
 Changelog
 ---------
 
+   - Minimum required version of NiBabel 1.1.0 is now dropped and updated to
+     NiBabel 1.2.0. Due to compatibility reasons with reading or loading annoted
+     data with freesurfer.
+
 Enhancements
 ............
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -7,7 +7,6 @@ See also nilearn.signal.
 # License: simplified BSD
 
 import collections
-from distutils.version import LooseVersion
 
 import numpy as np
 from scipy import ndimage
@@ -617,8 +616,7 @@ def new_img_like(ref_niimg, data, affine=None, copy_header=False):
         affine = get_affine(ref_niimg)
     if data.dtype == bool:
         default_dtype = np.int8
-        if (LooseVersion(nibabel.__version__) >= LooseVersion('1.2.0') and
-                isinstance(ref_niimg, nibabel.freesurfer.mghformat.MGHImage)):
+        if isinstance(ref_niimg, nibabel.freesurfer.mghformat.MGHImage):
             default_dtype = np.uint8
         data = as_ndarray(data, dtype=default_dtype)
     header = None

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -2,7 +2,6 @@
 Test image pre-processing functions
 """
 from nose.tools import assert_true, assert_false, assert_equal
-from distutils.version import LooseVersion
 from nose import SkipTest
 
 import platform
@@ -393,10 +392,6 @@ def test_new_img_like_mgz():
     This is usually when computing masks using MGZ inputs, e.g.
     when using plot_stap_map
     """
-
-    if not LooseVersion(nibabel.__version__) >= LooseVersion('1.2.0'):
-        # Old nibabel do not support MGZ files
-        raise SkipTest
 
     ref_img = nibabel.load(os.path.join(datadir, 'test.mgz'))
     data = np.ones(ref_img.get_data().shape, dtype=np.bool)

--- a/nilearn/input_data/tests/test_multi_nifti_masker.py
+++ b/nilearn/input_data/tests/test_multi_nifti_masker.py
@@ -116,9 +116,6 @@ def test_3d_images():
 
 
 def test_joblib_cache():
-    if not LooseVersion(nibabel.__version__) > LooseVersion('1.1.0'):
-        # Old nibabel do not pickle
-        raise SkipTest
     from sklearn.externals.joblib import hash
     # Dummy mask
     mask = np.zeros((40, 40, 40))

--- a/nilearn/input_data/tests/test_nifti_masker.py
+++ b/nilearn/input_data/tests/test_nifti_masker.py
@@ -9,7 +9,6 @@ test_signal.py for this.
 # License: simplified BSD
 import os
 import shutil
-from distutils.version import LooseVersion
 from tempfile import mkdtemp
 
 import nibabel
@@ -221,9 +220,6 @@ def test_sessions():
 
 
 def test_joblib_cache():
-    if not LooseVersion(nibabel.__version__) > LooseVersion('1.1.0'):
-        # Old nibabel do not pickle
-        raise SkipTest
     from sklearn.externals.joblib import hash, Memory
     mask = np.zeros((40, 40, 40))
     mask[20, 20, 20] = 1

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -42,7 +42,7 @@ REQUIRED_MODULE_METADATA = (
         'required_at_installation': True,
         'install_info': _NILEARN_INSTALL_MSG}),
     ('nibabel', {
-        'min_version': '1.1.0',
+        'min_version': '1.2.0',
         'required_at_installation': False}))
 
 OPTIONAL_MATPLOTLIB_MIN_VERSION = '1.1.1'


### PR DESCRIPTION
Following the discussion from PR #1016 . We bump the nibabel requirement to 1.2.0. which helps in grabbing a module 'freesurfer' useful to read/write labels for surface based atlases.

Reviews please. Thanks.