### PR TITLE
[MRG] ENH: Adds mask parameter to image.clean_img

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -5,16 +5,17 @@
 Changes
 -------
 
-- Default value of t_r in signal.clean and clean_img is changed from 2.5 to
-  None. If low_pass or high_pass is specified, then t_r needs to be specified
-  as well otherwise it will raise an error.
-- Order of filters in signal.clean and clean_img has changed to detrend, low-
-  and high-pass filter, remove confounds and standardize. To ensure
-  orthogonality between temporal filter and confound removal, an additional
-  temporal filter will be applied on the confounds before removing them. This
-  is according to Lindquist et al. (2018).
-- image.clean_img now accepts a mask to restrict the cleaning of the image.
-  This approach can help to reduce the memory load.
+- Default value of `t_r` in :func:nilearn.signal.clean: and
+  :func:nilearn.image.clean_img: is changed from 2.5 to None. If `low_pass` or
+  `high_pass` is specified, then `t_r` needs to be specified as well otherwise
+  it will raise an error.
+- Order of filters in :func:nilearn.signal.clean: and :func:nilearn.image.clean_img:
+  has changed to detrend, low- and high-pass filter, remove confounds and
+  standardize. To ensure orthogonality between temporal filter and confound
+  removal, an additional temporal filter will be applied on the confounds before
+  removing them. This is according to Lindquist et al. (2018).
+- :func:nilearn.image.clean_img: now accepts a mask to restrict the cleaning of
+  the image. This approach can help to reduce the memory load and computation time.
 
 
 Contributors

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -13,6 +13,8 @@ Changes
   orthogonality between temporal filter and confound removal, an additional
   temporal filter will be applied on the confounds before removing them. This
   is according to Lindquist et al. (2018).
+- image.clean_img now accepts a mask to restrict the cleaning of the image.
+  This approach can help to reduce the memory load.
 
 
 Contributors

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -5,16 +5,16 @@
 Changes
 -------
 
-- Default value of `t_r` in :func:nilearn.signal.clean: and
-  :func:nilearn.image.clean_img: is changed from 2.5 to None. If `low_pass` or
+- Default value of `t_r` in :func:`nilearn.signal.clean` and
+  :func:`nilearn.image.clean_img` is changed from 2.5 to None. If `low_pass` or
   `high_pass` is specified, then `t_r` needs to be specified as well otherwise
   it will raise an error.
-- Order of filters in :func:nilearn.signal.clean: and :func:nilearn.image.clean_img:
+- Order of filters in :func:`nilearn.signal.clean` and :func:`nilearn.image.clean_img`
   has changed to detrend, low- and high-pass filter, remove confounds and
   standardize. To ensure orthogonality between temporal filter and confound
   removal, an additional temporal filter will be applied on the confounds before
   removing them. This is according to Lindquist et al. (2018).
-- :func:nilearn.image.clean_img: now accepts a mask to restrict the cleaning of
+- :func:`nilearn.image.clean_img` now accepts a mask to restrict the cleaning of
   the image. This approach can help to reduce the memory load and computation time.
 
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -915,10 +915,9 @@ def clean_img(imgs, sessions=None, detrend=True, standardize=True,
         't_r': t_r, 'ensure_finite': ensure_finite}
 
     if mask_img is not None:
-        mask_img_ = check_niimg_3d(mask_img)
-        sigs = masking.apply_mask(imgs_, mask_img_)
+        sigs = masking.apply_mask(imgs_, mask_img)
         sigs_clean = signal.clean(sigs, **clean_paramters)
-        data = masking.unmask(sigs_clean, mask_img_).get_data()
+        data = masking.unmask(sigs_clean, mask_img).get_data()
     else:
         sigs = imgs_.get_data().reshape(-1, imgs_.shape[-1]).T
         data = signal.clean(sigs, **clean_paramters).T.reshape(imgs_.shape)

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -865,7 +865,8 @@ def clean_img(imgs, sessions=None, detrend=True, standardize=True,
 
     mask_img: Niimg-like object, optional
         See http://nilearn.github.io/manipulating_images/input_output.html
-        If provided, signal is only cleaned from voxels inside the mask.
+        If provided, signal is only cleaned from voxels inside the mask. If
+        mask is provided, it should have same shape and affine as imgs.
         If not provided, all voxels are used.
 
     Returns

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -863,7 +863,7 @@ def clean_img(imgs, sessions=None, detrend=True, standardize=True,
         If True, the non-finite values (NaNs and infs) found in the images
         will be replaced by zeros.
 
-    mask_img: Niimg-like object
+    mask_img: Niimg-like object, optional
         See http://nilearn.github.io/manipulating_images/input_output.html
         If provided, signal is only cleaned from voxels inside the mask.
         If not provided, all voxels are used.

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -586,6 +586,10 @@ def test_clean_img():
     img, mask_img = data_gen.generate_fake_fmri(shape=(10, 10, 10), length=10)
     data_img_mask_ = image.clean_img(img, mask_img=mask_img)
 
+    # Checks that output with full mask and without is equal
+    data_img_ = image.clean_img(img)
+    np.testing.assert_equal(data_img_.get_data(), data_img_mask_.get_data())
+
 
 def test_largest_cc_img():
     """ Check the extraction of the largest connected component, for niftis

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -588,7 +588,8 @@ def test_clean_img():
 
     # Checks that output with full mask and without is equal
     data_img_ = image.clean_img(img)
-    np.testing.assert_equal(data_img_.get_data(), data_img_mask_.get_data())
+    np.testing.assert_almost_equal(data_img_.get_data(),
+                                   data_img_mask_.get_data())
 
 
 def test_largest_cc_img():

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -582,6 +582,10 @@ def test_clean_img():
     data_img_nifti2_ = image.clean_img(
         data_img_nifti2, detrend=True, standardize=False, low_pass=0.1, t_r=1.0)
 
+    # if mask_img
+    img, mask_img = data_gen.generate_fake_fmri(shape=(10, 10, 10), length=10)
+    data_img_mask_ = image.clean_img(img, mask_img=mask_img)
+
 
 def test_largest_cc_img():
     """ Check the extraction of the largest connected component, for niftis


### PR DESCRIPTION
Closes https://github.com/nilearn/nilearn/issues/1839#issuecomment-432988036.

As discussed in https://github.com/nilearn/nilearn/issues/1839#issuecomment-432988036, this PR adds a `mask_img` parameter to `clean.img` to restrict the computation to voxels inside the mask.

I struggled a bit with the header information in the mask condition, [here](https://github.com/nilearn/nilearn/compare/master...miykael:add_mask_to_clean_img?expand=1#diff-b61cedb53334db86de8881757209d3feR921). I solved it by unmasking the image and then extracting the data. Because if we would just save the unmasked image, we wouldn't have the TR (temporal resolution) and probably other header information.