### PR TITLE
[MRG] FIX: Documentation failure with decoding_intro

### DIFF
--- a/doc/decoding/decoding_intro.rst
+++ b/doc/decoding/decoding_intro.rst
@@ -463,18 +463,17 @@ We can try Fisher's `Linear Discriminant Analysis (LDA)
 
 Import the module::
 
-    >>> from sklearn.lda import LDA  # doctest: +SKIP
+    >>> from sklearn.discriminant_analysis import LinearDiscriminantAnalysis  # doctest: +SKIP
 
 Construct the new estimator object and use it in a pipeline::
 
     >>> from sklearn.pipeline import Pipeline
-    >>> lda = LDA()  # doctest: +SKIP
+    >>> lda = LinearDiscriminantAnalysis()  # doctest: +SKIP
     >>> anova_lda = Pipeline([('anova', feature_selection), ('LDA', lda)])  # doctest: +SKIP
 
 .. note::
-  Import Linear Discriminant Analysis method in
-  "sklearn.discriminant_analysis.LinearDiscriminantAnalysis" in the newest
-  version of scikit-learn from 0.19.
+  Import Linear Discriminant Analysis method in "sklearn.lda.LDA" if you are using
+  scikit-learn older than version 0.17.
 
 and recompute the cross-validation score::
 

--- a/doc/decoding/decoding_intro.rst
+++ b/doc/decoding/decoding_intro.rst
@@ -8,6 +8,9 @@
     >>> session = np.ones_like(target)
     >>> n_samples = len(target)
 
+.. Remove doctest: +SKIP at LDA while dropping support for sklearn older than
+    versions 0.17
+
 .. _decoding_intro:
 
 =============================

--- a/doc/decoding/decoding_intro.rst
+++ b/doc/decoding/decoding_intro.rst
@@ -463,13 +463,13 @@ We can try Fisher's `Linear Discriminant Analysis (LDA)
 
 Import the module::
 
-    >>> from sklearn.lda import LDA
+    >>> from sklearn.lda import LDA  # doctest: +SKIP
 
 Construct the new estimator object and use it in a pipeline::
 
     >>> from sklearn.pipeline import Pipeline
-    >>> lda = LDA()
-    >>> anova_lda = Pipeline([('anova', feature_selection), ('LDA', lda)])
+    >>> lda = LDA()  # doctest: +SKIP
+    >>> anova_lda = Pipeline([('anova', feature_selection), ('LDA', lda)])  # doctest: +SKIP
 
 and recompute the cross-validation score::
 

--- a/doc/decoding/decoding_intro.rst
+++ b/doc/decoding/decoding_intro.rst
@@ -471,6 +471,11 @@ Construct the new estimator object and use it in a pipeline::
     >>> lda = LDA()  # doctest: +SKIP
     >>> anova_lda = Pipeline([('anova', feature_selection), ('LDA', lda)])  # doctest: +SKIP
 
+.. note::
+  Import Linear Discriminant Analysis method in
+  "sklearn.discriminant_analysis.LinearDiscriminantAnalysis" in the newest
+  version of scikit-learn from 0.19.
+
 and recompute the cross-validation score::
 
     >>> cv_scores = cross_val_score(anova_lda, fmri_masked, target, cv=cv, verbose=1)  # doctest: +SKIP


### PR DESCRIPTION
One of the Travis environment is failing with recent sklearn.
```FAIL: Doctest: decoding_intro.rst ```

FIX: I have added a doctest SKIP. I am open to better fix if anybody wants to suggest ?

Can I have reviews please ?