### PR TITLE
[MRG+1] Sets default value of t_r in singal.clean and image.clean_img to None

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -42,6 +42,7 @@ Changes
 - In nilearn.regions.img_to_signals_labels, the See Also section in documentation now also points to NiftiLabelsMasker and NiftiMapsMasker
 - Scipy is listed as a dependency for Nilearn installation.
 - Anaconda link in the installation documentation updated.
+- Default value of t_r in signal.clean and clean_img is changed from 2.5 to None. If low_pass or high_pass is specified, then t_r needs to be specified as well otherwise it will raise an error.
 
 Contributors
 -------------
@@ -87,6 +88,7 @@ The following people contributed to this release::
   1  Ivan Gonzalez
   1  Yaroslav Halchenko
   1  dtyulman
+  1  Michael Notter
 
 0.5.0 alpha
 ===========

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,3 +1,19 @@
+0.5.0
+=====
+
+
+Changes
+-------
+
+- Default value of t_r in signal.clean and clean_img is changed from 2.5 to None. If low_pass or high_pass is specified, then t_r needs to be specified as well otherwise it will raise an error.
+
+Contributors
+-------------
+
+The following people contributed to this release::
+
+  1  Michael Notter
+
 0.5.0 beta
 ==========
 
@@ -42,7 +58,6 @@ Changes
 - In nilearn.regions.img_to_signals_labels, the See Also section in documentation now also points to NiftiLabelsMasker and NiftiMapsMasker
 - Scipy is listed as a dependency for Nilearn installation.
 - Anaconda link in the installation documentation updated.
-- Default value of t_r in signal.clean and clean_img is changed from 2.5 to None. If low_pass or high_pass is specified, then t_r needs to be specified as well otherwise it will raise an error.
 
 Contributors
 -------------
@@ -88,7 +103,6 @@ The following people contributed to this release::
   1  Ivan Gonzalez
   1  Yaroslav Halchenko
   1  dtyulman
