### PR TITLE
Surface colorbars

### DIFF
--- a/examples/01_plotting/plot_3d_map_to_surface_projection.py
+++ b/examples/01_plotting/plot_3d_map_to_surface_projection.py
@@ -40,7 +40,7 @@ texture = surface.vol_to_surf(localizer_tmap, fsaverage.pial_right)
 from nilearn import plotting
 
 plotting.plot_surf_stat_map(fsaverage.infl_right, texture, hemi='right',
-                            title='Surface right hemisphere',
+                            title='Surface right hemisphere', colorbar=True,
                             threshold=1., bg_map=fsaverage.sulc_right)
 
 ##############################################################################
@@ -67,7 +67,7 @@ big_fsaverage = datasets.fetch_surf_fsaverage('fsaverage')
 big_texture = surface.vol_to_surf(localizer_tmap, big_fsaverage.pial_right)
 
 plotting.plot_surf_stat_map(big_fsaverage.infl_right,
-                            big_texture, hemi='right',
+                            big_texture, hemi='right', colorbar=True,
                             title='Surface right hemisphere: fine mesh',
                             threshold=1., bg_map=big_fsaverage.sulc_right)
 

--- a/examples/01_plotting/plot_surf_stat_map.py
+++ b/examples/01_plotting/plot_surf_stat_map.py
@@ -126,7 +126,7 @@ plotting.plot_surf_roi(fsaverage['pial_left'], roi_map=pcc_labels,
 ###############################################################################
 # Display unthresholded stat map  with dimmed background
 plotting.plot_surf_stat_map(fsaverage['pial_left'], stat_map=stat_map,
-                            hemi='left', view='medial',
+                            hemi='left', view='medial', colorbar=True,
                             bg_map=fsaverage['sulc_left'], bg_on_data=True,
                             darkness=.5, title='Correlation map')
 
@@ -134,14 +134,14 @@ plotting.plot_surf_stat_map(fsaverage['pial_left'], stat_map=stat_map,
 # Display unthresholded stat map without background map, transparency is
 # automatically set to .5, but can also be controlled with the alpha parameter
 plotting.plot_surf_stat_map(fsaverage['pial_left'], stat_map=stat_map,
-                            hemi='left', view='medial',
+                            hemi='left', view='medial', colorbar=True,
                             title='Plotting without background')
 
 ###############################################################################
 # Many different options are available for plotting, for example thresholding,
 # or using custom colormaps
 plotting.plot_surf_stat_map(fsaverage['pial_left'], stat_map=stat_map,
-                            hemi='left', view='medial',
+                            hemi='left', view='medial', colorbar=True,
                             bg_map=fsaverage['sulc_left'], bg_on_data=True,
                             cmap='Spectral', threshold=.5,
                             title='Threshold and colormap')
@@ -151,7 +151,7 @@ plotting.plot_surf_stat_map(fsaverage['pial_left'], stat_map=stat_map,
 # creating the figure
 plotting.plot_surf_stat_map(fsaverage['infl_left'], stat_map=stat_map,
                             hemi='left', bg_map=fsaverage['sulc_left'],
-                            bg_on_data=True, threshold=.6,
+                            bg_on_data=True, threshold=.6, colorbar=True,
                             output_file='plot_surf_stat_map.png')
 
 plotting.show()

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -8,13 +8,17 @@ import matplotlib.pyplot as plt
 
 from mpl_toolkits.mplot3d import Axes3D
 
+from matplotlib.colorbar import make_axes
+from matplotlib.cm import ScalarMappable, get_cmap
+from matplotlib.colors import Normalize, LinearSegmentedColormap
+
 from ..surface import load_surf_data, load_surf_mesh
 from .._utils.compat import _basestring
 from .img_plotting import _get_colorbar_and_data_ranges
 
 
 def plot_surf(surf_mesh, surf_map=None, bg_map=None,
-              hemi='left', view='lateral', cmap=None,
+              hemi='left', view='lateral', cmap=None, colorbar=False,
               avg_method='mean', threshold=None, alpha='auto',
               bg_on_data=False, darkness=1, vmin=None, vmax=None,
               title=None, output_file=None, axes=None, figure=None, **kwargs):
@@ -53,6 +57,9 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
         To use for plotting of the stat_map. Either a string
         which is a name of a matplotlib colormap, or a matplotlib
         colormap object. If None, matplolib default will be chosen
+
+    colorbar : bool, optional, default is False
+        If True, a colorbar is added.
 
     avg_method: {'mean', 'median'}, default is 'mean'
         How to average vertex values to derive the face value, mean results
@@ -189,6 +196,9 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
                                   antialiased=False,
                                   color='white')
 
+    # reduce viewing distance to remove space around mesh
+    axes.dist = 8
+
     # If depth_map and/or surf_map are provided, map these onto the surface
     # set_facecolors function of Poly3DCollection is used as passing the
     # facecolors argument to plot_trisurf does not seem to work
@@ -250,10 +260,40 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
             else:
                 face_colors[kept_indices] = cmap(surf_map_faces[kept_indices])
 
+            if colorbar and vmin != vmax:
+                our_cmap = get_cmap(cmap)
+                norm = Normalize(vmin=vmin, vmax=vmax)
+
+                nb_ticks = 5
+                ticks = np.linspace(vmin, vmax, nb_ticks)
+                bounds = np.linspace(vmin, vmax, our_cmap.N)
+
+                if threshold is not None:
+                    # some colormap hacking
+                    cmaplist = [our_cmap(i) for i in range(our_cmap.N)]
+                    istart = int(norm(-threshold, clip=True)
+                                 * (our_cmap.N - 1))
+                    istop = int(norm(threshold, clip=True)
+                                * (our_cmap.N - 1))
+                    for i in range(istart, istop):
+                        cmaplist[i] = (0.5, 0.5, 0.5, 1.)  # just an average gray color
+                    our_cmap = LinearSegmentedColormap.from_list(
+                        'Custom cmap', cmaplist, our_cmap.N)
+
+                # we need to create a proxy mappable
+                proxy_mappable = ScalarMappable(cmap=our_cmap, norm=norm)
+                proxy_mappable.set_array(surf_map_faces)
+                cax, kw = make_axes(axes, location='right', fraction=.1,
+                                    shrink=.6, pad=.0)
+                figure.colorbar(proxy_mappable, cax=cax, ticks=ticks,
+                                boundaries=bounds, spacing='proportional',
+                                format='%.2g', orientation='vertical')
+
+
         p3dcollec.set_facecolors(face_colors)
 
     if title is not None:
-        axes.set_title(title, position=(.5, .9))
+        axes.set_title(title, position=(.5, .95))
 
     # save figure if output file is given
     if output_file is not None:
@@ -266,9 +306,9 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
 def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
                        hemi='left', view='lateral', threshold=None,
                        alpha='auto', vmax=None, cmap='cold_hot',
-                       symmetric_cbar="auto", bg_on_data=False, darkness=1,
-                       title=None, output_file=None, axes=None, figure=None,
-                       **kwargs):
+                       colorbar=False, symmetric_cbar="auto", bg_on_data=False,
+                       darkness=1, title=None, output_file=None, axes=None,
+                       figure=None, **kwargs):
     """ Plotting a stats map on a surface mesh with optional background
 
     .. versionadded:: 0.3
@@ -311,6 +351,9 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
         To use for plotting of the stat_map. Either a string
         which is a name of a matplotlib colormap, or a matplotlib
         colormap object.
+
+    colorbar : bool, optional, default is False
+        If True, a colorbar is added.
 
     alpha : float, alpha level of the mesh (not the stat_map), default 'auto'
         If 'auto' is chosen, alpha will default to .5 when no bg_map is
@@ -368,9 +411,10 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
 
     display = plot_surf(
         surf_mesh, surf_map=stat_map, bg_map=bg_map, hemi=hemi, view=view,
-        avg_method='mean', threshold=threshold, cmap=cmap, alpha=alpha,
-        bg_on_data=bg_on_data, darkness=1, vmax=vmax, vmin=vmin, title=title,
-        output_file=output_file, axes=axes, figure=figure, **kwargs)
+        avg_method='mean', threshold=threshold, cmap=cmap, colorbar=colorbar,
+        alpha=alpha, bg_on_data=bg_on_data, darkness=1, vmax=vmax, vmin=vmin,
+        title=title, output_file=output_file, axes=axes, figure=figure,
+        **kwargs)
 
     return display
 

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -59,7 +59,7 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
         colormap object. If None, matplolib default will be chosen
 
     colorbar : bool, optional, default is False
-        If True, a colorbar is added.
+        If True, a colorbar of surf_map is displayed.
 
     avg_method: {'mean', 'median'}, default is 'mean'
         How to average vertex values to derive the face value, mean results
@@ -305,7 +305,7 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
 def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
                        hemi='left', view='lateral', threshold=None,
                        alpha='auto', vmax=None, cmap='cold_hot',
-                       colorbar=False, symmetric_cbar="auto", bg_on_data=False,
+                       colorbar=True, symmetric_cbar="auto", bg_on_data=False,
                        darkness=1, title=None, output_file=None, axes=None,
                        figure=None, **kwargs):
     """ Plotting a stats map on a surface mesh with optional background
