### PR TITLE
themes: improve css

### DIFF
--- a/doc/themes/nilearn/static/nature.css_t
+++ b/doc/themes/nilearn/static/nature.css_t
@@ -295,8 +295,6 @@ pre a {
 div.document {
     background-color: white;
     text-align: left;
-    background-image: url(contents.png);
-    background-repeat: repeat-x;
 }
 
 div.clearer {


### PR DESCRIPTION
The new nilearn website is online and I found a minor visual with the document content: there's a remaining gradient image at the top of the body content. It is just below the top bar menu but with a small shift.
This PR just removes the gradient image to have the whole background in plain white.