### PR TITLE
[MRG] Make parameter names in view_connectome() consistent with plot_connectome()

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -13,6 +13,7 @@ Changes
 
 - Lighting used for interactive surface plots changed; plots may look a bit
   different.
+- plotting.view_connectome default colormap is `bwr`, consistent with plot_connectome.
 - plotting.view_connectome parameter names are consistent with plot_connectome:
 
  - coords is now node_coord

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -13,6 +13,12 @@ Changes
 
 - Lighting used for interactive surface plots changed; plots may look a bit
   different.
+- plotting.view_connectome parameter names are consistent with plot_connectome:
+
+ - coords is now node_coord
+ - marker_size is noe node_size
+ - cmap is now edge_cmap
+ - threshold is now edge_threshold
 
 0.5.0
 =====

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -80,6 +80,9 @@ def _make_connectome_html(connectome_info, embed_js=True):
 
 
 def _deprecate_params_view_connectome(func):
+    """ Decorator to deprecate spcific parameters in view_connectome()
+     without modifying view_connectome().
+     """
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         _warn_deprecated_params_view_connectome(kwargs)
@@ -156,6 +159,8 @@ def view_connectome(adjacency_matrix, node_coords, edge_threshold=None,
 
 
 def _warn_deprecated_params_view_connectome(kwargs):
+    """ For view_connectome(), raises warnings about deprecated parameters.
+    """
     all_deprecated_params = {'coords': 'node_coords',
                              'threshold': 'edge_threshold',
                              'cmap': 'edge_cmap',
@@ -171,12 +176,15 @@ def _warn_deprecated_params_view_connectome(kwargs):
                                                             replacement_param,
                                                             )
         )
