### PR TITLE
[MRG] FIX: Passing meaningful error when y contains all 1s

### DIFF
--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -759,6 +759,11 @@ class BaseSpaceNet(LinearModel, RegressorMixin, CacheMixin):
         X, y = check_X_y(X, y, ['csr', 'csc', 'coo'], dtype=np.float,
                          multi_output=True, y_numeric=not self.is_classif)
 
+        if not self.is_classif and np.all(np.diff(y) == 0.):
+            raise ValueError("The given input 'y' must have atleast 3 targets"
+                             " to do regression analysis. You provided only"
+                             " one target {0}".format(np.unique(y)))
+
         # misc
         self.Xmean_ = X.mean(axis=0)
         self.Xstd_ = X.std(axis=0)

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -760,7 +760,7 @@ class BaseSpaceNet(LinearModel, RegressorMixin, CacheMixin):
                          multi_output=True, y_numeric=not self.is_classif)
 
         if not self.is_classif and np.all(np.diff(y) == 0.):
-            raise ValueError("The given input 'y' must have atleast 3 targets"
+            raise ValueError("The given input y must have atleast 2 targets"
                              " to do regression analysis. You provided only"
                              " one target {0}".format(np.unique(y)))
 

--- a/nilearn/decoding/tests/test_same_api.py
+++ b/nilearn/decoding/tests/test_same_api.py
@@ -102,8 +102,9 @@ def test_graph_net_and_tvl1_same_for_pure_l1(max_iter=100, decimal=2):
     # when l1_ratio = 1.
     ###############################################################
 
-    X, y, _, mask = _make_data()
-    alpha = .1
+    X, y, _, mask = _make_data(dim=(3, 3, 3))
+    y = np.round(y)
+    alpha = 0.01
     unmasked_X = np.rollaxis(X, -1, start=0)
     unmasked_X = np.array([x[mask] for x in unmasked_X])
 

--- a/nilearn/decoding/tests/test_space_net.py
+++ b/nilearn/decoding/tests/test_space_net.py
@@ -366,3 +366,17 @@ def test_checking_inputs_length():
                                         alphas=1. / .01 / X.shape[0],
                                         l1_ratios=1., tol=1e-10,
                                         screening_percentile=100.).fit, X_, y)
+
+
+def test_targets_in_y_space_net_regressor():
+    # This tests whether raises an error when unique targets given in y
+    # are single.
+    iris = load_iris()
+    X, _ = iris.data, iris.target
+    y = np.ones((iris.target.shape))
+
+    imgs, mask = to_niimgs(X, (2, 2, 2))
+    regressor = SpaceNetRegressor(mask=mask)
+    assert_raises_regex(ValueError,
+                        "The given input 'y' must have atleast 3 targets",
+                        regressor.fit, imgs, y)

--- a/nilearn/decoding/tests/test_space_net.py
+++ b/nilearn/decoding/tests/test_space_net.py
@@ -378,5 +378,5 @@ def test_targets_in_y_space_net_regressor():
     imgs, mask = to_niimgs(X, (2, 2, 2))
     regressor = SpaceNetRegressor(mask=mask)
     assert_raises_regex(ValueError,
-                        "The given input 'y' must have atleast 3 targets",
+                        "The given input y must have atleast 2 targets",
                         regressor.fit, imgs, y)


### PR DESCRIPTION
This PR is a follow-up to an issue posted in [neurostars](https://neurostars.org/t/nilearn-error-using-spacenetregressor/2298/6) which tries to raise a meaningful error message when target 'y' ends being all same values for regression task.

