### PR TITLE
[MRG+1] FIX: patch for older pandas versions in examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="2.7"
            NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.14"
            SCIKIT_LEARN_VERSION="0.15.1" MATPLOTLIB_VERSION="1.3.1"
-           NIBABEL_VERSION="2.0.2" COVERAGE="true"
+           PANDAS_VERSION="0.13.0" NIBABEL_VERSION="2.0.2" COVERAGE="true"
     # Oldest supported versions without matplotlib
     - env: DISTRIB="conda" PYTHON_VERSION="2.7"
            NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.14"
@@ -38,7 +38,7 @@ matrix:
            SCIKIT_LEARN_VERSION="0.15" MATPLOTLIB_VERSION="1.4"
     # Most recent versions
     - env: DISTRIB="conda" PYTHON_VERSION="3.5"
-           NUMPY_VERSION="*" SCIPY_VERSION="*"
+           NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
     # FLAKE8 linting on diff wrt common ancestor with upstream/master
     # Note: the python value is only there to trigger allow_failures

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -35,7 +35,7 @@ print_conda_requirements() {
     #   - for scikit-learn, SCIKIT_LEARN_VERSION is used
     TO_INSTALL_ALWAYS="pip nose"
     REQUIREMENTS="$TO_INSTALL_ALWAYS"
-    TO_INSTALL_MAYBE="python numpy scipy matplotlib scikit-learn flake8"
+    TO_INSTALL_MAYBE="python numpy scipy matplotlib scikit-learn pandas flake8"
     for PACKAGE in $TO_INSTALL_MAYBE; do
         # Capitalize package name and add _VERSION
         PACKAGE_VERSION_VARNAME="${PACKAGE^^}_VERSION"

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -563,6 +563,8 @@ def index_img(imgs, index):
      (91, 109, 91)
     """
     imgs = check_niimg_4d(imgs)
+    if hasattr(index, 'values') and hasattr(index, 'iloc'):
+        index = index.values
     return _index_img(imgs, index)
 
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -563,8 +563,9 @@ def index_img(imgs, index):
      (91, 109, 91)
     """
     imgs = check_niimg_4d(imgs)
+    # duck-type for pandas arrays, and select the 'values' attr
     if hasattr(index, 'values') and hasattr(index, 'iloc'):
-        index = index.values
+        index = index.values.flatten()
     return _index_img(imgs, index)
 
 

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -360,17 +360,29 @@ def test_index_img():
             'out of bounds|invalid index|out of range|boolean index',
             image.index_img, img_4d, i)
 
-    # if pandas is in the testing environment
-    if 'pandas' in sys.modules:
-        rng = np.random.RandomState(0)
 
-        arr = rng.rand(fourth_dim_size) > 0.5
-        df = pd.DataFrame({"arr": arr})
+def test_pd_index_img():
+    # confirm indices from pandas dataframes are handled correctly
+    if 'pandas' not in sys.modules:
+        raise SkipTest
 
-        np_index_img = image.index_img(img_4d, arr)
-        pd_index_img = image.index_img(img_4d, df)
-        assert_array_equal(np_index_img.get_data(),
-                           pd_index_img.get_data())
+    affine = np.array([[1., 2., 3., 4.],
+                       [5., 6., 7., 8.],
+                       [9., 10., 11., 12.],
+                       [0., 0., 0., 1.]])
+    img_4d, _ = testing.generate_fake_fmri(affine=affine)
+
+    fourth_dim_size = img_4d.shape[3]
+
+    rng = np.random.RandomState(0)
+
+    arr = rng.rand(fourth_dim_size) > 0.5
+    df = pd.DataFrame({"arr": arr})
+
+    np_index_img = image.index_img(img_4d, arr)
+    pd_index_img = image.index_img(img_4d, df)
+    assert_array_equal(np_index_img.get_data(),
+                       pd_index_img.get_data())
 
 
 def test_iter_img():

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -6,6 +6,7 @@ from nose import SkipTest
 
 import platform
 import os
+import sys
 import nibabel
 from nibabel import Nifti1Image
 import numpy as np
@@ -23,6 +24,11 @@ from nilearn.image import threshold_img
 from nilearn.image import iter_img
 from nilearn.image import math_img
 from nilearn.image import largest_connected_component_img
+
+try:
+    import pandas as pd
+except Exception:
+    pass
 
 X64 = (platform.architecture()[0] == '64bit')
 
@@ -353,6 +359,18 @@ def test_index_img():
             IndexError,
             'out of bounds|invalid index|out of range|boolean index',
             image.index_img, img_4d, i)
+
+    # if pandas is in the testing environment
+    if 'pandas' in sys.modules:
+        rng = np.random.RandomState(0)
+
+        arr = rng.rand(fourth_dim_size) > 0.5
+        df = pd.DataFrame({"arr": arr})
+
+        np_index_img = image.index_img(img_4d, arr)
+        pd_index_img = image.index_img(img_4d, df)
+        assert_array_equal(np_index_img.get_data(),
+                           pd_index_img.get_data())
 
 
 def test_iter_img():


### PR DESCRIPTION
Patch to eliminate the need for explicitly calling `.values` with older versions of Pandas, as discussed in #1582 and #1570 