### PR TITLE
[MRG] add symmetric_cmap option in view_img_on_surf

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -34,7 +34,8 @@ Changes
  - colors is now marker_color
 
 - :func:`nilearn.plotting.view_img_on_surf` now accepts a `symmetric_cmap`
-  argument to control whether the colormap is centered around 0.
+  argument to control whether the colormap is centered around 0 and a `vmin`
+  argument.
 
 Fixes
 -----

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -33,6 +33,9 @@ Changes
  - coords is now marker_coords
  - colors is now marker_color
 
+- :func:`nilearn.plotting.view_img_on_surf` now accepts a `symmetric_cmap`
+  argument to control whether the colormap is centered around 0.
+
 Fixes
 -----
 

--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -126,7 +126,7 @@ def _fill_html_template(info, embed_js=True):
 
 def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
                      threshold=None, cmap=cm.cold_hot,
-                     black_bg=False, vmax=None):
+                     black_bg=False, symmetric_cmap=True, vmax=None):
     """
     Insert a surface plot of a statistical map into an HTML page.
 
@@ -158,6 +158,10 @@ def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
         If True, image is plotted on a black background. Otherwise on a
         white background.
 
+    symmetric_cmap : bool, optional (default=True)
+        Make colormap symmetric (ranging from -vmax to vmax).
+        You can set it to False if you are plotting only positive values.
+
     vmax : float or None, optional (default=None)
         upper bound for the colorbar. if None, use the absolute max of the
         brain map.
@@ -180,7 +184,7 @@ def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
     stat_map_img = check_niimg_3d(stat_map_img)
     info = full_brain_info(
         volume_img=stat_map_img, mesh=surf_mesh, threshold=threshold,
-        cmap=cmap, black_bg=black_bg, vmax=vmax)
+        cmap=cmap, black_bg=black_bg, vmax=vmax, symmetric_cmap=symmetric_cmap)
     return _fill_html_template(info, embed_js=True)
 
 

--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -126,7 +126,7 @@ def _fill_html_template(info, embed_js=True):
 
 def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
                      threshold=None, cmap=cm.cold_hot,
-                     black_bg=False, symmetric_cmap=True, vmax=None):
+                     black_bg=False, vmax=None, symmetric_cmap=True):
     """
     Insert a surface plot of a statistical map into an HTML page.
 
@@ -158,13 +158,13 @@ def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
         If True, image is plotted on a black background. Otherwise on a
         white background.
 
-    symmetric_cmap : bool, optional (default=True)
-        Make colormap symmetric (ranging from -vmax to vmax).
-        You can set it to False if you are plotting only positive values.
-
     vmax : float or None, optional (default=None)
         upper bound for the colorbar. if None, use the absolute max of the
         brain map.
+
+    symmetric_cmap : bool, optional (default=True)
+        Make colormap symmetric (ranging from -vmax to vmax).
+        You can set it to False if you are plotting only positive values.
 
     Returns
     -------

--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -37,7 +37,7 @@ def _get_vertexcolor(surf_map, cmap, norm,
 
 def one_mesh_info(surf_map, surf_mesh, threshold=None, cmap=cm.cold_hot,
                   black_bg=False, bg_map=None, symmetric_cmap=True,
-                  vmax=None):
+                  vmax=None, vmin=None):
     """
     Prepare info for plotting one surface map on a single mesh.
 
@@ -49,7 +49,8 @@ def one_mesh_info(surf_map, surf_mesh, threshold=None, cmap=cm.cold_hot,
     """
     info = {}
     colors = colorscale(
-        cmap, surf_map, threshold, symmetric_cmap=symmetric_cmap, vmax=vmax)
+        cmap, surf_map, threshold, symmetric_cmap=symmetric_cmap,
+        vmax=vmax, vmin=vmin)
     info['inflated_left'] = mesh_to_plotly(surf_mesh)
     info['vertexcolor_left'] = _get_vertexcolor(
         surf_map, colors['cmap'], colors['norm'],
@@ -78,7 +79,7 @@ def _check_mesh(mesh):
 
 def full_brain_info(volume_img, mesh='fsaverage5', threshold=None,
                     cmap=cm.cold_hot, black_bg=False, symmetric_cmap=True,
-                    vmax=None, vol_to_surf_kwargs={}):
+                    vmax=None, vmin=None, vol_to_surf_kwargs={}):
     """
     Project 3D map on cortex; prepare info to plot both hemispheres.
 
@@ -97,7 +98,7 @@ def full_brain_info(volume_img, mesh='fsaverage5', threshold=None,
     }
     colors = colorscale(
         cmap, np.asarray(list(surface_maps.values())).ravel(), threshold,
-        symmetric_cmap=symmetric_cmap, vmax=vmax)
+        symmetric_cmap=symmetric_cmap, vmax=vmax, vmin=vmin)
 
     for hemi, surf_map in surface_maps.items():
         bg_map = surface.load_surf_data(mesh['sulc_{}'.format(hemi)])
@@ -126,7 +127,8 @@ def _fill_html_template(info, embed_js=True):
 
 def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
                      threshold=None, cmap=cm.cold_hot,
-                     black_bg=False, vmax=None, symmetric_cmap=True):
+                     black_bg=False, vmax=None, vmin=None,
+                     symmetric_cmap=True):
     """
     Insert a surface plot of a statistical map into an HTML page.
 
