### PR TITLE
[MRG] FIX add_markers plotting with glass_brain

### DIFF
--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -829,13 +829,19 @@ class BaseSlicer(object):
             coord = display_ax.coord
             marker_coords_2d, third_d = _coords_3d_to_2d(
                 marker_coords, direction, return_direction=True)
-            # Heuristic that plots only markers that are 2mm away from the
-            # current slice.
-            # XXX: should we keep this heuristic?
-            mask = np.abs(third_d - coord) <= 2.
             xdata, ydata = marker_coords_2d.T
-            display_ax.ax.scatter(xdata[mask], ydata[mask],
-                                  s=marker_size,
+            # Check if coord has integer represents a cut in direction
+            # to follow the heuristic. If no foreground image is given
+            # coordinate is empty or None. This case is valid for plotting
+            # markers on glass brain without any foreground image.
+            if isinstance(coord, numbers.Number):
+                # Heuristic that plots only markers that are 2mm away
+                # from the current slice.
+                # XXX: should we keep this heuristic?
+                mask = np.abs(third_d - coord) <= 2.
+                xdata = xdata[mask]
+                ydata = ydata[mask]
+            display_ax.ax.scatter(xdata, ydata, s=marker_size,
                                   c=marker_color, **kwargs)
 
     def annotate(self, left_right=True, positions=True, size=12, **kwargs):

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -91,3 +91,11 @@ def test_data_complete_mask():
     oslicer = OrthoSlicer(cut_coords=(0, 0, 0))
     oslicer.add_overlay(img)
     oslicer.close()
+
+
+def test_add_markers_cut_coords_is_none():
+    # A special case test for add_markers when cut_coords are None. This
+    # case is used when coords are placed on glass brain
+    orthoslicer = OrthoSlicer(cut_coords=(None, None, None))
+    orthoslicer.add_markers([(0, 0, 2)])
+    orthoslicer.close()

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -944,3 +944,10 @@ def test_plotting_functions_with_dim_invalid_input():
     # Test whether error raises with bad error to input
     img = _generate_img()
     assert_raises(ValueError, plot_stat_map, img, dim='-10')
+
+
+def test_add_markers_using_plot_glass_brain():
+    fig = plot_glass_brain(None)
+    coords = [(-34, -39, -9)]
+    fig.add_markers(coords)
+    fig.close()


### PR DESCRIPTION
Fixes #1595 

Error is returned when coord is None at https://github.com/nilearn/nilearn/blob/master/nilearn/plotting/displays.py#L835. This is because no image is given to find the positioning of the coordinates.

This patch checks if ```coord is None``` or a Number. If coord is None, plot as it is. Inspired from private/helper function ```_add_markers``` in class ```GlassBrainAxes```.

Added tests. Can I please have reviews/opinions on this ?