-        warnings.warn(category=FutureWarning,
+        warnings.warn(category=DeprecationWarning,
                       message=param_deprecation_msg,
                       stacklevel=3)
 
 
 def _transfer_deprecated_param_vals_view_connectome(kwargs):
+    """ For view_connectome(), reassigns new parameters the values passed
+    to their corresponding deprecated parameters.
+    """
     coords = kwargs.setdefault('coords', None)
     threshold = kwargs.setdefault('threshold', None)
     cmap = kwargs.setdefault('cmap', None)

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -171,7 +171,7 @@ def _warn_deprecated_params_view_connectome(kwargs):
     for deprecated_param_ in used_deprecated_params:
         replacement_param = all_deprecated_params[deprecated_param_]
         param_deprecation_msg = (
-            'The parameter "{}" will be removed in Nilearn version 0.7.0).'
+            'The parameter "{}" will be removed in Nilearn version 0.6.0.'
             ' Please use the parameter "{}" instead.'.format(deprecated_param_,
                                                             replacement_param,
                                                             )

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -94,7 +94,7 @@ def _deprecate_params_view_connectome(func):
 
 @_deprecate_params_view_connectome
 def view_connectome(adjacency_matrix, node_coords, edge_threshold=None,
-                    edge_cmap=cm.cyan_orange, symmetric_cmap=True,
+                    edge_cmap=cm.bwr, symmetric_cmap=True,
                     linewidth=6., node_size=3.,
                     **kwargs):
     """
@@ -185,10 +185,10 @@ def _transfer_deprecated_param_vals_view_connectome(kwargs):
     """ For view_connectome(), reassigns new parameters the values passed
     to their corresponding deprecated parameters.
     """
-    coords = kwargs.setdefault('coords', None)
-    threshold = kwargs.setdefault('threshold', None)
-    cmap = kwargs.setdefault('cmap', None)
-    marker_size = kwargs.setdefault('marker_size', None)
+    coords = kwargs.get('coords', None)
+    threshold = kwargs.get('threshold', None)
+    cmap = kwargs.get('cmap', None)
+    marker_size = kwargs.get('marker_size', None)
     
     if coords is not None:
         kwargs['node_coords'] = coords

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -1,4 +1,6 @@
+import functools
 import json
+import warnings
 
 import numpy as np
 from scipy import sparse
@@ -77,9 +79,21 @@ def _make_connectome_html(connectome_info, embed_js=True):
     return ConnectomeView(as_html)
 
 
-def view_connectome(adjacency_matrix, coords, threshold=None,
-                    cmap=cm.cyan_orange, symmetric_cmap=True,
-                    linewidth=6., marker_size=3.):
+def _deprecate_params_view_connectome(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        _warn_deprecated_params_view_connectome(kwargs)
+        kwargs = _transfer_deprecated_param_vals_view_connectome(kwargs)
+        return func(*args, **kwargs)
+    
+    return wrapper
+
+
+@_deprecate_params_view_connectome
+def view_connectome(adjacency_matrix, node_coords, edge_threshold=None,
+                    edge_cmap=cm.cyan_orange, symmetric_cmap=True,
+                    linewidth=6., node_size=3.,
+                    **kwargs):
     """
     Insert a 3d plot of a connectome into an HTML page.
 
@@ -88,10 +102,10 @@ def view_connectome(adjacency_matrix, coords, threshold=None,
     adjacency_matrix : ndarray, shape=(n_nodes, n_nodes)
         the weights of the edges.
 
-    coords : ndarray, shape=(n_nodes, 3)
+    node_coords : ndarray, shape=(n_nodes, 3)
         the coordinates of the nodes in MNI space.
 
-    threshold : str, number or None, optional (default=None)
+    edge_threshold : str, number or None, optional (default=None)
         If None, no thresholding.
         If it is a number only connections of amplitude greater
         than threshold will be shown.
@@ -99,7 +113,7 @@ def view_connectome(adjacency_matrix, coords, threshold=None,
         e.g. "25.3%", and only connections of amplitude above the
         given percentile will be shown.
 
-    cmap : str or matplotlib colormap, optional
+    edge_cmap : str or matplotlib colormap, optional
 
     symmetric_cmap : bool, optional (default=True)
         Make colormap symmetric (ranging from -vmax to vmax).
@@ -107,7 +121,7 @@ def view_connectome(adjacency_matrix, coords, threshold=None,
     linewidth : float, optional (default=6.)
         Width of the lines that show connections.
 
-    marker_size : float, optional (default=3.)
+    node_size : float, optional (default=3.)
         Size of the markers showing the seeds.
 
     Returns
@@ -134,11 +148,49 @@ def view_connectome(adjacency_matrix, coords, threshold=None,
 
     """
     connectome_info = _get_connectome(
-        adjacency_matrix, coords, threshold=threshold, cmap=cmap,
+        adjacency_matrix, node_coords, threshold=edge_threshold, cmap=edge_cmap,
         symmetric_cmap=symmetric_cmap)
     connectome_info["line_width"] = linewidth
-    connectome_info["marker_size"] = marker_size
+    connectome_info["marker_size"] = node_size
     return _make_connectome_html(connectome_info)
+
+
+def _warn_deprecated_params_view_connectome(kwargs):
+    all_deprecated_params = {'coords': 'node_coords',
+                             'threshold': 'edge_threshold',
+                             'cmap': 'edge_cmap',
+                             'marker_size': 'node_size',
+                             }
+    used_deprecated_params = set(kwargs.keys()
+                                 ).intersection(all_deprecated_params.keys())
+    for deprecated_param_ in used_deprecated_params:
+        replacement_param = all_deprecated_params[deprecated_param_]
+        param_deprecation_msg = (
+            'The parameter "{}" will be removed in a future version of Nilearn.'
+            'Please use the parameter "{}" instead.'.format(deprecated_param_,
+                                                            replacement_param,
+                                                            )
+        )
+        warnings.warn(category=FutureWarning,
+                      message=param_deprecation_msg,
+                      stacklevel=3)
+
+
+def _transfer_deprecated_param_vals_view_connectome(kwargs):
+    coords = kwargs.setdefault('coords', None)
+    threshold = kwargs.setdefault('threshold', None)
+    cmap = kwargs.setdefault('cmap', None)
+    marker_size = kwargs.setdefault('marker_size', None)
+    
+    if coords is not None:
+        kwargs['node_coords'] = coords
+    if threshold:
+        kwargs['edge_threshold'] = threshold
+    if cmap:
+        kwargs['edge_cmap'] = cmap
+    if marker_size:
+        kwargs['node_size'] = marker_size
+    return kwargs
 
 
 def view_markers(coords, colors=None, marker_size=5.):

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -171,8 +171,8 @@ def _warn_deprecated_params_view_connectome(kwargs):
     for deprecated_param_ in used_deprecated_params:
         replacement_param = all_deprecated_params[deprecated_param_]
         param_deprecation_msg = (
-            'The parameter "{}" will be removed in Nilearn version 0.6.0.'
-            ' Please use the parameter "{}" instead.'.format(deprecated_param_,
+            'The parameter "{}" will be removed in Nilearn version 0.6.0. '
+            'Please use the parameter "{}" instead.'.format(deprecated_param_,
                                                             replacement_param,
                                                             )
         )

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -176,9 +176,10 @@ def _warn_deprecated_params_view_connectome(kwargs):
                                                             replacement_param,
                                                             )
         )
+        warnings.filterwarnings('always', message=param_deprecation_msg)
         warnings.warn(category=DeprecationWarning,
-                      message=param_deprecation_msg,
-                      stacklevel=3)
+                  message=param_deprecation_msg,
+                  stacklevel=3)
 
 
 def _transfer_deprecated_param_vals_view_connectome(kwargs):

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -172,7 +172,7 @@ def _warn_deprecated_params_view_connectome(kwargs):
         replacement_param = all_deprecated_params[deprecated_param_]
         param_deprecation_msg = (
             'The parameter "{}" will be removed in a future version of Nilearn.'
-            'Please use the parameter "{}" instead.'.format(deprecated_param_,
+            ' Please use the parameter "{}" instead.'.format(deprecated_param_,
                                                             replacement_param,
                                                             )
         )

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -80,7 +80,7 @@ def _make_connectome_html(connectome_info, embed_js=True):
 
 
 def _deprecate_params_view_connectome(func):
-    """ Decorator to deprecate spcific parameters in view_connectome()
+    """ Decorator to deprecate specific parameters in view_connectome()
      without modifying view_connectome().
      """
     @functools.wraps(func)

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -166,8 +166,7 @@ def _warn_deprecated_params_view_connectome(kwargs):
                              'cmap': 'edge_cmap',
                              'marker_size': 'node_size',
                              }
-    used_deprecated_params = set(kwargs.keys()
-                                 ).intersection(all_deprecated_params.keys())
+    used_deprecated_params = set(kwargs).intersection(all_deprecated_params)
     for deprecated_param_ in used_deprecated_params:
         replacement_param = all_deprecated_params[deprecated_param_]
         param_deprecation_msg = (

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -171,7 +171,7 @@ def _warn_deprecated_params_view_connectome(kwargs):
     for deprecated_param_ in used_deprecated_params:
         replacement_param = all_deprecated_params[deprecated_param_]
         param_deprecation_msg = (
-            'The parameter "{}" will be removed in a future version of Nilearn.'
+            'The parameter "{}" will be removed in Nilearn version 0.7.0).'
             ' Please use the parameter "{}" instead.'.format(deprecated_param_,
                                                             replacement_param,
                                                             )

--- a/nilearn/plotting/tests/test_html_connectome.py
+++ b/nilearn/plotting/tests/test_html_connectome.py
@@ -56,7 +56,7 @@ def test_view_connectome():
     html = html_connectome.view_connectome(adj, coord, '85.3%')
     check_html(html, False, 'connectome-plot')
     html = html_connectome.view_connectome(adj, coord, '85.3%',
-                                           linewidth=8.5, marker_size=4.2)
+                                           linewidth=8.5, node_size=4.2)
     check_html(html, False, 'connectome-plot')
 
 

--- a/nilearn/plotting/tests/test_html_connectome.py
+++ b/nilearn/plotting/tests/test_html_connectome.py
@@ -66,10 +66,10 @@ def test_params_deprecation_view_connectome():
                          'cmap': 'edge_cmap',
                          'marker_size': 'node_size',
                          }
-    deprecation_msg = ('The parameter "{}" will be removed '
-                       'in Nilearn version 0.7.0).'
-                       'Please use the parameter "{}" instead.'
-                       )
+    deprecation_msg = (
+        'The parameter "{}" will be removed in Nilearn version 0.7.0).'
+        'Please use the parameter "{}" instead.'
+    )
     warning_msgs = {old_: deprecation_msg.format(old_, new_)
                     for old_, new_ in deprecated_params.items()
                     }

--- a/nilearn/plotting/tests/test_html_connectome.py
+++ b/nilearn/plotting/tests/test_html_connectome.py
@@ -67,7 +67,7 @@ def test_params_deprecation_view_connectome():
                          'marker_size': 'node_size',
                          }
     deprecation_msg = (
-        'The parameter "{}" will be removed in Nilearn version 0.6.0.'
+        'The parameter "{}" will be removed in Nilearn version 0.6.0. '
         'Please use the parameter "{}" instead.'
     )
     warning_msgs = {old_: deprecation_msg.format(old_, new_)

--- a/nilearn/plotting/tests/test_html_connectome.py
+++ b/nilearn/plotting/tests/test_html_connectome.py
@@ -66,8 +66,8 @@ def test_params_deprecation_view_connectome():
                          'cmap': 'edge_cmap',
                          'marker_size': 'node_size',
                          }
-    deprecation_msg = ('The parameter "{}" will be '
-                       'removed in a future version of Nilearn. '
+    deprecation_msg = ('The parameter "{}" will be removed '
+                       'in Nilearn version 0.7.0).'
                        'Please use the parameter "{}" instead.'
                        )
     warning_msgs = {old_: deprecation_msg.format(old_, new_)

--- a/nilearn/plotting/tests/test_html_connectome.py
+++ b/nilearn/plotting/tests/test_html_connectome.py
@@ -67,7 +67,7 @@ def test_params_deprecation_view_connectome():
                          'marker_size': 'node_size',
                          }
     deprecation_msg = (
-        'The parameter "{}" will be removed in Nilearn version 0.7.0).'
+        'The parameter "{}" will be removed in Nilearn version 0.6.0.'
         'Please use the parameter "{}" instead.'
     )
     warning_msgs = {old_: deprecation_msg.format(old_, new_)

--- a/nilearn/plotting/tests/test_html_connectome.py
+++ b/nilearn/plotting/tests/test_html_connectome.py
@@ -1,5 +1,8 @@
+import warnings
+
 import numpy as np
 
+from nilearn.plotting import cm
 from nilearn.plotting.js_plotting_utils import decode
 from nilearn.plotting import html_connectome
 
@@ -56,6 +59,76 @@ def test_view_connectome():
                                            linewidth=8.5, marker_size=4.2)
     check_html(html, False, 'connectome-plot')
 
+
+def test_params_deprecation_view_connectome():
+    deprecated_params = {'coords': 'node_coords',
+                         'threshold': 'edge_threshold',
+                         'cmap': 'edge_cmap',
+                         'marker_size': 'node_size',
+                         }
+    deprecation_msg = ('The parameter "{}" will be '
+                       'removed in a future version of Nilearn. '
+                       'Please use the parameter "{}" instead.'
+                       )
+    warning_msgs = {old_: deprecation_msg.format(old_, new_)
+                    for old_, new_ in deprecated_params.items()
+                    }
+    
+    adj, coord = _make_connectome()
+    with warnings.catch_warnings(record=True) as raised_warnings:
+        html_connectome.view_connectome(adjacency_matrix=adj,
+                                        coords=coord,
+                                        edge_threshold='85.3%',
+                                        edge_cmap=cm.cyan_orange,
+                                        linewidth=8.5, node_size=4.2,
+                                        )
+
+        html_connectome.view_connectome(adjacency_matrix=adj,
+                                        node_coords=coord,
+                                        threshold='85.3%',
+                                        edge_cmap=cm.cyan_orange,
+                                        linewidth=8.5,
+                                        node_size=4.2,
+                                        )
+
+        html_connectome.view_connectome(adjacency_matrix=adj,
+                                        node_coords=coord,
+                                        edge_threshold='85.3%',
+                                        cmap=cm.cyan_orange,
+                                        linewidth=8.5,
+                                        node_size=4.2,
+                                        )
+
+        html_connectome.view_connectome(adjacency_matrix=adj,
+                                        node_coords=coord,
+                                        edge_threshold='85.3%',
+                                        edge_cmap=cm.cyan_orange,
+                                        linewidth=8.5,
+                                        marker_size=4.2,
+                                        )
+
+        html_connectome.view_connectome(adjacency_matrix=adj,
+                                        node_coords=coord,
+                                        edge_threshold='85.3%',
+                                        edge_cmap=cm.cyan_orange,
+                                        linewidth=8.5,
+                                        node_size=4.2,
+                                        )
+
+        html_connectome.view_connectome(adj,
+                                        coord,
+                                        '85.3%',
+                                        cm.cyan_orange,
+                                        8.5,
+                                        4.2,
+                                        )
+    old_params = ['coords', 'threshold', 'cmap', 'marker_size']
+    
+    assert len(raised_warnings) == 4
+    for old_param_, raised_warning_ in zip(old_params, raised_warnings):
+        assert warning_msgs[old_param_] == str(raised_warning_.message)
+        assert raised_warning_.category is DeprecationWarning
+        
 
 def test_get_markers():
     coords = np.arange(12).reshape((4, 3))


### PR DESCRIPTION
For issue #1886 

Deprecated view_connectome params that differed from params of plot_connectome, docstrings & tests pending.