### PR TITLE
whats_new.rst update - transform_single_imgs

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -7,8 +7,8 @@ NEW
 - Calculate image data dtype from header information
 - New display mode 'tiled' which allows 2x2 plot arrangement when plotting three cuts
   (see :ref:`plotting`).
-- transform_single_imgs now consumes less memory. This is especially noteworthy when
-  applied to large datasets.
+- NiftiLabelsMasker now consumes less memory when extracting the signal from a 3D/4D
+  image. This is especially noteworthy when extracting signals from large 4D images.
 
 Changes
 -------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -7,6 +7,8 @@ NEW
 - Calculate image data dtype from header information
 - New display mode 'tiled' which allows 2x2 plot arrangement when plotting three cuts
   (see :ref:`plotting`).
+- transform_single_imgs now consumes less memory. This is especially noteworthy when
+  applied to large datasets.
 
 Changes
 -------


### PR DESCRIPTION
transform_single_imgs now uses less memory. The what's new document
didn't reflect this change.