### PR TITLE
[MRG] MAINT: Fix tests with plot_connectome add_markers

### DIFF
--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -176,13 +176,18 @@ Common data preparation steps: smoothing, filtering, resampling
 preparation::
 
    >>> from nilearn import input_data
-   >>> masker = input_data.NiftiMasker()
-   >>> masker
+   >>> masker = input_data.NiftiMasker() # doctest: +SKIP
+   >>> masker # doctest: +SKIP
    NiftiMasker(detrend=False, dtype=None, high_pass=None, low_pass=None,
          mask_args=None, mask_img=None, mask_strategy='background',
          memory=Memory(cachedir=None), memory_level=1, sample_mask=None,
          sessions=None, smoothing_fwhm=None, standardize=False, t_r=None,
          target_affine=None, target_shape=None, verbose=0)
+
+.. note::
+
+    From scikit-learn 0.20, the argument `cachedir` is deprecated in
+    favour of `location`. Hence `cachedir` might not be seen as here.
 
 The meaning of each parameter is described in the documentation of
 :class:`NiftiMasker` (click on the name :class:`NiftiMasker`), here we

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -538,7 +538,7 @@ def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
     """
     if url is None:
         url = "ftp://surfer.nmr.mgh.harvard.edu/" \
-              "pub/data/Yeo_JNeurophysiol11_MNI152.zip"
+              "pub/data/archive/Yeo_JNeurophysiol11_MNI152.zip"
     opts = {'uncompress': True}
 
     dataset_name = "yeo_2011"

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -440,6 +440,9 @@ def test_plot_connectome():
     plt.close()
 
     # NaN matrix support
+    node_color = ['green', 'blue', 'k']
+    # Overriding 'node_color' for 3  elements of size 3.
+    kwargs['node_color'] = node_color
     nan_adjacency_matrix = np.array([[1., np.nan, 0.],
                                      [np.nan, 1., 2.],
                                      [np.nan, 2., 1.]])


### PR DESCRIPTION
Following PR #1767 , seems like add_markers doesn't like to give 4 colors to a numpy array of size 3. This PR makes a minor adaptations to pass the tests.

here is the test failure: https://travis-ci.org/nilearn/nilearn/jobs/435402098#L7699