### PR TITLE
Replace specialized parameter deprecation code with a general utility

### DIFF
--- a/nilearn/_utils/__init__.py
+++ b/nilearn/_utils/__init__.py
@@ -8,7 +8,9 @@ from .numpy_conversions import as_ndarray
 from .cache_mixin import CacheMixin
 
 from .logger import _compose_err_msg
+from nilearn._utils.helpers import replace_parameters
 
 __all__ = ['check_niimg', 'check_niimg_3d', 'concat_niimgs', 'check_niimg_4d',
            '_repr_niimgs', 'copy_img', 'load_niimg',
-           'as_ndarray', 'CacheMixin', '_compose_err_msg']
+           'as_ndarray', 'CacheMixin', '_compose_err_msg', 'replace_parameters',
+           ]

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -59,19 +59,14 @@ def _warn_deprecated_params(replacement_params, end_version, lib_name, kwargs):
     Dictionary of all the keyword args passed on the decorated function.
 
     """
-    if end_version == 'future':
-        lib_end_ver = 'a future {} version'.format(lib_name)
-    elif end_version == 'next':
-        lib_end_ver = 'the next {} version'.format(lib_name)
-    else:
-        lib_end_ver = '{} version {}'.format(lib_name, end_version)
     used_deprecated_params = set(kwargs).intersection(replacement_params)
     for deprecated_param_ in used_deprecated_params:
         replacement_param = replacement_params[deprecated_param_]
         param_deprecation_msg = (
-            'The parameter "{}" will be removed in {}. '
+            'The parameter "{}" will be removed in {} release of {}. '
             'Please use the parameter "{}" instead.'.format(deprecated_param_,
-                                                            lib_end_ver,
+                                                            end_version,
+                                                            lib_name,
                                                             replacement_param,
                                                             )
         )

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -2,7 +2,10 @@ import functools
 import warnings
 
 
-def replace_parameters(replacement_params, end_version, lib_name='Nilearn'):
+def replace_parameters(replacement_params,
+                       end_version='future',
+                       lib_name='Nilearn',
+                       ):
     """
     Decorator to deprecate & replace specificied parameters
     in the decorated functions and methods
@@ -15,16 +18,13 @@ def replace_parameters(replacement_params, end_version, lib_name='Nilearn'):
         and their corresponding new parameters.
         Example: {old_param1: new_param1, old_param2: new_param2,...}
         
-    end_version : str (optional)
+    end_version : str (optional) {'future' (default) | 'next' | <version>}
         Version when using the deprecated parameters will raise an error.
         For informational purpose in the warning text.
-        Default: None / 'future'
-        Example: '0.6.0b', 'next'
         
-    lib_name: str (optional)
+    lib_name: str (optional) (Default: 'Nilearn')
         Name of the library to which the decoratee belongs.
         For informational purpose in the warning text.
-        Default: 'Nilearn'
     """
     
     def _replace_params(func):
@@ -59,7 +59,7 @@ def _warn_deprecated_params(replacement_params, end_version, lib_name, kwargs):
     Dictionary of all the keyword args passed on the decorated function.
 
     """
