### PR TITLE
load_niimg drops header if dtype is changed

### DIFF
--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -116,8 +116,12 @@ def load_niimg(niimg, dtype=None):
     dtype = _get_target_dtype(niimg.get_data().dtype, dtype)
 
     if dtype is not None:
+        if niimg.header is not None:
+            copyheader = True
+        else:
+            copyheader = False
         niimg = new_img_like(niimg, niimg.get_data().astype(dtype),
-                             niimg.affine,copy_header=True)
+                             niimg.affine, copy_header=copyheader)
         niimg.header.set_data_dtype(dtype)
 
     return niimg

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -117,7 +117,7 @@ def load_niimg(niimg, dtype=None):
 
     if dtype is not None:
         niimg = new_img_like(niimg, niimg.get_data().astype(dtype),
-                             niimg.affine)
+                             niimg.affine,copy_header=True)
     return niimg
 
 

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -118,6 +118,8 @@ def load_niimg(niimg, dtype=None):
     if dtype is not None:
         niimg = new_img_like(niimg, niimg.get_data().astype(dtype),
                              niimg.affine,copy_header=True)
+        niimg.header.set_data_dtype(dtype)
+
     return niimg
 
 

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -116,13 +116,14 @@ def load_niimg(niimg, dtype=None):
     dtype = _get_target_dtype(niimg.get_data().dtype, dtype)
 
     if dtype is not None:
+        # Copyheader and set dtype in header if header exists
         if niimg.header is not None:
-            copyheader = True
+            niimg = new_img_like(niimg, niimg.get_data().astype(dtype),
+                                niimg.affine, copy_header=True)
+            niimg.header.set_data_dtype(dtype)        
         else:
-            copyheader = False
-        niimg = new_img_like(niimg, niimg.get_data().astype(dtype),
-                             niimg.affine, copy_header=copyheader)
-        niimg.header.set_data_dtype(dtype)
+            niimg = new_img_like(niimg, niimg.get_data().astype(dtype),
+                                niimg.affine)
 
     return niimg
 

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -314,6 +314,7 @@ class _MNI152Template(SpatialImage):
     affine = None
     vmax = None
     _shape = None
+    header = None
 
     def __init__(self, data=None, affine=None, header=None):
         # Comply with spatial image requirements while allowing empty init

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -314,6 +314,7 @@ class _MNI152Template(SpatialImage):
     affine = None
     vmax = None
     _shape = None
+    # Having a header is required by the load_niimg function
     header = None
 
     def __init__(self, data=None, affine=None, header=None):


### PR DESCRIPTION
Hey, 

This appears to be a bug. Whenever there is a call to `nilearn._utils.load_niimg`, (or `nilearn._utils.check_niimg_4d()`) and dtype='auto' and the data's dtype!=target_dtype, the header gets dropped. This does not seem optimal. Here is an example mimicking the behaviour. 

But this can be fixed by adding copy_header flag and a call to niimg.header.set_data_dtype() 

The code below recreates the behaviour of the bug.

```
from nilearn import datasets
from nilearn._utils import check_niimg_4d
import nibabel as nb 
import numpy as np 
dataset = datasets.fetch_adhd(n_subjects=1)
fname = dataset.func[0]
img1 = nb.load(fname)
img2 = check_niimg_4d(img1,dtype=None)
img3 = check_niimg_4d(img1,dtype=np.int32)
# Answer = TR=2
print(img1.header.get_zooms()[-1])
# Answer = TR=2
print(img2.header.get_zooms()[-1])
# Answer = TR=1,  with my fix this = TR=2
print(img3.header.get_zooms()[-1])
```

