### PR TITLE
[WIP] MAINT: bump the nibabel version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="2.7"
            NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.13.3"
            SCIKIT_LEARN_VERSION="0.15.1" MATPLOTLIB_VERSION="1.3.1"
-           NIBABEL_VERSION="1.2.0" COVERAGE="true"
+           NIBABEL_VERSION="2.0.2" COVERAGE="true"
     # Ubuntu 14.04 versions without matplotlib
     - env: DISTRIB="conda" PYTHON_VERSION="2.7"
            NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.13.3"

--- a/nilearn/_utils/compat.py
+++ b/nilearn/_utils/compat.py
@@ -63,16 +63,3 @@ else:
         m.update(string)
         return m.hexdigest()
 
-
-if LooseVersion(nibabel.__version__) >= LooseVersion('2.0.0'):
-    def get_affine(img):
-        return img.affine
-
-    def get_header(img):
-        return img.header
-else:
-    def get_affine(img):
-        return img.get_affine()
-
-    def get_header(img):
-        return img.get_header()

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -627,7 +627,12 @@ def new_img_like(ref_niimg, data, affine=None, copy_header=False):
         header['glmax'] = 0.
         header['cal_max'] = np.max(data) if data.size > 0 else 0.
         header['cal_min'] = np.min(data) if data.size > 0 else 0.
-    return ref_niimg.__class__(data, affine, header=header)
+    klass = ref_niimg.__class__
+    if klass is nibabel.Nifti1Pair:
+        # Nifti1Pair is an internal class, without a to_filename,
+        # we shouldn't return it
+        klass = nibabel.Nifti1Image
+    return klass(data, affine, header=header)
 
 
 def threshold_img(img, threshold, mask_img=None):

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -42,7 +42,7 @@ REQUIRED_MODULE_METADATA = (
         'required_at_installation': True,
         'install_info': _NILEARN_INSTALL_MSG}),
     ('nibabel', {
-        'min_version': '1.2.0',
+        'min_version': '2.0.2',
         'required_at_installation': False}))
 
 OPTIONAL_MATPLOTLIB_MIN_VERSION = '1.1.1'


### PR DESCRIPTION
We can bump the requirement to nibabel 2.0.2, which has been release mid 2015 and is in most distributions.