### PR TITLE
[MRG] FIX: Doc test failures with recent NumPy

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -1,3 +1,8 @@
+.. for doc tests to run with recent NumPy 1.14, we need to set print options
+   to older versions. See issue #1593 for more details.
+    >>> import numpy as np
+    >>> np.set_printoptions(legacy='1.13')
+
 =====================================
 Introduction: nilearn in a nutshell
 =====================================

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -307,16 +307,16 @@ Basic numerics
 
     >>> import numpy as np
     >>> t = np.linspace(1, 10, 2000)  # 2000 points between 1 and 10
-    >>> t  # doctest: +SKIP
+    >>> t
     array([  1.        ,   1.00450225,   1.0090045 , ...,   9.9909955 ,
              9.99549775,  10.        ])
-    >>> t / 2  # doctest: +SKIP
+    >>> t / 2
     array([ 0.5       ,  0.50225113,  0.50450225, ...,  4.99549775,
             4.99774887,  5.        ])
-    >>> np.cos(t) # Operations on arrays are defined in the numpy module  # doctest: +SKIP
+    >>> np.cos(t) # Operations on arrays are defined in the numpy module
     array([ 0.54030231,  0.53650833,  0.53270348, ..., -0.84393609,
            -0.84151234, -0.83907153])
-    >>> t[:3] # In Python indexing is done with [] and starts at zero  # doctest: +SKIP
+    >>> t[:3] # In Python indexing is done with [] and starts at zero
     array([ 1.        ,  1.00450225,  1.0090045 ])
 
   `More documentation ...

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -307,16 +307,16 @@ Basic numerics
 
     >>> import numpy as np
     >>> t = np.linspace(1, 10, 2000)  # 2000 points between 1 and 10
-    >>> t
+    >>> t  # doctest: +SKIP
     array([  1.        ,   1.00450225,   1.0090045 , ...,   9.9909955 ,
              9.99549775,  10.        ])
-    >>> t / 2
+    >>> t / 2  # doctest: +SKIP
     array([ 0.5       ,  0.50225113,  0.50450225, ...,  4.99549775,
             4.99774887,  5.        ])
-    >>> np.cos(t) # Operations on arrays are defined in the numpy module
+    >>> np.cos(t) # Operations on arrays are defined in the numpy module  # doctest: +SKIP
     array([ 0.54030231,  0.53650833,  0.53270348, ..., -0.84393609,
            -0.84151234, -0.83907153])
-    >>> t[:3] # In Python indexing is done with [] and starts at zero
+    >>> t[:3] # In Python indexing is done with [] and starts at zero  # doctest: +SKIP
     array([ 1.        ,  1.00450225,  1.0090045 ])
 
   `More documentation ...

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -1,7 +1,9 @@
 .. for doc tests to run with recent NumPy 1.14, we need to set print options
-   to older versions. See issue #1593 for more details.
+   to older versions. See issue #1593 for more details
     >>> import numpy as np
-    >>> np.set_printoptions(legacy='1.13')
+    >>> from distutils.version import LooseVersion
+    >>> if LooseVersion(np.__version__) >= LooseVersion('1.14'):
+    ...     np.set_printoptions(legacy='1.13')
 
 =====================================
 Introduction: nilearn in a nutshell

--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -33,10 +33,20 @@ signal                  --- Set of preprocessing functions for time series
 """
 
 import gzip
+from distutils.version import LooseVersion
 
 from .version import _check_module_dependencies, __version__
 
 _check_module_dependencies()
+
+# Temporary work around to address formatting issues in doc tests
+# with NumPy 1.14. NumPy had made more consistent str/repr formatting
+# of numpy arrays. Hence we print the options to old versions.
+import numpy as np
+if LooseVersion(np.__version__) >= LooseVersion("1.14"):
+    from ._utils.testing import is_nose_running
+    if is_nose_running:
+        np.set_printoptions(legacy='1.13')
 
 # Monkey-patch gzip to have faster reads on large gzip files
 if hasattr(gzip.GzipFile, 'max_read_chunk'):

--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -45,7 +45,7 @@ _check_module_dependencies()
 import numpy as np
 if LooseVersion(np.__version__) >= LooseVersion("1.14"):
     from ._utils.testing import is_nose_running
-    if is_nose_running:
+    if is_nose_running():
         np.set_printoptions(legacy='1.13')
 
 # Monkey-patch gzip to have faster reads on large gzip files

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -4,7 +4,6 @@ Massively Univariate Linear Model estimated with OLS and permutation test.
 # Author: Benoit Da Mota, <benoit.da_mota@inria.fr>, sept. 2011
 #         Virgile Fritsch, <virgile.fritsch@inria.fr>, jan. 2014
 import warnings
-from distutils.version import LooseVersion
 
 import numpy as np
 from scipy import linalg

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -53,8 +53,6 @@ def normalize_matrix_on_axis(m, axis=0):
         ret = normalize_matrix_on_axis(m.T).T
     else:
         raise ValueError('axis(=%d) out of bounds' % axis)
-    if LooseVersion(np.__version__) > LooseVersion('1.13'):
-        np.set_printoptions(legacy='1.13')
     return ret
 
 

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -4,6 +4,7 @@ Massively Univariate Linear Model estimated with OLS and permutation test.
 # Author: Benoit Da Mota, <benoit.da_mota@inria.fr>, sept. 2011
 #         Virgile Fritsch, <virgile.fritsch@inria.fr>, jan. 2014
 import warnings
+from distutils.version import LooseVersion
 
 import numpy as np
 from scipy import linalg
@@ -52,6 +53,8 @@ def normalize_matrix_on_axis(m, axis=0):
         ret = normalize_matrix_on_axis(m.T).T
     else:
         raise ValueError('axis(=%d) out of bounds' % axis)
+    if LooseVersion(np.__version__) > LooseVersion('1.13'):
+        np.set_printoptions(legacy='1.13')
     return ret
 
 


### PR DESCRIPTION
We are seeing doc test failures in Travis with recent NumPy 0.14. From NumPy 0.14, we will not see any spaces in the output arrays. Which is where out tests are failing.

See for instance failures in this build. https://travis-ci.org/nilearn/nilearn/jobs/327386377#L3859
Failed example:
```python
    normalize_matrix_on_axis(X, axis=1)
Expected:
    array([[ 0.,  1.],
           [ 1.,  0.]])
Got:
    array([[0., 1.],
           [1., 0.]])
```
Doc tests in:
nilearn/mass_univariate/permuted_least_squares.normalize_matrix_on_axis
doc/introduction.rst

The idea is to use numpy.set_printoptions(legacy='1.13') to print the output to old pattern to be consistent will all versions. Otherwise, better solutions are welcome. @lesteve since you have already seen this problem. Could you please advice that this FIX seems better ?