### PR TITLE
[MRG] Issue #1822: volumetric plot arrangement

### DIFF
--- a/doc/plotting/index.rst
+++ b/doc/plotting/index.rst
@@ -166,6 +166,10 @@ Different display modes
      :target: ../auto_examples/01_plotting/plot_demo_more_plotting.html
      :scale: 50
 
+.. |plot_tiled| image:: ../auto_examples/01_plotting/images/sphx_glr_plot_demo_more_plotting_009.png
+     :target: ../auto_examples/01_plotting/plot_demo_more_plotting.html
+     :scale: 50
+
 .. |plot_lzr| image:: ../auto_examples/01_plotting/images/sphx_glr_plot_demo_glass_brain_extensive_006.png
      :target: ../auto_examples/01_plotting/plot_demo_glass_brain_extensive.html
      :scale: 50
@@ -215,6 +219,11 @@ Different display modes
                    |hack|
                    Cutting in the y and z direction, with cuts manually
                    positionned
+
+|plot_tiled|       `display_mode='tiled', cut_coords=[36, -27, 60]`
+                   |hack|
+                   Tiled slicer: 3 cuts along the x, y, z directions,
+                   arranged in a 2x2 grid
 
 |plot_lzr|         `Glass brain display_mode='lzr'`
                    |hack|

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,3 +1,12 @@
+0.5.1
+=====
+
+NEW
+---
+
+- New display mode 'tiled' which allows 2x2 plot arrangement when plotting three cuts
+  (see :ref:`plotting`).
+
 0.5.0
 =====
 

