### PR TITLE
ENH: partial duecredit support for nilearn

### DIFF
--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -62,4 +62,11 @@ __all__ = ['datasets', 'decoding', 'decomposition', 'connectome',
            'region', 'signal', '__version__']
 
 # DueCredit
-due.cite(Doi("10.3389/fninf.2014.00014"), description="Nilearn underlying patterns article", path="nilearn")
+due.cite(
+    Doi("10.3389/fninf.2014.00014"), 
+    description="Nilearn underlying patterns article",
+    tags=["reference-implementation"],
+    # would make it sufficient to import to get cited, which might not be the
+    # case that it was actually used, so disabled
+    #cite_module=True,
+    path="nilearn")

--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -35,6 +35,7 @@ signal                  --- Set of preprocessing functions for time series
 import gzip
 
 from .version import _check_module_dependencies, __version__
+from .due import due, Doi, BibTeX
 
 _check_module_dependencies()
 
@@ -59,3 +60,6 @@ CHECK_CACHE_VERSION = True
 __all__ = ['datasets', 'decoding', 'decomposition', 'connectome',
            'image', 'input_data', 'masking', 'mass_univariate', 'plotting',
            'region', 'signal', '__version__']
+
+# DueCredit
+due.cite(Doi("10.3389/fninf.2014.00014"), description="Nilearn underlying patterns article", path="nilearn")

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -14,7 +14,13 @@ from .._utils import check_niimg
 from .._utils.compat import _basestring, get_affine
 from ..image import new_img_like
 
+from ..due import due, Doi
 
+
+@due.dcite(
+    Doi('10.1002/hbm.21333'),
+    description='Dataset: Craddock 2012 parcellation',
+    tags=['dataset'])
 def fetch_atlas_craddock_2012(data_dir=None, url=None, resume=True, verbose=1):
     """Download and return file names for the Craddock 2012 parcellation
 
@@ -85,6 +91,14 @@ def fetch_atlas_craddock_2012(data_dir=None, url=None, resume=True, verbose=1):
     return Bunch(**params)
 
 
+@due.dcite(
+    Doi('10.1016/S1053-8119(09)71561-7'),
+    description='Destrieux cortical atlas (dated 2009)',
+    tags=['dataset'])
+@due.dcite(
+    Doi('10.1093/cercor/bhg087'),
+    description='Automatic parcellation of cerebral cortex',
+    tags=['implementation'])  # not sure about the tag
 def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
                                resume=True, verbose=1):
     """Download and load the Destrieux cortical atlas (dated 2009)
