### PR TITLE
[MRG] reorder argument for matrix plotting function

### DIFF
--- a/examples/03_connectivity/plot_probabilistic_atlas_extraction.py
+++ b/examples/03_connectivity/plot_probabilistic_atlas_extraction.py
@@ -62,8 +62,10 @@ import numpy as np
 from nilearn import plotting
 # Mask out the major diagonal
 np.fill_diagonal(correlation_matrix, 0)
+# We reorder the correlation matrix to make the block structure
+# of invidiual regions more visible.
 plotting.plot_matrix(correlation_matrix, labels=labels, colorbar=True,
-                     vmax=0.8, vmin=-0.8)
+                     vmax=0.8, vmin=-0.8, reorder=True)
 ############################################################################
 # And now display the corresponding graph
 # ----------------------------------------

--- a/examples/03_connectivity/plot_probabilistic_atlas_extraction.py
+++ b/examples/03_connectivity/plot_probabilistic_atlas_extraction.py
@@ -62,10 +62,8 @@ import numpy as np
 from nilearn import plotting
 # Mask out the major diagonal
 np.fill_diagonal(correlation_matrix, 0)
-# We reorder the correlation matrix to make the block structure
-# of invidiual regions more visible.
 plotting.plot_matrix(correlation_matrix, labels=labels, colorbar=True,
-                     vmax=0.8, vmin=-0.8, reorder=True)
+                     vmax=0.8, vmin=-0.8)
 ############################################################################
 # And now display the corresponding graph
 # ----------------------------------------

--- a/examples/03_connectivity/plot_signal_extraction.py
+++ b/examples/03_connectivity/plot_signal_extraction.py
@@ -19,6 +19,9 @@ NeuroImage 2013
 
 This is just a code example, see the :ref:`corresponding section in the
 documentation <parcellation_time_series>` for more.
+
+.. note::
+    This example needs SciPy >= 1.0.0 for the reordering of the matrix.
 """
 
 ##############################################################################
@@ -66,6 +69,7 @@ from nilearn import plotting
 np.fill_diagonal(correlation_matrix, 0)
 # The labels we have start with the background (0), hence we skip the
 # first label
+# matrices are ordered for block-like representation
 plotting.plot_matrix(correlation_matrix, figure=(10, 8), labels=labels[1:],
                      vmax=0.8, vmin=-0.8, reorder=True)
 

--- a/examples/03_connectivity/plot_signal_extraction.py
+++ b/examples/03_connectivity/plot_signal_extraction.py
@@ -67,7 +67,7 @@ np.fill_diagonal(correlation_matrix, 0)
 # The labels we have start with the background (0), hence we skip the
 # first label
 plotting.plot_matrix(correlation_matrix, figure=(10, 8), labels=labels[1:],
-                     vmax=0.8, vmin=-0.8)
+                     vmax=0.8, vmin=-0.8, reorder=True)
 
 ###############################################################################
 # Same thing without confounds, to stress the importance of confounds
@@ -82,6 +82,6 @@ correlation_matrix = correlation_measure.fit_transform([time_series])[0]
 np.fill_diagonal(correlation_matrix, 0)
 
 plotting.plot_matrix(correlation_matrix, figure=(10, 8), labels=labels[1:],
-                     vmax=0.8, vmin=-0.8, title='No confounds')
+                     vmax=0.8, vmin=-0.8, title='No confounds', reorder=True)
 
 plotting.show()

--- a/nilearn/plotting/matrix_plotting.py
+++ b/nilearn/plotting/matrix_plotting.py
@@ -66,12 +66,14 @@ def plot_matrix(mat, title=None, labels=None, figure=None, axes=None,
             If not False, reorders the matrix into blocks of clusters.
             Accepted linkage options for the clustering are 'single',
             'complete', and 'average'. True defaults to average linkage.
+            .. note::
+            This option is only available with SciPy >= 1.0.0.
         kwargs : extra keyword arguments
             Extra keyword arguments are sent to pylab.imshow
 
         Returns Matplotlib AxesImage instance
     """