-    if end_version is None or end_version == 'future':
+    if end_version == 'future':
         lib_end_ver = 'a future {} version'.format(lib_name)
     elif end_version == 'next':
         lib_end_ver = 'the next {} version'.format(lib_name)

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -1,0 +1,76 @@
+import functools
+import warnings
+
+
+def replace_parameters(replacement_params, end_version, lib_name='Nilearn'):
+    """
+    Decorator to deprecate & replace specificied parameters
+    in the decorated functions and methods.
+    
+    Add **kwargs as the last parameter in the decorated method/function.
+    
+    Parameters
+    ----------
+    replacement_params : Dict[string, string]
+        Dict where the key-value pairs represent the old parameters
+        and their corresponding new parameters.
+        Example: {old_param1: new_param1, old_param2: new_param2,...}
+        
+    end_version : str
+        Version when the deprecated parameters will cease functioning
+        and no more warnings will be displayed.
+        Default: None / 'future'
+        Example: '0.6.0b', 'next'
+        
+    lib_name: str
+        Name of the library to which the decoratee belongs.
+        Default: 'Nilearn'
+    """
+    
+    def _replace_params(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            _warn_deprecated_params(replacement_params, end_version, lib_name, kwargs)
+            kwargs = _transfer_deprecated_param_vals(replacement_params, kwargs)
+            return func(*args, **kwargs)
+        
+        return wrapper
+    return _replace_params
+
+
+def _warn_deprecated_params(replacement_params, end_version, lib_name, kwargs):
+    """ For the decorator replace_parameters(),
+        raises warnings about deprecated parameters.
+    """
+    if end_version is None or end_version == 'future':
+        lib_end_ver = 'a future {} version'.format(lib_name)
+    elif end_version == 'next':
+        lib_end_ver = 'the next {} version'.format(lib_name)
+    else:
+        lib_end_ver = '{} version {}'.format(lib_name, end_version)
+    used_deprecated_params = set(kwargs).intersection(replacement_params)
+    for deprecated_param_ in used_deprecated_params:
+        replacement_param = replacement_params[deprecated_param_]
+        param_deprecation_msg = (
+            'The parameter "{}" will be removed in {}. '
+            'Please use the parameter "{}" instead.'.format(deprecated_param_,
+                                                            lib_end_ver,
+                                                            replacement_param,
+                                                            )
+        )
+        warnings.filterwarnings('always', message=param_deprecation_msg)
+        warnings.warn(category=DeprecationWarning,
+                      message=param_deprecation_msg,
+                      stacklevel=3)
+
+
+def _transfer_deprecated_param_vals(replacement_params, kwargs):
+    """ For the decorator replace_parameters(), reassigns new parameters
+    the values passed to their corresponding deprecated parameters.
+    """
+    for old_param, new_param in replacement_params.items():
+        old_param_val = kwargs.setdefault(old_param, None)
+        if old_param_val is not None:
+            kwargs[new_param] = old_param_val
+        kwargs.pop(old_param)
+    return kwargs

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -30,8 +30,12 @@ def replace_parameters(replacement_params,
     def _replace_params(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            _warn_deprecated_params(replacement_params, end_version, lib_name, kwargs)
-            kwargs = _transfer_deprecated_param_vals(replacement_params, kwargs)
+            _warn_deprecated_params(replacement_params, end_version, lib_name,
+                                    kwargs
+                                    )
+            kwargs = _transfer_deprecated_param_vals(replacement_params,
+                                                     kwargs
+                                                     )
             return func(*args, **kwargs)
         
         return wrapper

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -5,9 +5,8 @@ import warnings
 def replace_parameters(replacement_params, end_version, lib_name='Nilearn'):
     """
     Decorator to deprecate & replace specificied parameters
-    in the decorated functions and methods.
-    
-    Add **kwargs as the last parameter in the decorated method/function.
+    in the decorated functions and methods
+    without changing function definition or signature.
     
     Parameters
     ----------
@@ -16,14 +15,15 @@ def replace_parameters(replacement_params, end_version, lib_name='Nilearn'):
         and their corresponding new parameters.
         Example: {old_param1: new_param1, old_param2: new_param2,...}
         
-    end_version : str
-        Version when the deprecated parameters will cease functioning
-        and no more warnings will be displayed.
+    end_version : str (optional)
+        Version when using the deprecated parameters will raise an error.
+        For informational purpose in the warning text.
         Default: None / 'future'
         Example: '0.6.0b', 'next'
         
-    lib_name: str
+    lib_name: str (optional)
         Name of the library to which the decoratee belongs.
+        For informational purpose in the warning text.
         Default: 'Nilearn'
     """
     
@@ -41,6 +41,23 @@ def replace_parameters(replacement_params, end_version, lib_name='Nilearn'):
 def _warn_deprecated_params(replacement_params, end_version, lib_name, kwargs):
     """ For the decorator replace_parameters(),
         raises warnings about deprecated parameters.
+        
+    Parameters
+    ----------
+    replacement_params: Dict[str, str]
+    Dictionary of old_parameters as keys with replacement parameters
+    as their corresponding values.
+    
+    end_version: str
+    The version where use of the deprecated parameters will raise an error.
+    For informational purpose in the warning text.
+    
+    lib_name: str
+    Name of the library. For informational purpose in the warning text.
+    
+    kwargs: Dict[str, any]
+    Dictionary of all the keyword args passed on the decorated function.
+
     """
     if end_version is None or end_version == 'future':
         lib_end_ver = 'a future {} version'.format(lib_name)
@@ -67,6 +84,22 @@ def _warn_deprecated_params(replacement_params, end_version, lib_name, kwargs):
 def _transfer_deprecated_param_vals(replacement_params, kwargs):
     """ For the decorator replace_parameters(), reassigns new parameters
     the values passed to their corresponding deprecated parameters.
+    
+    Parameters
+    ----------
+    replacement_params: Dict[str, str]
+    Dictionary of old_parameters as keys with replacement parameters
+    as their corresponding values.
+    
+    kwargs: Dict[str, any]
+    Dictionary of all the keyword args passed on the decorated function.
+    
+    Returns
+    -------
+    kwargs: Dict[str, any]
+    Dictionary of all the keyword args to be passed on
+    to the decorated function, with old parameter names
+    replaced by new parameters, with their values intact.
     """
     for old_param, new_param in replacement_params.items():
         old_param_val = kwargs.setdefault(old_param, None)

--- a/nilearn/_utils/param_validation.py
+++ b/nilearn/_utils/param_validation.py
@@ -1,7 +1,6 @@
 """
 Utilities to check for valid parameters
 """
-import functools
 
 import numpy as np
 import warnings
@@ -194,76 +193,3 @@ def check_feature_screening(screening_percentile, mask_img,
 
         return SelectPercentile(f_test, int(screening_percentile_))
 
-
-def replace_parameters(replacement_params, end_version, lib_name='Nilearn'):
-    """
-    Decorator to deprecate & replace specificied parameters
-    in the decorated functions and methods.
-    
-    Add **kwargs as the last parameter in the decorated method/function.
-    
-    Parameters
-    ----------
-    replacement_params : Dict[string, string]
-        Dict where the key-value pairs represent the old parameters
-        and their corresponding new parameters.
-        Example: {old_param1: new_param1, old_param2: new_param2,...}
-        
-    end_version : str
-        Version when the deprecated parameters will cease functioning
-        and no more warnings will be displayed.
-        Default: None / 'future'
-        Example: '0.6.0b', 'next'
-        
-    lib_name: str
-        Name of the library to which the decoratee belongs.
-        Default: 'Nilearn'
-    """
-    
-    def _replace_params(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            _warn_deprecated_params(replacement_params, end_version, lib_name, kwargs)
-            kwargs = _transfer_deprecated_param_vals(replacement_params, kwargs)
-            return func(*args, **kwargs)
-        
-        return wrapper
-    return _replace_params
-
-
-def _warn_deprecated_params(replacement_params, end_version, lib_name, kwargs):
-    """ For the decorator replace_parameters(),
-        raises warnings about deprecated parameters.
-    """
-    if end_version is None or end_version == 'future':
-        lib_end_ver = 'a future {} version'.format(lib_name)
-    elif end_version == 'next':
-        lib_end_ver = 'the next {} version'.format(lib_name)
-    else:
-        lib_end_ver = '{} version {}'.format(lib_name, end_version)
-    used_deprecated_params = set(kwargs).intersection(replacement_params)
-    for deprecated_param_ in used_deprecated_params:
-        replacement_param = replacement_params[deprecated_param_]
-        param_deprecation_msg = (
-            'The parameter "{}" will be removed in {}. '
-            'Please use the parameter "{}" instead.'.format(deprecated_param_,
-                                                            lib_end_ver,
-                                                            replacement_param,
-                                                            )
-        )
-        warnings.filterwarnings('always', message=param_deprecation_msg)
-        warnings.warn(category=DeprecationWarning,
-                      message=param_deprecation_msg,
-                      stacklevel=3)
-
-
-def _transfer_deprecated_param_vals(replacement_params, kwargs):
-    """ For the decorator replace_parameters(), reassigns new parameters
-    the values passed to their corresponding deprecated parameters.
-    """
-    for old_param, new_param in replacement_params.items():
-        old_param_val = kwargs.setdefault(old_param, None)
-        if old_param_val is not None:
-            kwargs[new_param] = old_param_val
-        kwargs.pop(old_param)
-    return kwargs

--- a/nilearn/_utils/param_validation.py
+++ b/nilearn/_utils/param_validation.py
@@ -195,7 +195,7 @@ def check_feature_screening(screening_percentile, mask_img,
         return SelectPercentile(f_test, int(screening_percentile_))
 
 
-def replace_parameters(replacement_params, end_version, lib_name):
+def replace_parameters(replacement_params, end_version, lib_name='Nilearn'):
     """
     Decorator to deprecate & replace specificied parameters
     in the decorated functions and methods.
@@ -211,12 +211,13 @@ def replace_parameters(replacement_params, end_version, lib_name):
         
     end_version : str
         Version when the deprecated parameters will cease functioning
-        and no more wrnings will be displayed.
-        Example: '0.6.0b'
+        and no more warnings will be displayed.
+        Default: None / 'future'
+        Example: '0.6.0b', 'next'
         
     lib_name: str
         Name of the library to which the decoratee belongs.
-        Example: 'Nilearn', 'Nistats'
+        Default: 'Nilearn'
     """
     
     def _replace_params(func):
@@ -234,14 +235,19 @@ def _warn_deprecated_params(replacement_params, end_version, lib_name, kwargs):
     """ For the decorator replace_parameters(),
         raises warnings about deprecated parameters.
     """
+    if end_version is None or end_version == 'future':
+        lib_end_ver = 'a future {} version'.format(lib_name)
+    elif end_version == 'next':
+        lib_end_ver = 'the next {} version'.format(lib_name)
+    else:
+        lib_end_ver = '{} version {}'.format(lib_name, end_version)
     used_deprecated_params = set(kwargs).intersection(replacement_params)
     for deprecated_param_ in used_deprecated_params:
         replacement_param = replacement_params[deprecated_param_]
         param_deprecation_msg = (
-            'The parameter "{}" will be removed in {} version {}. '
+            'The parameter "{}" will be removed in {}. '
             'Please use the parameter "{}" instead.'.format(deprecated_param_,
-                                                            lib_name,
-                                                            end_version,
+                                                            lib_end_ver,
                                                             replacement_param,
                                                             )
         )

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 from scipy import sparse
 
-from nilearn._utils.param_validation import replace_parameters
+from nilearn._utils import replace_parameters
 from .. import datasets
 from . import cm
 

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -99,7 +99,10 @@ def _replacement_params_view_connectome():
         'marker_size': 'node_size',
         }
 
-@replace_parameters(_replacement_params_view_connectome(), end_version='0.6.0', lib_name='Nilearn')
+@replace_parameters(replacement_params=_replacement_params_view_connectome(),
+                    end_version='0.6.0',
+                    lib_name='Nilearn',
+                    )
 def view_connectome(adjacency_matrix, node_coords, edge_threshold=None,
                     edge_cmap=cm.bwr, symmetric_cmap=True,
                     linewidth=6., node_size=3.,
@@ -173,7 +176,10 @@ def _replacement_params_view_markers():
             }
 
 
-@replace_parameters(_replacement_params_view_markers(), '0.6.0', 'Nilearn')
+@replace_parameters(replacement_params=_replacement_params_view_markers(),
+                    end_version='0.6.0',
+                    lib_name='Nilearn',
+                    )
 def view_markers(marker_coords, marker_color=None, marker_size=5., **kwargs):
     """
     Insert a 3d plot of markers in a brain into an HTML page.

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -106,7 +106,7 @@ def _replacement_params_view_connectome():
 def view_connectome(adjacency_matrix, node_coords, edge_threshold=None,
                     edge_cmap=cm.bwr, symmetric_cmap=True,
                     linewidth=6., node_size=3.,
-                    **kwargs):
+                    ):
     """
     Insert a 3d plot of a connectome into an HTML page.
 
@@ -180,7 +180,7 @@ def _replacement_params_view_markers():
                     end_version='0.6.0',
                     lib_name='Nilearn',
                     )
-def view_markers(marker_coords, marker_color=None, marker_size=5., **kwargs):
+def view_markers(marker_coords, marker_color=None, marker_size=5.):
     """
     Insert a 3d plot of markers in a brain into an HTML page.
 

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -85,19 +85,19 @@ def _make_connectome_html(connectome_info, embed_js=True):
     return ConnectomeView(as_html)
 
 
-def deprecate_params(replacement_params, end_version=None, lib_name=None):
-    def _deprecate_params_view_connectome(func):
+def replace_parameters(replacement_params, end_version, lib_name):
+    def _replace_params(func):
         """ Decorator to deprecate specific parameters in view_connectome()
          without modifying view_connectome().
          """
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            _warn_deprecated_params_view_connectome(kwargs)
+            _warn_deprecated_params_view_connectome(replacement_params, end_version, lib_name, kwargs)
             kwargs = _transfer_deprecated_param_vals(replacement_params, kwargs)
             return func(*args, **kwargs)
         
         return wrapper
-    return _deprecate_params_view_connectome
+    return _replace_params
 
 
 def _replacement_params_view_connectome():
@@ -108,7 +108,7 @@ def _replacement_params_view_connectome():
         'marker_size': 'node_size',
         }
 
-@deprecate_params(_replacement_params_view_connectome())
+@replace_parameters(_replacement_params_view_connectome(), end_version='0.6.0', lib_name='Nilearn')
 def view_connectome(adjacency_matrix, node_coords, edge_threshold=None,
                     edge_cmap=cm.bwr, symmetric_cmap=True,
                     linewidth=6., node_size=3.,
@@ -172,20 +172,17 @@ def view_connectome(adjacency_matrix, node_coords, edge_threshold=None,
     return _make_connectome_html(connectome_info)
 
 
-def _warn_deprecated_params_view_connectome(kwargs):
+def _warn_deprecated_params_view_connectome(replacement_params, end_version, lib_name, kwargs):
     """ For view_connectome(), raises warnings about deprecated parameters.
     """
-    all_deprecated_params = {'coords': 'node_coords',
-                             'threshold': 'edge_threshold',
-                             'cmap': 'edge_cmap',
-                             'marker_size': 'node_size',
-                             }
-    used_deprecated_params = set(kwargs).intersection(all_deprecated_params)
+    used_deprecated_params = set(kwargs).intersection(replacement_params)
     for deprecated_param_ in used_deprecated_params:
-        replacement_param = all_deprecated_params[deprecated_param_]
+        replacement_param = replacement_params[deprecated_param_]
         param_deprecation_msg = (
-            'The parameter "{}" will be removed in Nilearn version 0.6.0. '
+            'The parameter "{}" will be removed in {} version {}. '
             'Please use the parameter "{}" instead.'.format(deprecated_param_,
+                                                            lib_name,
+                                                            end_version,
                                                             replacement_param,
                                                             )
         )

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -86,10 +86,30 @@ def _make_connectome_html(connectome_info, embed_js=True):
 
 
 def replace_parameters(replacement_params, end_version, lib_name):
+    """
+    Decorator to deprecate & replace specificied parameters
+    in the decorated functions and methods.
+    
+    Add **kwargs as the last parameter in the decorated method/function.
+    
+    Parameters
+    ----------
+    replacement_params : Dict[string, string]
+        Dict where the key-value pairs represent the old parameters
+        and their corresponding new parameters.
+        Example: {old_param1: new_param1, old_param2: new_param2,...}
+        
+    end_version : str
+        Version when the deprecated parameters will cease functioning
+        and no more wrnings will be displayed.
+        Example: '0.6.0'
+        
+    lib_name: str
+        Name of the library to which the decoratee belongs.
+        Example: Nilearn, Nistats
+    """
+    
     def _replace_params(func):
-        """ Decorator to deprecate specific parameters in view_connectome()
-         without modifying view_connectome().
-         """
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             _warn_deprecated_params_view_connectome(replacement_params, end_version, lib_name, kwargs)
@@ -101,6 +121,10 @@ def replace_parameters(replacement_params, end_version, lib_name):
 
 
 def _replacement_params_view_connectome():
+    """ Returns a dict containing deprecated & replacement parameters
+        as key-value pair.
+        Avoids cluttering the global namespace.
+    """
     return {
         'coords': 'node_coords',
         'threshold': 'edge_threshold',
@@ -173,7 +197,8 @@ def view_connectome(adjacency_matrix, node_coords, edge_threshold=None,
 
 
 def _warn_deprecated_params_view_connectome(replacement_params, end_version, lib_name, kwargs):
-    """ For view_connectome(), raises warnings about deprecated parameters.
+    """ For the decorator replace_parameters(),
+        raises warnings about deprecated parameters.
     """
     used_deprecated_params = set(kwargs).intersection(replacement_params)
     for deprecated_param_ in used_deprecated_params:
@@ -193,8 +218,8 @@ def _warn_deprecated_params_view_connectome(replacement_params, end_version, lib
 
 
 def _transfer_deprecated_param_vals(replacement_params, kwargs):
-    """ For view_connectome(), reassigns new parameters the values passed
-    to their corresponding deprecated parameters.
+    """ For the decorator replace_parameters(), reassigns new parameters
+    the values passed to their corresponding deprecated parameters.
     """
     for old_param, new_param in replacement_params.items():
         old_param_val = kwargs.setdefault(old_param, None)

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -89,7 +89,7 @@ def _make_connectome_html(connectome_info, embed_js=True):
 
 def _replacement_params_view_connectome():
     """ Returns a dict containing deprecated & replacement parameters
-        as key-value pair.
+        as key-value pair for view_connectome().
         Avoids cluttering the global namespace.
     """
     return {
@@ -163,19 +163,17 @@ def view_connectome(adjacency_matrix, node_coords, edge_threshold=None,
     return _make_connectome_html(connectome_info)
 
 
-def _deprecate_params_view_markers(func):
-    """ Decorator to deprecate specific parameters in view_markers()
-     without modifying view_markers().
-     """
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        _warn_deprecated_params_view_markers(kwargs)
-        kwargs = _transfer_deprecated_param_vals_view_markers(kwargs)
-        return func(*args, **kwargs)
-    return wrapper
+def _replacement_params_view_markers():
+    """ Returns a dict containing deprecated & replacement parameters
+        as key-value pair for view_markers().
+        Avoids cluttering the global namespace.
+    """
+    return {'coords': 'marker_coords',
+            'colors': 'marker_color',
+            }
 
 
-@_deprecate_params_view_markers
+@replace_parameters(_replacement_params_view_markers(), '0.6.0', 'Nilearn')
 def view_markers(marker_coords, marker_color=None, marker_size=5., **kwargs):
     """
     Insert a 3d plot of markers in a brain into an HTML page.
@@ -223,40 +221,3 @@ def view_markers(marker_coords, marker_color=None, marker_size=5., **kwargs):
         marker_size = marker_size.tolist()
     connectome_info["marker_size"] = marker_size
     return _make_connectome_html(connectome_info)
-
-
-def _warn_deprecated_params_view_markers(kwargs):
-    """ For view_markers(), raises warnings about deprecated parameters.
-    """
-
-    all_deprecated_params = {'coords': 'marker_coords',
-                             'colors': 'marker_color',
-                             }
-    used_dperecated_params = set(kwargs).intersection(all_deprecated_params)
-    for deprecated_param_ in used_dperecated_params:
-        replacement_param = all_deprecated_params[deprecated_param_]
-        param_deprecation_msg = (
-            'The parameter "{}" will be removed in Nilearn version 0.6.0. '
-            'Please use the parameter "{}" instead.'.format(deprecated_param_,
-                                                            replacement_param,
-                                                            )
-        )
-        warnings.filterwarnings('always', message=param_deprecation_msg)
-        warnings.warn(category=DeprecationWarning,
-                      message=param_deprecation_msg,
-                      stacklevel=3,
-                      )
-
-
-def _transfer_deprecated_param_vals_view_markers(kwargs):
-    """ For view_markers(), reassigns new parameters the values passed
-    to their corresponding deprecated parameters.
-    """
-    coords = kwargs.get('coords', None)
-    colors = kwargs.get('colors', None)
-    
-    if coords is not None:
-        kwargs['marker_coords'] = coords
-    if colors is not None:
-        kwargs['marker_color'] = colors
-    return kwargs

--- a/nilearn/plotting/tests/test_html_connectome.py
+++ b/nilearn/plotting/tests/test_html_connectome.py
@@ -71,7 +71,7 @@ def test_params_deprecation_view_connectome():
                          'marker_size': 'node_size',
                          }
     deprecation_msg = (
-        'The parameter "{}" will be removed in Nilearn version 0.6.0. '
+        'The parameter "{}" will be removed in 0.6.0 release of Nilearn. '
         'Please use the parameter "{}" instead.'
     )
     warning_msgs = {old_: deprecation_msg.format(old_, new_)
@@ -170,7 +170,7 @@ def test_params_deprecation_view_markers():
                          'colors': 'marker_color',
                          }
     deprecation_msg = (
-        'The parameter "{}" will be removed in Nilearn version 0.6.0. '
+        'The parameter "{}" will be removed in 0.6.0 release of Nilearn. '
         'Please use the parameter "{}" instead.'
     )
     warning_msgs = {old_: deprecation_msg.format(old_, new_)

--- a/nilearn/tests/test_helpers.py
+++ b/nilearn/tests/test_helpers.py
@@ -32,24 +32,6 @@ def test_transfer_deprecated_param_vals():
     assert actual_ouput == expected_output
     
 
-def test_none_warn_deprecated_params():
-    mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
-    expected_warnings = [
-        ('The parameter "deprecated_param_0" will be removed in a future Nilearn version. Please use the parameter "replacement_param_0" instead.'),
-        ('The parameter "deprecated_param_1" will be removed in a future Nilearn version. Please use the parameter "replacement_param_1" instead.'),
-        ]
-    with warnings.catch_warnings(record=True) as raised_warnings:
-        helpers._warn_deprecated_params(
-                replacement_params,
-                end_version=None,
-                lib_name='Nilearn',
-                kwargs=mock_input,
-                )
-    raised_warnings.sort()
-    for raised_warning_, expected_warning_ in zip(raised_warnings, expected_warnings):
-        assert str(raised_warning_.message) == expected_warning_
-
-
 def test_future_warn_deprecated_params():
     mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
     expected_warnings = [

--- a/nilearn/tests/test_helpers.py
+++ b/nilearn/tests/test_helpers.py
@@ -1,0 +1,145 @@
+import warnings
+
+from nilearn._utils import helpers
+
+
+def _mock_args_for_testing_replace_parameter():
+    mock_kwargs_with_deprecated_params_used = {
+        'unchanged_param_0': 'unchanged_param_0_val',
+        'deprecated_param_0': 'deprecated_param_0_val',
+        'deprecated_param_1': 'deprecated_param_1_val',
+        'unchanged_param_1': 'unchanged_param_1_val',
+        }
+    replacement_params = {
+        'deprecated_param_0': 'replacement_param_0',
+        'deprecated_param_1': 'replacement_param_1',
+        }
+    return mock_kwargs_with_deprecated_params_used, replacement_params
+
+
+def test_transfer_deprecated_param_vals():
+    mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
+    expected_output = {
+        'unchanged_param_0': 'unchanged_param_0_val',
+        'replacement_param_0': 'deprecated_param_0_val',
+        'replacement_param_1': 'deprecated_param_1_val',
+        'unchanged_param_1': 'unchanged_param_1_val',
+        }
+    actual_ouput = helpers._transfer_deprecated_param_vals(
+            replacement_params,
+            mock_input,
+            )
+    assert actual_ouput == expected_output
+    
+
+def test_none_warn_deprecated_params():
+    mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
+    expected_warnings = [
+        ('The parameter "deprecated_param_0" will be removed in a future Nilearn version. Please use the parameter "replacement_param_0" instead.'),
+        ('The parameter "deprecated_param_1" will be removed in a future Nilearn version. Please use the parameter "replacement_param_1" instead.'),
+        ]
+    with warnings.catch_warnings(record=True) as raised_warnings:
+        helpers._warn_deprecated_params(
+                replacement_params,
+                end_version=None,
+                lib_name='Nilearn',
+                kwargs=mock_input,
+                )
+    raised_warnings.sort()
+    for raised_warning_, expected_warning_ in zip(raised_warnings, expected_warnings):
+        assert str(raised_warning_.message) == expected_warning_
+
+
+def test_future_warn_deprecated_params():
+    mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
+    expected_warnings = [
+        ('The parameter "deprecated_param_0" will be removed in a future Nilearn version. Please use the parameter "replacement_param_0" instead.'),
+        ('The parameter "deprecated_param_1" will be removed in a future Nilearn version. Please use the parameter "replacement_param_1" instead.'),
+        ]
+    with warnings.catch_warnings(record=True) as raised_warnings:
+        helpers._warn_deprecated_params(
+                replacement_params,
+                end_version='future',
+                lib_name='Nilearn',
+                kwargs=mock_input,
+                )
+    for raised_warning_, expected_warning_ in zip(raised_warnings, expected_warnings):
+        assert str(raised_warning_.message) == expected_warning_
+
+
+def test_next_warn_deprecated_params():
+    mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
+    expected_warnings = [
+        ('The parameter "deprecated_param_0" will be removed in the next Nilearn version. Please use the parameter "replacement_param_0" instead.'),
+        ('The parameter "deprecated_param_1" will be removed in the next Nilearn version. Please use the parameter "replacement_param_1" instead.'),
+        ]
+    with warnings.catch_warnings(record=True) as raised_warnings:
+        helpers._warn_deprecated_params(
+                replacement_params,
+                end_version='next',
+                lib_name='Nilearn',
+                kwargs=mock_input,
+                )
+    for raised_warning_, expected_warning_ in zip(raised_warnings, expected_warnings):
+        assert str(raised_warning_.message) == expected_warning_
+
+
+def test_version_warn_deprecated_params():
+    mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
+    expected_warnings = [
+        ('The parameter "deprecated_param_0" will be removed in Nilearn version 0.6.1rc. Please use the parameter "replacement_param_0" instead.'),
+        ('The parameter "deprecated_param_1" will be removed in Nilearn version 0.6.1rc. Please use the parameter "replacement_param_1" instead.'),
+        ]
+    with warnings.catch_warnings(record=True) as raised_warnings:
+        helpers._warn_deprecated_params(
+                replacement_params,
+                end_version='0.6.1rc',
+                lib_name='Nilearn',
+                kwargs=mock_input,
+                )
+    for raised_warning_, expected_warning_ in zip(raised_warnings,
+                                                  expected_warnings):
+        assert str(raised_warning_.message) == expected_warning_
+
+
+def test_other_lib_warn_deprecated_params():
+    mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
+    expected_warnings = [
+        ('The parameter "deprecated_param_0" will be removed in the next other_lib version. Please use the parameter "replacement_param_0" instead.'),
+        ('The parameter "deprecated_param_1" will be removed in the next other_lib version. Please use the parameter "replacement_param_1" instead.'),
+        ]
+    with warnings.catch_warnings(record=True) as raised_warnings:
+        helpers._warn_deprecated_params(
+                replacement_params,
+                end_version='next',
+                lib_name='other_lib',
+                kwargs=mock_input,
+                )
+    for raised_warning_, expected_warning_ in zip(raised_warnings,
+                                                  expected_warnings):
+        assert str(raised_warning_.message) == expected_warning_
+
+
+def test_replace_parameters():
+    mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
+    expected_output = ('dp0', 'dp1', 'up0', 'up1')
+    expected_warnings = [
+        ('The parameter "deprecated_param_0" will be removed in other_lib version 0.6.1rc. Please use the parameter "replacement_param_0" instead.'),
+        ('The parameter "deprecated_param_1" will be removed in other_lib version 0.6.1rc. Please use the parameter "replacement_param_1" instead.'),
+        ]
+
+    @helpers.replace_parameters(replacement_params, '0.6.1rc', 'other_lib',)
+    def mock_function(replacement_param_0, replacement_param_1, unchanged_param_0, unchanged_param_1):
+        return replacement_param_0, replacement_param_1, unchanged_param_0, unchanged_param_1
+    
+    with warnings.catch_warnings(record=True) as raised_warnings:
+        actual_output = mock_function(deprecated_param_0='dp0',
+                                      deprecated_param_1='dp1',
+                                      unchanged_param_0='up0',
+                                      unchanged_param_1='up1',
+                                      )
+    
+    assert actual_output == expected_output
+    for raised_warning_, expected_warning_ in zip(raised_warnings,
+                                                  expected_warnings):
+        assert str(raised_warning_.message) == expected_warning_

--- a/nilearn/tests/test_helpers.py
+++ b/nilearn/tests/test_helpers.py
@@ -82,8 +82,7 @@ def test_transfer_deprecated_param_vals():
     
 
 def test_future_warn_deprecated_params():
-    """ Unit test to check that the correct warning is displayed when
-    end_version is 'future'.
+    """ Unit test to check that the correct warning is displayed.
     """
     mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
     expected_warnings = [

--- a/nilearn/tests/test_helpers.py
+++ b/nilearn/tests/test_helpers.py
@@ -4,6 +4,10 @@ from nilearn._utils import helpers
 
 
 def _mock_args_for_testing_replace_parameter():
+    """
+    :return: Creates mock deprecated & replacement parameters for use with
+    testing functions related to replace_parameters().
+    """
     mock_kwargs_with_deprecated_params_used = {
         'unchanged_param_0': 'unchanged_param_0_val',
         'deprecated_param_0': 'deprecated_param_0_val',
@@ -17,7 +21,47 @@ def _mock_args_for_testing_replace_parameter():
     return mock_kwargs_with_deprecated_params_used, replacement_params
 
 
+def test_replace_parameters():
+    """ Integration tests that deprecates mock parameters in a mock function
+    and checks that the deprecated parameters transfer their values correctly
+    to replacement parameters and all deprecation warning are raised as
+    expected.
+    """
+    mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
+    expected_output = ('dp0', 'dp1', 'up0', 'up1')
+    expected_warnings = [
+        ('The parameter "deprecated_param_0" will be removed in 0.6.1rc '
+         'release of other_lib. Please use the parameter "replacement_param_0"'
+         ' instead.'
+         ),
+        ('The parameter "deprecated_param_1" will be removed in 0.6.1rc '
+         'release of other_lib. Please use the parameter "replacement_param_1"'
+         ' instead.'
+         ),
+        ]
+    
+    @helpers.replace_parameters(replacement_params, '0.6.1rc', 'other_lib', )
+    def mock_function(replacement_param_0, replacement_param_1,
+                      unchanged_param_0, unchanged_param_1):
+        return replacement_param_0, replacement_param_1, unchanged_param_0, unchanged_param_1
+    
+    with warnings.catch_warnings(record=True) as raised_warnings:
+        actual_output = mock_function(deprecated_param_0='dp0',
+                                      deprecated_param_1='dp1',
+                                      unchanged_param_0='up0',
+                                      unchanged_param_1='up1',
+                                      )
+    
+    assert actual_output == expected_output
+    for raised_warning_, expected_warning_ in zip(raised_warnings,
+                                                  expected_warnings):
+        assert str(raised_warning_.message) == expected_warning_
+
+
 def test_transfer_deprecated_param_vals():
+    """ Unit test to check that values assigned to deprecated parameters are
+    correctly reassigned to the replacement parameters.
+    """
     mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
     expected_output = {
         'unchanged_param_0': 'unchanged_param_0_val',
@@ -33,95 +77,26 @@ def test_transfer_deprecated_param_vals():
     
 
 def test_future_warn_deprecated_params():
+    """ Unit test to check that the correct warning is displayed when
+    end_version is 'future'.
+    """
     mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
     expected_warnings = [
-        ('The parameter "deprecated_param_0" will be removed in a future Nilearn version. Please use the parameter "replacement_param_0" instead.'),
-        ('The parameter "deprecated_param_1" will be removed in a future Nilearn version. Please use the parameter "replacement_param_1" instead.'),
+        ('The parameter "deprecated_param_0" will be removed in sometime '
+         'release of somelib. Please use the parameter "replacement_param_0" '
+         'instead.'
+         ),
+        ('The parameter "deprecated_param_1" will be removed in sometime '
+         'release of somelib. Please use the parameter "replacement_param_1" '
+         'instead.'
+         ),
         ]
     with warnings.catch_warnings(record=True) as raised_warnings:
         helpers._warn_deprecated_params(
                 replacement_params,
-                end_version='future',
-                lib_name='Nilearn',
+                end_version='sometime',
+                lib_name='somelib',
                 kwargs=mock_input,
                 )
     for raised_warning_, expected_warning_ in zip(raised_warnings, expected_warnings):
-        assert str(raised_warning_.message) == expected_warning_
-
-
-def test_next_warn_deprecated_params():
-    mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
-    expected_warnings = [
-        ('The parameter "deprecated_param_0" will be removed in the next Nilearn version. Please use the parameter "replacement_param_0" instead.'),
-        ('The parameter "deprecated_param_1" will be removed in the next Nilearn version. Please use the parameter "replacement_param_1" instead.'),
-        ]
-    with warnings.catch_warnings(record=True) as raised_warnings:
-        helpers._warn_deprecated_params(
-                replacement_params,
-                end_version='next',
-                lib_name='Nilearn',
-                kwargs=mock_input,
-                )
-    for raised_warning_, expected_warning_ in zip(raised_warnings, expected_warnings):
-        assert str(raised_warning_.message) == expected_warning_
-
-
-def test_version_warn_deprecated_params():
-    mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
-    expected_warnings = [
-        ('The parameter "deprecated_param_0" will be removed in Nilearn version 0.6.1rc. Please use the parameter "replacement_param_0" instead.'),
-        ('The parameter "deprecated_param_1" will be removed in Nilearn version 0.6.1rc. Please use the parameter "replacement_param_1" instead.'),
-        ]
-    with warnings.catch_warnings(record=True) as raised_warnings:
-        helpers._warn_deprecated_params(
-                replacement_params,
-                end_version='0.6.1rc',
-                lib_name='Nilearn',
-                kwargs=mock_input,
-                )
-    for raised_warning_, expected_warning_ in zip(raised_warnings,
-                                                  expected_warnings):
-        assert str(raised_warning_.message) == expected_warning_
-
-
-def test_other_lib_warn_deprecated_params():
-    mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
-    expected_warnings = [
-        ('The parameter "deprecated_param_0" will be removed in the next other_lib version. Please use the parameter "replacement_param_0" instead.'),
-        ('The parameter "deprecated_param_1" will be removed in the next other_lib version. Please use the parameter "replacement_param_1" instead.'),
-        ]
-    with warnings.catch_warnings(record=True) as raised_warnings:
-        helpers._warn_deprecated_params(
-                replacement_params,
-                end_version='next',
-                lib_name='other_lib',
-                kwargs=mock_input,
-                )
-    for raised_warning_, expected_warning_ in zip(raised_warnings,
-                                                  expected_warnings):
-        assert str(raised_warning_.message) == expected_warning_
-
-
-def test_replace_parameters():
-    mock_input, replacement_params = _mock_args_for_testing_replace_parameter()
-    expected_output = ('dp0', 'dp1', 'up0', 'up1')
-    expected_warnings = [
-        ('The parameter "deprecated_param_0" will be removed in other_lib version 0.6.1rc. Please use the parameter "replacement_param_0" instead.'),
-        ('The parameter "deprecated_param_1" will be removed in other_lib version 0.6.1rc. Please use the parameter "replacement_param_1" instead.'),
-        ]
-
-    @helpers.replace_parameters(replacement_params, '0.6.1rc', 'other_lib',)
-    def mock_function(replacement_param_0, replacement_param_1, unchanged_param_0, unchanged_param_1):
-        return replacement_param_0, replacement_param_1, unchanged_param_0, unchanged_param_1
-    
-    with warnings.catch_warnings(record=True) as raised_warnings:
-        actual_output = mock_function(deprecated_param_0='dp0',
-                                      deprecated_param_1='dp1',
-                                      unchanged_param_0='up0',
-                                      unchanged_param_1='up1',
-                                      )
-    
-    assert actual_output == expected_output
-    for raised_warning_, expected_warning_ in zip(raised_warnings,
-                                                  expected_warnings):
         assert str(raised_warning_.message) == expected_warning_

--- a/nilearn/tests/test_helpers.py
+++ b/nilearn/tests/test_helpers.py
@@ -55,6 +55,9 @@ def test_replace_parameters():
                                       )
     
     assert actual_output == expected_output
+
+    expected_warnings.sort()
+    raised_warnings.sort(key=lambda mem: str(mem.message))
     for raised_warning_, expected_warning_ in zip(raised_warnings,
                                                   expected_warnings):
         assert str(raised_warning_.message) == expected_warning_
@@ -100,6 +103,8 @@ def test_future_warn_deprecated_params():
                 lib_name='somelib',
                 kwargs=mock_input,
                 )
+    expected_warnings.sort()
+    raised_warnings.sort(key=lambda mem: str(mem.message))
     for raised_warning_, expected_warning_ in zip(raised_warnings,
                                                   expected_warnings
                                                   ):

--- a/nilearn/tests/test_helpers.py
+++ b/nilearn/tests/test_helpers.py
@@ -43,7 +43,9 @@ def test_replace_parameters():
     @helpers.replace_parameters(replacement_params, '0.6.1rc', 'other_lib', )
     def mock_function(replacement_param_0, replacement_param_1,
                       unchanged_param_0, unchanged_param_1):
-        return replacement_param_0, replacement_param_1, unchanged_param_0, unchanged_param_1
+        return (replacement_param_0, replacement_param_1, unchanged_param_0,
+                unchanged_param_1
+                )
     
     with warnings.catch_warnings(record=True) as raised_warnings:
         actual_output = mock_function(deprecated_param_0='dp0',
@@ -98,5 +100,7 @@ def test_future_warn_deprecated_params():
                 lib_name='somelib',
                 kwargs=mock_input,
                 )
-    for raised_warning_, expected_warning_ in zip(raised_warnings, expected_warnings):
+    for raised_warning_, expected_warning_ in zip(raised_warnings,
+                                                  expected_warnings
+                                                  ):
         assert str(raised_warning_.message) == expected_warning_


### PR DESCRIPTION
This PR intends to undo the code redundancy introduced via PRs #1913 & #1918 by refactoring the functionality into one utility function. This will also help with the same functionality in Nistats and address code redundancy there as well.
Finally I foresee this as a useful function in future use cases as well.