### PR TITLE
[MRG] Fix #1424: control smoothing in region extraction

### DIFF
--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -296,7 +296,8 @@ class RegionExtractor(NiftiMapsMasker):
 
     smoothing_fwhm: scalar, default 6mm, optional
         To smooth an image to extract most sparser regions. This parameter
-        is passed `connected_regions` and exists only for extractor 'local_regions'.
+        is passed to `connected_regions` and exists only for extractor
+        'local_regions'.
 
     standardize: bool, True or False, default False, optional
         If True, the time series signals are centered and normalized by

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -297,7 +297,8 @@ class RegionExtractor(NiftiMapsMasker):
     smoothing_fwhm: scalar, default 6mm, optional
         To smooth an image to extract most sparser regions. This parameter
         is passed to `connected_regions` and exists only for extractor
-        'local_regions'.
+        'local_regions'. Please set this parameter according to maps
+        resolution, otherwise extraction will fail.
 
     standardize: bool, True or False, default False, optional
         If True, the time series signals are centered and normalized by

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -260,7 +260,7 @@ class RegionExtractor(NiftiMapsMasker):
         Mask to be applied to input data, passed to NiftiMapsMasker.
         If None, no masking is applied.
 
-    min_region_size: int, default 1350 mm^3, optional
+    min_region_size: float, default 1350 mm^3, optional
         Minimum volume in mm3 for a region to be kept. For example, if
         the voxel size is 3x3x3 mm then the volume of the voxel is
         27mm^3. By default, it is 1350mm^3 which means we take minimum
@@ -293,6 +293,10 @@ class RegionExtractor(NiftiMapsMasker):
         their maximum peak value to define a seed marker and then using
         random walker segementation algorithm on these markers for region
         separation.
+
+    smoothing_fwhm: scalar, default 6mm, optional
+        To smooth an image to extract most sparser regions. This parameter
+        is passed `connected_regions` and exists only for extractor 'local_regions'.
 
     standardize: bool, True or False, default False, optional
         If True, the time series signals are centered and normalized by
@@ -358,11 +362,13 @@ class RegionExtractor(NiftiMapsMasker):
     """
     def __init__(self, maps_img, mask_img=None, min_region_size=1350,
                  threshold=1., thresholding_strategy='ratio_n_voxels',
-                 extractor='local_regions', standardize=False, detrend=False,
+                 extractor='local_regions', smoothing_fwhm=6,
+                 standardize=False, detrend=False,
                  low_pass=None, high_pass=None, t_r=None,
                  memory=Memory(cachedir=None), memory_level=0, verbose=0):
         super(RegionExtractor, self).__init__(
             maps_img=maps_img, mask_img=mask_img,
+            smoothing_fwhm=smoothing_fwhm,
             standardize=standardize, detrend=detrend, low_pass=low_pass,
             high_pass=high_pass, t_r=t_r, memory=memory,
             memory_level=memory_level, verbose=verbose)
@@ -371,6 +377,7 @@ class RegionExtractor(NiftiMapsMasker):
         self.thresholding_strategy = thresholding_strategy
         self.threshold = threshold
         self.extractor = extractor
+        self.smoothing_fwhm = smoothing_fwhm
 
     def fit(self, X=None, y=None):
         """ Prepare the data and setup for the region extraction
@@ -400,7 +407,8 @@ class RegionExtractor(NiftiMapsMasker):
         # connected component extraction
         self.regions_img_, self.index_ = connected_regions(threshold_maps,
                                                            self.min_region_size,
-                                                           self.extractor)
+                                                           self.extractor,
+                                                           self.smoothing_fwhm)
 
         self.maps_img = self.regions_img_
         super(RegionExtractor, self).fit()

--- a/nilearn/regions/tests/test_region_extractor.py
+++ b/nilearn/regions/tests/test_region_extractor.py
@@ -159,10 +159,7 @@ def test_region_extractor_fit_and_transform():
     extract_ratio = RegionExtractor(maps, threshold=0.2,
                                     thresholding_strategy='ratio_n_voxels',
                                     smoothing_fwhm=12)
