### PR TITLE
raise HttpError than AttributeError and print the user friendly error message

### DIFF
--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -575,6 +575,10 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
             # Complete the reporting hook
             sys.stderr.write(' ...done. ({0:.0f} seconds, {1:.0f} min)\n'
                              .format(dt, dt // 60))
+    except (_urllib.error.HTTPError, _urllib.error.URLError) as e:
+        sys.stderr.write("Error while fetching file %s; dataset "
+                         "fetching aborted." % (file_name))
+        raise
     finally:
         if local_file is not None:
             if not local_file.closed:

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -575,8 +575,6 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
             # Complete the reporting hook
             sys.stderr.write(' ...done. ({0:.0f} seconds, {1:.0f} min)\n'
                              .format(dt, dt // 60))
-    except (_urllib.error.HTTPError, _urllib.error.URLError) as e:
-        raise
     finally:
         if local_file is not None:
             if not local_file.closed:

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -576,13 +576,6 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
             sys.stderr.write(' ...done. ({0:.0f} seconds, {1:.0f} min)\n'
                              .format(dt, dt // 60))
     except (_urllib.error.HTTPError, _urllib.error.URLError) as e:
-        if 'Error while fetching' not in str(e):
-            # For some odd reason, the error message gets doubled up
-            #   (possibly from the re-raise), so only add extra info
-            #   if it's not already there.
-            e.reason = ("%s| Error while fetching file %s; "
-                          "dataset fetching aborted." % (
-                            str(e.reason), file_name))
         raise
     finally:
         if local_file is not None:

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -575,7 +575,7 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
             # Complete the reporting hook
             sys.stderr.write(' ...done. ({0:.0f} seconds, {1:.0f} min)\n'
                              .format(dt, dt // 60))
-    except (_urllib.error.HTTPError, _urllib.error.URLError) as e:
+    except (_urllib.error.HTTPError, _urllib.error.URLError):
         sys.stderr.write("Error while fetching file %s; dataset "
                          "fetching aborted." % (file_name))
         raise


### PR DESCRIPTION
Fixes #1644 and supersedes #1645 