### PR TITLE
DOC: Update changelog

### DIFF
--- a/doc/themes/nilearn/layout.html
+++ b/doc/themes/nilearn/layout.html
@@ -195,13 +195,13 @@ $(function () {
 
 <h4> News </h4>
   <ul>
+      <li><p> <strong>June 14th 2018</strong>: Nilearn 0.4.2 released
+      </p></li>
       <li><p> <strong>March 12th 2018</strong>: Nilearn 0.4.1 released
       </p></li>
       <li><p> <strong>November 19th 2017</strong>: Nilearn 0.4 released
       </p></li>
       <li><p> <strong>June 20th 2017</strong>: Nilearn 0.3.1 released
-      </p></li>
-      <li><p> <strong>April 18th 2017</strong>: Nilearn 0.3.0 released
       </p></li>
       <li><p> <strong>March 2014</strong>: <a
           href="http://journal.frontiersin.org/Journal/10.3389/fninf.2014.00014/abstract"

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,3 +1,33 @@
+0.4.2
+=====
+Few important bugs fix release for OHBM conference.
+
+Changes
+-------
+    - Default colormaps for surface plotting functions have changed to be more
+      consistent with slice plotting.
+      :func:`nilearn.plotting.plot_surf_stat_map` now uses "cold_hot", as
+      :func:`nilearn.plotting.plot_stat_map` does, and
+      :func:`nilearn.plotting.plot_surf_roi` now uses "gist_ncar", as
+      :func:`nilearn.plotting.plot_roi` does.
+
+    - Improve 3D surface plotting: lock the aspect ratio of the plots and
+      reduce the whitespace around the plots.
+
+Bug fixes
+---------
+
+    - Fix bug with input repetition time (TR) which had no effect in signal
+      cleaning. Fixed by Pradeep Raamana.
+
+    - Fix issues with signal extraction on list of 3D images in
+      :class:`nilearn.regions.Parcellations`.
+
+    - Fix issues with raising AttributeError rather than HTTPError in datasets
+      fetching utilities. By Jerome Dockes.
+
+    - Fix issues in datasets testing function uncompression of files. By Pierre Glaser.
+
 0.4.1
 =====
 
@@ -28,16 +58,6 @@ Changes
       in :class:`nilearn.decomposition.CanICA` and
       :class:`nilearn.decomposition.DictLearning` is deprecated and will
       be removed in next two releases. Use `components_img_` instead.
-
-    - Default colormaps for surface plotting functions have changed to be more
-      consistent with slice plotting.
-      :func:`nilearn.plotting.plot_surf_stat_map` now uses "cold_hot", as
-      :func:`nilearn.plotting.plot_stat_map` does, and
-      :func:`nilearn.plotting.plot_surf_roi` now uses "gist_ncar", as
-      :func:`nilearn.plotting.plot_roi` does.
-
-   - Improve 3D surface plotting: lock the aspect ratio of the plots and
-     reduce the whitespace around the plots.
 
 Bug fixes
 ---------

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -21,7 +21,7 @@ nilearn version, required package versions, and utilities for checking
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.4.1'
+__version__ = '0.4.2'
 
 _NILEARN_INSTALL_MSG = 'See %s for installation information.' % (
     'http://nilearn.github.io/introduction.html#installation')


### PR DESCRIPTION
Update doc/whats_new.rst for release of Nilearn 0.4.2 and moved the changelog additions in 0.4.1 to 0.4.2.