### PR TITLE
[ENH] allow for extracting percent signal-change from ROIs

### DIFF
--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -116,6 +116,7 @@ def filter_and_extract(imgs, extraction_function,
             t_r=parameters['t_r'],
             low_pass=parameters['low_pass'],
             high_pass=parameters['high_pass'],
+            standardize_strategy=parameters['standardize_strategy'],
             confounds=confounds,
             sessions=sessions)
 

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -60,6 +60,10 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         If standardize is True, the time-series are centered and normed:
         their mean is put to 0 and their variance to 1 in the time dimension.
 
+    standardize_strategy : str, optional
+        This parameter sets how the signal gets normalized by signal.clean()
+        (z-scored or percent signal change).
+
     detrend: boolean, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
@@ -103,9 +107,9 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
     # memory and memory_level are used by CacheMixin.
 
     def __init__(self, labels_img, background_label=0, mask_img=None,
-                 smoothing_fwhm=None, standardize=False, detrend=False,
-                 low_pass=None, high_pass=None, t_r=None,
-                 resampling_target="data",
+                 smoothing_fwhm=None, standardize=False, 
+                 standardize_strategy='zscore', detrend=False, low_pass=None, 
+                 high_pass=None, t_r=None, resampling_target="data",
                  memory=Memory(cachedir=None, verbose=0), memory_level=1,
                  verbose=0):
         self.labels_img = labels_img
@@ -121,6 +125,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         self.low_pass = low_pass
         self.high_pass = high_pass
         self.t_r = t_r
+        self.standardize_strategy = standardize_strategy
 
         # Parameters for resampling
         self.resampling_target = resampling_target

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -62,6 +62,10 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         If standardize is True, the time-series are centered and normed:
         their mean is put to 0 and their variance to 1 in the time dimension.
 
+    standardize_strategy : str, optional
+        This parameter sets how the signal gets normalized by signal.clean()
+        (z-scored or percent signal change).
+
     detrend: boolean, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
