### PR TITLE
Add a patch to fix issues with matplotlib 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
     # Most recent versions
     - env: DISTRIB="conda" PYTHON_VERSION="3.5"
            NUMPY_VERSION="*" SCIPY_VERSION="*"
-           SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="2.0.2" COVERAGE="true"
+           SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
     # FLAKE8 linting on diff wrt common ancestor with upstream/master
     # Note: the python value is only there to trigger allow_failures
     - python: 2.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   # See similar fix which made for travis and circleci
   # https://github.com/nilearn/nilearn/pull/1525
   # Should be removed after a new matplotlib release 2.1.1
-  - "conda install pip numpy scipy scikit-learn nose wheel matplotlib=2.0.2 -y -q"
+  - "conda install pip numpy scipy scikit-learn nose wheel matplotlib -y -q"
 
   # Install other nilearn dependencies
   - "pip install nibabel coverage nose-timer"

--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ dependencies:
             NUMPY_VERSION: "*"
             SCIPY_VERSION: "*"
             SCIKIT_LEARN_VERSION: "*"
-            MATPLOTLIB_VERSION: "2.0.2"
+            MATPLOTLIB_VERSION: "*"
     - conda install sphinx coverage pillow -y -n testenv
 
     # Generating html documentation (with warnings as errors)

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -695,9 +695,11 @@ class BaseSlicer(object):
         to_iterate_over = zip(self.axes.values(), data_2d_list)
         for display_ax, data_2d in to_iterate_over:
             if data_2d is not None:
-                if LooseVersion(matplotlib.__version__) == LooseVersion("2.1.0"):
-                    if data_2d.min() is np.ma.masked:
-                        continue
+                # If data_2d is completely masked, then there is nothing to
+                # plot. Hence, continued to loop over. This problem came up
+                # with matplotlib 2.1.0. See issue #9280 in matplotlib.
+                if data_2d.min() is np.ma.masked:
+                    continue
                 im = display_ax.draw_2d(data_2d, data_bounds, bounding_box,
                                         type=type, **kwargs)
                 ims.append(im)

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -695,6 +695,9 @@ class BaseSlicer(object):
         to_iterate_over = zip(self.axes.values(), data_2d_list)
         for display_ax, data_2d in to_iterate_over:
             if data_2d is not None:
+                if LooseVersion(matplotlib.__version__) == LooseVersion("2.1.0"):
+                    if data_2d.min() is np.ma.masked:
+                        continue
                 im = display_ax.draw_2d(data_2d, data_bounds, bounding_box,
                                         type=type, **kwargs)
                 ims.append(im)

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -1,8 +1,12 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 import tempfile
+from distutils.version import LooseVersion
 
 import matplotlib.pyplot as plt
+import matplotlib
+import nibabel
+import numpy as np
 
 from nilearn.plotting.displays import OrthoSlicer, XSlicer, OrthoProjector
 from nilearn.datasets import load_mni152_template
@@ -72,3 +76,20 @@ def test_user_given_cmap_with_colorbar():
     # Test with cmap given as a string
     oslicer.add_overlay(img, cmap='Paired', colorbar=True)
     oslicer.close()
+
+
+def test_data_complete_mask():
+    """This special case test is due to recent matplotlib 2.1.0.
+
+    When the data is completely masked, then we have plotting issues
+    See similar issue #9280 reported in matplotlib. This function
+    tests the patch added for this particular issue.
+    """
+    if LooseVersion(matplotlib.__version__) == LooseVersion("2.1.0"):
+        # data is completely masked
+        data = np.zeros((10, 20, 30))
+        affine = np.eye(4)
+
+        img = nibabel.Nifti1Image(data, affine)
+        oslicer = OrthoSlicer(cut_coords=(0, 0, 0))
+        oslicer.add_overlay(img)

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -1,10 +1,8 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 import tempfile
-from distutils.version import LooseVersion
 
 import matplotlib.pyplot as plt
-import matplotlib
 import nibabel
 import numpy as np
 
@@ -79,17 +77,17 @@ def test_user_given_cmap_with_colorbar():
 
 
 def test_data_complete_mask():
