### PR TITLE
FIX: CircleCI timedout error

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,6 @@ dependencies:
     # Generating html documentation (with warnings as errors)
     # we need to do this here so the datasets will be cached
     - source continuous_integration/circle_ci_test_doc.sh:
-        parallel: True
         timeout: 2500 # seconds
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,8 @@ dependencies:
     # Generating html documentation (with warnings as errors)
     # we need to do this here so the datasets will be cached
     - source continuous_integration/circle_ci_test_doc.sh:
-        timeout: 1500
+        parallel: True
+        timeout: 2500 # seconds
 
 test:
   override:


### PR DESCRIPTION
Attempts to FIX,

 - CircleCI failure particularly with timedout errors where every PR is failing on this.

- To make it a faster to build doc.

This was done basically to increase timeout (I don't have better alternative right now) and use parallel=true.
Both changes are made in circle.yml.

It is just an attempt to see CircleCI now. Other suggestions are also welcome.