-    if reorder is not False:
+    if reorder:
         if labels is None or labels is False:
             raise ValueError("Labels are needed to show the reordering.")
         try:
@@ -79,11 +81,12 @@ def plot_matrix(mat, title=None, labels=None, figure=None, axes=None,
                                                  leaves_list)
         except ImportError:
             raise ImportError("A scipy version of at least 1.0 is needed "
-                    "for ordering the matrix with optimal_leaf_ordering.")
+                              "for ordering the matrix with "
+                              "optimal_leaf_ordering.")
         valid_reorder_args = [True, 'single', 'complete', 'average']
         if reorder not in valid_reorder_args:
-            raise ValueError("Parameter reorder "
-            "needs to be one of {}.".format(valid_reorder_args))
+            raise ValueError("Parameter reorder needs to be "
+                             "one of {}.".format(valid_reorder_args))
         if reorder is True:
             reorder = 'average'
         linkage_matrix = linkage(mat, method=reorder)

--- a/nilearn/plotting/matrix_plotting.py
+++ b/nilearn/plotting/matrix_plotting.py
@@ -28,7 +28,7 @@ def fit_axes(ax):
 
 def plot_matrix(mat, title=None, labels=None, figure=None, axes=None,
                 colorbar=True, cmap=plt.cm.RdBu_r, tri='full',
-                auto_fit=True, grid=False, **kwargs):
+                auto_fit=True, grid=False, reorder=False, **kwargs):
     """ Plot the given matrix.
 
         Parameters
@@ -62,11 +62,40 @@ def plot_matrix(mat, title=None, labels=None, figure=None, axes=None,
         grid : color or False, optional
             If not False, a grid is plotted to separate rows and columns
             using the given color.
+        reorder : boolean or {'single', 'complete', 'average'}, optional
+            If not False, reorders the matrix into blocks of clusters.
+            Accepted linkage options for the clustering are 'single',
+            'complete', and 'average'. True defaults to average linkage.
         kwargs : extra keyword arguments
             Extra keyword arguments are sent to pylab.imshow
 
         Returns Matplotlib AxesImage instance
     """
+    if reorder is not False:
+        if labels is None or labels is False:
+            raise ValueError("Labels are needed to show the reordering.")
+        try:
+            from scipy.cluster.hierarchy import (linkage, optimal_leaf_ordering,
+                                                 leaves_list)
+        except ImportError:
+            raise ImportError("A scipy version of at least 1.0 is needed "
+                    "for ordering the matrix with optimal_leaf_ordering.")
+        valid_reorder_args = [True, 'single', 'complete', 'average']
+        if reorder not in valid_reorder_args:
+            raise ValueError("Parameter reorder "
+            "needs to be one of {}.".format(valid_reorder_args))
+        if reorder is True:
+            reorder = 'average'
+        linkage_matrix = linkage(mat, method=reorder)
+        ordered_linkage = optimal_leaf_ordering(linkage_matrix, mat)
+        index = leaves_list(ordered_linkage)
+        # make sure labels is an ndarray and copy it
+        labels = np.array(labels).copy()
+        mat = mat.copy()
+        # and reorder labels and matrix
+        labels = labels[index]
+        mat = mat[index, :][:, index]
+
     if tri == 'lower':
         mask = np.tri(mat.shape[0], k=-1, dtype=np.bool) ^ True
         mat = np.ma.masked_array(mat, mask)

--- a/nilearn/plotting/tests/test_matrix_plotting.py
+++ b/nilearn/plotting/tests/test_matrix_plotting.py
@@ -2,7 +2,7 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
 import matplotlib.pyplot as plt
-
+from nose.tools import assert_true
 from nilearn.plotting.matrix_plotting import plot_matrix
 
 ##############################################################################
@@ -20,6 +20,18 @@ def test_matrix_plotting():
     # test if it returns an AxesImage
     ax.axes.set_title('Title')
     plt.close()
