### PR TITLE
[WIP] Overriding reducer of SpatialImage

### DIFF
--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -4,12 +4,12 @@ Neuroimaging file input and output.
 # Author: Gael Varoquaux, Alexandre Abraham, Philippe Gervais
 # License: simplified BSD
 
-import copy
-import gc
 import collections
+import copy
 
-import numpy as np
+import gc
 import nibabel
+import numpy as np
 
 from .compat import _basestring, get_affine
 
@@ -103,7 +103,9 @@ def load_niimg(niimg, dtype=None):
     img: image
         A loaded image object.
     """
-    from ..image import new_img_like  # avoid circular imports
+    from ..image import new_img_like
+    from ..image.image import _cachable_niimg_factory
+    # avoid circular imports
 
     if isinstance(niimg, _basestring):
         # data is a filename, we load it
@@ -118,6 +120,8 @@ def load_niimg(niimg, dtype=None):
     if dtype is not None:
         niimg = new_img_like(niimg, niimg.get_data().astype(dtype),
                              get_affine(niimg))
+    else:
+        niimg = _cachable_niimg_factory(niimg)
     return niimg
 
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -25,7 +25,12 @@ from .._utils.param_validation import check_threshold
 
 
 def _spatial_image_getstate(self):
-    state = {'dataobj': self._dataobj,
+    dataobj = self.get_data()
+    if dataobj.flags['C_CONTIGUOUS']:
+        dataobj = np.asarray(dataobj)
+    else:
+        dataobj = np.asarray(dataobj, order='F')
+    state = {'dataobj': dataobj,
              'header': self.header,
              'filename': self.get_filename(),
              'affine': self.affine,
@@ -45,8 +50,8 @@ def _spatial_image_setstate(self, state):
 
 
 def _cachable_niimg_factory(niimg):
-    # niimg.__class__.__setstate__ = _spatial_image_setstate
-    # niimg.__class__.__getstate__ = _spatial_image_getstate
+    niimg.__class__.__setstate__ = _spatial_image_setstate
+    niimg.__class__.__getstate__ = _spatial_image_getstate
     return niimg
 
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -45,8 +45,8 @@ def _spatial_image_setstate(self, state):
 
 
 def _cachable_niimg_factory(niimg):
-    niimg.__class__.__setstate__ = _spatial_image_setstate
-    niimg.__class__.__getstate__ = _spatial_image_getstate
+    # niimg.__class__.__setstate__ = _spatial_image_setstate
+    # niimg.__class__.__getstate__ = _spatial_image_getstate
     return niimg
 
 


### PR DESCRIPTION
This should sort #1362, but may make things slower. I took to use monkey patch instead of inheritance as we should be able to handle Nifti1Image, Nifti1Pair and what not, so I think this is the most elegant way. `test_image.py` now fails on master.