@@ -112,7 +116,8 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
 
     def __init__(self, maps_img, mask_img=None,
                  allow_overlap=True,
-                 smoothing_fwhm=None, standardize=False, detrend=False,
+                 smoothing_fwhm=None, standardize=False,
+                 standardize_strategy='zscore', detrend=False,
                  low_pass=None, high_pass=None, t_r=None,
                  resampling_target="data",
                  memory=Memory(cachedir=None, verbose=0), memory_level=0,
@@ -128,6 +133,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
 
         # Parameters for clean()
         self.standardize = standardize
+        self.standardize_strategy = standardize_strategy
         self.detrend = detrend
         self.low_pass = low_pass
         self.high_pass = high_pass

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -83,8 +83,12 @@ class NiftiMasker(BaseMasker, CacheMixin):
         millimeters of the spatial smoothing to apply to the signal.
 
     standardize : boolean, optional
-        If standardize is True, the time-series are centered and normed:
-        their mean is put to 0 and their variance to 1 in the time dimension.
+        If standardize is True, the time-series are normalized using
+        signal.clean().
+
+    standardize_strategy : str, optional
+        This parameter sets how the signal gets normalized by signal.clean()
+        (z-scored or percent signal change).
 
     detrend : boolean, optional
         This parameter is passed to signal.clean. Please see the related
@@ -160,7 +164,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
     """
 
     def __init__(self, mask_img=None, sessions=None, smoothing_fwhm=None,
-                 standardize=False, detrend=False,
+                 standardize=False, standardize_strategy='zscore', detrend=False,
                  low_pass=None, high_pass=None, t_r=None,
                  target_affine=None, target_shape=None,
                  mask_strategy='background',
@@ -182,6 +186,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
         self.target_shape = target_shape
         self.mask_strategy = mask_strategy
         self.mask_args = mask_args
+        self.standardize_strategy = standardize_strategy
         self.sample_mask = sample_mask
 
         self.memory = memory

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -171,6 +171,10 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         If standardize is True, the time-series are centered and normed:
         their mean is set to 0 and their variance to 1 in the time dimension.
 
+    standardize_strategy : str, optional
+        This parameter sets how the signal gets normalized by signal.clean()
+        (z-scored or percent signal change).
+
     detrend: boolean, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details.
@@ -206,7 +210,8 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
     # memory and memory_level are used by CacheMixin.
 
     def __init__(self, seeds, radius=None, mask_img=None, allow_overlap=False,
-                 smoothing_fwhm=None, standardize=False, detrend=False,
+                 smoothing_fwhm=None, standardize=False,
+                 standardize_strategy='zscore', detrend=False,
                  low_pass=None, high_pass=None, t_r=None,
                  memory=Memory(cachedir=None, verbose=0), memory_level=1,
                  verbose=0):
@@ -220,6 +225,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
 
         # Parameters for clean()
         self.standardize = standardize
+        self.standardize_strategy = standardize_strategy
         self.detrend = detrend
         self.low_pass = low_pass
         self.high_pass = high_pass

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -20,7 +20,8 @@ from ._utils.numpy_conversions import csv_to_array, as_ndarray
 NP_VERSION = distutils.version.LooseVersion(np.version.short_version).version
 
 
-def _standardize(signals, detrend=False, normalize=True):
+def _standardize(signals, detrend=False, normalize=True, 
+                 normalization_strategy='variance'):
     """ Center and norm a given signal (time is along first axis)
 
     Parameters
@@ -35,11 +36,26 @@ def _standardize(signals, detrend=False, normalize=True):
         if True, shift timeseries to zero mean value and scale
         to unit energy (sum of squares).
 
+    normalize: {bool}
+        if True, signal gets normalized
+
+    normalization_strategy: str, optional
+       Signals normalization strategy.
+       'variance', shift timeseries to zero mean value and scale
+        to unit energy (sum of squares).
+       'zscore', the signal is z-scored, variance is set to 1.
+       'psc', variance of the signal corresponds to the percent signal
+       change (percent of the mean signal). The mean of the signal is set to
+       0.
+
     Returns
     -------
     std_signals: numpy.ndarray
         copy of signals, normalized.
     """
+
+    if normalization_strategy not in ['psc', 'zscore', 'variance']:
+        raise Exception('{} is no valid normalization strategy.'.format(normalization_strategy))
 
     if detrend:
         signals = _detrend(signals, inplace=False)
@@ -48,19 +64,33 @@ def _standardize(signals, detrend=False, normalize=True):
 
     if normalize:
         if signals.shape[0] == 1:
-            warnings.warn('Standardization of 3D signal has been requested but '
-                'would lead to zero values. Skipping.')
+            warnings.warn('Standardization of 3D signal has been requested but'
+                ' would lead to zero values. Skipping.')
             return signals
 
-        if not detrend:
-            # remove mean if not already detrended
-            signals = signals - signals.mean(axis=0)
+        if normalization_strategy == 'variance':
+            if not detrend:
+                signals = signals - signals.mean(axis=0)
 
-        std = np.sqrt((signals ** 2).sum(axis=0))
-        std[std < np.finfo(np.float).eps] = 1.  # avoid numerical problems
-        signals /= std
+            std = np.sqrt((signals ** 2).sum(axis=0))
+            std[std < np.finfo(np.float).eps] = 1.  # avoid numerical problems
+            signals /= std
+
+        elif normalization_strategy == 'zscore':
+            if not detrend:
+                # remove mean if not already detrended
+                signals = signals - signals.mean(axis=0)
+
+            std = signals.std(axis=0)
+            std[std < np.finfo(np.float).eps] = 1.  # avoid numerical problems
+            signals /= std
+
+        elif normalization_strategy == 'psc':
+            mean_signal = signals.mean(0)
+            signals = (signals / mean_signal) * 100
+            signals -= 100
+
     return signals
-
 
 def _mean_of_squares(signals, n_batches=20):
     """Compute mean of squares for each signal.
@@ -355,15 +385,15 @@ def _ensure_float(data):
 
 
 def clean(signals, sessions=None, detrend=True, standardize=True,
-          confounds=None, low_pass=None, high_pass=None, t_r=2.5,
-          ensure_finite=False):
+          standardize_strategy='zscore', confounds=None, low_pass=None,
+          high_pass=None, t_r=2.5, ensure_finite=False):
     """Improve SNR on masked fMRI signals.
 
     This function can do several things on the input signals, in
     the following order:
 
-    - detrend
     - standardize
+    - detrend
     - remove confounds
     - low- and high-pass filter
 
@@ -405,7 +435,17 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
         confound removal)
 
     standardize: bool
-        If True, returned signals are set to unit variance.
+        If True, returned signals are z-scored (unit variance) or converted
+        to percent signal-change.
+
+    standardize_strategy: str
+       Signals normalization method.
+       'variance', shift timeseries to zero mean value and scale
+        to unit energy (sum of squares).
+       'zscore', the signal is z-scored, variance is set to 1.
+       'psc', variance of the signal corresponds to the percent signal
+       change (percent of the mean signal). The mean of the signal is set to
+       0.
 
     ensure_finite: bool
         If True, the non-finite values (NANs and infs) found in the data
@@ -501,12 +541,17 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
             signals[sessions == s, :] = \
                 clean(signals[sessions == s],
                       detrend=detrend, standardize=standardize,
+                      standardize_strategy=standardize_strategy,
                       confounds=session_confounds, low_pass=low_pass,
                       high_pass=high_pass, t_r=t_r)
 
+
     # detrend
     signals = _ensure_float(signals)
-    signals = _standardize(signals, normalize=False, detrend=detrend)
+
+    if detrend:
+        mean_signals = signals.mean(axis=0)
+        signals = _standardize(signals, normalize=False, detrend=detrend)
 
     # Remove confounds
     if confounds is not None:
@@ -534,10 +579,15 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
         signals = butterworth(signals, sampling_rate=1. / t_r,
                               low_pass=low_pass, high_pass=high_pass)
 
-    if standardize:
-        signals = _standardize(signals, normalize=True, detrend=False)
-        signals *= np.sqrt(signals.shape[0])  # for unit variance
+    # Standardize
+    if detrend:
+        signals = _standardize(signals + mean_signals, normalize=standardize,
+                               detrend=False,
+                               normalization_strategy=standardize_strategy)
+    else:
+        signals = _standardize(signals, normalize=standardize,
+                               detrend=False,
+                               normalization_strategy=standardize_strategy)
 
     return signals
-
 

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -485,3 +485,17 @@ def test_high_variance_confounds():
     np.testing.assert_almost_equal(
         np.min(np.abs(np.dstack([outG - outGt, outG + outGt])), axis=2),
         np.zeros(outG.shape))
+
+
+
+def test_clean_psc():
+    rng = np.random.RandomState(0)
+    n_samples = 500
+    n_features = 5
+
+    signals, _, _ = generate_signals(n_features=n_features,
+                                     length=n_samples)
+
+    signals += rng.randn(1, n_features)
+    cleaned_signals = clean(signals, standardize_strategy='psc')
+    np.testing.assert_almost_equal(cleaned_signals.mean(), 0)


### PR DESCRIPTION
For my research I really like to have BOLD time series in "percent signal-change. I looked at an [old pull-request](https://github.com/nilearn/nilearn/pull/949) but found it very hard to finish. It seems like that request was doing much more than just introducing psc.

Please have a look at this one.