### PR TITLE
BUG: Fixing Parcellations transform on list of 3D images

### DIFF
--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -11,6 +11,7 @@ from ..decomposition.multi_pca import MultiPCA
 from ..input_data import NiftiLabelsMasker
 from .._utils.compat import _basestring
 from .._utils.niimg import _safe_get_data
+from .._utils.niimg_conversions import _iter_check_niimg
 
 
 def _estimator_fit(data, estimator):
@@ -334,6 +335,9 @@ class Parcellations(MultiPCA):
         self._check_fitted()
         imgs, confounds, single_subject = _check_parameters_transform(
             imgs, confounds)
+        # Requires for special cases like extracting signals on list of
+        # 3D images
+        imgs_list = _iter_check_niimg(imgs, atleast_4d=True)
 
         masker = NiftiLabelsMasker(self.labels_img_,
                                    mask_img=self.masker_.mask_img_,
@@ -351,7 +355,7 @@ class Parcellations(MultiPCA):
             delayed(self._cache(_labels_masker_extraction,
                                 func_memory_level=2))
             (img, masker, confound)
-            for img, confound in zip(imgs, confounds))
+            for img, confound in zip(imgs_list, confounds))
 
         if single_subject:
             return region_signals[0]

--- a/nilearn/regions/tests/test_parcellations.py
+++ b/nilearn/regions/tests/test_parcellations.py
@@ -252,3 +252,25 @@ def test_inverse_transform_single_nifti_image():
         assert_true(isinstance(fmri_compressed, nibabel.Nifti1Image))
         # returns shape of fmri_img
         assert_true(fmri_compressed.shape, (10, 11, 12, 10))
+
+
+def test_transform_3d_input_images():
+    # test list of 3D images
+    data = np.ones((10, 11, 12))
+    data[6, 7, 8] = 2
+    data[9, 10, 11] = 3
+    img = nibabel.Nifti1Image(data, affine=np.eye(4))
+    # list of 3
+    imgs = [img, img, img]
+    parcellate = Parcellations(method='ward', n_parcels=20)
+    X = parcellate.fit_transform(imgs)
+    assert_true(isinstance(X, list))
+    # (number of samples, number of features)
+    assert_equal(np.concatenate(X).shape, (3, 20))
+    # inverse transform
+    imgs_ = parcellate.inverse_transform(X)
+    assert_true(isinstance(imgs_, list))
+    # test single 3D image
+    X = parcellate.fit_transform(imgs[0])
+    assert_true(isinstance(X, np.ndarray))
+    assert_equal(X.shape, (1, 20))


### PR DESCRIPTION
With @glemaitre while working on structural images which contains list of 3D images. Particularly, while extracting signals using ```transform``` method.

As ```transform``` method in ```Parcellations``` object iterates over list of images for joblib Parallel. Hence, fails to extract signals on 3D image by NiftiLabelsMasker which is invalid as masker requires 4D-like images to extract signals.

This PR should fix this issue. I just make use of ```_iter_check_niimg``` and used argument to ```atleast_4d=True```.

Reproducible script:
```python
from nilearn import datasets
from nilearn.regions import Parcellations

oasis = datasets.fetch_oasis_vbm(n_subjects=5)
parcellations = Parcellations(method='ward', n_parcels=20000)
X = parcellations.fit_transform(oasis.gray_matter_maps)
```

Can I please have reviews on this ?
@glemaitre could you please check this PR please on data you worked on ?

Thanks