### PR TITLE
FIX: globbing issues with decomposition estimators

### DIFF
--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_array_almost_equal
 from nose.tools import assert_true, assert_raises
 import nibabel
 
-from nilearn._utils.testing import (assert_less_equal,
+from nilearn._utils.testing import (assert_less_equal, write_tmp_imgs,
                                     assert_raises_regex)
 from nilearn.decomposition.canica import CanICA
 from nilearn.input_data import MultiNiftiMasker
@@ -184,3 +184,34 @@ def test_components_img():
     assert_true(isinstance(components_img, nibabel.Nifti1Image))
     check_shape = data[0].shape[:3] + (n_components,)
     assert_true(components_img.shape, check_shape)
+
+
+def test_with_globbing_patterns_with_single_subject():
+    # single subject
+    data, mask_img, _, _ = _make_canica_test_data(n_subjects=1)
+    n_components = 3
+    canica = CanICA(n_components=n_components, mask=mask_img)
+    with write_tmp_imgs(data[0], create_files=True, use_wildcards=True) as img:
+        input_image = '/tmp/' + img
+        canica.fit(input_image)
+        components_img = canica.components_img_
+        assert_true(isinstance(components_img, nibabel.Nifti1Image))
+        # n_components = 3
+        check_shape = data[0].shape[:3] + (3,)
+        assert_true(components_img.shape, check_shape)
+
+
+def test_with_globbing_patterns_with_multi_subjects():
+    # Multi subjects
+    data, mask_img, _, _ = _make_canica_test_data(n_subjects=3)
+    n_components = 3
+    canica = CanICA(n_components=n_components, mask=mask_img)
+    with write_tmp_imgs(data[0], data[1], data[2], create_files=True,
+                        use_wildcards=True) as img:
+        input_image = '/tmp/' + img
+        canica.fit(input_image)
+        components_img = canica.components_img_
+        assert_true(isinstance(components_img, nibabel.Nifti1Image))
+        # n_components = 3
+        check_shape = data[0].shape[:3] + (3,)
+        assert_true(components_img.shape, check_shape)

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -10,6 +10,7 @@ from nilearn._utils.testing import (assert_less_equal, write_tmp_imgs,
 from nilearn.decomposition.canica import CanICA
 from nilearn.input_data import MultiNiftiMasker
 from nilearn.image import iter_img
+from nilearn.decomposition.tests.test_multi_pca import _tmp_dir
 
 
 def _make_data_from_components(components, affine, shape, rng=None,
@@ -192,7 +193,7 @@ def test_with_globbing_patterns_with_single_subject():
     n_components = 3
     canica = CanICA(n_components=n_components, mask=mask_img)
     with write_tmp_imgs(data[0], create_files=True, use_wildcards=True) as img:
-        input_image = '/tmp/' + img
+        input_image = _tmp_dir() + img
         canica.fit(input_image)
         components_img = canica.components_img_
         assert_true(isinstance(components_img, nibabel.Nifti1Image))
@@ -208,7 +209,7 @@ def test_with_globbing_patterns_with_multi_subjects():
     canica = CanICA(n_components=n_components, mask=mask_img)
     with write_tmp_imgs(data[0], data[1], data[2], create_files=True,
                         use_wildcards=True) as img:
-        input_image = '/tmp/' + img
+        input_image = _tmp_dir() + img
         canica.fit(input_image)
         components_img = canica.components_img_
         assert_true(isinstance(components_img, nibabel.Nifti1Image))

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -2,7 +2,8 @@ import numpy as np
 import nibabel
 
 from nose.tools import assert_true
-from nilearn._utils.testing import assert_less_equal, assert_raises_regex
+from nilearn._utils.testing import (assert_less_equal, assert_raises_regex,
+                                    write_tmp_imgs)
 from nilearn.decomposition.dict_learning import DictLearning
 from nilearn.decomposition.tests.test_canica import _make_canica_test_data
 from nilearn.image import iter_img
@@ -116,3 +117,34 @@ def test_components_img():
     assert_true(isinstance(components_img, nibabel.Nifti1Image))
     check_shape = data[0].shape + (n_components,)
     assert_true(components_img.shape, check_shape)
+
+
+def test_with_globbing_patterns_with_single_subject():
+    # single subject
+    data, mask_img, _, _ = _make_canica_test_data(n_subjects=1)
+    n_components = 3
+    dictlearn = DictLearning(n_components=n_components, mask=mask_img)
+    with write_tmp_imgs(data[0], create_files=True, use_wildcards=True) as img:
+        input_image = '/tmp/' + img
+        dictlearn.fit(input_image)
+        components_img = dictlearn.components_img_
+        assert_true(isinstance(components_img, nibabel.Nifti1Image))
+        # n_components = 3
+        check_shape = data[0].shape[:3] + (3,)
+        assert_true(components_img.shape, check_shape)
+
+
+def test_with_globbing_patterns_with_multi_subjects():
+    # multi subjects
+    data, mask_img, _, _ = _make_canica_test_data(n_subjects=3)
+    n_components = 3
+    dictlearn = DictLearning(n_components=n_components, mask=mask_img)
+    with write_tmp_imgs(data[0], data[1], data[2], create_files=True,
+                        use_wildcards=True) as img:
+        input_image = '/tmp/' + img
+        dictlearn.fit(input_image)
+        components_img = dictlearn.components_img_
+        assert_true(isinstance(components_img, nibabel.Nifti1Image))
+        # n_components = 3
+        check_shape = data[0].shape[:3] + (3,)
+        assert_true(components_img.shape, check_shape)

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -8,6 +8,7 @@ from nilearn.decomposition.dict_learning import DictLearning
 from nilearn.decomposition.tests.test_canica import _make_canica_test_data
 from nilearn.image import iter_img
 from nilearn.input_data import NiftiMasker
+from nilearn.decomposition.tests.test_multi_pca import _tmp_dir
 
 
 def test_dict_learning():
@@ -125,7 +126,7 @@ def test_with_globbing_patterns_with_single_subject():
     n_components = 3
     dictlearn = DictLearning(n_components=n_components, mask=mask_img)
     with write_tmp_imgs(data[0], create_files=True, use_wildcards=True) as img:
-        input_image = '/tmp/' + img
+        input_image = _tmp_dir() + img
         dictlearn.fit(input_image)
         components_img = dictlearn.components_img_
         assert_true(isinstance(components_img, nibabel.Nifti1Image))
@@ -141,7 +142,7 @@ def test_with_globbing_patterns_with_multi_subjects():
     dictlearn = DictLearning(n_components=n_components, mask=mask_img)
     with write_tmp_imgs(data[0], data[1], data[2], create_files=True,
                         use_wildcards=True) as img:
-        input_image = '/tmp/' + img
+        input_image = _tmp_dir() + img
         dictlearn.fit(input_image)
         components_img = dictlearn.components_img_
         assert_true(isinstance(components_img, nibabel.Nifti1Image))

--- a/nilearn/decomposition/tests/test_multi_pca.py
+++ b/nilearn/decomposition/tests/test_multi_pca.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_almost_equal, assert_equal
 
 from nilearn.decomposition.multi_pca import MultiPCA
 from nilearn.input_data import MultiNiftiMasker, NiftiMasker
-from nilearn._utils.testing import assert_raises_regex
+from nilearn._utils.testing import assert_raises_regex, write_tmp_imgs
 
 
 def test_multi_pca():
@@ -161,3 +161,40 @@ def test_components_img():
     check_shape = data[0].shape[:3] + (n_components,)
     assert_equal(components_img.shape, check_shape)
     assert_equal(len(components_img.shape), 4)
+
+
+def test_with_globbing_patterns_with_single_image():
+    # With single image
+    data_4d = np.zeros((40, 40, 40, 3))
+    data_4d[20, 20, 20] = 1
+    img_4d = nibabel.Nifti1Image(data_4d, affine=np.eye(4))
+    multi_pca = MultiPCA(n_components=3)
+
+    with write_tmp_imgs(img_4d, create_files=True, use_wildcards=True) as img:
+        input_image = '/tmp/' + img
+        multi_pca.fit(input_image)
+        components_img = multi_pca.components_img_
+        assert_true(isinstance(components_img, nibabel.Nifti1Image))
+        # n_components = 3
+        check_shape = img_4d.shape[:3] + (3,)
+        assert_equal(components_img.shape, check_shape)
+        assert_equal(len(components_img.shape), 4)
+
+
+def test_with_globbing_patterns_with_multiple_images():
+    # With multiple images
+    data_4d = np.zeros((40, 40, 40, 3))
+    data_4d[20, 20, 20] = 1
+    img_4d = nibabel.Nifti1Image(data_4d, affine=np.eye(4))
+    multi_pca = MultiPCA(n_components=3)
+
+    with write_tmp_imgs(img_4d, img_4d, create_files=True,
+                        use_wildcards=True) as imgs:
+        input_image = '/tmp/' + imgs
+        multi_pca.fit(input_image)
+        components_img = multi_pca.components_img_
+        assert_true(isinstance(components_img, nibabel.Nifti1Image))
+        # n_components = 3
+        check_shape = img_4d.shape[:3] + (3,)
+        assert_equal(components_img.shape, check_shape)
+        assert_equal(len(components_img.shape), 4)

--- a/nilearn/decomposition/tests/test_multi_pca.py
+++ b/nilearn/decomposition/tests/test_multi_pca.py
@@ -1,7 +1,8 @@
 """
 Test the multi-PCA module
 """
-
+import os
+import tempfile
 import numpy as np
 from nose.tools import assert_raises, assert_true
 import nibabel
@@ -10,6 +11,13 @@ from numpy.testing import assert_almost_equal, assert_equal
 from nilearn.decomposition.multi_pca import MultiPCA
 from nilearn.input_data import MultiNiftiMasker, NiftiMasker
 from nilearn._utils.testing import assert_raises_regex, write_tmp_imgs
+
+
+def _tmp_dir():
+    """For testing globbing patterns in input images
+    """
+    tmp_dir = tempfile.tempdir + os.sep
+    return tmp_dir
 
 
 def test_multi_pca():
@@ -171,7 +179,7 @@ def test_with_globbing_patterns_with_single_image():
     multi_pca = MultiPCA(n_components=3)
 
     with write_tmp_imgs(img_4d, create_files=True, use_wildcards=True) as img:
-        input_image = '/tmp/' + img
+        input_image = _tmp_dir() + img
         multi_pca.fit(input_image)
         components_img = multi_pca.components_img_
         assert_true(isinstance(components_img, nibabel.Nifti1Image))
@@ -190,7 +198,7 @@ def test_with_globbing_patterns_with_multiple_images():
 
     with write_tmp_imgs(img_4d, img_4d, create_files=True,
                         use_wildcards=True) as imgs:
-        input_image = '/tmp/' + imgs
+        input_image = _tmp_dir() + imgs
         multi_pca.fit(input_image)
         components_img = multi_pca.components_img_
         assert_true(isinstance(components_img, nibabel.Nifti1Image))


### PR DESCRIPTION
Attempts to close issue #1575 

Took the opportunity to close this issue of having globbing patterns in the input images given to
decomposition estimators i.e. MultiPCA, CanICA, Dictionary Learning.

Can I have opinions/reviews on this please ?

Still to do so far:
 - Add this whats_new section