### PR TITLE
Removing the "value" annotation in view_stat_map

### DIFF
--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -3,7 +3,6 @@ from io import BytesIO
 
 import numpy as np
 from numpy.testing import assert_raises
-from matplotlib.colors import LinearSegmentedColormap
 
 from nibabel import Nifti1Image
 
@@ -123,34 +122,6 @@ def test_save_cmap():
 
     # Check the colormap is correct
     assert cmap_base64 == '//////////8=\n'
-
-
-def test_deduplicate_cmap():
-    # Build a cold_hot colormap
-    n_colors = 4
-    cmap, value = html_stat_map._deduplicate_cmap(
-        'cold_hot', n_colors=n_colors, annotate=True)
-
-    assert cmap.N == n_colors
-    assert value
-
-    # Check that there are no duplicated colors
-    cmaplist = [cmap(i) for i in range(cmap.N)]
-    mask = [cmaplist.count(cmap(i)) == 1 for i in range(cmap.N)]
-    assert np.min(mask)
-
-    # Build a custom colormap with only repeated colors
-    n_colors = 2
-    cmap_custom = LinearSegmentedColormap.from_list(
-        'Custom cmap', [[0, 0, 0], [1, 1, 1], [0, 0, 0], [1, 1, 1]], 4)
-    cmap, value = html_stat_map._deduplicate_cmap(
-        cmap_custom, n_colors=n_colors, annotate=True)
-
-    assert cmap.N == cmap_custom.N
-
-    # Check that annotation were automatically turned off because it is not
-    # possible to deduplicate this map
-    assert value is False
 
 
 def test_mask_stat_map():


### PR DESCRIPTION
As discussed in PR #1766 , I got rid of plotting.html_stat_map._deduplicate_cmap, and the "value" annotation is now absent from the brainsprite viewer.