### PR TITLE
[MAINT] Improves error message while installing Nilearn with Python 3 and install dependencies automatically

### DIFF
--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -48,22 +48,6 @@ REQUIRED_MODULE_METADATA = (
 OPTIONAL_MATPLOTLIB_MIN_VERSION = '1.1.1'
 
 
-def get_module_status(module_name):
-    """
-    Returns a dictionary 'module_status' containing a boolean status
-    specifying whether module given in parameter module_name is installed
-    or not. Also, returns import "module" if found otherwise empty.
-    """
-    module_status = {}
-    try:
-        module = __import__(module_name)
-        module_status['installed'] = True
-    except ImportError:
-        module_status['installed'] = False
-        module = ""
-    return module, module_status
-
-
 def _import_module_with_version_check(
         module_name,
         minimum_version,
@@ -72,16 +56,21 @@ def _import_module_with_version_check(
     """
     from distutils.version import LooseVersion
 
-    module, module_status = get_module_status(module_name)
-    if module_status['installed'] is False:
+    try:
+        module = __import__(module_name)
+    except ImportError as exc:
         user_friendly_info = ('Module "{0}" could not be found. {1}').format(
             module_name,
             install_info or 'Please install it properly to use nilearn.')
-        raise ImportError(user_friendly_info)
+        exc.args += (user_friendly_info,)
+        # Necessary for Python 3 because the repr/str of ImportError
+        # objects was changed in Python 3
+        if hasattr(exc, 'msg'):
+            exc.msg += '. ' + user_friendly_info
+        raise
 
-    if module_status['installed'] is True:
-        # Avoid choking on modules with no __version__ attribute
-        module_version = getattr(module, '__version__', '0.0.0')
+    # Avoid choking on modules with no __version__ attribute
+    module_version = getattr(module, '__version__', '0.0.0')
 
     version_too_old = (not LooseVersion(module_version) >=
                        LooseVersion(minimum_version))


### PR DESCRIPTION
As raised in this issue https://github.com/nistats/nistats/issues/154, current error management does not provide user friendly information with Python 3. Example as in #1507 displays there is no user friendly information.  This PR attempts to improve that. Keeping functionality which works both for Python 2 and 3. Mostly, the idea is from Scikit-learn. This is mostly done. Ready for getting some opinions on this.

The another concern raised in that issue is installing dependencies automatically. Especially when user does not necessarily have installed the dependencies before pip install nilearn.
This can be done by setting dependencies requirement in “install_requires”.

I have few questions on this:

- is_installing() functionality should go below setup ? This makes installation first and then raises an error if some of the modules are not installed. This is where user should try to do by themselves.
   - If agreed upon this. What would happen if user had already done dependencies requirement ? Does this again overrides the installation ?
- Minimum NumPy version required for scikit-learn is 1.8.2 while Nilearn minimum version is 1.6.1 ? Will this be a problem ?