### PR TITLE
Lighting surf plot

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -7,6 +7,12 @@ NEW
 - New display mode 'tiled' which allows 2x2 plot arrangement when plotting three cuts
   (see :ref:`plotting`).
 
+Changes
+-------
+
+- Lighting used for interactive surface plots changed; plots may look a bit
+  different.
+
 0.5.0
 =====
 

--- a/nilearn/plotting/data/js/surface-plot-utils.js
+++ b/nilearn/plotting/data/js/surface-plot-utils.js
@@ -43,15 +43,16 @@ function getAxisConfig() {
 }
 
 function getLighting() {
-    return {
-        "ambient": 0.5,
-        "diffuse": 1,
-        "fresnel": .1,
-        "specular": .05,
-        "roughness": .1,
-        "facenormalsepsilon": 1e-6,
-        "vertexnormalsepsilon": 1e-12
-    };
+    return {};
+    // return {
+    //     "ambient": 0.5,
+    //     "diffuse": 1,
+    //     "fresnel": .1,
+    //     "specular": .05,
+    //     "roughness": .1,
+    //     "facenormalsepsilon": 1e-6,
+    //     "vertexnormalsepsilon": 1e-12
+    // };
 
 }
 

--- a/nilearn/plotting/data/js/surface-plot-utils.js
+++ b/nilearn/plotting/data/js/surface-plot-utils.js
@@ -44,12 +44,13 @@ function getAxisConfig() {
 
 function getLighting() {
     return {};
-    // return {
-    //     "ambient": 0.5,
-    //     "diffuse": 1,
-    //     "fresnel": .1,
+    // i.e. use plotly defaults:
+    // {
+    //     "ambient": 0.8,
+    //     "diffuse": .8,
+    //     "fresnel": .2,
     //     "specular": .05,
-    //     "roughness": .1,
+    //     "roughness": .5,
     //     "facenormalsepsilon": 1e-6,
     //     "vertexnormalsepsilon": 1e-12
     // };


### PR DESCRIPTION
plotly defaults for lighting of the surface plots actually look better than those we use in my opinion; main difference is more ambient light (shadows are not so dark) and no reflection (surface is more rough, less shiny, no bright spots)