### PR TITLE
Revert "Fix for  Masker family reloaded: NiftiSpheresMasker silently ignores voxels"

### DIFF
--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -6,13 +6,11 @@ Mask nifti images by spherical volumes for seed-region analyses
 """
 import numpy as np
 import sklearn
-import warnings
 from sklearn import neighbors
 from sklearn.externals.joblib import Memory
 from distutils.version import LooseVersion
 
 from ..image.resampling import coord_transform
-from .._utils.niimg_conversions import _safe_get_data
 from .._utils import CacheMixin
 from .._utils.niimg_conversions import check_niimg_4d, check_niimg_3d
 from .._utils.class_inspect import get_params
@@ -38,13 +36,8 @@ def _apply_mask_and_get_affinity(seeds, niimg, radius, allow_overlap,
 
         X = masking._apply_mask_fmri(niimg, mask_img)
     else:
-        if np.isnan(np.sum(_safe_get_data(niimg))):
-            warnings.warn('The imgs you have fed into fit_transform() contains'
-                          ' NaN values which will be converted to zeroes ')
-            X = _safe_get_data(niimg, True).reshape([-1, niimg.shape[3]]).T
-        else:
-            X = _safe_get_data(niimg).reshape([-1, niimg.shape[3]]).T
         mask_coords = list(np.ndindex(niimg.shape[:3]))
+        X = niimg.get_data().reshape([-1, niimg.shape[3]]).T
 
     # For each seed, get coordinates of nearest voxel
     nearests = []

--- a/nilearn/input_data/tests/test_nifti_spheres_masker.py
+++ b/nilearn/input_data/tests/test_nifti_spheres_masker.py
@@ -3,7 +3,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 from nilearn.input_data import NiftiSpheresMasker
 from nilearn._utils.testing import assert_raises_regex
-from nose.tools import assert_false
+
 
 def test_seed_extraction():
     data = np.random.random((3, 3, 3, 5))
@@ -126,28 +126,3 @@ def test_small_radius():
     masker = NiftiSpheresMasker([seed], radius=1.6,
                                 mask_img=nibabel.Nifti1Image(mask, affine))
     masker.fit_transform(nibabel.Nifti1Image(data, affine))
-
-
-def test_is_nifti_spheres_masker_give_nans():
-    affine = np.eye(4)
-
-    data_with_nans = np.zeros((10, 10, 10), dtype=np.float32)
-    data_with_nans[:, :, :] = np.nan
-
-    data_without_nans = np.random.random((9, 9, 9))
-    indices = np.nonzero(data_without_nans)
-
-    # Leaving nans outside of some data
-    data_with_nans[indices] = data_without_nans[indices]
-    img = nibabel.Nifti1Image(data_with_nans, affine)
-    seed = [(7, 7, 7)]
-
-    # Interaction of seed with nans
-    masker = NiftiSpheresMasker(seeds=seed, radius=2.)
-    assert_false(np.isnan(np.sum(masker.fit_transform(img))))
-
-    mask = np.ones((9, 9, 9))
-    mask_img = nibabel.Nifti1Image(mask, affine)
-    # When mask_img is provided, the seed interacts within the brain, so no nan
-    masker = NiftiSpheresMasker(seeds=seed, radius=2., mask_img=mask_img)
-    assert_false(np.isnan(np.sum(masker.fit_transform(img))))


### PR DESCRIPTION
Reverts nilearn/nilearn#1906
The PR merged before (#1869( this is failing in CircleCI. I am reverting this and that one to forestall any potential (un)merge conflicts, and then will remerge this.