### PR TITLE
[MRG] FIX: plot_connectome displaying hemispheric cuts in single node color

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -21,6 +21,13 @@ Changes
       :class:`nilearn.decomposition.DictLearning` is deprecated and will
       be removed in next two releases. Use `components_img_` instead.
 
+Bug fixes
+---------
+
+    - Fix issues using :func:`nilearn.plotting.plot_connectome` when string is
+      passed in `node_color` display modes left and right hemispheric cuts
+      in the glass brain.
+
 0.4.0
 =====
 

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -308,6 +308,9 @@ class GlassBrainAxes(BaseAxes):
 
         # Allow markers only in their respective hemisphere when appropriate
         if self.direction in 'lr':
+            if not isinstance(marker_color, _utils.compat._basestring) and \
+                    not isinstance(marker_color, np.ndarray):
+                marker_color = np.asarray(marker_color)
             relevant_coords = []
             xcoords, ycoords, zcoords = marker_coords.T
             for cidx, xc in enumerate(xcoords):
@@ -317,7 +320,14 @@ class GlassBrainAxes(BaseAxes):
                         relevant_coords.append(cidx)
             xdata = xdata[relevant_coords]
             ydata = ydata[relevant_coords]
-            marker_color = marker_color[relevant_coords]
+            # if marker_color is string for example 'red' or 'blue', then
+            # we pass marker_color as it is to matplotlib scatter without
+            # making any selection in 'l' or 'r' color.
+            # More likely that user wants to display all nodes to be in
+            # same color.
+            if not isinstance(marker_color, _utils.compat._basestring) and \
+                    len(marker_color) != 1:
+                marker_color = marker_color[relevant_coords]
 
         defaults = {'marker': 'o',
                     'zorder': 1000}

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -1186,7 +1186,8 @@ def plot_connectome(adjacency_matrix, node_coords,
         node_coords : numpy array_like of shape (n, 3)
             3d coordinates of the graph nodes in world space.
         node_color : color or sequence of colors
-            color(s) of the nodes.
+            color(s) of the nodes. If string is given, all nodes
+            are plotted with same color given in string.
         node_size : scalar or array_like
             size(s) of the nodes in points^2.
         edge_cmap : colormap

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -7,6 +7,7 @@ import nibabel
 import numpy as np
 
 from nilearn.plotting.displays import OrthoSlicer, XSlicer, OrthoProjector
+from nilearn.plotting.displays import LZRYProjector
 from nilearn.datasets import load_mni152_template
 
 ##############################################################################
@@ -99,3 +100,15 @@ def test_add_markers_cut_coords_is_none():
     orthoslicer = OrthoSlicer(cut_coords=(None, None, None))
     orthoslicer.add_markers([(0, 0, 2)])
     orthoslicer.close()
+
+
+def test_add_graph_with_node_color_as_string():
+    lzry_projector = LZRYProjector(cut_coords=(0, 0, 0, 0))
+    matrix = np.array([[0, 3], [3, 0]])
+    node_coords = [[-53.60, -62.80, 36.64], [23.87, 0.31, 69.42]]
+    # node_color as string
+    lzry_projector.add_graph(matrix, node_coords, node_color='red')
+    lzry_projector.close()
+    # node_color as sequence of string
+    lzry_projector.add_graph(matrix, node_coords, node_color=['red', 'blue'])
+    lzry_projector.close()

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -460,6 +460,12 @@ def test_plot_connectome():
     plot_connectome(*args, display_mode='lzry')
     plt.close()
 
+    # test node_color as a string with display_mode='lzry'
+    plot_connectome(*args, node_color='red', display_mode='lzry')
+    plt.close()
+    plot_connectome(*args, node_color=['red'], display_mode='lzry')
+    plt.close()
+
 
 def test_plot_connectome_exceptions():
     node_coords = np.arange(2 * 3).reshape((2, 3))


### PR DESCRIPTION
Fixes issue as reported in #1607 

This PR will allow to ```plot_connectome``` to display nodes when a unique color is passed in ```node_color``` parameter. It can be either be as a string node_color='red' or sequence ['red'].

Still-to-do

- Add into whats_new

Thank you for reviewing.