### PR TITLE
FIX: glmax error in new_img_like with Nifti2Images

### DIFF
--- a/doc/sphinxext/numpydoc/numpydoc.py
+++ b/doc/sphinxext/numpydoc/numpydoc.py
@@ -26,7 +26,6 @@ if sphinx.__version__ < '1.0.1':
     raise RuntimeError("Sphinx 1.0.1 or newer is required")
 
 from .docscrape_sphinx import get_doc_object, SphinxDocString
-from sphinx.util.compat import Directive
 
 if sys.version_info[0] >= 3:
     sixu = lambda s: s

--- a/doc/sphinxext/sphinx_gallery/docs_resolv.py
+++ b/doc/sphinxext/sphinx_gallery/docs_resolv.py
@@ -12,7 +12,9 @@ import posixpath
 import re
 import shelve
 import sys
+from distutils.version import LooseVersion
 
+import sphinx
 from sphinx.util.console import fuchsia
 
 # Try Python 2 first, otherwise load from Python 3
@@ -370,9 +372,17 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
     flat = [[dirpath, filename]
             for dirpath, _, filenames in os.walk(html_gallery_dir)
             for filename in filenames]
-    iterator = app.status_iterator(
-        flat, os.path.basename(html_gallery_dir), colorfunc=fuchsia,
-        length=len(flat), stringify_func=lambda x: os.path.basename(x[1]))
+    if LooseVersion(sphinx.__version__) >= LooseVersion('1.6'):
+        # It will be removed once upgraded to new sphinx-gallery version
+        from sphinx.util import status_iterator
+        iterator = status_iterator(
+            flat, os.path.basename(html_gallery_dir), color='fuchsia',
+            length=len(flat), stringify_func=lambda x: os.path.basename(x[1]))
+    else:
+        iterator = app.status_iterator(
+            flat, os.path.basename(html_gallery_dir), colorfunc=fuchsia,
+            length=len(flat), stringify_func=lambda x: os.path.basename(x[1]))
+
     for dirpath, fname in iterator:
         full_fname = os.path.join(html_gallery_dir, dirpath, fname)
         subpath = dirpath[len(html_gallery_dir) + 1:]

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -638,7 +638,9 @@ def new_img_like(ref_niimg, data, affine=None, copy_header=False):
         header = copy.deepcopy(ref_niimg.header)
         header['scl_slope'] = 0.
         header['scl_inter'] = 0.
-        header['glmax'] = 0.
+        # "glmax" is available only for Nifti1Image
+        if not isinstance(ref_niimg, nibabel.nifti2.Nifti2Image):
+            header['glmax'] = 0.
         header['cal_max'] = np.max(data) if data.size > 0 else 0.
         header['cal_min'] = np.min(data) if data.size > 0 else 0.
     klass = ref_niimg.__class__

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -638,8 +638,9 @@ def new_img_like(ref_niimg, data, affine=None, copy_header=False):
         header = copy.deepcopy(ref_niimg.header)
         header['scl_slope'] = 0.
         header['scl_inter'] = 0.
-        # "glmax" is available only for Nifti1Image
-        if not isinstance(ref_niimg, nibabel.nifti2.Nifti2Image):
+        # 'glmax' is removed for Nifti2Image. Modify only if 'glmax' is
+        # available in header. See issue #1611
+        if 'glmax' in header:
             header['glmax'] = 0.
         header['cal_max'] = np.max(data) if data.size > 0 else 0.
         header['cal_min'] = np.min(data) if data.size > 0 else 0.

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -179,6 +179,14 @@ def test_smooth_img():
     out_fwhm_zero = image.smooth_img(img1, fwhm=0.)
     assert_array_equal(out_fwhm_none.get_data(), out_fwhm_zero.get_data())
 
+    data1 = np.zeros((10, 11, 12))
+    data1[2:4, 1:5, 3:6] = 1
+    data2 = np.zeros((13, 14, 15))
+    data2[2:4, 1:5, 3:6] = 9
+    img1_nifti2 = nibabel.Nifti2Image(data1, affine=np.eye(4))
+    img2_nifti2 = nibabel.Nifti2Image(data2, affine=np.eye(4))
+    out = image.smooth_img([img1_nifti2, img2_nifti2], fwhm=1.)
+
 
 def test__crop_img_to():
     data = np.zeros((5, 6, 7))
@@ -452,6 +460,11 @@ def test_new_img_like():
     img2 = new_img_like([img, ], data)
     np.testing.assert_array_equal(img.get_data(), img2.get_data())
 
+    # test_new_img_like_with_nifti2image_copy_header
+    img_nifti2 = nibabel.Nifti2Image(data, affine=affine)
+    img2_nifti2 = new_img_like([img_nifti2, ], data, copy_header=True)
+    np.testing.assert_array_equal(img_nifti2.get_data(), img2_nifti2.get_data())
+
 
 def test_validity_threshold_value_in_threshold_img():
     shape = (6, 8, 10)
@@ -559,6 +572,12 @@ def test_clean_img():
     nan_img = nibabel.Nifti1Image(data, np.eye(4))
     clean_im = image.clean_img(nan_img, ensure_finite=True)
     assert_true(np.any(np.isfinite(clean_im.get_data())), True)
+
+    # test_clean_img_passing_nifti2image
+    data_img_nifti2 = nibabel.Nifti2Image(data, np.eye(4))
+
+    data_img_nifti2_ = image.clean_img(
+        data_img_nifti2, detrend=True, standardize=False, low_pass=0.1)
 
 
 def test_largest_cc_img():


### PR DESCRIPTION
As reported in neurostars tracker https://neurostars.org/t/missing-field-error-in-nilearn-with-nifti-2/1365

A fix to overcome the error regarding header attribute "glmax" which is not present in the Nifti2 images.