### PR TITLE
BUG: Fix alpha for transparent colormaps

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -66,6 +66,9 @@ Changes
     - `sklearn.cross_validation` and `sklearn.grid_search` have been
       replaced by `sklearn.model_selection` in all the examples.
 
+    - Colorbars in plotting functions now have a middle gray background
+      suitable for use with custom colormaps with a non-unity alpha channel.
+
 
 0.4.2
 =====

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -763,8 +763,9 @@ class BaseSlicer(object):
         cmaplist = [our_cmap(i) for i in range(our_cmap.N)]
         istart = int(norm(-offset, clip=True) * (our_cmap.N - 1))
         istop = int(norm(offset, clip=True) * (our_cmap.N - 1))
+        mid_gray = (0.5, 0.5, 0.5)  # just an average gray color
         for i in range(istart, istop):
-            cmaplist[i] = (0.5, 0.5, 0.5, 1.)  # just an average gray color
+            cmaplist[i] = mid_gray + (0.,)  # transparent
         if norm.vmin == norm.vmax:  # len(np.unique(data)) == 1 ?
             return
         else:
@@ -775,6 +776,7 @@ class BaseSlicer(object):
             self._colorbar_ax, ticks=ticks, norm=norm,
             orientation='vertical', cmap=our_cmap, boundaries=bounds,
             spacing='proportional', format='%.2g')
+        self._cbar.patch.set_facecolor(mid_gray)
 
         self._colorbar_ax.yaxis.tick_left()
         tick_color = 'w' if self._black_bg else 'k'

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -435,7 +435,8 @@ class BaseSlicer(object):
     _default_figsize = [2.2, 2.6]
     _axes_class = CutAxes
 
-    def __init__(self, cut_coords, axes=None, black_bg=False, **kwargs):
+    def __init__(self, cut_coords, axes=None, black_bg=False,
+                 brain_color=(0.5, 0.5, 0.5), **kwargs):
         """ Create 3 linked axes for plotting orthogonal cuts.
 
         Parameters
@@ -449,7 +450,9 @@ class BaseSlicer(object):
             black. If you wish to save figures with a black background,
             you will need to pass "facecolor='k', edgecolor='k'"
             to matplotlib.pyplot.savefig.
-
+        brain_color : tuple
+            The brain color to use as the background color (e.g., for
+            transparent colorbars).
         """
         self.cut_coords = cut_coords
         if axes is None:
@@ -460,6 +463,7 @@ class BaseSlicer(object):
         bb = axes.get_position()
         self.rect = (bb.x0, bb.y0, bb.x1, bb.y1)
         self._black_bg = black_bg
+        self._brain_color = brain_color
         self._colorbar = False
         self._colorbar_width = 0.05 * bb.width
         self._colorbar_margin = dict(left=0.25 * bb.width,
@@ -478,7 +482,7 @@ class BaseSlicer(object):
     def init_with_figure(cls, img, threshold=None,
                          cut_coords=None, figure=None, axes=None,
                          black_bg=False, leave_space=False, colorbar=False,
-                         **kwargs):
+                         brain_color=(0.5, 0.5, 0.5), **kwargs):
         "Initialize the slicer with an image"
         # deal with "fake" 4D images
         if img is not None and img is not False:
@@ -519,7 +523,7 @@ class BaseSlicer(object):
         # People forget to turn their axis off, or to set the zorder, and
         # then they cannot see their slicer
         axes.axis('off')
-        return cls(cut_coords, axes, black_bg, **kwargs)
+        return cls(cut_coords, axes, black_bg, brain_color, **kwargs)
 
     def title(self, text, x=0.01, y=0.99, size=15, color=None, bgcolor=None,
               alpha=1, **kwargs):
@@ -763,9 +767,8 @@ class BaseSlicer(object):
         cmaplist = [our_cmap(i) for i in range(our_cmap.N)]
         istart = int(norm(-offset, clip=True) * (our_cmap.N - 1))
         istop = int(norm(offset, clip=True) * (our_cmap.N - 1))
-        mid_gray = (0.5, 0.5, 0.5)  # just an average gray color
         for i in range(istart, istop):
-            cmaplist[i] = mid_gray + (0.,)  # transparent
+            cmaplist[i] = self._brain_color + (0.,)  # transparent
         if norm.vmin == norm.vmax:  # len(np.unique(data)) == 1 ?
             return
         else:
@@ -776,7 +779,7 @@ class BaseSlicer(object):
             self._colorbar_ax, ticks=ticks, norm=norm,
             orientation='vertical', cmap=our_cmap, boundaries=bounds,
             spacing='proportional', format='%.2g')
-        self._cbar.patch.set_facecolor(mid_gray)
+        self._cbar.patch.set_facecolor(self._brain_color)
 
         self._colorbar_ax.yaxis.tick_left()
         tick_color = 'w' if self._black_bg else 'k'

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -765,9 +765,9 @@ class BaseSlicer(object):
 
         # some colormap hacking
         cmaplist = [our_cmap(i) for i in range(our_cmap.N)]
-        istart = int(norm(-offset, clip=True) * (our_cmap.N - 1))
-        istop = int(norm(offset, clip=True) * (our_cmap.N - 1))
-        for i in range(istart, istop):
+        transparent_start = int(norm(-offset, clip=True) * (our_cmap.N - 1))
+        transparent_stop = int(norm(offset, clip=True) * (our_cmap.N - 1))
+        for i in range(transparent_start, transparent_stop):
             cmaplist[i] = self._brain_color + (0.,)  # transparent
         if norm.vmin == norm.vmax:  # len(np.unique(data)) == 1 ?
             return

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -112,6 +112,7 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
                       bg_vmin=None, bg_vmax=None, interpolation="nearest",
                       display_factory=get_slicer,
                       cbar_vmin=None, cbar_vmax=None,
+                      brain_color=(0.5, 0.5, 0.5),
                       **kwargs):
     """ Internal function, please refer to the docstring of plot_img for
         parameters not listed below.
@@ -167,7 +168,9 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
         cut_coords=cut_coords,
         figure=figure, axes=axes,
         black_bg=black_bg,
-        colorbar=colorbar)
+        colorbar=colorbar,
+        brain_color=brain_color,
+        )
 
     if bg_img is not None:
         bg_img = _utils.check_niimg_3d(bg_img)
@@ -1156,12 +1159,13 @@ def plot_glass_brain(stat_map_img,
         return functools.partial(get_projector(display_mode),
                                  alpha=alpha, plot_abs=plot_abs)
 
+    brain_color = (0. if black_bg else 1.,) * 3
     display = _plot_img_with_bg(
         img=stat_map_img, output_file=output_file, display_mode=display_mode,
         figure=figure, axes=axes, title=title, annotate=annotate,
         black_bg=black_bg, threshold=threshold, cmap=cmap, colorbar=colorbar,
         display_factory=display_factory, vmin=vmin, vmax=vmax,
-        cbar_vmin=cbar_vmin, cbar_vmax=cbar_vmax,
+        cbar_vmin=cbar_vmin, cbar_vmax=cbar_vmax, brain_color=brain_color,
         resampling_interpolation=resampling_interpolation, **kwargs)
 
     return display


### PR DESCRIPTION
For plotting functions, the colorbar has a white background. This is problematic because colormaps with an alpha channel are displayed incorrectly. This sets the background color to mid gray, and thus also sets the `cmaplist` entries that are below `threshold` just to be fully transparent. This should have the same effect as using `(0.5, 0.5, 0.5, 1.0)` directly but is more consistent with what the plotting is actually doing.