-    """This special case test is due to recent matplotlib 2.1.0.
+    """This special case test is due to matplotlib 2.1.0.
 
     When the data is completely masked, then we have plotting issues
     See similar issue #9280 reported in matplotlib. This function
     tests the patch added for this particular issue.
     """
-    if LooseVersion(matplotlib.__version__) == LooseVersion("2.1.0"):
-        # data is completely masked
-        data = np.zeros((10, 20, 30))
-        affine = np.eye(4)
+    # data is completely masked
+    data = np.zeros((10, 20, 30))
+    affine = np.eye(4)
 
-        img = nibabel.Nifti1Image(data, affine)
-        oslicer = OrthoSlicer(cut_coords=(0, 0, 0))
-        oslicer.add_overlay(img)
+    img = nibabel.Nifti1Image(data, affine)
+    oslicer = OrthoSlicer(cut_coords=(0, 0, 0))
+    oslicer.add_overlay(img)
+    oslicer.close()

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -170,29 +170,25 @@ def test_plot_stat_map():
 
 
 def test_plot_stat_map_threshold_for_affine_with_rotation():
-    # Test this function only if matplotlib version is not 2.1.0. When the
-    # data is completely masked we have issues with plotting with this version
-    # of matplotlib. See #9280 in matplotlib.
-    if LooseVersion(matplotlib.__version__) != LooseVersion("2.1.0"):
-        # threshold was not being applied when affine has a rotation
-        # see https://github.com/nilearn/nilearn/issues/599 for more details
-        data = np.random.randn(10, 10, 10)
-        # matrix with rotation
-        affine = np.array([[-3., 1., 0., 1.],
-                           [-1., -3., 0., -2.],
-                           [0., 0., 3., 3.],
-                           [0., 0., 0., 1.]])
-        img = nibabel.Nifti1Image(data, affine)
-        display = plot_stat_map(img, bg_img=None, threshold=1e6,
-                                display_mode='z', cut_coords=1)
-        # Next two lines retrieve the numpy array from the plot
-        ax = list(display.axes.values())[0].ax
-        plotted_array = ax.images[0].get_array()
-        # Given the high threshold the array should be entirely masked
-        assert_true(plotted_array.mask.all())
+    # threshold was not being applied when affine has a rotation
+    # see https://github.com/nilearn/nilearn/issues/599 for more details
+    data = np.random.randn(10, 10, 10)
+    # matrix with rotation
+    affine = np.array([[-3., 1., 0., 1.],
+                       [-1., -3., 0., -2.],
+                       [0., 0., 3., 3.],
+                       [0., 0., 0., 1.]])
+    img = nibabel.Nifti1Image(data, affine)
+    display = plot_stat_map(img, bg_img=None, threshold=1.,
+                            display_mode='z', cut_coords=1)
+    # Next two lines retrieve the numpy array from the plot
+    ax = list(display.axes.values())[0].ax
+    plotted_array = ax.images[0].get_array()
+    # Given the high threshold the array should be partly masked
+    assert_true(plotted_array.mask.any())
 
-        # Save execution time and memory
-        plt.close()
+    # Save execution time and memory
+    plt.close()
 
 
 def test_plot_stat_map_threshold_for_uint8():

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -170,25 +170,29 @@ def test_plot_stat_map():
 
 
 def test_plot_stat_map_threshold_for_affine_with_rotation():
-    # threshold was not being applied when affine has a rotation
-    # see https://github.com/nilearn/nilearn/issues/599 for more details
-    data = np.random.randn(10, 10, 10)
-    # matrix with rotation
-    affine = np.array([[-3., 1., 0., 1.],
-                       [-1., -3., 0., -2.],
-                       [0., 0., 3., 3.],
-                       [0., 0., 0., 1.]])
-    img = nibabel.Nifti1Image(data, affine)
-    display = plot_stat_map(img, bg_img=None, threshold=1e6,
-                            display_mode='z', cut_coords=1)
-    # Next two lines retrieve the numpy array from the plot
-    ax = list(display.axes.values())[0].ax
-    plotted_array = ax.images[0].get_array()
-    # Given the high threshold the array should be entirely masked
-    assert_true(plotted_array.mask.all())
+    # Test this function only if matplotlib version is not 2.1.0. When the
+    # data is completely masked we have issues with plotting with this version
+    # of matplotlib. See #9280 in matplotlib.
+    if LooseVersion(matplotlib.__version__) != LooseVersion("2.1.0"):
+        # threshold was not being applied when affine has a rotation
+        # see https://github.com/nilearn/nilearn/issues/599 for more details
+        data = np.random.randn(10, 10, 10)
+        # matrix with rotation
+        affine = np.array([[-3., 1., 0., 1.],
+                           [-1., -3., 0., -2.],
+                           [0., 0., 3., 3.],
+                           [0., 0., 0., 1.]])
+        img = nibabel.Nifti1Image(data, affine)
+        display = plot_stat_map(img, bg_img=None, threshold=1e6,
+                                display_mode='z', cut_coords=1)
+        # Next two lines retrieve the numpy array from the plot
+        ax = list(display.axes.values())[0].ax
+        plotted_array = ax.images[0].get_array()
+        # Given the high threshold the array should be entirely masked
+        assert_true(plotted_array.mask.all())
 
-    # Save execution time and memory
-    plt.close()
+        # Save execution time and memory
+        plt.close()
 
 
 def test_plot_stat_map_threshold_for_uint8():


### PR DESCRIPTION
Attempts to fix the issues with matplotlib 2.1.0 by removing temporary work-around with CIs.
We are trying this way with this small patch because to release soon for teaching.