@@ -352,7 +352,7 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
         colormap object.
 
     colorbar : bool, optional, default is False
-        If True, a colorbar is added.
+        If True, a symmetric colorbar of the statistical map is displayed.
 
     alpha : float, alpha level of the mesh (not the stat_map), default 'auto'
         If 'auto' is chosen, alpha will default to .5 when no bg_map is

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -260,7 +260,7 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
             else:
                 face_colors[kept_indices] = cmap(surf_map_faces[kept_indices])
 
-            if colorbar and vmin != vmax:
+            if colorbar:
                 our_cmap = get_cmap(cmap)
                 norm = Normalize(vmin=vmin, vmax=vmax)
 
@@ -269,14 +269,14 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
                 bounds = np.linspace(vmin, vmax, our_cmap.N)
 
                 if threshold is not None:
-                    # some colormap hacking
                     cmaplist = [our_cmap(i) for i in range(our_cmap.N)]
-                    istart = int(norm(-threshold, clip=True)
-                                 * (our_cmap.N - 1))
-                    istop = int(norm(threshold, clip=True)
-                                * (our_cmap.N - 1))
+                    # set colors to grey for absolute values < threshold
+                    istart = int(norm(-threshold, clip=True) *
+                                 (our_cmap.N - 1))
+                    istop = int(norm(threshold, clip=True) *
+                                (our_cmap.N - 1))
                     for i in range(istart, istop):