@@ -278,6 +292,10 @@ def fetch_atlas_harvard_oxford(atlas_name, data_dir=None,
     return Bunch(maps=atlas_img, labels=new_names)
 
 
+@due.dcite(
+    Doi('10.1007/978-3-642-22092-0_46'),
+    description='MSDL brain atlas',
+    tags=['dataset'])
 def fetch_atlas_msdl(data_dir=None, url=None, resume=True, verbose=1):
     """Download and load the MSDL brain atlas.
 
@@ -345,6 +363,10 @@ def fetch_atlas_msdl(data_dir=None, url=None, resume=True, verbose=1):
                  networks=net_names, description=fdescr)
 
 
+@due.dcite(
+    Doi('10.1016/j.neuron.2011.09.006'),
+    description='Power et al. brain atlas',
+    tags=['dataset'])
 def fetch_coords_power_2011():
     """Download and load the Power et al. brain atlas composed of 264 ROIs.
 
@@ -369,6 +391,14 @@ def fetch_coords_power_2011():
     return Bunch(**params)
 
 
+@due.dcite(
+    Doi('10.1073/pnas.0905267106'),
+    description='Smith ICA and BrainMap atlas',
+    tags=['dataset'])
+@due.dcite(
+    Doi('10.1162/jocn_a_00077'),
+    description='Smith ICA and BrainMap atlas',
+    tags=['dataset'])
 def fetch_atlas_smith_2009(data_dir=None, mirror='origin', url=None,
                            resume=True, verbose=1):
     """Download and load the Smith ICA and BrainMap atlas (dated 2009)
@@ -467,6 +497,10 @@ def fetch_atlas_smith_2009(data_dir=None, mirror='origin', url=None,
     return Bunch(**params)
 
 
+@due.dcite(
+    Doi('10.1152/jn.00338.2011'),
+    description='Yeo 2011 parcellation',
+    tags=['dataset'])
 def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
     """Download and return file names for the Yeo 2011 parcellation.
 
@@ -545,6 +579,14 @@ def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
     return Bunch(**params)
 
 
+@due.dcite(
+    Doi('10.1109/42.712135'),
+    description='AAL atlas',
+    tags=['dataset'])
+@due.dcite(
+    Doi('10.1006/nimg.2001.0978'),
+    description='AAL atlas for SPM',
+    tags=['dataset'])
 def fetch_atlas_aal(version='SPM12', data_dir=None, url=None, resume=True,
                     verbose=1):
     """Downloads and returns the AAL template for SPM 12.
@@ -634,6 +676,14 @@ def fetch_atlas_aal(version='SPM12', data_dir=None, url=None, resume=True,
     return Bunch(**params)
 
 
+@due.dcite(
+    Doi('10.1016/j.neuroimage.2010.02.082'),
+    description='Multiscale functional brain parcellations',
+    tags=['dataset'])
+@due.dcite(
+    Doi('10.1109/PRNI.2013.23'),
+    description='Multiscale functional brain parcellations',
+    tags=['dataset'])
 def fetch_atlas_basc_multiscale_2015(version='sym', data_dir=None,
                                      resume=True, verbose=1):
     """Downloads and loads multiscale functional brain parcellations
@@ -740,6 +790,10 @@ def fetch_atlas_basc_multiscale_2015(version='sym', data_dir=None,
     return Bunch(**params)
 
 
+@due.dcite(
+    Doi('10.1126/science.1194144'),
+    description='Dosenbach et al. ROIs',
+    tags=['dataset'])
 def fetch_coords_dosenbach_2010(ordered_regions=True):
     """Load the Dosenbach et al. 160 ROIs. These ROIs cover
     much of the cerebral cortex and cerebellum and are assigned to 6
@@ -785,6 +839,10 @@ def fetch_coords_dosenbach_2010(ordered_regions=True):
     return Bunch(**params)
 
 
+@due.dcite(
+    Doi('10.3389/fnsys.2011.00002'),
+    description='Allen and MIALAB ICA atlas (2011)',
+    tags=['dataset'])
 def fetch_atlas_allen_2011(data_dir=None, url=None, resume=True, verbose=1):
     """Download and return file names for the Allen and MIALAB ICA atlas
     (dated 2011).
@@ -867,6 +925,10 @@ def fetch_atlas_allen_2011(data_dir=None, url=None, resume=True, verbose=1):
     return Bunch(**dict(params))
 
 
+@due.dcite(
+    Doi('10.1016/j.neuroimage.2010.06.010'),
+    description='Destrieux et al, 2010 cortical atlas',
+    tags=['dataset'])
 def fetch_atlas_surf_destrieux(data_dir=None, url=None,
                                resume=True, verbose=1):
     """Download and load Destrieux et al, 2010 cortical atlas.

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -27,10 +27,18 @@ from .. import masking
 from ..image.resampling import coord_transform
 from ..input_data.nifti_spheres_masker import _apply_mask_and_get_affinity
 from .._utils.compat import _basestring
+from ..due import due, Doi
 
 ESTIMATOR_CATALOG = dict(svc=svm.LinearSVC, svr=svm.SVR)
 
-
+@due.dcite(
+	Doi('10.1073/pnas.0600244103'),
+	description="Searchlight analysis approach",
+	tags=["implementation"])
+@due.dcite(
+	Doi('10.1038/nrn1931'),
+	description="Application of the searchlight approach to decoding using classifiers",
+	tags=["use"])
 def search_light(X, y, estimator, A, scoring=None, cv=None, n_jobs=-1,
                  verbose=0):
     """Function for computing a search_light

--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -14,8 +14,17 @@ from sklearn.externals.joblib import Memory, delayed, Parallel
 from sklearn.utils import check_random_state
 
 from .multi_pca import MultiPCA
+from ..due import due, Doi
 
 
+@due.dcite(
+    Doi('10.1016/j.neuroimage.2010.02.010'),
+    description='Canonical ICA for fMRI datasets',
+    tags=['implementation'])
+@due.dcite(
+    Doi('10.1109/ISBI.2010.5490204'),
+    description='ICA-based sparse features recovery from fMRI datasets',
+    tags=['implementation'])
 class CanICA(MultiPCA):
     """Perform Canonical Independent Component Analysis.
 

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -21,6 +21,7 @@ from sklearn.linear_model import Ridge
 
 from .base import BaseDecomposition, mask_and_reduce
 from .canica import CanICA
+from ..due import due, Doi
 
 
 if LooseVersion(sklearn.__version__) >= LooseVersion('0.17'):
@@ -39,6 +40,10 @@ def _compute_loadings(components, data):
     return loadings
 
 
+@due.dcite(
+    Doi('10.1109/ISBI.2016.7493501'),
+    description='Map learning algorithm based on spatial component sparsity',
+    tags=['implementation'])
 class DictLearning(BaseDecomposition, TransformerMixin):
     """Perform a map learning algorithm based on spatial component sparsity,
     over a CanICA initialization.  This yields more stable maps than CanICA.

--- a/nilearn/due.py
+++ b/nilearn/due.py
@@ -1,0 +1,73 @@
+# emacs: at the end of the file
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### #
+"""
+
+Stub file for a guaranteed safe import of duecredit constructs:  if duecredit
+is not available.
+
+To use it, place it into your project codebase to be imported, e.g. copy as
+
+    cp stub.py /path/tomodule/module/due.py
+
+Note that it might be better to avoid naming it duecredit.py to avoid shadowing
+installed duecredit.
+
+Then use in your code as
+
+    from .due import due, Doi, BibTeX
+
+See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
+
+Origin:     Originally a part of the duecredit
+Copyright:  2015-2016  DueCredit developers
+License:    BSD-2
+"""
+
+__version__ = '0.0.5'
+
+
+class InactiveDueCreditCollector(object):
+    """Just a stub at the Collector which would not do anything"""
+    def _donothing(self, *args, **kwargs):
+        """Perform no good and no bad"""
+        pass
+
+    def dcite(self, *args, **kwargs):
+        """If I could cite I would"""
+        def nondecorating_decorator(func):
+            return func
+        return nondecorating_decorator
+
+    cite = load = add = _donothing
+
+    def __repr__(self):
+        return self.__class__.__name__ + '()'
+
+
+def _donothing_func(*args, **kwargs):
+    """Perform no good and no bad"""
+    pass
+
+
+try:
+    from duecredit import due, BibTeX, Doi, Url
+    if 'due' in locals() and not hasattr(due, 'cite'):
+        raise RuntimeError(
+            "Imported due lacks .cite. DueCredit is now disabled")
+except Exception as e:
+    if type(e).__name__ != 'ImportError':
+        import logging
+        logging.getLogger("duecredit").error(
+            "Failed to import duecredit due to %s" % str(e))
+    # Initiate due stub
+    due = InactiveDueCreditCollector()
+    BibTeX = Doi = Url = _donothing_func
+
+# Emacs mode definitions
+# Local Variables:
+# mode: python
+# py-indent-offset: 4
+# tab-width: 4
+# indent-tabs-mode: nil
+# End:


### PR DESCRIPTION
Trying to address:
![Gael's complaint](http://www.onerussian.com/tmp/gkrellShoot_06-23-17_182817.png)

Usage example:
```
(dev27) dhcp-206-12-53-73:OHBM_Hackathon michal$ python -m duecredit nilearn/examples/02_decoding/plot_haxby_searchlight.py
Anatomical nifti image (3D) is located at: /Users/michal/nilearn_data/haxby2001/mask.nii.gz
Functional nifti image (4D) is located at: /Users/michal/nilearn_data/haxby2001/subj2/bold.nii.gz
/Users/michal/Documents/OHBM_Hackathon/duecredit/venvs/dev27/lib/python2.7/site-packages/sklearn/cross_validation.py:44: DeprecationWarning: This module was deprecated in version 0.18 in favor of the model_selection module into which all the refactored classes and functions are moved. Also note that the interface of the new CV iterators are different from that of this module. This module will be removed in 0.20.
  "This module will be removed in 0.20.", DeprecationWarning)
[Parallel(n_jobs=1)]: Done   1 out of   1 | elapsed:   54.0s finished

DueCredit Report:
- I/O library to access to common neuroimaging file formats / nibabel (v 2.1) [1]
- Nilearn underlying patterns article / nilearn (v 0.3.1) [2]
  - Searchlight analysis approach / nilearn.decoding.searchlight:search_light (v 0.3.1) [3]
- Scientific tools library / numpy (v 1.8.0rc1) [4]

3 packages cited
0 modules cited
1 function cited

References
----------

[1] Brett, M. et al., 2015. nibabel 2.0.1.
[2] Abraham, A. et al., 2014. Machine learning for neuroimaging with scikit-learn. Frontiers in Neuroinformatics, 8.
[3] Kriegeskorte, N., Goebel, R. & Bandettini, P., 2006. Information-based functional brain mapping. Proceedings of the National Academy of Sciences, 103(10), pp.3863–3868.
[4] Van Der Walt, S., Colbert, S.C. & Varoquaux, G., 2011. The NumPy array: a structure for efficient numerical computation. Computing in Science & Engineering, 13(2), pp.22–30.
```

For more information, see [DueCredit](https://github.com/duecredit/duecredit)