--- a/examples/01_plotting/plot_demo_more_plotting.py
+++ b/examples/01_plotting/plot_demo_more_plotting.py
@@ -131,7 +131,7 @@ plotting.plot_stat_map(stat_img, display_mode='yz',
 # display_mode='tiled' for sagittal, coronal and axial view
 
 plotting.plot_stat_map(stat_img, display_mode='tiled',
-                       cut_coords=[36,-27,60],
+                       cut_coords=[36, -27, 60],
                        title="display_mode='tiled'")
 
 ###############################################################################

--- a/examples/01_plotting/plot_demo_more_plotting.py
+++ b/examples/01_plotting/plot_demo_more_plotting.py
@@ -15,7 +15,7 @@ The display features shown here are inherited from the
 
 The parameter `display_mode` is used to draw brain slices along given
 specific directions, where directions can be one of 'ortho',
-'x', 'y', 'z', 'xy', 'xz', 'yz'. whereas parameter `cut_coords`
+'tiled','x', 'y', 'z', 'yx', 'xz', 'yz'. whereas parameter `cut_coords`
 is used to specify a limited number of slices to visualize along given
 specific slice direction. The parameter `cut_coords` can also be used
 to draw the specific cuts in the slices by giving its particular
@@ -111,7 +111,7 @@ plotting.plot_stat_map(stat_img, display_mode='xz',
 ########################################
 # Changing the views to 'coronal', 'sagittal' views with coordinates
 # -------------------------------------------------------------------
-# display_mode='yx' for coronal and saggital view and coordinates will be
+# display_mode='yx' for coronal and sagittal view and coordinates will be
 # assigned in the order of direction as [x, y, z]
 plotting.plot_stat_map(stat_img, display_mode='yx',
                        cut_coords=[-27, 36],
@@ -126,13 +126,12 @@ plotting.plot_stat_map(stat_img, display_mode='yz',
                        title="display_mode='yz', cut_coords=[-27, 60]")
 
 ########################################
-# Visualizing in - three views 'sagittal', 'coronal' and 'axial' and arranging
-# views in a 2x2 fashion
+# Visualizing three views in 2x2 fashion
 # -------------------------------------------------------------------------
-# display_mode='tiled' for saggital, coronal and axial view with plots
-# arranged in a 2x2 matrix
+# display_mode='tiled' for sagittal, coronal and axial view
 
 plotting.plot_stat_map(stat_img, display_mode='tiled',
+                       cut_coords=[36,-27,60],
                        title="display_mode='tiled'")
 
 ###############################################################################

--- a/examples/01_plotting/plot_demo_more_plotting.py
+++ b/examples/01_plotting/plot_demo_more_plotting.py
@@ -125,6 +125,16 @@ plotting.plot_stat_map(stat_img, display_mode='yz',
                        cut_coords=[-27, 60],
                        title="display_mode='yz', cut_coords=[-27, 60]")
 
+########################################
+# Visualizing in - three views 'sagittal', 'coronal' and 'axial' and arranging
+# views in a 2x2 fashion
+# -------------------------------------------------------------------------
+# display_mode='tiled' for saggital, coronal and axial view with plots
+# arranged in a 2x2 matrix
+
+plotting.plot_stat_map(stat_img, display_mode='tiled',
+                       title="display_mode='tiled'")
+
 ###############################################################################
 # Demonstrating various display features
 # ---------------------------------------

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -1273,7 +1273,8 @@ class TiledSlicer(BaseSlicer):
         Returns
         ----------
         [coord1, coord2, coord3, coord4]: list of int
-            x0, y0, x1, y1 coordinates used by matplotlib to position axes in figure.
+            x0, y0, x1, y1 coordinates used by matplotlib
+            to position axes in figure.
 
         """
 
@@ -1332,7 +1333,7 @@ class TiledSlicer(BaseSlicer):
             ax.set_axes_locator(self._locator)
 
     def _adjust_width_height(self, width_dict, height_dict,
-                            rect_x0, rect_y0, rect_x1, rect_y1):
+                             rect_x0, rect_y0, rect_x1, rect_y1):
         """ Adjusts absolute image width and height to ratios.
 
         Parameters
@@ -1377,13 +1378,14 @@ class TiledSlicer(BaseSlicer):
 
         for ax, width in width_dict.items():
             width_dict[ax] = width / total_width * (rect_x1 - rect_x0)
-        
+
         for ax, height in height_dict.items():
             height_dict[ax] = height / total_height * (rect_y1 - rect_y0)
 
         return (width_dict, height_dict)
 
-    def _find_axes_coord(self, rel_width_dict, rel_height_dict, rect_x0, rect_y0, rect_x1, rect_y1):
+    def _find_axes_coord(self, rel_width_dict, rel_height_dict,
+                         rect_x0, rect_y0, rect_x1, rect_y1):
         """"find coordinates for inital axes placement for xyz cuts.
 
         Parameters
@@ -1397,8 +1399,9 @@ class TiledSlicer(BaseSlicer):
 
         Returns
         ----------
-        coord1, coord2, coord3, coord4: dict of {matplotlib.axes._axes.Axes: float}
-            x0, y0, x1, y1 coordinates per axes used by matplotlib to position axes in figure.
+        coord1, coord2, coord3, coord4: dict
+            x0, y0, x1, y1 coordinates per axes used by matplotlib
+            to position axes in figure.
 
         """
 
@@ -1436,7 +1439,7 @@ class TiledSlicer(BaseSlicer):
             coord4[ax] = rect_y0 + rel_height_dict[ax]
 
         return(coord1, coord2, coord3, coord4)
-          
+
     def _locator(self, axes, renderer):
         """ The locator function used by matplotlib to position axes.
             Here we put the logic used to adjust the size of the axes.
@@ -1444,7 +1447,7 @@ class TiledSlicer(BaseSlicer):
 
         rect_x0, rect_y0, rect_x1, rect_y1 = self.rect
 
-        #image width and height
+        # image width and height
         width_dict = dict()
         height_dict = dict()
 
@@ -1473,14 +1476,18 @@ class TiledSlicer(BaseSlicer):
             width_dict[display_ax.ax] = (xmax - xmin)
             height_dict[display_ax.ax] = (ymax - ymin)
 
-        #relative image height and width
-        rel_width_dict, rel_height_dict = self._adjust_width_height(width_dict, height_dict, rect_x0, rect_y0, rect_x1, rect_y1)
-    
+        # relative image height and width
+        rel_width_dict, rel_height_dict = self._adjust_width_height(
+                width_dict, height_dict,
+                rect_x0, rect_y0, rect_x1, rect_y1)
+
         direction_ax = []
         for d in self._cut_displayed:
             direction_ax.append(display_ax_dict.get(d, dummy_ax).ax)
 
-        coord1, coord2, coord3, coord4 = self._find_axes_coord(rel_width_dict, rel_height_dict, rect_x0, rect_y0, rect_x1, rect_y1)
+        coord1, coord2, coord3, coord4 = self._find_axes_coord(
+                rel_width_dict, rel_height_dict,
+                rect_x0, rect_y0, rect_x1, rect_y1)
 
         return transforms.Bbox([[coord1[axes], coord2[axes]],
                                [coord3[axes], coord4[axes]]])
@@ -1514,7 +1521,7 @@ class TiledSlicer(BaseSlicer):
                 kwargs['color'] = '.8' if self._black_bg else 'k'
             except KeyError:
                 pass
-            
+
         try:
             ax = self.axes['y'].ax
         except KeyError:
@@ -1531,9 +1538,9 @@ class TiledSlicer(BaseSlicer):
             pass
         else:
             if y is not None:
-                ax.axvline(y,  **kwargs)
+                ax.axvline(y, **kwargs)
             if z is not None:
-                ax.axhline(z,  **kwargs)
+                ax.axhline(z, **kwargs)
 
         try:
             ax = self.axes['z'].ax
@@ -1541,7 +1548,7 @@ class TiledSlicer(BaseSlicer):
             pass
         else:
             if x is not None:
-                ax.axvline(x,  **kwargs)
+                ax.axvline(x, **kwargs)
             if y is not None:
                 ax.axhline(y, **kwargs)
 
@@ -1694,7 +1701,7 @@ class YZSlicer(OrthoSlicer):
 
 
 SLICERS = dict(ortho=OrthoSlicer,
-               tiled= TiledSlicer,
+               tiled=TiledSlicer,
                xz=XZSlicer,
                yz=YZSlicer,
                yx=YXSlicer,

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -1263,7 +1263,7 @@ class TiledSlicer(BaseSlicer):
         return cut_coords
 
     def _find_inital_axes_coord(self, index):
-        """"Find coordinates for initial axes placement for xyz cuts.
+        """Find coordinates for initial axes placement for xyz cuts.
 
         Parameters
         ----------
@@ -1287,7 +1287,7 @@ class TiledSlicer(BaseSlicer):
         elif index == 1:
                 coord1 = 0.5 * (rect_x1 - rect_x0) + rect_x0
                 coord2 = 0.5 * (rect_y1 - rect_y0) + rect_y0
-                coord3 = rect_x1 -rect_x0
+                coord3 = rect_x1 - rect_x0
                 coord4 = rect_y1 - rect_y0
         elif index == 2:
                 coord1 = rect_x1 - rect_x0
@@ -1331,7 +1331,8 @@ class TiledSlicer(BaseSlicer):
             self.axes[direction] = display_ax
             ax.set_axes_locator(self._locator)
 
-    def _adjust_width_height(self, width_dict, height_dict, rect_x0, rect_y0, rect_x1, rect_y1):
+    def _adjust_width_height(self, width_dict, height_dict,
+                            rect_x0, rect_y0, rect_x1, rect_y1):
         """ Adjusts absolute image width and height to ratios.
 
         Parameters

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -1356,24 +1356,17 @@ class TiledSlicer(BaseSlicer):
         total_height = 0
         total_width = 0
 
-        try:
+        if 'y' in self.axes:
             ax = self.axes['y'].ax
-        except KeyError:
-            pass
-        else:
             total_height = total_height + height_dict[ax]
             total_width = total_width + width_dict[ax]
-        try:
+
+        if 'x' in self.axes:
             ax = self.axes['x'].ax
-        except KeyError:
-            pass
-        else:
             total_width = total_width + width_dict[ax]
-        try:
+
+        if 'z' in self.axes:
             ax = self.axes['z'].ax
-        except KeyError:
-            pass
-        else:
             total_height = total_height + height_dict[ax]
 
         for ax, width in width_dict.items():
@@ -1410,29 +1403,22 @@ class TiledSlicer(BaseSlicer):
         coord3 = dict()
         coord4 = dict()
 
-        try:
+        if 'y' in self.axes:
             ax = self.axes['y'].ax
-        except KeyError:
-            pass
-        else:
             coord1[ax] = rect_x0
             coord2[ax] = (rect_y1) - rel_height_dict[ax]
             coord3[ax] = rect_x0 + rel_width_dict[ax]
             coord4[ax] = rect_y1
-        try:
+
+        if 'x' in self.axes:
             ax = self.axes['x'].ax
-        except KeyError:
-            pass
-        else:
             coord1[ax] = (rect_x1) - rel_width_dict[ax]
             coord2[ax] = (rect_y1) - rel_height_dict[ax]
             coord3[ax] = rect_x1
             coord4[ax] = rect_y1
-        try:
+
+        if 'z' in self.axes:
             ax = self.axes['z'].ax
-        except KeyError:
-            pass
-        else:
             coord1[ax] = rect_x0
             coord2[ax] = rect_y0
             coord3[ax] = rect_x0 + rel_width_dict[ax]
@@ -1522,31 +1508,22 @@ class TiledSlicer(BaseSlicer):
             except KeyError:
                 pass
 
-        try:
+        if 'y' in self.axes:
             ax = self.axes['y'].ax
-        except KeyError:
-            pass
-        else:
             if x is not None:
                 ax.axvline(x, **kwargs)
             if z is not None:
                 ax.axhline(z, **kwargs)
 
-        try:
+        if 'x' in self.axes:
             ax = self.axes['x'].ax
-        except KeyError:
-            pass
-        else:
             if y is not None:
                 ax.axvline(y, **kwargs)
             if z is not None:
                 ax.axhline(z, **kwargs)
 
-        try:
+        if 'z' in self.axes:
             ax = self.axes['z'].ax
-        except KeyError:
-            pass
-        else:
             if x is not None:
                 ax.axvline(x, **kwargs)
             if y is not None:

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -1351,21 +1351,28 @@ class TiledSlicer(BaseSlicer):
             Height ratios of image cuts for optimal positioning of axes.
 
         """
+        total_height = 0
+        total_width = 0
 
-        unique_width = {}
-
-        for key, value in width_dict.items():
-            if value not in unique_width.values():
-                unique_width[key] = value
-
-        unique_height = {}
-
-        for key, value in height_dict.items():
-            if value not in unique_height.values():
-                unique_height[key] = value
-
-        total_height = float(sum(unique_height.values()))
-        total_width = float(sum(unique_width.values()))
+        try:
+            ax = self.axes['y'].ax
+        except KeyError:
+            pass
+        else:
+            total_height = total_height + height_dict[ax]
+            total_width = total_width + width_dict[ax]
+        try:
+            ax = self.axes['x'].ax
+        except KeyError:
+            pass
+        else:
+            total_width = total_width + width_dict[ax]
+        try:
+            ax = self.axes['z'].ax
+        except KeyError:
+            pass
+        else:
+            total_height = total_height + height_dict[ax]
 
         for ax, width in width_dict.items():
             width_dict[ax] = width / total_width * (rect_x1 - rect_x0)

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -143,11 +143,13 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
                    'Tip: Use np.nanmax() instead of np.max().')
         warnings.warn(nan_msg)
 
-    if isinstance(cut_coords, numbers.Number) and (display_mode == 'ortho' or display_mode == 'tiled'):
+    if (isinstance(cut_coords, numbers.Number) and
+            (display_mode == 'ortho' or display_mode == 'tiled')):
         raise ValueError(
             "The input given for display_mode='{0}' needs to be "
             "a list of 3d world coordinates in (x, y, z). "
-            "You provided single cut, cut_coords={1}".format(display_mode,cut_coords))
+            "You provided single cut, "
+            "cut_coords={1}".format(display_mode, cut_coords))
 
     if img is not False and img is not None:
         img = _utils.check_niimg_3d(img, dtype='auto')
@@ -239,7 +241,8 @@ def plot_img(img, cut_coords=None, output_file=None, display_mode='ortho',
             See http://nilearn.github.io/manipulating_images/input_output.html
         cut_coords: None, a tuple of floats, or an integer
             The MNI coordinates of the point where the cut is performed
-            If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
+            If display_mode is 'ortho' or 'tiled',
+            this should be a 3-tuple: (x, y, z)
             For display_mode == 'x', 'y', or 'z', then these are the
             coordinates of each cut in the corresponding direction.
             If None is given, the cuts is calculated automaticaly.
@@ -252,7 +255,8 @@ def plot_img(img, cut_coords=None, output_file=None, display_mode='ortho',
         display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
-            directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
+            directions, 'tiled' - three cuts are performed
+            and arranged in a 2x2 grid.
         figure : integer or matplotlib figure, optional
             Matplotlib figure used or its number. If None is given, a
             new figure is created.
@@ -439,7 +443,8 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
             given, nilearn tries to find a T1 template.
         cut_coords : None, a tuple of floats, or an integer
             The MNI coordinates of the point where the cut is performed
-            If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
+            If display_mode is 'ortho' or 'tiled',
+            this should be a 3-tuple: (x, y, z)
             For display_mode == 'x', 'y', or 'z', then these are the
             coordinates of each cut in the corresponding direction.
             If None is given, the cuts is calculated automaticaly.
@@ -452,7 +457,8 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
         display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
-            directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
+            directions, 'tiled' - three cuts are performed
+            and arranged in a 2x2 grid.
         figure : integer or matplotlib figure, optional
             Matplotlib figure used or its number. If None is given, a
             new figure is created.
@@ -532,7 +538,8 @@ def plot_epi(epi_img=None, cut_coords=None, output_file=None,
             The EPI (T2*) image
         cut_coords : None, a tuple of floats, or an integer
             The MNI coordinates of the point where the cut is performed
-            If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
+            If display_mode is 'ortho' or 'tiled',
+            this should be a 3-tuple: (x, y, z)
             For display_mode == 'x', 'y', or 'z', then these are the
             coordinates of each cut in the corresponding direction.
             If None is given, the cuts is calculated automaticaly.
@@ -545,7 +552,8 @@ def plot_epi(epi_img=None, cut_coords=None, output_file=None,
         display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
-            directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
+            directions, 'tiled' - three cuts are performed
+            and arranged in a 2x2 grid.
         figure : integer or matplotlib figure, optional
             Matplotlib figure used or its number. If None is given, a
             new figure is created.
@@ -616,7 +624,8 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         cut_coords : None, or a tuple of floats
             The MNI coordinates of the point where the cut is performed, in
             MNI coordinates and order.
-            If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
+            If display_mode is 'ortho' or 'tiled',
+            this should be a 3-tuple: (x, y, z)
             For display_mode == 'x', 'y', or 'z', then these are the
             coordinates of each cut in the corresponding direction.
             If None is given, the cuts is calculated automaticaly.
@@ -627,7 +636,8 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
-            directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
+            directions, 'tiled' - three cuts are performed
+            and arranged in a 2x2 grid.
         figure : integer or matplotlib figure, optional
             Matplotlib figure used or its number. If None is given, a
             new figure is created.
@@ -753,7 +763,8 @@ def plot_prob_atlas(maps_img, bg_img=MNI152TEMPLATE, view_type='auto',
             contours.
         cut_coords : None, a tuple of floats, or an integer
             The MNI coordinates of the point where the cut is performed
-            If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
+            If display_mode is 'ortho' or 'tiled',
+            this should be a 3-tuple: (x, y, z)
             For display_mode == 'x', 'y', or 'z', then these are the
             coordinates of each cut in the corresponding direction.
             If None is given, the cuts is calculated automaticaly.
@@ -766,7 +777,8 @@ def plot_prob_atlas(maps_img, bg_img=MNI152TEMPLATE, view_type='auto',
         display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
-            directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
+            directions, 'tiled' - three cuts are performed
+            and arranged in a 2x2 grid.
         figure : integer or matplotlib figure, optional
             Matplotlib figure used or its number. If None is given, a
             new figure is created.
@@ -930,7 +942,8 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
             To turn off background image, just pass "bg_img=False".
         cut_coords : None, a tuple of floats, or an integer
             The MNI coordinates of the point where the cut is performed
-            If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
+            If display_mode is 'ortho' or 'tiled',
+            this should be a 3-tuple: (x, y, z)
             For display_mode == 'x', 'y', or 'z', then these are the
             coordinates of each cut in the corresponding direction.
             If None is given, the cuts is calculated automaticaly.
@@ -943,7 +956,8 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
-            directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
+            directions, 'tiled' - three cuts are performed
+            and arranged in a 2x2 grid.
         colorbar : boolean, optional
             If True, display a colorbar on the right of the plots.
         figure : integer or matplotlib figure, optional

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -249,10 +249,10 @@ def plot_img(img, cut_coords=None, output_file=None, display_mode='ortho',
             The name of an image file to export the plot to. Valid extensions
             are .png, .pdf, .svg. If output_file is not None, the plot
             is saved to a file, and the display is closed.
-        display_mode : {'ortho', 'x', 'y', 'z', 'xy', 'xz', 'yz'}
+        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'xy', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
-            directions.
+            directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
         figure : integer or matplotlib figure, optional
             Matplotlib figure used or its number. If None is given, a
             new figure is created.
@@ -449,10 +449,10 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
             The name of an image file to export the plot to. Valid extensions
             are .png, .pdf, .svg. If output_file is not None, the plot
             is saved to a file, and the display is closed.
-        display_mode : {'ortho', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
+        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'xy', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
-            directions.
+            directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
         figure : integer or matplotlib figure, optional
             Matplotlib figure used or its number. If None is given, a
             new figure is created.
@@ -542,10 +542,10 @@ def plot_epi(epi_img=None, cut_coords=None, output_file=None,
             The name of an image file to export the plot to. Valid extensions
             are .png, .pdf, .svg. If output_file is not None, the plot
             is saved to a file, and the display is closed.
-        display_mode : {'ortho', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
+        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'xy', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
-            directions.
+            directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
         figure : integer or matplotlib figure, optional
             Matplotlib figure used or its number. If None is given, a
             new figure is created.
@@ -624,10 +624,10 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
             The name of an image file to export the plot to. Valid extensions
             are .png, .pdf, .svg. If output_file is not None, the plot
             is saved to a file, and the display is closed.
-        display_mode : {'ortho', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
+        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'xy', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
-            directions.
+            directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
         figure : integer or matplotlib figure, optional
             Matplotlib figure used or its number. If None is given, a
             new figure is created.
@@ -763,10 +763,10 @@ def plot_prob_atlas(maps_img, bg_img=MNI152TEMPLATE, view_type='auto',
             The name of an image file to export the plot to. Valid extensions
             are .png, .pdf, .svg. If output_file is not None, the plot
             is saved to a file, and the display is closed.
-        display_mode : {'ortho', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
+        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'xy', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
-            directions.
+            directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
         figure : integer or matplotlib figure, optional
             Matplotlib figure used or its number. If None is given, a
             new figure is created.
@@ -940,10 +940,10 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
             The name of an image file to export the plot to. Valid extensions
             are .png, .pdf, .svg. If output_file is not None, the plot
             is saved to a file, and the display is closed.
-        display_mode : {'ortho', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
+        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'xy', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
-            directions.
+            directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
         colorbar : boolean, optional
             If True, display a colorbar on the right of the plots.
         figure : integer or matplotlib figure, optional

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -143,11 +143,11 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
                    'Tip: Use np.nanmax() instead of np.max().')
         warnings.warn(nan_msg)
 
-    if isinstance(cut_coords, numbers.Number) and display_mode == 'ortho':
+    if isinstance(cut_coords, numbers.Number) and (display_mode == 'ortho' or display_mode == 'tiled'):
         raise ValueError(
-            "The input given for display_mode='ortho' needs to be "
+            "The input given for display_mode='{0}' needs to be "
             "a list of 3d world coordinates in (x, y, z). "
-            "You provided single cut, cut_coords={0}".format(cut_coords))
+            "You provided single cut, cut_coords={1}".format(display_mode,cut_coords))
 
     if img is not False and img is not None:
         img = _utils.check_niimg_3d(img, dtype='auto')
@@ -239,7 +239,7 @@ def plot_img(img, cut_coords=None, output_file=None, display_mode='ortho',
             See http://nilearn.github.io/manipulating_images/input_output.html
         cut_coords: None, a tuple of floats, or an integer
             The MNI coordinates of the point where the cut is performed
-            If display_mode is 'ortho', this should be a 3-tuple: (x, y, z)
+            If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
             For display_mode == 'x', 'y', or 'z', then these are the
             coordinates of each cut in the corresponding direction.
             If None is given, the cuts is calculated automaticaly.
@@ -249,7 +249,7 @@ def plot_img(img, cut_coords=None, output_file=None, display_mode='ortho',
             The name of an image file to export the plot to. Valid extensions
             are .png, .pdf, .svg. If output_file is not None, the plot
             is saved to a file, and the display is closed.
-        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'xy', 'xz', 'yz'}
+        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
             directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
@@ -439,7 +439,7 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
             given, nilearn tries to find a T1 template.
         cut_coords : None, a tuple of floats, or an integer
             The MNI coordinates of the point where the cut is performed
-            If display_mode is 'ortho', this should be a 3-tuple: (x, y, z)
+            If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
             For display_mode == 'x', 'y', or 'z', then these are the
             coordinates of each cut in the corresponding direction.
             If None is given, the cuts is calculated automaticaly.
@@ -449,7 +449,7 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
             The name of an image file to export the plot to. Valid extensions
             are .png, .pdf, .svg. If output_file is not None, the plot
             is saved to a file, and the display is closed.
-        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'xy', 'xz', 'yz'}
+        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
             directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
@@ -532,7 +532,7 @@ def plot_epi(epi_img=None, cut_coords=None, output_file=None,
             The EPI (T2*) image
         cut_coords : None, a tuple of floats, or an integer
             The MNI coordinates of the point where the cut is performed
-            If display_mode is 'ortho', this should be a 3-tuple: (x, y, z)
+            If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
             For display_mode == 'x', 'y', or 'z', then these are the
             coordinates of each cut in the corresponding direction.
             If None is given, the cuts is calculated automaticaly.
@@ -542,7 +542,7 @@ def plot_epi(epi_img=None, cut_coords=None, output_file=None,
             The name of an image file to export the plot to. Valid extensions
             are .png, .pdf, .svg. If output_file is not None, the plot
             is saved to a file, and the display is closed.
-        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'xy', 'xz', 'yz'}
+        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
             directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
@@ -616,7 +616,7 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         cut_coords : None, or a tuple of floats
             The MNI coordinates of the point where the cut is performed, in
             MNI coordinates and order.
-            If display_mode is 'ortho', this should be a 3-tuple: (x, y, z)
+            If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
             For display_mode == 'x', 'y', or 'z', then these are the
             coordinates of each cut in the corresponding direction.
             If None is given, the cuts is calculated automaticaly.
@@ -624,7 +624,7 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
             The name of an image file to export the plot to. Valid extensions
             are .png, .pdf, .svg. If output_file is not None, the plot
             is saved to a file, and the display is closed.
-        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'xy', 'xz', 'yz'}
+        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
             directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
@@ -753,7 +753,7 @@ def plot_prob_atlas(maps_img, bg_img=MNI152TEMPLATE, view_type='auto',
             contours.
         cut_coords : None, a tuple of floats, or an integer
             The MNI coordinates of the point where the cut is performed
-            If display_mode is 'ortho', this should be a 3-tuple: (x, y, z)
+            If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
             For display_mode == 'x', 'y', or 'z', then these are the
             coordinates of each cut in the corresponding direction.
             If None is given, the cuts is calculated automaticaly.
@@ -763,7 +763,7 @@ def plot_prob_atlas(maps_img, bg_img=MNI152TEMPLATE, view_type='auto',
             The name of an image file to export the plot to. Valid extensions
             are .png, .pdf, .svg. If output_file is not None, the plot
             is saved to a file, and the display is closed.
-        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'xy', 'xz', 'yz'}
+        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
             directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.
@@ -930,7 +930,7 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
             To turn off background image, just pass "bg_img=False".
         cut_coords : None, a tuple of floats, or an integer
             The MNI coordinates of the point where the cut is performed
-            If display_mode is 'ortho', this should be a 3-tuple: (x, y, z)
+            If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
             For display_mode == 'x', 'y', or 'z', then these are the
             coordinates of each cut in the corresponding direction.
             If None is given, the cuts is calculated automaticaly.
@@ -940,7 +940,7 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
             The name of an image file to export the plot to. Valid extensions
             are .png, .pdf, .svg. If output_file is not None, the plot
             is saved to a file, and the display is closed.
-        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'xy', 'xz', 'yz'}
+        display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
             Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
             'z' - axial, 'ortho' - three cuts are performed in orthogonal
             directions, 'tiled' - three cuts are performed and arranged in a 2x2 grid.

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -43,7 +43,8 @@ def test_stacked_slicer():
 
 def test_tiled_slicer():
     img = load_mni152_template()
-    slicer = TiledSlicer.init_with_figure(img=img, cut_coords=(0, 0, 0))
+    slicer = TiledSlicer.init_with_figure(img=img, cut_coords=(0, 0, 0),
+                                          colorbar=True)
     slicer.add_overlay(img, cmap=plt.cm.gray)
     # Forcing a layout here, to test the locator code
     with tempfile.TemporaryFile() as fp:

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import nibabel
 import numpy as np
 
-from nilearn.plotting.displays import OrthoSlicer, XSlicer, OrthoProjector
+from nilearn.plotting.displays import OrthoSlicer, XSlicer, OrthoProjector, TiledSlicer
 from nilearn.plotting.displays import LZRYProjector
 from nilearn.datasets import load_mni152_template
 
@@ -22,10 +22,27 @@ def test_demo_ortho_slicer():
     oslicer.close()
 
 
+def test_demo_tiled_slicer():
+    tslicer = TiledSlicer(cut_coords=(0, 0, 0))
+    img = load_mni152_template()
+    tslicer.add_overlay(img, cmap=plt.cm.gray)
+    tslicer.close()
+
+
 def test_stacked_slicer():
     # Test stacked slicers, like the XSlicer
     img = load_mni152_template()
     slicer = XSlicer.init_with_figure(img=img, cut_coords=3)
+    slicer.add_overlay(img, cmap=plt.cm.gray)
+    # Forcing a layout here, to test the locator code
+    with tempfile.TemporaryFile() as fp:
+        slicer.savefig(fp)
+    slicer.close()
+
+
+def test_tiled_slicer():
+    img = load_mni152_template()
+    slicer = TiledSlicer.init_with_figure(img=img, cut_coords=(0,0,0))
     slicer.add_overlay(img, cmap=plt.cm.gray)
     # Forcing a layout here, to test the locator code
     with tempfile.TemporaryFile() as fp:

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -6,7 +6,8 @@ import matplotlib.pyplot as plt
 import nibabel
 import numpy as np
 
-from nilearn.plotting.displays import OrthoSlicer, XSlicer, OrthoProjector, TiledSlicer
+from nilearn.plotting.displays import OrthoSlicer, XSlicer, OrthoProjector
+from nilearn.plotting.displays import TiledSlicer
 from nilearn.plotting.displays import LZRYProjector
 from nilearn.datasets import load_mni152_template
 
@@ -42,7 +43,7 @@ def test_stacked_slicer():
 
 def test_tiled_slicer():
     img = load_mni152_template()
-    slicer = TiledSlicer.init_with_figure(img=img, cut_coords=(0,0,0))
+    slicer = TiledSlicer.init_with_figure(img=img, cut_coords=(0, 0, 0))
     slicer.add_overlay(img, cmap=plt.cm.gray)
     # Forcing a layout here, to test the locator code
     with tempfile.TemporaryFile() as fp:

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -45,7 +45,7 @@ def test_tiled_slicer():
     img = load_mni152_template()
     slicer = TiledSlicer.init_with_figure(img=img, cut_coords=(0, 0, 0),
                                           colorbar=True)
-    slicer.add_overlay(img, cmap=plt.cm.gray)
+    slicer.add_overlay(img, cmap=plt.cm.gray,colorbar=True)
     # Forcing a layout here, to test the locator code
     with tempfile.TemporaryFile() as fp:
         slicer.savefig(fp)

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -958,3 +958,20 @@ def test_add_markers_using_plot_glass_brain():
     coords = [(-34, -39, -9)]
     fig.add_markers(coords)
     fig.close()
+
+
+def test_plotting_functions_with_TiledSlicer():
+    img = _generate_img()
+    plot_stat_map(img,display_mode='tiled')
+    plot_anat(display_mode='tiled')
+    plot_img(img,display_mode='tiled')
+    plt.close()
+
+
+def test_display_methods_TiledSlicer():
+    img = _generate_img()
+    display = plot_img(img,display_mode='tiled')
+    display.add_overlay(img,threshold=0)
+    display.add_edges(img,color='c')
+    display.add_contours(img,contours=2,linewidth=4,
+            colors=['limegreen', 'yellow'])

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -872,7 +872,7 @@ def test_invalid_in_display_mode_cut_coords_all_plots():
                             img, display_mode='ortho', cut_coords=2)
 
 
-def test_invalid_in_display_mode_tiled_cut_coords_all_plots():
+def test_invalid_in_display_mode_tiled_cut_coords_single_all_plots():
     img = _generate_img()
 
     for plot_func in [plot_img, plot_anat, plot_roi, plot_epi,
@@ -882,6 +882,18 @@ def test_invalid_in_display_mode_tiled_cut_coords_all_plots():
                             "be a list of 3d world coordinates.",
                             plot_func,
                             img, display_mode='tiled', cut_coords=2)
+
+
+def test_invalid_in_display_mode_tiled_cut_coords_all_plots():
+    img = _generate_img()
+
+    for plot_func in [plot_img, plot_anat, plot_roi, plot_epi,
+                      plot_stat_map,plot_prob_atlas]:
+        assert_raises_regex(ValueError,
+                            "The number cut_coords passed does not "
+                            "match the display_mode",
+                            plot_func,
+                            img, display_mode='tiled', cut_coords=(2,2))
 
 
 def test_outlier_cut_coords():

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -872,6 +872,18 @@ def test_invalid_in_display_mode_cut_coords_all_plots():
                             img, display_mode='ortho', cut_coords=2)
 
 
+def test_invalid_in_display_mode_tiled_cut_coords_all_plots():
+    img = _generate_img()
+
+    for plot_func in [plot_img, plot_anat, plot_roi, plot_epi,
+                      plot_stat_map,plot_prob_atlas]:
+        assert_raises_regex(ValueError,
+                            "The input given for display_mode='tiled' needs to "
+                            "be a list of 3d world coordinates.",
+                            plot_func,
+                            img, display_mode='tiled', cut_coords=2)
+
+
 def test_outlier_cut_coords():
     """ Test to plot a subset of a large set of cuts found for a small area."""
     bg_img = load_mni152_template()
@@ -960,7 +972,7 @@ def test_add_markers_using_plot_glass_brain():
     fig.close()
 
 
-def test_plotting_functions_with_TiledSlicer():
+def test_plotting_functions_with_display_mode_tiled():
     img = _generate_img()
     plot_stat_map(img, display_mode='tiled')
     plot_anat(display_mode='tiled')
@@ -968,7 +980,7 @@ def test_plotting_functions_with_TiledSlicer():
     plt.close()
 
 
-def test_display_methods_TiledSlicer():
+def test_display_methods_with_display_mode_tiled():
     img = _generate_img()
     display = plot_img(img, display_mode='tiled')
     display.add_overlay(img, threshold=0)

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -962,16 +962,16 @@ def test_add_markers_using_plot_glass_brain():
 
 def test_plotting_functions_with_TiledSlicer():
     img = _generate_img()
-    plot_stat_map(img,display_mode='tiled')
+    plot_stat_map(img, display_mode='tiled')
     plot_anat(display_mode='tiled')
-    plot_img(img,display_mode='tiled')
+    plot_img(img, display_mode='tiled')
     plt.close()
 
 
 def test_display_methods_TiledSlicer():
     img = _generate_img()
-    display = plot_img(img,display_mode='tiled')
-    display.add_overlay(img,threshold=0)
-    display.add_edges(img,color='c')
-    display.add_contours(img,contours=2,linewidth=4,
-            colors=['limegreen', 'yellow'])
+    display = plot_img(img, display_mode='tiled')
+    display.add_overlay(img, threshold=0)
+    display.add_edges(img, color='c')
+    display.add_contours(img, contours=2, linewidth=4,
+                         colors=['limegreen', 'yellow'])


### PR DESCRIPTION
Adressing  issue #1822  opened by @TheChymera, we have created a new display class called TiledSlicer, which is a variation of the OrthoSlicer class with changed `_locator `method, changed` _init_axes` method and different `_default_figsize` to arrange plots in a 2x2 fashion.

It can be called with specifying `display_mode='tiled'` in nilearns plotting functions, for example
`plot_anat(display_mode='tiled')`