@@ -162,6 +164,13 @@ def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
         upper bound for the colorbar. if None, use the absolute max of the
         brain map.
 
+    vmin : float, or None (default=None)
+        min value for mapping colors.
+        If `symmetric_cmap` is `True`, `vmin` is always equal to `-vmax` and
+        cannot be chosen.
+        If `symmetric_cmap` is `False`, `vmin` defaults to the min of the
+        image, or 0 when a threshold is used.
+
     symmetric_cmap : bool, optional (default=True)
         Make colormap symmetric (ranging from -vmax to vmax).
         You can set it to False if you are plotting only positive values.
@@ -184,12 +193,13 @@ def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
     stat_map_img = check_niimg_3d(stat_map_img)
     info = full_brain_info(
         volume_img=stat_map_img, mesh=surf_mesh, threshold=threshold,
-        cmap=cmap, black_bg=black_bg, vmax=vmax, symmetric_cmap=symmetric_cmap)
+        cmap=cmap, black_bg=black_bg, vmax=vmax, vmin=vmin,
+        symmetric_cmap=symmetric_cmap)
     return _fill_html_template(info, embed_js=True)
 
 
 def view_surf(surf_mesh, surf_map=None, bg_map=None, threshold=None,
-              cmap=cm.cold_hot, black_bg=False, vmax=None,
+              cmap=cm.cold_hot, black_bg=False, vmax=None, vmin=None,
               symmetric_cmap=True):
     """
     Insert a surface plot of a surface map into an HTML page.
@@ -239,6 +249,13 @@ def view_surf(surf_mesh, surf_map=None, bg_map=None, threshold=None,
         upper bound for the colorbar. if None, use the absolute max of the
         brain map.
 
+    vmin : float, or None (default=None)
+        min value for mapping colors.
+        If `symmetric_cmap` is `True`, `vmin` is always equal to `-vmax` and
+        cannot be chosen.
+        If `symmetric_cmap` is `False`, `vmin` defaults to the min of the
+        image, or 0 when a threshold is used.
+
     Returns
     -------
     SurfaceView : plot of the stat map.
@@ -264,5 +281,5 @@ def view_surf(surf_mesh, surf_map=None, bg_map=None, threshold=None,
     info = one_mesh_info(
         surf_map=surf_map, surf_mesh=surf_mesh, threshold=threshold,
         cmap=cmap, black_bg=black_bg, bg_map=bg_map,
-        symmetric_cmap=symmetric_cmap, vmax=vmax)
+        symmetric_cmap=symmetric_cmap, vmax=vmax, vmin=vmin)
     return _fill_html_template(info, embed_js=True)

--- a/nilearn/plotting/tests/test_html_surface.py
+++ b/nilearn/plotting/tests/test_html_surface.py
@@ -140,3 +140,6 @@ def test_view_img_on_surf():
     assert len(img_4d.shape) == 4
     html = html_surface.view_img_on_surf(img, threshold='92.3%')
     check_html(html)
+    np.clip(img.get_data(), 0, None, out=img.get_data())
+    html = html_surface.view_img_on_surf(img, symmetric_cmap=False)
+    check_html(html)


### PR DESCRIPTION
after all I think the symmetric_cmap option is useful for `view_img_on_surf`
