### PR TITLE
ENH add dtype option for NiftiMasker

### DIFF
--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -178,8 +178,8 @@ preparation::
    >>> from nilearn import input_data
    >>> masker = input_data.NiftiMasker()
    >>> masker
-   NiftiMasker(detrend=False, high_pass=None, low_pass=None, mask_args=None,
-         mask_img=None, mask_strategy='background',
+   NiftiMasker(detrend=False, dtype=None, high_pass=None, low_pass=None,
+         mask_args=None, mask_img=None, mask_strategy='background',
          memory=Memory(cachedir=None), memory_level=1, sample_mask=None,
          sessions=None, smoothing_fwhm=None, standardize=False, t_r=None,
          target_affine=None, target_shape=None, verbose=0)

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -188,6 +188,14 @@ The meaning of each parameter is described in the documentation of
 :class:`NiftiMasker` (click on the name :class:`NiftiMasker`), here we
 comment on the most important.
 
+.. topic:: **`dtype` argument**
+
+    Forcing your data to have a `dtype` of **float32** can help
+    save memory and is often a good-enough numerical precision.
+    You can force this cast by choosing `dtype` to be 'auto'.
+    In the future this cast will be the default behaviour.
+
+
 .. seealso::
 
    If you do not want to use the :class:`NiftiMasker` to perform these

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -3,6 +3,9 @@
 
 Enhancements
 ------------
+    - All NiftiMaskers now have a `dtype` argument. For now the default behaviour
+      is to keep the same data type as the input data.
+
     - :func:`nilearn.plotting.view_surf` and
       :func:`nilearn.plotting.view_img_on_surf` for interactive visualization of
       maps on the cortical surface in a web browser.

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -26,7 +26,8 @@ def filter_and_extract(imgs, extraction_function,
                        memory_level=0, memory=Memory(cachedir=None),
                        verbose=0,
                        confounds=None,
-                       copy=True):
+                       copy=True,
+                       dtype=None):
     """Extract representative time series using given function.
 
     Parameters
@@ -63,7 +64,8 @@ def filter_and_extract(imgs, extraction_function,
         print("[%s] Loading data from %s" % (
             class_name,
             _utils._repr_niimgs(imgs)[:200]))
-    imgs = _utils.check_niimg(imgs, atleast_4d=True, ensure_ndim=4)
+    imgs = _utils.check_niimg(imgs, atleast_4d=True, ensure_ndim=4,
+                              dtype=dtype)
 
     sample_mask = parameters.get('sample_mask')
     if sample_mask is not None:
@@ -103,7 +105,6 @@ def filter_and_extract(imgs, extraction_function,
     # Filtering
     # Confounds removing (from csv file or numpy array)
     # Normalizing
-
     if verbose > 0:
         print("[%s] Cleaning extracted signals" % class_name)
     sessions = parameters.get('sessions')

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -269,8 +269,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
                                        target_fov=target_fov,
                                        memory=self.memory,
                                        memory_level=self.memory_level,
-                                       verbose=self.verbose,
-                                       dtype=self.dtype)
+                                       verbose=self.verbose)
 
         if confounds is None:
             confounds = itertools.repeat(None, len(imgs_list))

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -83,6 +83,11 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         to fine-tune mask computation. Please see the related documentation
         for details.
 
+    dtype: {dtype, "auto"}
+        Data type toward which the data should be converted. If "auto", the
+        data will be converted to int32 if dtype is discrete and float32 if it
+        is continuous.
+
     memory: instance of joblib.Memory or string
         Used to cache the masking process.
         By default, no caching is done. If a string is given, it is the
@@ -119,7 +124,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
                  standardize=False, detrend=False,
                  low_pass=None, high_pass=None, t_r=None,
                  target_affine=None, target_shape=None,
-                 mask_strategy='background', mask_args=None,
+                 mask_strategy='background', mask_args=None, dtype=None,
                  memory=Memory(cachedir=None), memory_level=0,
                  n_jobs=1, verbose=0
                  ):
@@ -136,6 +141,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         self.target_shape = target_shape
         self.mask_strategy = mask_strategy
         self.mask_args = mask_args
+        self.dtype = dtype
 
         self.memory = memory
         self.memory_level = memory_level
@@ -263,7 +269,8 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
                                        target_fov=target_fov,
                                        memory=self.memory,
                                        memory_level=self.memory_level,
-                                       verbose=self.verbose)
+                                       verbose=self.verbose,
+                                       dtype=self.dtype)
 
         if confounds is None:
             confounds = itertools.repeat(None, len(imgs_list))

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -269,8 +269,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
                                        target_fov=target_fov,
                                        memory=self.memory,
                                        memory_level=self.memory_level,
-                                       verbose=self.verbose,
-                                       dtype=self.dtype)
+                                       verbose=self.verbose)
 
         if confounds is None:
             confounds = itertools.repeat(None, len(imgs_list))
@@ -293,6 +292,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
                           verbose=self.verbose,
                           confounds=cfs,
                           copy=copy,
+                          dtype=self.dtype
                           )
             for imgs, cfs in izip(niimg_iter, confounds))
         return data

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -269,7 +269,8 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
                                        target_fov=target_fov,
                                        memory=self.memory,
                                        memory_level=self.memory_level,
-                                       verbose=self.verbose)
+                                       verbose=self.verbose,
+                                       dtype=self.dtype)
 
         if confounds is None:
             confounds = itertools.repeat(None, len(imgs_list))

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -76,6 +76,11 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
+    dtype: {dtype, "auto"}
+        Data type toward which the data should be converted. If "auto", the
+        data will be converted to int32 if dtype is discrete and float32 if it
+        is continuous.
+
     resampling_target: {"data", "labels", None}, optional.
         Gives which image gives the final shape/size. For example, if
         `resampling_target` is "data", the atlas is resampled to the
@@ -104,7 +109,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
 
     def __init__(self, labels_img, background_label=0, mask_img=None,
                  smoothing_fwhm=None, standardize=False, detrend=False,
-                 low_pass=None, high_pass=None, t_r=None,
+                 low_pass=None, high_pass=None, t_r=None, dtype=None,
                  resampling_target="data",
                  memory=Memory(cachedir=None, verbose=0), memory_level=1,
                  verbose=0):
@@ -121,6 +126,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         self.low_pass = low_pass
         self.high_pass = high_pass
         self.t_r = t_r
+        self.dtype = dtype
 
         # Parameters for resampling
         self.resampling_target = resampling_target
@@ -253,6 +259,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             # Pre-processing
             params,
             confounds=confounds,
+            dtype=self.dtype,
             # Caching
             memory=self.memory,
             memory_level=self.memory_level,

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -78,6 +78,11 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
+    dtype: {dtype, "auto"}
+        Data type toward which the data should be converted. If "auto", the
+        data will be converted to int32 if dtype is discrete and float32 if it
+        is continuous.
+
     resampling_target: {"mask", "maps", "data", None} optional.
         Gives which image gives the final shape/size. For example, if
         `resampling_target` is "mask" then maps_img and images provided to
@@ -113,7 +118,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
     def __init__(self, maps_img, mask_img=None,
                  allow_overlap=True,
                  smoothing_fwhm=None, standardize=False, detrend=False,
-                 low_pass=None, high_pass=None, t_r=None,
+                 low_pass=None, high_pass=None, t_r=None, dtype=None,
                  resampling_target="data",
                  memory=Memory(cachedir=None, verbose=0), memory_level=0,
                  verbose=0):
@@ -132,6 +137,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         self.low_pass = low_pass
         self.high_pass = high_pass
         self.t_r = t_r
+        self.dtype = dtype
 
         # Parameters for resampling
         self.resampling_target = resampling_target
@@ -161,7 +167,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
                    _utils._repr_niimgs(self.maps_img)[:200],
                    verbose=self.verbose)
 
-        self.maps_img_ = _utils.check_niimg_4d(self.maps_img)
+        self.maps_img_ = _utils.check_niimg_4d(self.maps_img, dtype=self.dtype)
         self.maps_img_ = image.clean_img(self.maps_img_, detrend=False,
                                          standardize=False,
                                          ensure_finite=True)
@@ -312,6 +318,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
                 # Pre-treatments
                 params,
                 confounds=confounds,
+                dtype=self.dtype,
                 # Caching
                 memory=self.memory,
                 memory_level=self.memory_level,

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -34,8 +34,7 @@ def filter_and_mask(imgs, mask_img_, parameters,
                     confounds=None,
                     copy=True,
                     dtype=None):
-    imgs = _utils.check_niimg(imgs, atleast_4d=True, ensure_ndim=4,
-                              dtype=dtype)
+    imgs = _utils.check_niimg(imgs, atleast_4d=True, ensure_ndim=4)
 
     # Check whether resampling is truly necessary. If so, crop mask
     # as small as possible in order to speed up the process

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -31,8 +31,10 @@ def filter_and_mask(imgs, mask_img_, parameters,
                     memory_level=0, memory=Memory(cachedir=None),
                     verbose=0,
                     confounds=None,
-                    copy=True):
-    imgs = _utils.check_niimg(imgs, atleast_4d=True, ensure_ndim=4)
+                    copy=True,
+                    dtype=None):
+    imgs = _utils.check_niimg(imgs, atleast_4d=True, ensure_ndim=4,
+                              dtype=dtype)
 
     # Check whether resampling is truly necessary. If so, crop mask
     # as small as possible in order to speed up the process
@@ -133,6 +135,11 @@ class NiftiMasker(BaseMasker, CacheMixin):
         This is useful to perform data subselection as part of a scikit-learn
         pipeline.
 
+    `dtype: {dtype, "auto"}
+        Data type toward which the data should be converted. If "auto", the
+        data will be converted to int32 if dtype is discrete and float32 if it
+        is continuous.
+
     memory : instance of joblib.Memory or string
         Used to cache the masking process.
         By default, no caching is done. If a string is given, it is the
@@ -167,7 +174,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
                  low_pass=None, high_pass=None, t_r=None,
                  target_affine=None, target_shape=None,
                  mask_strategy='background',
-                 mask_args=None, sample_mask=None,
+                 mask_args=None, sample_mask=None, dtype=None,
                  memory_level=1, memory=Memory(cachedir=None),
                  verbose=0
                  ):
@@ -186,6 +193,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
         self.mask_strategy = mask_strategy
         self.mask_args = mask_args
         self.sample_mask = sample_mask
+        self.dtype = dtype
 
         self.memory = memory
         self.memory_level = memory_level
@@ -294,7 +302,8 @@ class NiftiMasker(BaseMasker, CacheMixin):
             memory=self.memory,
             verbose=self.verbose,
             confounds=confounds,
-            copy=copy
+            copy=copy,
+            dtype=self.dtype
         )
 
         return data

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -34,7 +34,8 @@ def filter_and_mask(imgs, mask_img_, parameters,
                     confounds=None,
                     copy=True,
                     dtype=None):
-    imgs = _utils.check_niimg(imgs, atleast_4d=True, ensure_ndim=4)
+    imgs = _utils.check_niimg(imgs, atleast_4d=True, ensure_ndim=4,
+                              dtype=dtype)
 
     # Check whether resampling is truly necessary. If so, crop mask
     # as small as possible in order to speed up the process

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -24,7 +24,8 @@ class _ExtractionFunctor(object):
         self.mask_img_ = mask_img_
 
     def __call__(self, imgs):
-        return masking.apply_mask(imgs, self.mask_img_), imgs.affine
+        return(masking.apply_mask(imgs, self.mask_img_,
+                                  dtype=imgs.get_data_dtype()), imgs.affine)
 
 
 def filter_and_mask(imgs, mask_img_, parameters,
@@ -33,8 +34,7 @@ def filter_and_mask(imgs, mask_img_, parameters,
                     confounds=None,
                     copy=True,
                     dtype=None):
-    imgs = _utils.check_niimg(imgs, atleast_4d=True, ensure_ndim=4,
-                              dtype=dtype)
+    imgs = _utils.check_niimg(imgs, atleast_4d=True, ensure_ndim=4)
 
     # Check whether resampling is truly necessary. If so, crop mask
     # as small as possible in order to speed up the process
@@ -51,7 +51,8 @@ def filter_and_mask(imgs, mask_img_, parameters,
                                       memory_level=memory_level,
                                       memory=memory,
                                       verbose=verbose,
-                                      confounds=confounds, copy=copy)
+                                      confounds=confounds, copy=copy,
+                                      dtype=dtype)
 
     # For _later_: missing value removal or imputing of missing data
     # (i.e. we want to get rid of NaNs, if smoothing must be done

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -119,22 +119,23 @@ class _ExtractionFunctor(object):
 
     func_name = 'nifti_spheres_masker_extractor'
 
-    def __init__(self, seeds_, radius, mask_img, allow_overlap):
+    def __init__(self, seeds_, radius, mask_img, allow_overlap, dtype):
         self.seeds_ = seeds_
         self.radius = radius
         self.mask_img = mask_img
         self.allow_overlap = allow_overlap
+        self.dtype = dtype
 
     def __call__(self, imgs):
         n_seeds = len(self.seeds_)
-        imgs = check_niimg_4d(imgs)
+        imgs = check_niimg_4d(imgs, dtype=self.dtype)
 
-        signals = np.empty((imgs.shape[3], n_seeds))
+        signals = np.empty((imgs.shape[3], n_seeds),
+                           dtype=imgs.get_data_dtype())
         for i, sphere in enumerate(_iter_signals_from_spheres(
                 self.seeds_, imgs, self.radius, self.allow_overlap,
                 mask_img=self.mask_img)):
             signals[:, i] = np.mean(sphere, axis=1)
-
         return signals, None
 
 
@@ -187,6 +188,11 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         This parameter is passed to signal.clean. Please see the related
         documentation for details.
 
+    dtype: {dtype, "auto"}
+        Data type toward which the data should be converted. If "auto", the
+        data will be converted to int32 if dtype is discrete and float32 if it
+        is continuous.
+
     memory: joblib.Memory or str, optional
         Used to cache the region extraction process.
         By default, no caching is done. If a string is given, it is the
@@ -207,7 +213,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
 
     def __init__(self, seeds, radius=None, mask_img=None, allow_overlap=False,
                  smoothing_fwhm=None, standardize=False, detrend=False,
-                 low_pass=None, high_pass=None, t_r=None,
+                 low_pass=None, high_pass=None, t_r=None, dtype=None,
                  memory=Memory(cachedir=None, verbose=0), memory_level=1,
                  verbose=0):
         self.seeds = seeds
@@ -224,6 +230,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         self.low_pass = low_pass
         self.high_pass = high_pass
         self.t_r = t_r
+        self.dtype = dtype
 
         # Parameters for joblib
         self.memory = memory
@@ -310,10 +317,11 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
                 ignore=['verbose', 'memory', 'memory_level'])(
             # Images
             imgs, _ExtractionFunctor(self.seeds_, self.radius, self.mask_img,
-                                     self.allow_overlap),
+                                     self.allow_overlap, self.dtype),
             # Pre-processing
             params,
             confounds=confounds,
+            dtype=self.dtype,
             # Caching
             memory=self.memory,
             memory_level=self.memory_level,

--- a/nilearn/input_data/tests/test_multi_nifti_masker.py
+++ b/nilearn/input_data/tests/test_multi_nifti_masker.py
@@ -184,3 +184,14 @@ def test_compute_multi_gray_matter_mask():
 
     np.testing.assert_array_equal(mask.get_data(), mask_ref)
     np.testing.assert_array_equal(mask2.get_data(), mask_ref)
+
+def test_dtype():
+    data = np.zeros((9, 9, 9), dtype=np.float64)
+    data[2:-2, 2:-2, 2:-2] = 10
+    img = Nifti1Image(data, np.eye(4))
+
+    masker = MultiNiftiMasker(dtype='auto')
+    masker.fit([[img]])
+
+    masked_img = masker.transform([[img]])
+    assert(masked_img[0].dtype == np.float32)

--- a/nilearn/input_data/tests/test_multi_nifti_masker.py
+++ b/nilearn/input_data/tests/test_multi_nifti_masker.py
@@ -185,6 +185,7 @@ def test_compute_multi_gray_matter_mask():
     np.testing.assert_array_equal(mask.get_data(), mask_ref)
     np.testing.assert_array_equal(mask2.get_data(), mask_ref)
 
+
 def test_dtype():
     data = np.zeros((9, 9, 9), dtype=np.float64)
     data[2:-2, 2:-2, 2:-2] = 10

--- a/nilearn/input_data/tests/test_nifti_masker.py
+++ b/nilearn/input_data/tests/test_nifti_masker.py
@@ -356,3 +356,24 @@ def test_filter_and_mask():
     # Test return_affine = False
     data = filter_and_mask(data_img, mask_img, params)
     assert_equal(data.shape, (5, 24000))
+
+
+def test_dtype():
+    data_32 = np.zeros((9, 9, 9), dtype=np.float32)
+    data_64 = np.zeros((9, 9, 9), dtype=np.float64)
+    data_32[2:-2, 2:-2, 2:-2] = 10
+    data_64[2:-2, 2:-2, 2:-2] = 10
+
+    affine_32 = np.eye(4, dtype=np.float32)
+    affine_64 = np.eye(4, dtype=np.float64)
+
+    img_32 = Nifti1Image(data_32, affine_32)
+    img_64 = Nifti1Image(data_64, affine_64)
+
+    masker_1 = NiftiMasker(dtype='auto')
+    assert(masker_1.fit_transform(img_32).dtype == np.float32)
+    assert(masker_1.fit_transform(img_64).dtype == np.float32)
+
+    masker_2 = NiftiMasker(dtype='float64')
+    assert(masker_2.fit_transform(img_32).dtype == np.float64)
+    assert(masker_2.fit_transform(img_64).dtype == np.float64)

--- a/nilearn/regions/signal_extraction.py
+++ b/nilearn/regions/signal_extraction.py
@@ -99,7 +99,8 @@ def img_to_signals_labels(imgs, labels_img, mask_img=None,
         labels_data[np.logical_not(mask_data)] = background_label
 
     data = _safe_get_data(imgs)
-    signals = np.ndarray((data.shape[-1], len(labels)), order=order)
+    signals = np.ndarray((data.shape[-1], len(labels)), order=order,
+                         dtype=data.dtype)
     for n, img in enumerate(np.rollaxis(data, -1)):
         signals[n] = np.asarray(ndimage.measurements.mean(img,
                                                           labels=labels_data,


### PR DESCRIPTION
This PR aims at solving issue #1669 

I only used `_utils.check_niimg` which already has this `dtype` feature and is used in both `NiftiMasker` and `MultiNiftiMasker`