### PR TITLE
fix: quote iframe attributes

### DIFF
--- a/nilearn/plotting/js_plotting_utils.py
+++ b/nilearn/plotting/js_plotting_utils.py
@@ -123,7 +123,7 @@ class HTMLDocument(object):
         if height is None:
             height = self.height
         escaped = escape(self.html, quote=True)
-        wrapped = ('<iframe srcdoc="{}" width={} height={} '
+        wrapped = ('<iframe srcdoc="{}" width="{}" height="{}" '
                    'frameBorder="0"></iframe>').format(escaped, width, height)
         return wrapped
 

--- a/nilearn/plotting/tests/test_js_plotting_utils.py
+++ b/nilearn/plotting/tests/test_js_plotting_utils.py
@@ -239,8 +239,8 @@ def check_html(html, check_selects=True, plot_div_id='surface-plot'):
     resized = html.resize(3, 17)
     assert resized is html
     assert (html.width, html.height) == (3, 17)
-    assert "width=3 height=17" in html.get_iframe()
-    assert "width=33 height=37" in html.get_iframe(33, 37)
+    assert 'width="3" height="17"' in html.get_iframe()
+    assert 'width="33" height="37"' in html.get_iframe(33, 37)
     if not LXML_INSTALLED:
         return
     root = etree.HTML(html.html.encode('utf-8'),


### PR DESCRIPTION
Closes #1915 

- Quotes iframe attributes for `width` and `height`.