### PR TITLE
FIX: Appveyor, force install matplotlib=2.0.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Miniconda3-x64"
+    - PYTHON: "C:\\Miniconda35-x64"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,11 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   # Installed prebuilt dependencies from conda
-  - "conda install pip numpy scipy scikit-learn nose wheel matplotlib -y -q"
+  # a temporary work around with failures related to matplotlib 2.1.0
+  # See similar fix which made for travis and circleci
+  # https://github.com/nilearn/nilearn/pull/1525
+  # Should be removed after a new matplotlib release 2.1.1
+  - "conda install pip numpy scipy scikit-learn nose wheel matplotlib=2.0.2 -y -q"
 
   # Install other nilearn dependencies
   - "pip install nibabel coverage nose-timer"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Miniconda3-x64"
-      PYTHON_VERSION: "3.4.x"
+      PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
 
 install:


### PR DESCRIPTION
- Temporary work around
- This work around will be removed after a new matplotlib release
- Currently master is failing on this. [See](https://ci.appveyor.com/project/nilearn-ci/nilearn/build/1.0.2100/job/2cckvjw356wim35p)

We have two environments failing on master with AppVeyor CI.

One failure is because of the issues with recent matplotlib 2.1.0.
For instance, see the FIX made with travis and CircleCI a while ago.
See https://github.com/nilearn/nilearn/pull/1525
Similar step can taken here to force matplotlib install in this environment to 2.0.2.

Another failure is because of the conflict issues with matplotlib forced version 2.0.2 dependency in Python 3.4.3 environment. We have conflict issues for matplotlib > 2.0.0 with this Python version.

Here, I am upgrading environment to Python 3.5 and also forcing installation to 2.0.2 to make AppVeyor work. These temporary fix can be removed when the matplotlib 2.1.1 is released.

Hope it will be clear for review.