### PR TITLE
[MRG+2] FIX : new_img_like broken with mgz files

### DIFF
--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -636,14 +636,18 @@ def new_img_like(ref_niimg, data, affine=None, copy_header=False):
     header = None
     if copy_header:
         header = copy.deepcopy(ref_niimg.header)
-        header['scl_slope'] = 0.
-        header['scl_inter'] = 0.
+        if 'scl_slope' in header:
+            header['scl_slope'] = 0.
+        if 'scl_inter' in header:
+            header['scl_inter'] = 0.
         # 'glmax' is removed for Nifti2Image. Modify only if 'glmax' is
         # available in header. See issue #1611
         if 'glmax' in header:
             header['glmax'] = 0.
-        header['cal_max'] = np.max(data) if data.size > 0 else 0.
-        header['cal_min'] = np.min(data) if data.size > 0 else 0.
+        if 'cal_max' in header:
+            header['cal_max'] = np.max(data) if data.size > 0 else 0.
+        if 'cal_min' in header:
+            header['cal_min'] = np.min(data) if data.size > 0 else 0.
     klass = ref_niimg.__class__
     if klass is nibabel.Nifti1Pair:
         # Nifti1Pair is an internal class, without a to_filename,

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -653,3 +653,9 @@ def test_largest_cc_img():
 
     out_non_native = largest_connected_component_img(img1_change_dtype)
     np.testing.assert_equal(out_native.get_data(), out_non_native.get_data())
+
+
+def test_new_img_like_mgh_image():
+    data = np.zeros((5, 5, 5), dtype=np.uint8)
+    niimg = nibabel.freesurfer.MGHImage(dataobj=data, affine=np.eye(4))
+    new_img_like(niimg, data.astype(float), niimg.affine, copy_header=True)


### PR DESCRIPTION
the last release broken the MNE CIs due to plotting from .mgz files. This fixes it.

to replicate the pb:

```
from nilearn.image import new_img_like
import nibabel

niimg = nibabel.load('/Applications/freesurfer/subjects/fsaverage/mri/T1.mgz')
new_img_like(niimg, niimg.get_data().astype(float), niimg.affine, copy_header=True)
```

let me know if I can turn this into a non-regression test