### PR TITLE
[WIP] fetch_atlas_allen_2011() downloads compressed dataset from OSF server

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -72,6 +72,51 @@ Changes
     - Colorbars in plotting functions now have a middle gray background
       suitable for use with custom colormaps with a non-unity alpha channel.
 
+Contributors
+------------
+
+The following people contributed to the Beta release of Nilearn 0.5.0::
+
+    58  Gael Varoquaux
+    3  Bertrand Thirion
+    111  Kshitij Chawla (kchawla-pi)
+    15  Jerome Dockes
+    14  oesteban
+    10  Eric Larson
+    6  Kamalakar Daddy
+    5  Alexandre Abadie
+    4  Sourav Singh
+    3  Alex Rothberg
+    3  AnaLu
+    3  Demian Wassermann
+    3  Horea Christian
+    3  Jason Gors
+    3  Jean Remi King
+    3  MADHYASTHA Meghana
+    3  SRSteinkamp
+    3  Simon Steinkamp
+    3  jerome-alexis_chevalier
+    3  salma
+    3  sfvnMAC
+    2  Akshay
+    2  Daniel Gomez
+    2  Guillaume Lemaitre
+    2  Pierre Bellec
+    2  arokem
+    2  erramuzpe
+    2  foucault
+    2  jehane
+    1  Sylvain LANNUZEL
+    1  Aki Nikolaidis
+    1  Christophe Bedetti
+    1  Dan Gale
+    1  Dillon Plunkett
+    1  Dimitri Papadopoulos Orfanos
+    1  Greg Operto
+    1  Ivan Gonzalez
+    1  Yaroslav Halchenko
+    1  dtyulman
+
 
 0.4.2
 =====

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -72,51 +72,6 @@ Changes
     - Colorbars in plotting functions now have a middle gray background
       suitable for use with custom colormaps with a non-unity alpha channel.
 
-Contributors
-------------
-
-The following people contributed to the Beta release of Nilearn 0.5.0::
-
-    58  Gael Varoquaux
-    3  Bertrand Thirion
-    111  Kshitij Chawla (kchawla-pi)
-    15  Jerome Dockes
-    14  oesteban
-    10  Eric Larson
-    6  Kamalakar Daddy
-    5  Alexandre Abadie
-    4  Sourav Singh
-    3  Alex Rothberg
-    3  AnaLu
-    3  Demian Wassermann
-    3  Horea Christian
-    3  Jason Gors
-    3  Jean Remi King
-    3  MADHYASTHA Meghana
-    3  SRSteinkamp
-    3  Simon Steinkamp
-    3  jerome-alexis_chevalier
-    3  salma
-    3  sfvnMAC
-    2  Akshay
-    2  Daniel Gomez
-    2  Guillaume Lemaitre
-    2  Pierre Bellec
-    2  arokem
-    2  erramuzpe
-    2  foucault
-    2  jehane
-    1  Sylvain LANNUZEL
-    1  Aki Nikolaidis
-    1  Christophe Bedetti
-    1  Dan Gale
-    1  Dillon Plunkett
-    1  Dimitri Papadopoulos Orfanos
-    1  Greg Operto
-    1  Ivan Gonzalez
-    1  Yaroslav Halchenko
-    1  dtyulman
-
 
 0.4.2
 =====

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -8,8 +8,6 @@ from tempfile import mkdtemp
 import json
 import shutil
 
-from collections import OrderedDict
-
 import nibabel as nb
 import numpy as np
 from sklearn.datasets.base import Bunch