-                        cmaplist[i] = (0.5, 0.5, 0.5, 1.)  # just an average gray color
+                        cmaplist[i] = (0.5, 0.5, 0.5, 1.)
                     our_cmap = LinearSegmentedColormap.from_list(
                         'Custom cmap', cmaplist, our_cmap.N)
 
@@ -288,7 +288,6 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
                 figure.colorbar(proxy_mappable, cax=cax, ticks=ticks,
                                 boundaries=bounds, spacing='proportional',
                                 format='%.2g', orientation='vertical')
-
 
         p3dcollec.set_facecolors(face_colors)
 

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -38,6 +38,9 @@ def test_plot_surf():
     plot_surf(mesh, bg_map=bg, view='medial')
     plot_surf(mesh, bg_map=bg, hemi='right', view='medial')
 
+    # Plot with colorbar
+    plot_surf(mesh, bg_map=bg, colorbar=True)
+
     # Save execution time and memory
     plt.close()
 
@@ -86,28 +89,39 @@ def test_plot_surf_stat_map():
 
     # Plot mesh with stat map
     plot_surf_stat_map(mesh, stat_map=data)
+    plot_surf_stat_map(mesh, stat_map=data, colorbar=True)
     plot_surf_stat_map(mesh, stat_map=data, alpha=1)
 
     # Plot mesh with background and stat map
     plot_surf_stat_map(mesh, stat_map=data, bg_map=bg)
     plot_surf_stat_map(mesh, stat_map=data, bg_map=bg,
-                       bg_on_stat=True, darkness=0.5)
+                       bg_on_data=True, darkness=0.5)
+    plot_surf_stat_map(mesh, stat_map=data, bg_map=bg, colorbar=True,
+                       bg_on_data=True, darkness=0.5)
 
     # Apply threshold
     plot_surf_stat_map(mesh, stat_map=data, bg_map=bg,
-                       bg_on_stat=True, darkness=0.5,
+                       bg_on_data=True, darkness=0.5,
+                       threshold=0.3)
+    plot_surf_stat_map(mesh, stat_map=data, bg_map=bg, colorbar=True,
+                       bg_on_data=True, darkness=0.5,
                        threshold=0.3)
 
     # Change vmax
     plot_surf_stat_map(mesh, stat_map=data, vmax=5)
