### PR TITLE
increase threshold for stopping dl in neurovault

### DIFF
--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -47,12 +47,12 @@ _DEFAULT_MAX_IMAGES = 100
 # if _MAX_CONSECUTIVE_FAILS downloads fail in a row, we consider there is a
 # problem(e.g. no internet connection, or the Neurovault server is down), and
 # we abort the fetching.
-_MAX_CONSECUTIVE_FAILS = 10
+_MAX_CONSECUTIVE_FAILS = 500
 
 # if _MAX_FAILS_IN_COLLECTION images fail to be downloaded from the same
 # collection, we consider this collection is garbage and we move on to the
 # next collection.
-_MAX_FAILS_IN_COLLECTION = 10
+_MAX_FAILS_IN_COLLECTION = 100
 
 _DEBUG = 3
 _INFO = 2

--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -47,12 +47,12 @@ _DEFAULT_MAX_IMAGES = 100
 # if _MAX_CONSECUTIVE_FAILS downloads fail in a row, we consider there is a
 # problem(e.g. no internet connection, or the Neurovault server is down), and
 # we abort the fetching.
-_MAX_CONSECUTIVE_FAILS = 500
+_MAX_CONSECUTIVE_FAILS = 100
 
 # if _MAX_FAILS_IN_COLLECTION images fail to be downloaded from the same
 # collection, we consider this collection is garbage and we move on to the
 # next collection.
-_MAX_FAILS_IN_COLLECTION = 100
+_MAX_FAILS_IN_COLLECTION = 30
 
 _DEBUG = 3
 _INFO = 2

--- a/nilearn/datasets/tests/test_neurovault.py
+++ b/nilearn/datasets/tests/test_neurovault.py
@@ -618,9 +618,3 @@ def test_fetch_neurovault_ids():
                 image_ids=[111], data_dir=data_dir, mode='offline')
             # should be back to the original version
             assert_equal(data['images_meta'][0]['figure'], '3A')
-        # try downloading collections that don't exist
-        # (get some HTTPErrors - 404);
-        # download stops early and raises warning
-        assert_warns(
-            UserWarning, neurovault.fetch_neurovault_ids,
-            data_dir=data_dir, collection_ids=range(-12, 0))


### PR DESCRIPTION
The neurovault download stops if too many images fail to be downloaded in a row, so that it doesn't continue trying if there is no internet connection, for example. The current value for max fails in a row is 10 but this is far too optimistic; it's actually likely to find 10 bad images in a row (in the cases I've seen, it's metadata referencing files that don't exist). I suggest we allow 500 failures instead.