### PR TITLE
[MRG] Added largest_connected_component_img

### DIFF
--- a/doc/modules/reference.rst
+++ b/doc/modules/reference.rst
@@ -160,6 +160,7 @@ uses.
    high_variance_confounds
    index_img
    iter_img
+   largest_connected_component_img
    load_img
    math_img
    mean_img

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -102,7 +102,7 @@ Enhancements
 
     - Function :func:`nilearn._utils.ndimage.largest_connected_component_img`
       so that niftis can now be passed to 
-      :func:`nilearn._utils.ndimage.lagest_connected_component`.
+      :func:`nilearn._utils.ndimage.largest_connected_component`.
 
 0.2.6
 =====

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,8 +23,8 @@ Highlights
 Changelog
 ---------
 
-    -  A helper function _safe_get_data as a nilearn utility now safely
-       removes NAN values in the images with argument ensure_finite=True.
+    - A helper function _safe_get_data as a nilearn utility now safely
+      removes NAN values in the images with argument ensure_finite=True.
 
     - Connectome functions :func:`nilearn.connectome.cov_to_corr` and
       :func:`nilearn.connectome.prec_to_partial` can now be used.
@@ -100,9 +100,8 @@ Enhancements
     - Extensive plotting example shows how to use contours and filled contours
       on glass brain.
 
-    - Function :func:`nilearn._utils.ndimage.largest_connected_component_img`
-      so that niftis can now be passed to 
-      :func:`nilearn._utils.ndimage.largest_connected_component`.
+    - Function :func:`nilearn.image.largest_connected_component_img` to
+      directly extract the largest connected component from Nifti images.
 
 0.2.6
 =====

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -100,6 +100,10 @@ Enhancements
     - Extensive plotting example shows how to use contours and filled contours
       on glass brain.
 
+    - Function :func:`nilearn._utils.ndimage.largest_connected_component_img`
+      so that niftis can now be passed to 
+      :func:`nilearn._utils.ndimage.lagest_connected_component`.
+
 0.2.6
 =====
 

--- a/nilearn/_utils/ndimage.py
+++ b/nilearn/_utils/ndimage.py
@@ -6,15 +6,11 @@ N-dimensional image manipulation
 
 import numpy as np
 from scipy import ndimage
-
-from .._utils import  check_niimg_3d
-from .._utils.compat import _basestring, get_affine
-from .._utils.niimg_conversions import _safe_get_data
-from ..image import new_img_like
-
+from .._utils.compat import _basestring
 ###############################################################################
 # Operating on connected components
 ###############################################################################
+
 
 def largest_connected_component(volume):
     """Return the largest connected component of a 3D array.
@@ -47,42 +43,6 @@ def largest_connected_component(volume):
     return labels == label_count.argmax()
 
 
-def largest_connected_component_img(imgs):
-    """ Return the largest connected component of an image or list of images.
-
-    ..versionadded:: 0.3
-
-    Parameters
-    ----------
-    imgs: Niimg-like object or iterable of Niimg-like objects
-        See http://nilearn.github.io/manipulating_images/input_output.html
-        Image(s) to extract the largest connected component from.
-
-    Returns
-    -------
-        img or list of img containing the largest connected component
-    """
-    if hasattr(imgs, "__iter__") \
-       and not isinstance(imgs, _basestring):
-        single_img = False
-    else:
-        single_img = True
-        imgs = [imgs]
-
-    ret = []
-    for img in imgs:
-        img = check_niimg_3d(img)
-        affine = get_affine(img)
-        largest_component = largest_connected_component(_safe_get_data(img))
-        ret.append(new_img_like(img, largest_component, affine,
-                                copy_header=True))
-
-    if single_img:
-        return ret[0]
-    else:
-        return ret
-
-
 def get_border_data(data, border_size):
     return np.concatenate([
         data[:border_size, :, :].ravel(),
@@ -111,7 +71,8 @@ def _peak_local_max(image, min_distance=10, threshold_abs=0, threshold_rel=0.1,
     min_distance : int
         Minimum number of pixels separating peaks in a region of `2 *
         min_distance + 1` (i.e. peaks are separated by at least
-        `min_distance`). To find the maximum number of peaks, use `min_distance=1`.
+        `min_distance`). To find the maximum number of peaks, use
+        `min_distance=1`.
     threshold_abs : float
         Minimum intensity of peaks.
     threshold_rel : float
@@ -123,7 +84,8 @@ def _peak_local_max(image, min_distance=10, threshold_abs=0, threshold_rel=0.1,
     Returns
     -------
     output : ndarray or ndarray of bools
-        Boolean array shaped like `image`, with peaks represented by True values.
+        Boolean array shaped like `image`, with peaks represented by True
+        values.
 
     Notes
     -----
@@ -134,7 +96,8 @@ def _peak_local_max(image, min_distance=10, threshold_abs=0, threshold_rel=0.1,
     coordinates of peaks where dilated image = original.
 
     This code is mostly adapted from scikit image 0.11.3 release.
-    Location of file in scikit image: peak_local_max function in skimage.feature.peak
+    Location of file in scikit image: peak_local_max function in
+    skimage.feature.peak
     """
     out = np.zeros_like(image, dtype=np.bool)
 
