### PR TITLE
make surface default cmaps same as in slice plotting

### DIFF
--- a/examples/01_plotting/plot_3d_map_to_surface_projection.py
+++ b/examples/01_plotting/plot_3d_map_to_surface_projection.py
@@ -41,8 +41,7 @@ from nilearn import plotting
 
 plotting.plot_surf_stat_map(fsaverage.infl_right, texture, hemi='right',
                             title='Surface right hemisphere',
-                            threshold=1., bg_map=fsaverage.sulc_right,
-                            cmap='cold_hot')
+                            threshold=1., bg_map=fsaverage.sulc_right)
 
 ##############################################################################
 # Plot 3D image for comparison

--- a/examples/01_plotting/plot_surf_atlas.py
+++ b/examples/01_plotting/plot_surf_atlas.py
@@ -55,26 +55,26 @@ from nilearn import plotting
 plotting.plot_surf_roi(fsaverage['pial_left'], roi_map=parcellation,
                        hemi='left', view='lateral',
                        bg_map=fsaverage['sulc_left'], bg_on_data=True,
-                       darkness=.5, cmap='gist_ncar')
+                       darkness=.5)
 
 ###############################################################################
 # Display Destrieux parcellation on inflated fsaverage5 surface
 plotting.plot_surf_roi(fsaverage['infl_left'], roi_map=parcellation,
                        hemi='left', view='lateral',
                        bg_map=fsaverage['sulc_left'], bg_on_data=True,
-                       darkness=.5, cmap='gist_ncar')
+                       darkness=.5)
 
 ###############################################################################
 # Display Destrieux parcellation with different views: posterior
 plotting.plot_surf_roi(fsaverage['infl_left'], roi_map=parcellation,
                        hemi='left', view='posterior',
                        bg_map=fsaverage['sulc_left'], bg_on_data=True,
-                       darkness=.5, cmap='gist_ncar')
+                       darkness=.5)
 
 ###############################################################################
 # Display Destrieux parcellation with different views: ventral
 plotting.plot_surf_roi(fsaverage['infl_left'], roi_map=parcellation,
                        hemi='left', view='ventral',
                        bg_map=fsaverage['sulc_left'], bg_on_data=True,
-                       darkness=.5, cmap='gist_ncar')
+                       darkness=.5)
 plotting.show()

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -264,7 +264,7 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
 
 def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
                        hemi='left', view='lateral', threshold=None,
-                       alpha='auto', vmax=None, cmap='coolwarm',
+                       alpha='auto', vmax=None, cmap='cold_hot',
                        symmetric_cbar="auto", bg_on_data=False, darkness=1,
                        title=None, output_file=None, axes=None, figure=None,
                        **kwargs):
@@ -376,7 +376,7 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
 
 def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
                   hemi='left', view='lateral', alpha='auto',
-                  vmin=None, vmax=None, cmap='coolwarm',
+                  vmin=None, vmax=None, cmap='gist_ncar',
                   bg_on_data=False, darkness=1, title=None,
                   output_file=None, axes=None, figure=None, **kwargs):
     """ Plotting of surfaces with optional background and stats map

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -472,7 +472,7 @@ def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
         roi_data = load_surf_data(roi_map)
         # or a single array with indices for a single roi
         if roi_data.shape[0] != v.shape[0]:
-            roi_map = np.zeros(v.shape[0])
+            roi_map = np.zeros(v.shape[0], dtype=int)
             roi_map[roi_data] = 1
 
     else:
@@ -483,7 +483,7 @@ def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
                          'value for each vertex, or a list of Numpy arrays, '
                          'one array per ROI which contains indices of all '
                          'vertices included in that ROI')
-
+    vmin, vmax = np.min(roi_map), 1 + np.max(roi_map)
     display = plot_surf(surf_mesh, surf_map=roi_map, bg_map=bg_map,
                         hemi=hemi, view=view, avg_method='median',
                         cmap=cmap, alpha=alpha, bg_on_data=bg_on_data,


### PR DESCRIPTION
by default, `plot_stat_map` uses the `cold_hot` colormap. `plot_glass_brain`
does too, if the background is black, otherwise `cold_white_hot`.
`plot_surf_stat_map` uses `coolwarm`.

current default:
![surf_stat_map_coolwarm](https://user-images.githubusercontent.com/9196501/41038103-7e3a2f3e-6995-11e8-96b7-4b0b3cfeba4f.png)

suggested default:

![surf_stat_map_cold_hot](https://user-images.githubusercontent.com/9196501/41038120-89ca44c4-6995-11e8-8ecd-9cfdd1c4acf9.png)


more importantly, `plot_roi` uses a rainbow colormap, namely
`gist_ncar`. `plot_surf_roi` uses `coolwarm`, which is not adapted for rois.

current default:

![surf_roi_coolwarm](https://user-images.githubusercontent.com/9196501/41038147-9b938396-6995-11e8-8ab3-5f8d6a751cc3.png)



suggested default:

![surf_roi_gist_ncar](https://user-images.githubusercontent.com/9196501/41038202-c196a71c-6995-11e8-9fa1-5e791f3c513c.png)


I suggest we use the same defaults for surface plots as for slice plots.
note that the suggested defaults are the colormaps actually used in the
examples.