### PR TITLE
FIX: changes default colormap of plotting, due to drop of 'spectral' in matplotlib v 2.2

### DIFF
--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -508,7 +508,7 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
 def plot_epi(epi_img=None, cut_coords=None, output_file=None,
              display_mode='ortho', figure=None, axes=None, title=None,
              annotate=True, draw_cross=True, black_bg=True,
-             cmap=plt.cm.spectral, vmin=None, vmax=None, **kwargs):
+             cmap=plt.cm.nipy_spectral, vmin=None, vmax=None, **kwargs):
     """ Plot cuts of an EPI image (by default 3 cuts:
         Frontal, Axial, and Lateral)
 


### PR DESCRIPTION
The newest release of matplotlib [v2.2](https://github.com/matplotlib/matplotlib/releases) removed the colormap `spectral` (see [commit](https://github.com/matplotlib/matplotlib/commit/b42a9f87142d0ff9200bfa57a976cef9a6db788e#diff-ef5eff380470cb1e91c47fe27bf3bdc3L1423)). This leads to the following error when I've tried to `import nilearn.plotting`:

```bash
----> 1 from nilearn import plotting
/opt/conda/envs/neuro/lib/python3.6/site-packages/nilearn/plotting/__init__.py in <module>()
     39 
     40 from . import cm
---> 41 from .img_plotting import plot_img, plot_anat, plot_epi, \
     42     plot_roi, plot_stat_map, plot_glass_brain, plot_connectome, \
     43     plot_prob_atlas, show

/opt/conda/envs/neuro/lib/python3.6/site-packages/nilearn/plotting/img_plotting.py in <module>()
    509              display_mode='ortho', figure=None, axes=None, title=None,
    510              annotate=True, draw_cross=True, black_bg=True,
--> 511              cmap=plt.cm.spectral, vmin=None, vmax=None, **kwargs):
    512     """ Plot cuts of an EPI image (by default 3 cuts:
    513         Frontal, Axial, and Lateral)

AttributeError: module 'matplotlib.cm' has no attribute 'spectral'
```

To solve this, I replaced `cm.spectral` with `cm.nipy_spectral`. This should work as they anyhow were the same thing before the [changes](https://github.com/matplotlib/matplotlib/commit/b42a9f87142d0ff9200bfa57a976cef9a6db788e#diff-ef5eff380470cb1e91c47fe27bf3bdc3L1423).