@@ -156,7 +119,8 @@ def _peak_local_max(image, min_distance=10, threshold_abs=0, threshold_rel=0.1,
     coordinates = np.argwhere(image > peak_threshold)
 
     if coordinates.shape[0] > num_peaks:
-        intensities = image.flat[np.ravel_multi_index(coordinates.transpose(), image.shape)]
+        intensities = image.flat[np.ravel_multi_index(coordinates.transpose(),
+                                                      image.shape)]
         idx_maxsort = np.argsort(intensities)[::-1]
         coordinates = coordinates[idx_maxsort][:num_peaks]
 

--- a/nilearn/_utils/ndimage.py
+++ b/nilearn/_utils/ndimage.py
@@ -51,6 +51,7 @@ def largest_connected_component_img(imgs):
     """ Return the largest connected component of an image or list of images.
 
     ..versionadded:: 0.3
+
     Parameters
     ----------
     imgs: Niimg-like object or iterable of Niimg-like objects

--- a/nilearn/_utils/ndimage.py
+++ b/nilearn/_utils/ndimage.py
@@ -50,6 +50,7 @@ def largest_connected_component(volume):
 def largest_connected_component_img(imgs):
     """ Return the largest connected component of an image or list of images.
 
+    ..versionadded:: 0.3
     Parameters
     ----------
     imgs: Niimg-like object or iterable of Niimg-like objects

--- a/nilearn/image/__init__.py
+++ b/nilearn/image/__init__.py
@@ -5,7 +5,7 @@ data, and an affine.
 from .resampling import resample_img, resample_to_img, reorder_img
 from .image import high_variance_confounds, smooth_img, crop_img, \
     mean_img, swap_img_hemispheres, index_img, iter_img, threshold_img, \
-    math_img, load_img, clean_img
+    math_img, load_img, clean_img, largest_connected_component_img
 from .image import new_img_like  # imported this way to avoid circular imports
 from .._utils.niimg_conversions import concat_niimgs as concat_imgs
 from .._utils.niimg import copy_img
@@ -14,4 +14,5 @@ __all__ = ['resample_img', 'resample_to_img', 'high_variance_confounds',
            'smooth_img', 'crop_img', 'mean_img', 'reorder_img',
            'swap_img_hemispheres', 'concat_imgs', 'copy_img',
            'index_img', 'iter_img', 'new_img_like', 'threshold_img',
-           'math_img', 'load_img', 'clean_img']
+           'math_img', 'load_img', 'clean_img',
+           'largest_connected_component_img']

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -901,3 +901,41 @@ def load_img(img, wildcards=True, dtype=None):
         that the returned object has get_data() and affine attributes.
     """
     return check_niimg(img, wildcards=wildcards, dtype=dtype)
+
+
+def largest_connected_component_img(imgs):
+    """ Return the largest connected component of an image or list of images.
+
+    .. versionadded:: 0.3
+
+    Parameters
+    ----------
+    imgs: Niimg-like object or iterable of Niimg-like objects
+        See http://nilearn.github.io/manipulating_images/input_output.html
+        Image(s) to extract the largest connected component from.
+
+    Returns
+    -------
+        img or list of img containing the largest connected component
+    """
+    from .._utils.ndimage import largest_connected_component
+
+    if hasattr(imgs, "__iter__") \
+       and not isinstance(imgs, _basestring):
+        single_img = False
+    else:
+        single_img = True
+        imgs = [imgs]
+
+    ret = []
+    for img in imgs:
+        img = check_niimg_3d(img)
+        affine = get_affine(img)
+        largest_component = largest_connected_component(_safe_get_data(img))
+        ret.append(new_img_like(img, largest_component, affine,
+                                copy_header=True))
+
+    if single_img:
+        return ret[0]
+    else:
+        return ret

--- a/nilearn/tests/test_ndimage.py
+++ b/nilearn/tests/test_ndimage.py
@@ -3,16 +3,13 @@
 This test file is in nilearn/tests because nosetests ignores modules whose
 name starts with an underscore
 """
