### PR TITLE
Preferentially import system joblib

### DIFF
--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -506,7 +506,7 @@ def resample_img(img, target_affine=None, target_shape=None,
 
     all_img = (slice(None), ) * 3
 
-    # Iter overr a set of 3D volumes, as the interpolation problem is
+    # Iterate over a set of 3D volumes, as the interpolation problem is
     # separable in the extra dimensions. This reduces the
     # computational cost
     for ind in np.ndindex(*other_shape):


### PR DESCRIPTION
While testing some plotting examples for the brainhack2017 in Zurich, we noticed that nilearn crashed on machines which had an unbundled scikit_learn distribution.

Currently, it seems nilearn depends on another piece of software bundling a third piece of software. Ideally packages should depend on each other directly. This makes dependency management more "flat", tracebacks more transparent, and ensures that bugfixes and enhancements get directed to the proper upstream.

The current PR preferentially imports the system joblib. Should such not be present, it falls back to the current behaviour.