### PR TITLE
FIX: Data downloading failures from _uncompress_file

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -77,13 +77,12 @@ Enhancements
     - Two good examples in plotting gallery shows how to fetch atlas and NKI
       data and used for plotting on brain surface.
 
-    - Helper function :func:`nilearn.plotting.surf_plotting.load_surf_mesh`
-      for loading surface mesh data into two arrays, containing (x, y, z)
-      coordinates for mesh vertices and indices of mesh faces.
+    - Helper function `load_surf_mesh` in surf_plotting module for loading
+      surface mesh data into two arrays, containing (x, y, z) coordinates
+      for mesh vertices and indices of mesh faces.
 
-    - Helper function :func:`nilearn.plotting.surf_plotting.load_surf_data`
-      for loading data of numpy array to represented on a surface mesh.
-
+    - Helper function `load_surf_data` in surf_plotting module for loading
+      data of numpy array to represented on a surface mesh.
 
     - Add fetcher for Allen et al. 2011 RSN atlas in
       :func:`nilearn.datasets.fetch_atlas_allen_2011`.

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -330,6 +330,9 @@ def _uncompress_file(file_, delete_archive=True, verbose=1):
             z = zipfile.ZipFile(file_)
             z.extractall(path=data_dir)
             z.close()
+            if delete_archive:
+                os.remove(file_)
+            file_ = filename
             processed = True
         elif ext == '.gz' or header.startswith(b'\x1f\x8b'):
             import gzip
@@ -345,7 +348,7 @@ def _uncompress_file(file_, delete_archive=True, verbose=1):
                 os.remove(file_)
             file_ = filename
             processed = True
-        if tarfile.is_tarfile(file_):
+        if os.path.isfile(file_) and tarfile.is_tarfile(file_):
             with contextlib.closing(tarfile.open(file_, "r")) as tar:
                 tar.extractall(path=data_dir)
             if delete_archive:
@@ -354,9 +357,6 @@ def _uncompress_file(file_, delete_archive=True, verbose=1):
         if not processed:
             raise IOError(
                     "[Uncompress] unknown archive file format: %s" % file_)
-        else:
-            if delete_archive and os.path.isfile(file_):
-                os.remove(file_)
 
         if verbose > 0:
             sys.stderr.write('.. done.\n')

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -330,9 +330,6 @@ def _uncompress_file(file_, delete_archive=True, verbose=1):
             z = zipfile.ZipFile(file_)
             z.extractall(path=data_dir)
             z.close()
-            if delete_archive:
-                os.remove(file_)
-            file_ = filename
             processed = True
         elif ext == '.gz' or header.startswith(b'\x1f\x8b'):
             import gzip

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -354,6 +354,10 @@ def _uncompress_file(file_, delete_archive=True, verbose=1):
         if not processed:
             raise IOError(
                     "[Uncompress] unknown archive file format: %s" % file_)
+        else:
+            if delete_archive and os.path.isfile(file_):
+                os.remove(file_)
+
         if verbose > 0:
             sys.stderr.write('.. done.\n')
     except Exception as e:


### PR DESCRIPTION
Currently master has data fetching failures. See for instance below link
https://circleci.com/gh/nilearn/nilearn/2280?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

Hopefully, this fix will address the failure of data fetching in master which will therefore fix documentation errors in CircleCI. We have to wait and see if everything goes green.