-    assert_raises_regex(ValueError,
-                        "zero-size array to reduction operation maximum "
-                        "which has no identity",
-                        extract_ratio.fit)
+    assert_raises_regex(ValueError, "zero-size array", extract_ratio.fit)
 
     # smoke test with threshold=string and strategy=percentile
     extractor = RegionExtractor(maps, threshold=30,

--- a/nilearn/regions/tests/test_region_extractor.py
+++ b/nilearn/regions/tests/test_region_extractor.py
@@ -174,7 +174,7 @@ def test_region_extractor_fit_and_transform():
         assert_equal(expected_signal_shape, signal.shape)
 
     # smoke test with high resolution image
-    maps, mask_img = generate_maps((40, 40, 40), n_regions=n_regions,
+    maps, mask_img = generate_maps((20, 20, 20), n_regions=n_regions,
                                    affine=.2 * np.eye(4))
 
     extract_ratio = RegionExtractor(maps,

--- a/nilearn/regions/tests/test_region_extractor.py
+++ b/nilearn/regions/tests/test_region_extractor.py
@@ -155,12 +155,6 @@ def test_region_extractor_fit_and_transform():
     assert_not_equal(extract_ratio.regions_img_, '')
     assert_true(extract_ratio.regions_img_.shape[-1] >= 9)
 
-    # No region for too high FWHM
-    extract_ratio = RegionExtractor(maps, threshold=0.2,
-                                    thresholding_strategy='ratio_n_voxels',
-                                    smoothing_fwhm=12)
-    assert_raises_regex(ValueError, "zero-size array", extract_ratio.fit)
-
     # smoke test with threshold=string and strategy=percentile
     extractor = RegionExtractor(maps, threshold=30,
                                 thresholding_strategy='percentile',
@@ -178,6 +172,18 @@ def test_region_extractor_fit_and_transform():
         # smoke test NiftiMapsMasker transform inherited in Region Extractor
         signal = extractor.transform(img)
         assert_equal(expected_signal_shape, signal.shape)
+
+    # smoke test with high resolution image
+    maps, mask_img = generate_maps((40, 40, 40), n_regions=n_regions,
+                                   affine=.2 * np.eye(4))
+
+    extract_ratio = RegionExtractor(maps,
+                                    thresholding_strategy='ratio_n_voxels',
+                                    smoothing_fwhm=.6,
+                                    min_region_size=.4)
+    extract_ratio.fit()
+    assert_not_equal(extract_ratio.regions_img_, '')
+    assert_true(extract_ratio.regions_img_.shape[-1] >= 9)
 
 
 def test_error_messages_connected_label_regions():

--- a/nilearn/regions/tests/test_region_extractor.py
+++ b/nilearn/regions/tests/test_region_extractor.py
@@ -160,7 +160,8 @@ def test_region_extractor_fit_and_transform():
                                     thresholding_strategy='ratio_n_voxels',
                                     smoothing_fwhm=12)
     assert_raises_regex(ValueError,
-                        "zero-size array to reduction operation maximum",
+                        "zero-size array to reduction operation maximum "
+                        "which has no identity",
                         extract_ratio.fit)
 
     # smoke test with threshold=string and strategy=percentile

--- a/nilearn/regions/tests/test_region_extractor.py
+++ b/nilearn/regions/tests/test_region_extractor.py
@@ -155,6 +155,14 @@ def test_region_extractor_fit_and_transform():
     assert_not_equal(extract_ratio.regions_img_, '')
     assert_true(extract_ratio.regions_img_.shape[-1] >= 9)
 
+    # No region for too high FWHM
+    extract_ratio = RegionExtractor(maps, threshold=0.2,
+                                    thresholding_strategy='ratio_n_voxels',
+                                    smoothing_fwhm=12)
+    assert_raises_regex(ValueError,
+                        "zero-size array to reduction operation maximum",
+                        extract_ratio.fit)
+
     # smoke test with threshold=string and strategy=percentile
     extractor = RegionExtractor(maps, threshold=30,
                                 thresholding_strategy='percentile',


### PR DESCRIPTION
Added `smoothing_fwhm` attribute to `RegionExtractor`