### PR TITLE
FIX: find_xyz_cut_coords returns MNI default coordinate to AC-PC line

### DIFF
--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -24,6 +24,8 @@ from ..image.image import _smooth_array
 # Functions for automatic choice of cuts coordinates
 ################################################################################
 
+DEFAULT_CUT_COORDS = (0., 0., 0.)
+
 
 def find_xyz_cut_coords(img, mask_img=None, activation_threshold=None):
     """ Find the center of the largest activation connected component.
@@ -52,6 +54,15 @@ def find_xyz_cut_coords(img, mask_img=None, activation_threshold=None):
     # we reduce to a single 3D image to find the coordinates
     img = check_niimg_3d(img)
     data = _safe_get_data(img)
+
+    # when given image is empty, return (0., 0., 0.)
+    if data.sum() == 0.:
+        warnings.warn(
+            "Given img is empty. Returning default cut_coords={0} instead."
+            .format(DEFAULT_CUT_COORDS))
+        x_map, y_map, z_map = DEFAULT_CUT_COORDS
+        return np.asarray(coord_transform(x_map, y_map, z_map,
+                                          img.affine)).tolist()
 
     # Retrieve optional mask
     if mask_img is not None:

--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -56,7 +56,7 @@ def find_xyz_cut_coords(img, mask_img=None, activation_threshold=None):
     data = _safe_get_data(img)
 
     # when given image is empty, return (0., 0., 0.)
-    if data.sum() == 0.:
+    if np.all(data == 0.):
         warnings.warn(
             "Given img is empty. Returning default cut_coords={0} instead."
             .format(DEFAULT_CUT_COORDS))

--- a/nilearn/plotting/tests/test_find_cuts.py
+++ b/nilearn/plotting/tests/test_find_cuts.py
@@ -57,6 +57,14 @@ def test_find_cut_coords():
     img_4d = nibabel.Nifti1Image(data_4d, affine)
     assert_equal(find_xyz_cut_coords(img_3d), find_xyz_cut_coords(img_4d))
 
+    # test passing empty image returns coordinates pointing to AC-PC line
+    data = np.zeros((20, 30, 40))
+    affine = np.eye(4)
+    img = nibabel.Nifti1Image(data, affine)
+    cut_coords = find_xyz_cut_coords(img)
+    assert_equal(cut_coords, [0.0, 0.0, 0.0])
+    cut_coords = assert_warns(UserWarning, find_xyz_cut_coords, img)
+
 
 def test_find_cut_slices():
     data = np.zeros((50, 50, 50))


### PR DESCRIPTION
This PR tries to return the central cut coordinates (0., 0., 0.) when an empty image is passed to ```nilearn.plotting.find_xyz_cut_coords```.

Current code returns coordinates half the image data shape and not in real world coordinates. This came across while working on a PR #1602 

Thanks for reviewing.