### PR TITLE
FIX: issues with recent SciPy

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -6,6 +6,10 @@ Changelog
 
     - Dropped support for Nibabel older than 2.0.2.
 
+    - :func:`nilearn.image.smooth_img` no longer accepts smoothing
+      parameter fwhm as 0. Behavior is changed in according to the
+      issues with recent SciPy version 1.0.0.
+
 Enhancements
 -------------
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -7,8 +7,12 @@ See also nilearn.signal.
 # License: simplified BSD
 
 import collections
+import warnings
+
+from distutils.version import LooseVersion
 
 import numpy as np
+import scipy
 from scipy import ndimage
 from scipy.stats import scoreatpercentile
 import copy
@@ -183,6 +187,14 @@ def _smooth_array(arr, affine, fwhm=None, ensure_finite=True, copy=True):
     -----
     This function is most efficient with arr in C order.
     """
+    # Here, we have to investigate use cases of fwhm. Particularly, if fwhm=0.
+    # See issue #1537
+    if LooseVersion(scipy.__version__) >= LooseVersion('1.0.0'):
+        if fwhm is not None and fwhm == 0.:
+            warnings.warn("The parameter 'fwhm' for smoothing is specified "
+                          "as {0}. Converting to None (no smoothing option)"
+                          .format(fwhm))
+            fwhm = None
 
     if arr.dtype.kind == 'i':
         if arr.dtype == np.int64:
@@ -233,7 +245,10 @@ def smooth_img(imgs, fwhm):
         a filter [0.2, 1, 0.2] in each direction and a normalisation
         to preserve the scale.
         If fwhm is None, no filtering is performed (useful when just removal
-        of non-finite values is needed)
+        of non-finite values is needed).
+
+        In corner case situations, fwhm is simply kept to None when fwhm is
+        specified as fwhm=0.
 
     Returns
     -------

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -9,10 +9,7 @@ See also nilearn.signal.
 import collections
 import warnings
 
-from distutils.version import LooseVersion
-
 import numpy as np
-import scipy
 from scipy import ndimage
 from scipy.stats import scoreatpercentile
 import copy

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -189,12 +189,11 @@ def _smooth_array(arr, affine, fwhm=None, ensure_finite=True, copy=True):
     """
     # Here, we have to investigate use cases of fwhm. Particularly, if fwhm=0.
     # See issue #1537