-  1  Michael Notter
 
 0.5.0 alpha
 ===========

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -852,7 +852,8 @@ def clean_img(imgs, sessions=None, detrend=True, standardize=True,
         Respectively low and high cutoff frequencies, in Hertz.
 
     t_r: float, optional
-        Repetition time, in second (sampling period).
+        Repetition time, in second (sampling period). Set to None if not
+        specified. Mandatory if used together with low_pass or high_pass.
 
     ensure_finite: bool, optional
         If True, the non-finite values (NaNs and infs) found in the images

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -880,6 +880,15 @@ def clean_img(imgs, sessions=None, detrend=True, standardize=True,
     from .image import new_img_like
 
     imgs_ = check_niimg_4d(imgs)
+
+    # Check if t_r is set, otherwise propse t_r from imgs header
+    if low_pass is not None or high_pass is not None:
+        if t_r is None:
+            t_r = imgs.header.get_zooms()[3]
+            raise ValueError(
+                "Repetition time (t_r) must be specified for filtering. You "
+                "specified None. imgs header suggest it to be {0}".format(t_r))
+
     data = signal.clean(
         imgs_.get_data().reshape(-1, imgs_.shape[-1]).T, sessions=sessions,
         detrend=detrend, standardize=standardize, confounds=confounds,

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -800,7 +800,7 @@ def math_img(formula, **imgs):
 
 
 def clean_img(imgs, sessions=None, detrend=True, standardize=True,
-              confounds=None, low_pass=None, high_pass=None, t_r=2.5,
+              confounds=None, low_pass=None, high_pass=None, t_r=None,
               ensure_finite=False):
     """Improve SNR on masked fMRI signals.
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -881,10 +881,13 @@ def clean_img(imgs, sessions=None, detrend=True, standardize=True,
 
     imgs_ = check_niimg_4d(imgs)
 
-    # Check if t_r is set, otherwise propse t_r from imgs header
+    # Check if t_r is set, otherwise propose t_r from imgs header
     if low_pass is not None or high_pass is not None:
         if t_r is None:
             t_r = imgs.header.get_zooms()[3]
+
+            # We raise an error, instead of using the header's t_r as this
+            # value is considered to be non-reliable
             raise ValueError(
                 "Repetition time (t_r) must be specified for filtering. You "
                 "specified None. imgs header suggest it to be {0}".format(t_r))

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -884,13 +884,13 @@ def clean_img(imgs, sessions=None, detrend=True, standardize=True,
     # Check if t_r is set, otherwise propose t_r from imgs header
     if low_pass is not None or high_pass is not None:
         if t_r is None:
-            t_r = imgs.header.get_zooms()[3]
 
             # We raise an error, instead of using the header's t_r as this
             # value is considered to be non-reliable
             raise ValueError(
                 "Repetition time (t_r) must be specified for filtering. You "
-                "specified None. imgs header suggest it to be {0}".format(t_r))
+                "specified None. imgs header suggest it to be {0}".format(
+                    imgs.header.get_zooms()[3]))
 
     data = signal.clean(
         imgs_.get_data().reshape(-1, imgs_.shape[-1]).T, sessions=sessions,

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -558,10 +558,13 @@ def test_clean_img():
     data_flat = data.T.reshape(100, -1)
     data_img = nibabel.Nifti1Image(data, np.eye(4))
 
+    assert_raises(
+        ValueError, image.clean_img, data_img, t_r=None, low_pass=0.1)
+
     data_img_ = image.clean_img(
-        data_img, detrend=True, standardize=False, low_pass=0.1)
+        data_img, detrend=True, standardize=False, low_pass=0.1, t_r=1.0)
     data_flat_ = signal.clean(
-        data_flat, detrend=True, standardize=False, low_pass=0.1)
+        data_flat, detrend=True, standardize=False, low_pass=0.1, t_r=1.0)
 
     np.testing.assert_almost_equal(data_img_.get_data().T.reshape(100, -1),
                                    data_flat_)
@@ -577,10 +580,7 @@ def test_clean_img():
     data_img_nifti2 = nibabel.Nifti2Image(data, np.eye(4))
 
     data_img_nifti2_ = image.clean_img(
-        data_img_nifti2, detrend=True, standardize=False, low_pass=0.1)
-
-    assert_raises(
-        ValueError, image.clean_img, data_img, t_r=None, low_pass=0.1)
+        data_img_nifti2, detrend=True, standardize=False, low_pass=0.1, t_r=1.0)
 
 
 def test_largest_cc_img():

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -579,6 +579,9 @@ def test_clean_img():
     data_img_nifti2_ = image.clean_img(
         data_img_nifti2, detrend=True, standardize=False, low_pass=0.1)
 
+    assert_raises(
+        ValueError, image.clean_img, data_img, t_r=None, low_pass=0.1)
+
 
 def test_largest_cc_img():
     """ Check the extraction of the largest connected component, for niftis

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -355,7 +355,7 @@ def _ensure_float(data):
 
 
 def clean(signals, sessions=None, detrend=True, standardize=True,
-          confounds=None, low_pass=None, high_pass=None, t_r=2.5,
+          confounds=None, low_pass=None, high_pass=None, t_r=None,
           ensure_finite=False):
     """Improve SNR on masked fMRI signals.
 

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -395,7 +395,8 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
         signal, as if all were in the same array.
 
     t_r: float
-        Repetition time, in second (sampling period).
+        Repetition time, in second (sampling period). Set to None if not
+        specified. Mandatory if used together with low_pass or high_pass.
 
     low_pass, high_pass: float
         Respectively low and high cutoff frequencies, in Hertz.

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -529,7 +529,7 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
     if low_pass is not None or high_pass is not None:
         if t_r is None:
             raise ValueError("Repetition time (t_r) must be specified for "
-                             "filtering")
+                             "filtering. You specified None.")
 
         signals = butterworth(signals, sampling_rate=1. / t_r,
                               low_pass=low_pass, high_pass=high_pass)
@@ -539,5 +539,3 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
         signals *= np.sqrt(signals.shape[0])  # for unit variance
 
     return signals
-
-

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -337,12 +337,13 @@ def test_clean_frequencies():
     sx1 = np.sin(np.linspace(0, 100, 2000))
     sx2 = np.sin(np.linspace(0, 100, 2000))
     sx = np.vstack((sx1, sx2)).T
-    assert_true(clean(sx, standardize=False, high_pass=0.002, low_pass=None)
-                .max() > 0.1)
-    assert_true(clean(sx, standardize=False, high_pass=0.2, low_pass=None)
-                .max() < 0.01)
-    assert_true(clean(sx, standardize=False, low_pass=0.01).max() > 0.9)
-    assert_raises(ValueError, clean, sx, low_pass=0.4, high_pass=0.5)
+    assert_true(clean(sx, standardize=False, high_pass=0.002, low_pass=None,
+                      t_r=2.5).max() > 0.1)
+    assert_true(clean(sx, standardize=False, high_pass=0.2, low_pass=None,
+                      t_r=2.5) .max() < 0.01)
+    assert_true(
+        clean(sx, standardize=False, low_pass=0.01, t_r=2.5).max() > 0.9)
+    assert_raises(ValueError, clean, sx, low_pass=0.4, high_pass=0.5, t_r=2.5)
 
 
 def test_clean_confounds():


### PR DESCRIPTION
This PR closes https://github.com/nilearn/nilearn/issues/1021.

As recapped by @GaelVaroquaux (https://github.com/nilearn/nilearn/issues/1021#issuecomment-190209612), the following changes were requested:
 1. `signals.clean` should have a default of `None` (actually, `t_r` should always default to `None`) https://github.com/nilearn/nilearn/blob/master/nilearn/signal.py#L347
 2. When `t_r` is `None` and we are asking for filtering, we should raise an error (probably in `filter_and_extract` https://github.com/nilearn/nilearn/blob/master/nilearn/input_data/base_masker.py#L24) and inspect the nifti image header to suggest a value.

https://github.com/nilearn/nilearn/pull/1164 added the error message for `clean`, if `t_r` is set to `None`, but the rest was still missing.

This PR...
 - sets the default value of `t_r` in `signal.clean` and `image.clean_img` to `None`
 - adds an error message to `image.clean_img` if `t_r` is `None`, that suggests the TR from the NIfTI header
 - tests for this error.