### PR TITLE
Improve html_surface colorbar range using 0.3 and 99.7 percentiles.

### DIFF
--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -190,10 +190,11 @@ def colorscale(cmap, values, threshold=None, symmetric_cmap=True):
     cmap = mpl_cm.get_cmap(cmap)
     abs_values = np.abs(values)
     if symmetric_cmap:
-        vmax = abs_values.max()
-        vmin = - vmax
+        vmax = fast_abs_percentile(abs_values, 99.7)
+        vmin = -vmax
     else:
-        vmin, vmax = values.min(), values.max()
+        vmin = fast_abs_percentile(abs_values, 0.3)
+        vmax = fast_abs_percentile(abs_values, 99.7)
     norm = mpl.colors.Normalize(vmin=vmin, vmax=vmax)
     cmaplist = [cmap(i) for i in range(cmap.N)]
     abs_threshold = None

--- a/nilearn/plotting/tests/test_html_surface.py
+++ b/nilearn/plotting/tests/test_html_surface.py
@@ -19,6 +19,7 @@ from nilearn import datasets, surface
 from nilearn.plotting import html_surface
 from nilearn.datasets import fetch_surf_fsaverage
 from nilearn._utils.exceptions import DimensionError
+from nilearn._utils.extmath import fast_abs_percentile
 
 # Note: html output by view_surf and view_img_on_surf
 # should validate as html5 using https://validator.w3.org/nu/ with no
@@ -187,7 +188,7 @@ def test_one_mesh_info():
     assert len(html_surface.decode(
         info['inflated_left']['_x'], '<f4')) == len(surf_map)
     assert len(info['vertexcolor_left']) == len(surf_map)
-    cmax = np.max(np.abs(surf_map))
+    cmax = fast_abs_percentile(np.abs(surf_map), 99.7)
     assert (info['cmin'], info['cmax']) == (-cmax, cmax)
     assert type(info['cmax']) == float
     json.dumps(info)


### PR DESCRIPTION
Setting the limits of the colorbar using percentiles makes the color window more robust against outliers and "empirically" guarantees better usage of the color range.