-    if LooseVersion(scipy.__version__) >= LooseVersion('1.0.0'):
-        if fwhm is not None and fwhm == 0.:
-            warnings.warn("The parameter 'fwhm' for smoothing is specified "
-                          "as {0}. Converting to None (no smoothing option)"
-                          .format(fwhm))
-            fwhm = None
+    if fwhm == 0.:
+        warnings.warn("The parameter 'fwhm' for smoothing is specified "
+                      "as {0}. Converting to None (no smoothing option)"
+                      .format(fwhm))
+        fwhm = None
 
     if arr.dtype.kind == 'i':
         if arr.dtype == np.int64:

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -3,14 +3,12 @@ Test image pre-processing functions
 """
 from nose.tools import assert_true, assert_false, assert_equal, assert_raises
 from nose import SkipTest
-from distutils.version import LooseVersion
 
 import platform
 import os
 import nibabel
 from nibabel import Nifti1Image
 import numpy as np
-import scipy
 from numpy.testing import assert_array_equal, assert_allclose
 from nilearn._utils.testing import assert_raises_regex, assert_warns
 from nilearn._utils.exceptions import DimensionError

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -129,15 +129,14 @@ def test__smooth_array():
         np.testing.assert_equal(image._smooth_array(data, affine, fwhm='fast'),
                                 image._fast_smooth_array(data))
 
-    # Check corner case when fwhm=0. from SciPy 1.0.0
-    if LooseVersion(scipy.__version__) >= LooseVersion('1.0.0'):
-        # Test whether function _smooth_array raises a warning when fwhm=0.
-        assert_warns(UserWarning, image._smooth_array, data, affine, fwhm=0.)
+    # Check corner case when fwhm=0. See #1537
+    # Test whether function _smooth_array raises a warning when fwhm=0.
+    assert_warns(UserWarning, image._smooth_array, data, affine, fwhm=0.)
 
-        # Test output equal when fwhm=None and fwhm=0
-        out_fwhm_none = image._smooth_array(data, affine, fwhm=None)
-        out_fwhm_zero = image._smooth_array(data, affine, fwhm=0.)
-        assert_array_equal(out_fwhm_none, out_fwhm_zero)
+    # Test output equal when fwhm=None and fwhm=0
+    out_fwhm_none = image._smooth_array(data, affine, fwhm=None)
+    out_fwhm_zero = image._smooth_array(data, affine, fwhm=0.)
+    assert_array_equal(out_fwhm_none, out_fwhm_zero)
 
 
 def test_smooth_img():
@@ -167,15 +166,14 @@ def test_smooth_img():
             assert_true(isinstance(out, nibabel.Nifti1Image))
             assert_true(out.shape == (shapes[0] + (lengths[0],)))
 
-    # Check corner case situations when fwhm=0. from SciPy 1.0.0.
-    if LooseVersion(scipy.__version__) >= LooseVersion('1.0.0'):
-        # Test whether function smooth_img raises a warning when fwhm=0.
-        assert_warns(UserWarning, image.smooth_img, img1, fwhm=0.)
+    # Check corner case situations when fwhm=0, See issue #1537
+    # Test whether function smooth_img raises a warning when fwhm=0.
+    assert_warns(UserWarning, image.smooth_img, img1, fwhm=0.)
 
-        # Test output equal when fwhm=None and fwhm=0
-        out_fwhm_none = image.smooth_img(img1, fwhm=None)
-        out_fwhm_zero = image.smooth_img(img1, fwhm=0.)
-        assert_array_equal(out_fwhm_none.get_data(), out_fwhm_zero.get_data())
+    # Test output equal when fwhm=None and fwhm=0
+    out_fwhm_none = image.smooth_img(img1, fwhm=None)
+    out_fwhm_zero = image.smooth_img(img1, fwhm=0.)
+    assert_array_equal(out_fwhm_none.get_data(), out_fwhm_zero.get_data())
 
 
 def test__crop_img_to():

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -167,13 +167,19 @@ def _detrend(signals, inplace=False, type="linear", n_batches=10):
 
 def _check_wn(btype, freq, nyq):
     wn = freq / float(nyq)
-    if wn > 1.:
+    if wn >= 1.:
         warnings.warn(
             'The frequency specified for the %s pass filter is '
             'too high to be handled by a digital filter (superior to '
             'nyquist frequency). It has been lowered to %.2f (nyquist '
             'frequency).' % (btype, nyq))
-        wn = 1.
+        # results looked unstable when the critical frequencies are
+        # exactly at the Nyquist frequency. See issue at SciPy
+        # https://github.com/scipy/scipy/issues/6265. Before, SciPy 1.0.0 ("wn
+        # should be btw 0 and 1"). But, after ("0 < wn < 1"). Due to unstable
+        # results as pointed in the issue above. Hence, we forced the
+        # critical frequencies to be slightly less than 1. but not 1.
+        wn = 1 - 10 * np.finfo(1.).eps
     return wn
 
 


### PR DESCRIPTION
Two issues was seen with recent SciPy here:

- smoothing_fwhm=0. fails with ```scipy.ndimage.gaussian_filter1d``` (see https://travis-ci.org/nilearn/nilearn/jobs/299711990#L3471). More details about this particular FIX is discussed in this issue #1537 
- Having more strict checks on the critical frequencies should be ```Digital filter critical frequencies must be 0 < Wn < 1``` with ```scipy.signal.butter``` rather should be btw 0 and 1. This FIX seems like a more reasonable approach to restrict to ```1 - 10 * np.finfo(1.).eps``` when given frequency is more than nyquist criteria.

Can I please have reviews ?