-from nose.tools import assert_raises, assert_true
-
+from nose.tools import assert_raises
 import numpy as np
 
-from nibabel import Nifti1Image
 from nilearn._utils.ndimage import (largest_connected_component,
-                                    _peak_local_max,
-                                    largest_connected_component_img)
-from nilearn._utils.exceptions import DimensionError
+                                    _peak_local_max)
 from nilearn._utils import testing
+
 
 def test_largest_cc():
     """ Check the extraction of the largest connected component.
@@ -26,47 +23,12 @@ def test_largest_cc():
     np.testing.assert_equal(a, largest_connected_component(b))
 
     # Tests for correct errors, when an image or string are passed.
-    img = testing.generate_labeled_regions(shape = (10,11,12),
-                                           n_regions = 2 )
+    img = testing.generate_labeled_regions(shape=(10, 11, 12),
+                                           n_regions=2)
 
     assert_raises(ValueError, largest_connected_component, img)
     assert_raises(ValueError, largest_connected_component, "Test String")
 
-
-def test_largest_cc_img():
-    """ Check the extraction of the largest connected component, for niftis
-
-    Similiar to smooth_img tests for largest connected_component_img, here also
-    only the added features for largest_connected_component are tested.
-    """
-
-    #Test whether dimension of 3Dimg and list of 3Dimgs are kept.
-    shapes = ((10, 11, 12), (13, 14, 15))
-    regions = [1,3]
-
-    img1 = testing.generate_labeled_regions(shape = shapes[0],
-                                            n_regions =regions[0] )
-    img2 = testing.generate_labeled_regions(shape = shapes[1],
-                                            n_regions =regions[1] )
-
-    for create_files in (False, True):
-        with testing.write_tmp_imgs(img1, img2,
-                                    create_files=create_files) as imgs:
-            # List of images as input
-            out = largest_connected_component_img(imgs)
-            assert_true(isinstance(out, list))
-            assert_true(len(out) == 2)
-            for o, s in zip(out, shapes):
-                assert_true(o.shape == (s))
-
-            # Single image as input
-            out = largest_connected_component_img(imgs[0])
-            assert_true(isinstance(out, Nifti1Image))
-            assert_true(out.shape == (shapes[0] ))
-
-        # Test whether 4D Nifti throws the right error.
-        img_4D = testing.generate_fake_fmri(shapes[0], length =17)
-        assert_raises(DimensionError, largest_connected_component_img, img_4D)
 
 def test_empty_peak_local_max():
     image = np.zeros((10, 20))

--- a/nilearn/tests/test_ndimage.py
+++ b/nilearn/tests/test_ndimage.py
@@ -11,6 +11,7 @@ from nibabel import Nifti1Image
 from nilearn._utils.ndimage import (largest_connected_component,
                                     _peak_local_max,
                                     largest_connected_component_img)
+from nilearn._utils.exceptions import DimensionError
 from nilearn._utils import testing
 
 def test_largest_cc():
@@ -24,6 +25,7 @@ def test_largest_cc():
     b[5, 5, 5] = 1
     np.testing.assert_equal(a, largest_connected_component(b))
 
+    # Tests for correct errors, when an image or string are passed.
     img = testing.generate_labeled_regions(shape = (10,11,12),
                                            n_regions = 2 )
 
@@ -38,6 +40,7 @@ def test_largest_cc_img():
     only the added features for largest_connected_component are tested.
     """
 
