### PR TITLE
Error on tangent

### DIFF
--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -475,7 +475,6 @@ class ConnectivityMeasure(BaseEstimator, TransformerMixin):
         self._check_input(X)
         self.cov_estimator_ = clone(self.cov_estimator)
 
-
         covariances = [self.cov_estimator_.fit(x).covariance_ for x in X]
         if self.kind == 'tangent':
             self.mean_ = _geometric_mean(covariances, max_iter=30, tol=1e-7)

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -489,7 +489,7 @@ class ConnectivityMeasure(BaseEstimator, TransformerMixin):
         return self
 
     def fit_transform(self, X, y=None):
-        if self.kind in ('tangent', 'tangent_geometric'):
+        if self.kind == 'tangent':
             # Check that people are applying fit_transform to a group of
             # subject
             # We can only impose this in fit_transform, as it is legit to

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -435,22 +435,7 @@ class ConnectivityMeasure(BaseEstimator, TransformerMixin):
         self.vectorize = vectorize
         self.discard_diagonal = discard_diagonal
 
-    def fit(self, X, y=None):
-        """Fit the covariance estimator to the given time series for each
-        subject.
-
-        Parameters
-        ----------
-        X : list of numpy.ndarray, shape for each (n_samples, n_features)
-            The input subjects time series. The number of samples may differ
-            from one subject to another.
-
-        Returns
-        -------
-        self : ConnectivityMatrix instance
-            The object itself. Useful for chaining operations.
-        """
-        self.cov_estimator_ = clone(self.cov_estimator)
+    def _check_input(self, X):
         if not hasattr(X, "__iter__"):
             raise ValueError("'subjects' input argument must be an iterable. "
                              "You provided {0}".format(X.__class__))
@@ -466,19 +451,57 @@ class ConnectivityMeasure(BaseEstimator, TransformerMixin):
                              "provided arrays of dimensions "
                              "{0}".format(str(subjects_dims)))
 
-        n_subjects = [s.shape[1] for s in X]
-        if len(set(n_subjects)) > 1:
+        features_dims = [s.shape[1] for s in X]
+        if len(set(features_dims)) > 1:
             raise ValueError("All subjects must have the same number of "
                              "features.\nYou provided: "
-                             "{0}".format(str(n_subjects)))
+                             "{0}".format(str(features_dims)))
 
+    def fit(self, X, y=None):
+        """Fit the covariance estimator to the given time series for each
+        subject.
+
+        Parameters
+        ----------
+        X : list of numpy.ndarray, shape for each (n_samples, n_features)
+            The input subjects time series. The number of samples may differ
+            from one subject to another.
+
+        Returns
+        -------
+        self : ConnectivityMatrix instance
+            The object itself. Useful for chaining operations.
+        """
+        self._check_input(X)
+        self.cov_estimator_ = clone(self.cov_estimator)
+
+
+        covariances = [self.cov_estimator_.fit(x).covariance_ for x in X]
         if self.kind == 'tangent':
-            covariances = [self.cov_estimator_.fit(x).covariance_ for x in X]
             self.mean_ = _geometric_mean(covariances, max_iter=30, tol=1e-7)
             self.whitening_ = _map_eigenvalues(lambda x: 1. / np.sqrt(x),
                                                self.mean_)
+        else:
+            self.mean_ = np.mean(covariances, axis=0)
+            # Fight numerical instabilities: make symmetric
+            self.mean_ = self.mean_ + self.mean_.T
+            self.mean_ *= .5
 
         return self
+
+    def fit_transform(self, X, y=None):
+        if self.kind in ('tangent', 'tangent_geometric'):
+            # Check that people are applying fit_transform to a group of
+            # subject
+            # We can only impose this in fit_transform, as it is legit to
+            # fit only on a single given reference point
+            if not len(X) > 1:
+                raise ValueError("Tangent space parametrization can only "
+                    "be applied to a group of subjects, as it returns "
+                    "deviations to the mean. You provided %r" % X
+                    )
+        self.fit(X, y)
+        return self.transform(X)
 
     def transform(self, X):
         """Apply transform to covariances matrices to get the connectivity
@@ -525,8 +548,6 @@ class ConnectivityMeasure(BaseEstimator, TransformerMixin):
                                  '"{}"'.format(self.kind))
 
         connectivities = np.array(connectivities)
-        if self.kind != 'tangent':
-            self.mean_ = connectivities.mean(axis=0)
 
         if self.vectorize:
             connectivities = sym_matrix_to_vec(

--- a/nilearn/connectome/tests/test_connectivity_matrices.py
+++ b/nilearn/connectome/tests/test_connectivity_matrices.py
@@ -15,7 +15,7 @@ from nilearn.tests.test_signal import generate_signals
 from nilearn.connectome.connectivity_matrices import (
     _check_square, _check_spd, _map_eigenvalues, _form_symmetric,
     _geometric_mean, sym_matrix_to_vec, vec_to_sym_matrix, prec_to_partial,
-    cov_to_corr, ConnectivityMeasure)
+    ConnectivityMeasure)
 
 
 def grad_geometric_mean(mats, init=None, max_iter=10, tol=1e-7):
@@ -414,6 +414,13 @@ def test_connectivity_measure_errors():
     # Raising error for input subjects with different number of features
     assert_raises(ValueError, conn_measure.fit,
                   [np.ones((100, 40)), np.ones((100, 41))])
+
+
+    # Raising an error for fit_transform with a single subject and
+    # kind=tangent
+    conn_measure = ConnectivityMeasure(kind='tangent')
+    assert_raises(ValueError, conn_measure.fit_transform,
+                  [np.ones((100, 40)), ])
 
 
 def test_connectivity_measure_outputs():

--- a/nilearn/connectome/tests/test_connectivity_matrices.py
+++ b/nilearn/connectome/tests/test_connectivity_matrices.py
@@ -496,6 +496,17 @@ def test_connectivity_measure_outputs():
         conn_measure = ConnectivityMeasure(kind=kind)
         conn_measure.fit_transform(signals)
         assert_equal((conn_measure.mean_).shape, (n_features, n_features))
+        if kind != 'tangent':
+            assert_array_almost_equal(
+                conn_measure.mean_,
+                np.mean(conn_measure.transform(signals), axis=0))
+
+    # Check that the mean isn't modified in transform
+    conn_measure = ConnectivityMeasure(kind='covariance')
+    conn_measure.fit(signals[:1])
+    mean = conn_measure.mean_
+    conn_measure.transform(signals[1:])
+    assert_array_equal(mean, conn_measure.mean_)
 
     # Check vectorization option
     for kind in kinds:


### PR DESCRIPTION
ENH: error for a single subject in fit_transform for tangent space

A classic error is that people call fit_transform on single subjects when the tangent space parametrization. This cannot work.

This PR raises an error in this case.

The code is extracted from PR #1477 that we will probably drop.