@@ -862,18 +860,14 @@ def fetch_atlas_allen_2011(data_dir=None, url=None, resume=True,
     url = url if url else 'https://osf.io/hrcku/download'
     dataset_name = "allen_rsn_2011"
     data_dir = get_data_dirs(data_dir=data_dir)[0]
-    dataset_components_filenames = OrderedDict(
-            {'maps': 'ALL_HC_unthresholded_tmaps.nii.gz',
-             'rsn28': 'RSN_HC_unthresholded_tmaps.nii.gz',
-             'comps': 'rest_hcp_agg__component_ica_.nii.gz',
-             }
-            )
-    expected_files = OrderedDict(
-            {component: os.path.join(data_dir, dataset_name, file_)
-             for component, file_
-             in dataset_components_filenames.items()
-             }
-            )
+    dataset_components_filenames = {'maps': 'ALL_HC_unthresholded_tmaps.nii.gz',
+                                    'rsn28': 'RSN_HC_unthresholded_tmaps.nii.gz',
+                                    'comps': 'rest_hcp_agg__component_ica_.nii.gz',
+                                    }
+    expected_files = {component: os.path.join(data_dir, dataset_name, file_)
+                      for component, file_
+                      in dataset_components_filenames.items()
+                      }
     expected_files_present = all([os.path.isfile(filepath)
                                   for filepath in expected_files.values()
                                   ])

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -860,7 +860,7 @@ def fetch_atlas_allen_2011(data_dir=None,
     See http://mialab.mrn.org/data/index.html for more information
     on this dataset.
     """
-    url = 'https://osf.io/hrcku/downloa'
+    url = 'https://osf.io/hrcku/download'
     dataset_name = "allen_rsn_2011"
     data_dir = get_data_dirs(data_dir=data_dir)[0]
     

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -7,7 +7,12 @@ import xml.etree.ElementTree
 from tempfile import mkdtemp
 import json
 import shutil
-import urllib2
+
+try:
+    from urllib.request import URLError, HTTPError  # py3
+except ImportError:
+    from urllib2 import URLError  # py2; HTTPError unavailable
+    HTTPError = URLError
 
 
 import nibabel as nb
@@ -855,7 +860,7 @@ def fetch_atlas_allen_2011(data_dir=None,
     See http://mialab.mrn.org/data/index.html for more information
     on this dataset.
     """
-    url = 'https://osf.io/hrcku/download'
+    url = 'https://osf.io/hrcku/downloa'
     dataset_name = "allen_rsn_2011"
     data_dir = get_data_dirs(data_dir=data_dir)[0]
     
@@ -887,13 +892,13 @@ def _download_allen_2011(expected_files, data_dir, dataset_name, url, verbose):
                   )
         try:
             downloaded_filepath = _fetch_file(url, data_dir, verbose=verbose)
-        except urllib2.URLError as excep:
+        except (URLError, HTTPError) as url_excep:
             err_msg = ('\nERROR: There was a problem downloading the file '
                        '"allen_rsn_2011.zip". \nPlease verify you have '
                        'a working internet connection and '
                        'the file is still present at {}'.format(url))
             print(err_msg)
-            raise excep
+            raise url_excep
         except (OSError, IOError) as os_excep:
             if os_excep.strerror == 'Permission denied':
                 error_msg = ('\nERROR: You do not have permission '

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -459,11 +459,11 @@ def test_fetch_atlas_allen_2011():
             "rsn28",
             "comps")
 
-    filenames = ["ALL_HC_unthresholded_tmaps.nii",
-                 "RSN_HC_unthresholded_tmaps.nii",
-                 "rest_hcp_agg__component_ica_.nii"]
+    filenames = ["ALL_HC_unthresholded_tmaps.nii.gz",
+                 "RSN_HC_unthresholded_tmaps.nii.gz",
+                 "rest_hcp_agg__component_ica_.nii.gz"]
 
-    assert_equal(len(tst.mock_url_request.urls), 3)
+    # assert_equal(len(tst.mock_url_request.urls), 3)
     for key, fn in zip(keys, filenames):
         assert_equal(bunch[key], os.path.join(tst.tmpdir, 'allen_rsn_2011', fn))
 


### PR DESCRIPTION
For issue #1792 
Functionality lost: `resume`
I found it too onerous to adapt the new URL as per _fetch_files().
The download is ~31MB so I figure this is not a big deal.

**The tests will break**, I believe as they must be re-adapted according to the new code.
I am pushing this code here for review & discussion so I do not modify the tests in error.

Additionally, why do we have a `url` parameter? Do we expect users to give their own URL here and expect it to work seamlessly with the function? Should we remove it?