### PR TITLE
FIX: travis and circle with matplotlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
     # Most recent versions
     - env: DISTRIB="conda" PYTHON_VERSION="3.5"
            NUMPY_VERSION="*" SCIPY_VERSION="*"
-           SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
+           SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="2.0.2" COVERAGE="true"
     # FLAKE8 linting on diff wrt common ancestor with upstream/master
     # Note: the python value is only there to trigger allow_failures
     - python: 2.7

--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ dependencies:
             NUMPY_VERSION: "*"
             SCIPY_VERSION: "*"
             SCIKIT_LEARN_VERSION: "*"
-            MATPLOTLIB_VERSION: "*"
+            MATPLOTLIB_VERSION: "2.0.2"
     - conda install sphinx coverage pillow -y -n testenv
 
     # Generating html documentation (with warnings as errors)

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -35,7 +35,7 @@ print_conda_requirements() {
     #   - for scikit-learn, SCIKIT_LEARN_VERSION is used
     TO_INSTALL_ALWAYS="pip nose"
     REQUIREMENTS="$TO_INSTALL_ALWAYS"
-    TO_INSTALL_MAYBE="python numpy scipy 'matplotlib=2.0.2' scikit-learn flake8"
+    TO_INSTALL_MAYBE="python numpy scipy matplotlib scikit-learn flake8"
     for PACKAGE in $TO_INSTALL_MAYBE; do
         # Capitalize package name and add _VERSION
         PACKAGE_VERSION_VARNAME="${PACKAGE^^}_VERSION"

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -35,7 +35,7 @@ print_conda_requirements() {
     #   - for scikit-learn, SCIKIT_LEARN_VERSION is used
     TO_INSTALL_ALWAYS="pip nose"
     REQUIREMENTS="$TO_INSTALL_ALWAYS"
-    TO_INSTALL_MAYBE="python numpy scipy matplotlib scikit-learn flake8"
+    TO_INSTALL_MAYBE="python numpy scipy 'matplotlib=2.0.2' scikit-learn flake8"
     for PACKAGE in $TO_INSTALL_MAYBE; do
         # Capitalize package name and add _VERSION
         PACKAGE_VERSION_VARNAME="${PACKAGE^^}_VERSION"


### PR DESCRIPTION
Few examples and travis are failing with recent matplotlib 2.1.0.

Details about recent failures with ```imshow``` matplotlib 2.1.0 are in [here](https://github.com/matplotlib/matplotlib/issues/9280)

Examples: plot_overlay.py & plot_prob_atlas.py

I agree this is not a good FIX and I even don't know if this fixes it.
Any ideas are welcome