+    #Test whether dimension of 3Dimg and list of 3Dimgs are kept.
     shapes = ((10, 11, 12), (13, 14, 15))
     regions = [1,3]
 
@@ -61,6 +64,9 @@ def test_largest_cc_img():
             assert_true(isinstance(out, Nifti1Image))
             assert_true(out.shape == (shapes[0] ))
 
+        # Test whether 4D Nifti throws the right error.
+        img_4D = testing.generate_fake_fmri(shapes[0], length =17)
+        assert_raises(DimensionError, largest_connected_component_img, img_4D)
 
 def test_empty_peak_local_max():
     image = np.zeros((10, 20))

--- a/nilearn/tests/test_ndimage.py
+++ b/nilearn/tests/test_ndimage.py
@@ -3,12 +3,15 @@
 This test file is in nilearn/tests because nosetests ignores modules whose
 name starts with an underscore
 """
-from nose.tools import assert_raises
+from nose.tools import assert_raises, assert_true
 
 import numpy as np
 
-from nilearn._utils.ndimage import largest_connected_component, _peak_local_max
-
+from nibabel import Nifti1Image
+from nilearn._utils.ndimage import (largest_connected_component,
+                                    _peak_local_max,
+                                    largest_connected_component_img)
+from nilearn._utils import testing
 
 def test_largest_cc():
     """ Check the extraction of the largest connected component.
@@ -20,6 +23,43 @@ def test_largest_cc():
     b = a.copy()
     b[5, 5, 5] = 1
     np.testing.assert_equal(a, largest_connected_component(b))
+
+    img = testing.generate_labeled_regions(shape = (10,11,12),
+                                           n_regions = 2 )
+
+    assert_raises(ValueError, largest_connected_component, img)
+    assert_raises(ValueError, largest_connected_component, "Test String")
+
+
+def test_largest_cc_img():
+    """ Check the extraction of the largest connected component, for niftis
+
+    Similiar to smooth_img tests for largest connected_component_img, here also
+    only the added features for largest_connected_component are tested.
+    """
+
+    shapes = ((10, 11, 12), (13, 14, 15))
+    regions = [1,3]
+
+    img1 = testing.generate_labeled_regions(shape = shapes[0],
+                                            n_regions =regions[0] )
+    img2 = testing.generate_labeled_regions(shape = shapes[1],
+                                            n_regions =regions[1] )
+
+    for create_files in (False, True):
+        with testing.write_tmp_imgs(img1, img2,
+                                    create_files=create_files) as imgs:
+            # List of images as input
+            out = largest_connected_component_img(imgs)
+            assert_true(isinstance(out, list))
+            assert_true(len(out) == 2)
+            for o, s in zip(out, shapes):
+                assert_true(o.shape == (s))
+
+            # Single image as input
+            out = largest_connected_component_img(imgs[0])
+            assert_true(isinstance(out, Nifti1Image))
+            assert_true(out.shape == (shapes[0] ))
 
 
 def test_empty_peak_local_max():


### PR DESCRIPTION
Work on Issue: #1296  
Created the largest_connected_component_img and fixed a small bug in largest_connected_component, where entering a nifti image returns True. 