-    # test if reordering with default linkage works
-    ax = plot_matrix(mat, labels=labels, reorder=True)
-    plt.close()
+    import scipy
+    if int(scipy.__version__.split('.')[0]) >= 1:
+        # test if reordering with default linkage works
+        idx = [2, 3, 5]
+        from itertools import permutations
+        # make symmetric matrix of similarities so we can get a block
+        for perm in permutations(idx, 2):
+            mat[perm] = 1
+        ax = plot_matrix(mat, labels=labels, reorder=True)
+        reordered_labels = [int(lbl.get_text())
+                            for lbl in ax.axes.get_xticklabels()]
+        # block order does not matter
+        assert_true(reordered_labels[:3] == idx or reordered_labels[-3:] == idx,
+                    'Clustering does not find block structure.')
+        plt.close()

--- a/nilearn/plotting/tests/test_matrix_plotting.py
+++ b/nilearn/plotting/tests/test_matrix_plotting.py
@@ -2,7 +2,7 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
 import matplotlib.pyplot as plt
-from nose.tools import assert_true
+from nose.tools import assert_true, assert_equal, assert_raises
 from nilearn.plotting.matrix_plotting import plot_matrix
 
 ##############################################################################
@@ -11,6 +11,7 @@ from nilearn.plotting.matrix_plotting import plot_matrix
 
 def test_matrix_plotting():
     from numpy import zeros
+    from distutils.version import LooseVersion
     mat = zeros((10, 10))
     labels = [str(i) for i in range(10)]
     ax = plot_matrix(mat, labels=labels, title='foo')
@@ -21,7 +22,11 @@ def test_matrix_plotting():
     ax.axes.set_title('Title')
     plt.close()
     import scipy
-    if int(scipy.__version__.split('.')[0]) >= 1:
+    if LooseVersion(scipy.__version__) >= LooseVersion('1.0.0'):
+        # test if a ValueError is raised when reorder=True without labels
+        assert_raises(ValueError, plot_matrix, mat, labels=None, reorder=True)
+        # test if a ValueError is raised when reorder argument is wrong
+        assert_raises(ValueError, plot_matrix, mat, labels=labels, reorder=' ')
         # test if reordering with default linkage works
         idx = [2, 3, 5]
         from itertools import permutations
@@ -29,9 +34,13 @@ def test_matrix_plotting():
         for perm in permutations(idx, 2):
             mat[perm] = 1
         ax = plot_matrix(mat, labels=labels, reorder=True)
+        assert_equal(len(labels), len(ax.axes.get_xticklabels()))
         reordered_labels = [int(lbl.get_text())
                             for lbl in ax.axes.get_xticklabels()]
         # block order does not matter
         assert_true(reordered_labels[:3] == idx or reordered_labels[-3:] == idx,
                     'Clustering does not find block structure.')
+        plt.close()
+        # test if reordering with specific linkage works
+        ax = plot_matrix(mat, labels=labels, reorder='complete')
         plt.close()

--- a/nilearn/plotting/tests/test_matrix_plotting.py
+++ b/nilearn/plotting/tests/test_matrix_plotting.py
@@ -12,7 +12,7 @@ from nilearn.plotting.matrix_plotting import plot_matrix
 def test_matrix_plotting():
     from numpy import zeros
     mat = zeros((10, 10))
-    labels = str(range(10))
+    labels = [str(i) for i in range(10)]
     ax = plot_matrix(mat, labels=labels, title='foo')
     plt.close()
     # test if plotting lower triangle works
@@ -20,5 +20,6 @@ def test_matrix_plotting():
     # test if it returns an AxesImage
     ax.axes.set_title('Title')
     plt.close()
-
-
+    # test if reordering with default linkage works
+    ax = plot_matrix(mat, labels=labels, reorder=True)
+    plt.close()


### PR DESCRIPTION
Hey y'all,

this is the pull request for issue #1543 
I added a reorder argument to the plot_matrix function. Default (for reorder=True) is average linkage.
A quick comparison on the probabilistic atlas example, seems to give the most sensible ("blockiest") ordering for average and complete. 
![different_linkages](https://user-images.githubusercontent.com/7125006/34205651-795b83e6-e583-11e7-96d9-5099737c1c6e.png)

Should this be tested on more/different data?