### PR TITLE
[MRG+1] ENH: Corrects order and behavior of filters in `nilearn.signal.clean`

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -8,11 +8,11 @@ Changes
 - Default value of t_r in signal.clean and clean_img is changed from 2.5 to
   None. If low_pass or high_pass is specified, then t_r needs to be specified
   as well otherwise it will raise an error.
-- Order of filters in signal.clean and clean_img is changed to detrend, low- and
-  high-pass filter, remove confounds and standardize. To ensure orthogonality
-  between temporal filter and confound removal, an additional temporal filter
-  will be applied on the confounds before removing them. This is according to
-  `Lindquist et al. (2018)<http://dx.doi.org/10.1101/407676>`_.
+- Order of filters in signal.clean and clean_img has changed to detrend, low-
+  and high-pass filter, remove confounds and standardize. To ensure
+  orthogonality between temporal filter and confound removal, an additional
+  temporal filter will be applied on the confounds before removing them. This
+  is according to Lindquist et al. (2018).
 
 
 Contributors

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,3 +1,28 @@
+0.5.0
+=====
+
+
+Changes
+-------
+
+- Default value of t_r in signal.clean and clean_img is changed from 2.5 to
+  None. If low_pass or high_pass is specified, then t_r needs to be specified
+  as well otherwise it will raise an error.
+- Order of filters in signal.clean and clean_img is changed to detrend, low- and
+  high-pass filter, remove confounds and standardize. To ensure orthogonality
+  between temporal filter and confound removal, an additional temporal filter
+  will be applied on the confounds before removing them. This is according to
+  `Lindquist et al. (2018)<http://dx.doi.org/10.1101/407676>`_.
+
+
+Contributors
+-------------
+
+The following people contributed to this release::
+
+  2  Michael Notter
+
+
 0.5.0 beta
 ==========
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -808,9 +808,9 @@ def clean_img(imgs, sessions=None, detrend=True, standardize=True,
     the following order:
 
     - detrend
-    - standardize
-    - remove confounds
     - low- and high-pass filter
+    - remove confounds
+    - standardize
 
     Low-pass filtering improves specificity.
 
@@ -818,6 +818,10 @@ def clean_img(imgs, sessions=None, detrend=True, standardize=True,
     sensitivity.
 
     Filtering is only meaningful on evenly-sampled signals.
+
+    According to Lindquist et al. (2018), removal of confounds will be done
+    orthogonally to temporal filters (low- and/or high-pass filters), if both
+    are specified.
 
     .. versionadded:: 0.2.5
 
@@ -871,6 +875,11 @@ def clean_img(imgs, sessions=None, detrend=True, standardize=True,
     "Statistical Parametric Maps in Functional Imaging: A General
     Linear Approach". Human Brain Mapping 2, no 4 (1994): 189-210.
     <http://dx.doi.org/10.1002/hbm.460020402>`_
+
+    Orthogonalization between temporal filters and confound removal is based on
+    suggestions in `Lindquist, M., Geuter, S., Wager, T., & Caffo, B. (2018).
+    Modular preprocessing pipelines can reintroduce artifacts into fMRI data.
+    bioRxiv, 407676. <http://dx.doi.org/10.1101/407676>`_
 
     See Also
     --------

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -508,6 +508,15 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
     signals = _ensure_float(signals)
     signals = _standardize(signals, normalize=False, detrend=detrend)
 
+    # Apply low- and high-pass filters
+    if low_pass is not None or high_pass is not None:
+        if t_r is None:
+            raise ValueError("Repetition time (t_r) must be specified for "
+                             "filtering")
+
+        signals = butterworth(signals, sampling_rate=1. / t_r,
+                              low_pass=low_pass, high_pass=high_pass)
+
     # Remove confounds
     if confounds is not None:
         confounds = _ensure_float(confounds)
@@ -525,14 +534,6 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
         Q, R, _ = linalg.qr(confounds, mode='economic', pivoting=True)
         Q = Q[:, np.abs(np.diag(R)) > np.finfo(np.float).eps * 100.]
         signals -= Q.dot(Q.T).dot(signals)
-
-    if low_pass is not None or high_pass is not None:
-        if t_r is None:
-            raise ValueError("Repetition time (t_r) must be specified for "
-                             "filtering")
-
-        signals = butterworth(signals, sampling_rate=1. / t_r,
-                              low_pass=low_pass, high_pass=high_pass)
 
     if standardize:
         signals = _standardize(signals, normalize=True, detrend=False)

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -363,9 +363,9 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
     the following order:
 
     - detrend
-    - standardize
-    - remove confounds
     - low- and high-pass filter
+    - remove confounds
+    - standardize
 
     Low-pass filtering improves specificity.
 

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -374,6 +374,10 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
 
     Filtering is only meaningful on evenly-sampled signals.
 
+    According to Lindquist et al. (2018), removal of confounds will be done
+    orthogonally to temporal filters (low- and/or high-pass filters), if both
+    are specified.
+
     Parameters
     ----------
     signals: numpy.ndarray
@@ -424,6 +428,11 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
     "Statistical Parametric Maps in Functional Imaging: A General
     Linear Approach". Human Brain Mapping 2, no 4 (1994): 189-210.
     <http://dx.doi.org/10.1002/hbm.460020402>`_
+
+    Orthogonalization between temporal filters and confound removal is based on
+    suggestions in `Lindquist, M., Geuter, S., Wager, T., & Caffo, B. (2018).
+    Modular preprocessing pipelines can reintroduce artifacts into fMRI data.
+    bioRxiv, 407676. <http://dx.doi.org/10.1101/407676>`_
 
     See Also
     --------

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -522,6 +522,14 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
         confounds = _ensure_float(confounds)
         confounds = _standardize(confounds, normalize=standardize,
                                  detrend=detrend)
+
+        # Apply low- and high-pass filters to keep filters orthogonal
+        # (according to Lindquist et al. (2018))
+        if low_pass is not None or high_pass is not None:
+
+            confounds = butterworth(confounds, sampling_rate=1. / t_r,
+                                    low_pass=low_pass, high_pass=high_pass)
+
         if not standardize:
             # Improve numerical stability by controlling the range of
             # confounds. We don't rely on _standardize as it removes any
@@ -540,5 +548,3 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
         signals *= np.sqrt(signals.shape[0])  # for unit variance
 
     return signals
-
-

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -529,8 +529,6 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
     # Remove confounds
     if confounds is not None:
         confounds = _ensure_float(confounds)
-        confounds = _standardize(confounds, normalize=standardize,
-                                 detrend=detrend)
 
         # Apply low- and high-pass filters to keep filters orthogonal
         # (according to Lindquist et al. (2018))
@@ -538,6 +536,9 @@ def clean(signals, sessions=None, detrend=True, standardize=True,
 
             confounds = butterworth(confounds, sampling_rate=1. / t_r,
                                     low_pass=low_pass, high_pass=high_pass)
+
+        confounds = _standardize(confounds, normalize=standardize,
+                                 detrend=detrend)
 
         if not standardize:
             # Improve numerical stability by controlling the range of

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -442,6 +442,38 @@ def test_clean_confounds():
                                    np.zeros((20, 2)))
 
 
+
+
+def test_clean_frequencies():
+
+    # Create signal
+    sx = np.array([np.sin(np.linspace(0, 100, 100) * 1.5),
+                   np.sin(np.linspace(0, 100, 100) * 3.),
+                   np.sin(np.linspace(0, 100, 100) / 8.),
+                   ]).T
+
+    # Create confound
+    _, _, confounds = generate_signals(
+        n_features=10, n_confounds=10, length=100)
+
+    # Apply low- and high-pass filter (separately)
+    t_r = 1.0
+    low_pass = 0.1
+    high_pass = 0.4
+    res_low = clean(sx, detrend=False, standardize=False, low_pass=low_pass,
+                    high_pass=None, t_r=t_r)
+    res_high = clean(sx, detrend=False, standardize=False, low_pass=None,
+                    high_pass=high_pass, t_r=t_r)
+
+    # Compute power spectrum density for both test
+    f, Pxx_den_low = scipy.signal.welch(np.mean(res_low.T, axis=0), fs=t_r)
+    f, Pxx_den_high = scipy.signal.welch(np.mean(res_high.T, axis=0), fs=t_r)
+
+    # Verify that the filtered frequencies are removed
+    assert_true(np.sum(Pxx_den_low[f >= low_pass * 2.]) <= 1e-4)
+    assert_true(np.sum(Pxx_den_high[f <= high_pass / 2.]) <= 1e-4)
+
+
 def test_high_variance_confounds():
 
     # C and F order might take different paths in the function. Check that the


### PR DESCRIPTION
This PR changes the order of the cleaning function, as discussed in https://github.com/nilearn/nilearn/issues/1828.

As a new feature, confound removal will be done orthogonally to temporal filters (according to [Lindquist et al. (2018)](https://www.biorxiv.org/content/biorxiv/early/2018/09/04/407676.full.pdf)), if both are specified.