+    plot_surf_stat_map(mesh, stat_map=data, vmax=5, colorbar=True)
 
     # Change colormap
     plot_surf_stat_map(mesh, stat_map=data, cmap='cubehelix')
+    plot_surf_stat_map(mesh, stat_map=data, cmap='cubehelix', colorbar=True)
 
     # Plot to axes
     axes = plt.subplots(ncols=2, subplot_kw={'projection': '3d'})[1]
     for ax in axes.flatten():
         plot_surf_stat_map(mesh, stat_map=data, ax=ax)
+    axes = plt.subplots(ncols=2, subplot_kw={'projection': '3d'})[1]
+    for ax in axes.flatten():
+        plot_surf_stat_map(mesh, stat_map=data, ax=ax, colorbar=True)
 
     # Save execution time and memory
     plt.close()
@@ -152,12 +166,15 @@ def test_plot_surf_roi():
 
     # plot roi
     plot_surf_roi(mesh, roi_map=roi1)
+    plot_surf_roi(mesh, roi_map=roi1, colorbar=True)
 
     # plot parcellation
     plot_surf_roi(mesh, roi_map=parcellation)
+    plot_surf_roi(mesh, roi_map=parcellation, colorbar=True)
 
     # plot roi list
     plot_surf_roi(mesh, roi_map=[roi1, roi2])
+    plot_surf_roi(mesh, roi_map=[roi1, roi2], colorbar=True)
 
     # plot to axes
     plot_surf_roi(mesh, roi_map=roi1, ax=None, figure=plt.gcf())
@@ -166,6 +183,9 @@ def test_plot_surf_roi():
     with tempfile.NamedTemporaryFile() as tmp_file:
         plot_surf_roi(mesh, roi_map=roi1, ax=plt.gca(), figure=None,
                       output_file=tmp_file.name)
+    with tempfile.NamedTemporaryFile() as tmp_file:
+        plot_surf_roi(mesh, roi_map=roi1, ax=plt.gca(), figure=None,
+                      output_file=tmp_file.name, colorbar=True)
 
     # Save execution time and memory
     plt.close()


### PR DESCRIPTION
This is the PR for #1649 

Several things to note:

- If no texture is given, the colorbar argument is ignored. The alternative would be to throw an error or show an empty colorbar.

- In the tests I changed `bg_on_stat` to `bg_on_data` since the first one doesn't seem to be used anymore.

- Cropping of the space around the surface is done via viewing distance. In addition the Figure margins can be cropped, but I am hesitant to do this since the user can give a Figure or Axes argument (then using subplots_adjust might force a messed up layout on them).