### PR TITLE
MAINT: temp work-around for conda install 1.11.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
            SCIKIT_LEARN_VERSION="0.15"
     # Fake Ubuntu Xenial (Travis doesn't support Xenial yet)
     - env: DISTRIB="conda" PYTHON_VERSION="2.7"
-           NUMPY_VERSION="1.11" SCIPY_VERSION="0.17"
+           NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.17"
            SCIKIT_LEARN_VERSION="0.17"
            NIBABEL_VERSION="2.0.2"
     # Python 3.4 with intermediary versions


### PR DESCRIPTION
To check if travis environment 3 is happy with NumPy 1.11.2