### PR TITLE
FIX: unknow document build error plot_seed_to_voxel_correlation

### DIFF
--- a/examples/01_plotting/plot_surf_stat_map.py
+++ b/examples/01_plotting/plot_surf_stat_map.py
@@ -21,9 +21,10 @@ coefficient.
 The :func:`nilearn.plotting.plot_surf_stat_map` function is used
 to plot the resulting statistical map on the (inflated) pial surface.
 
-See :ref:`plotting` for more details.
-See also :doc:`plot_seed_to_voxel_correlation` for a similar example using
-volumetric input data.
+See also :ref:`for a similar example but using volumetric input data
+<sphx_glr_auto_examples_03_connectivity_plot_seed_to_voxel_correlation.py>`.
+
+See :ref:`plotting` for more details on plotting tools.
 
 NOTE: This example needs matplotlib version higher than 1.3.1.
 

--- a/examples/03_connectivity/plot_seed_to_voxel_correlation.py
+++ b/examples/03_connectivity/plot_seed_to_voxel_correlation.py
@@ -10,8 +10,8 @@ This example is an advanced one that requires manipulating the data with numpy.
 Note the difference between images, that lie in brain space, and the
 numpy array, corresponding to the data inside the mask.
 
-See also :doc:`plot_surf_stat_map` for a similar example using cortical surface
-input data.
+See also :ref:`for a similar example using cortical surface input data
+<sphx_glr_auto_examples_01_plotting_plot_surf_stat_map.py>`.
 """
 
 # author: Franz Liem


### PR DESCRIPTION
Attempts to Fix #1388.
Sphinx documentation error related to could not find source location in current example folder when used to refer using ```:doc:```. Fixed using with ```:ref:``` which can be able to find source location.

Reviews are welcome. ping @chrisfilo @GaelVaroquaux 