### PR TITLE
FIX: Non-native endian bug with largest_connected_component function

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -13,6 +13,12 @@ Changelog
     - The function sym_to_vec is deprecated and will be removed in
       release 0.4. Use :func:`nilearn.connectome.sym_matrix_to_vec` instead.
 
+Bug fix
+-------
+
+    - The helper function `largest_connected_component` should now work with
+      inputs of non-native data dtypes.
+
 Enhancements
 -------------
     - New data fetcher functions :func:`nilearn.datasets.fetch_neurovault` and

--- a/nilearn/_utils/ndimage.py
+++ b/nilearn/_utils/ndimage.py
@@ -17,18 +17,36 @@ def largest_connected_component(volume):
 
     Parameters
     -----------
-    volume: numpy.array
+    volume: numpy.ndarray
         3D boolean array indicating a volume.
 
     Returns
     --------
-    volume: numpy.array
+    volume: numpy.ndarray
         3D boolean array with only one connected component.
+
+    See Also
+    --------
+    nilearn.image.largest_connected_component_img : To simply operate the
+        same manipulation directly on Nifti images.
+
+    Notes
+    -----
+
+    **Handling big-endian in given numpy.ndarray**
+    This function changes the existing byte-ordering information to new byte
+    order, if the given volume has non-native data type. This operation
+    is done inplace to avoid big-endian issues with scipy ndimage module.
+
     """
     if hasattr(volume, "get_data") \
        or isinstance(volume, _basestring):
         raise ValueError('Please enter a valid numpy array. For images use\
                          largest_connected_component_img')
+    # Get the new byteorder to handle issues like "Big-endian buffer not
+    # supported on little-endian compiler" with scipy ndimage label.
+    if not volume.dtype.isnative:
+        volume.dtype = volume.dtype.newbyteorder('N')
 
     # We use asarray to be able to work with masked arrays.
     volume = np.asarray(volume)

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -910,13 +910,22 @@ def largest_connected_component_img(imgs):
 
     Parameters
     ----------
-    imgs: Niimg-like object or iterable of Niimg-like objects
+    imgs: Niimg-like object or iterable of Niimg-like objects (3D)
         See http://nilearn.github.io/manipulating_images/input_output.html
         Image(s) to extract the largest connected component from.
 
     Returns
     -------
         img or list of img containing the largest connected component
+
+    Notes
+    -----
+
+    **Handling big-endian in given Nifti image**
+    This function changes the existing byte-ordering information to new byte
+    order, if the dtype in given Nifti image has non-native data type.
+    This operation is done internally to avoid big-endian issues with
+    scipy ndimage module.
     """
     from .._utils.ndimage import largest_connected_component
 

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -325,6 +325,17 @@ def test_intersect_masks():
     mask_ab[2, 2] = 1
     mask_ab_ = intersect_masks([mask_a_img, mask_b_img], threshold=1.)
     assert_array_equal(mask_ab, mask_ab_.get_data())
+    # Test intersect mask images with '>f8'. This function uses
+    # largest_connected_component to check if intersect_masks passes with
+    # connected=True (which is by default)
+    mask_a_img_change_dtype = Nifti1Image(mask_a_img.get_data().astype('>f8'),
+                                          affine=mask_a_img.get_affine())
+    mask_b_img_change_dtype = Nifti1Image(mask_b_img.get_data().astype('>f8'),
+                                          affine=mask_b_img.get_affine())
+    mask_ab_change_type = intersect_masks([mask_a_img_change_dtype,
+                                           mask_b_img_change_dtype],
+                                          threshold=1.)
+    assert_array_equal(mask_ab, mask_ab_change_type.get_data())
 
     mask_abc = mask_a + mask_b + mask_c
     mask_abc_ = intersect_masks([mask_a_img, mask_b_img, mask_c_img],

--- a/nilearn/tests/test_ndimage.py
+++ b/nilearn/tests/test_ndimage.py
@@ -18,9 +18,16 @@ def test_largest_cc():
     assert_raises(ValueError, largest_connected_component, a)
     a[1:3, 1:3, 1:3] = 1
     np.testing.assert_equal(a, largest_connected_component(a))
+    # A simple test with non-native dtype
+    a_change_type = a.astype('>f8')
+    np.testing.assert_equal(a, largest_connected_component(a_change_type))
+
     b = a.copy()
     b[5, 5, 5] = 1
     np.testing.assert_equal(a, largest_connected_component(b))
+    # A simple test with non-native dtype
+    b_change_type = b.astype('>f8')
+    np.testing.assert_equal(a, largest_connected_component(b_change_type))
 
     # Tests for correct errors, when an image or string are passed.
     img = testing.generate_labeled_regions(shape=(10, 11, 12),


### PR DESCRIPTION
This issue came across with this PR #1409 