### PR TITLE
[FIX] revert fwhm for dosenbach example back to 4mm

### DIFF
--- a/examples/03_connectivity/plot_sphere_based_connectome.py
+++ b/examples/03_connectivity/plot_sphere_based_connectome.py
@@ -57,7 +57,7 @@ print('Stacked power coordinates in array of shape {0}.'.format(coords.shape))
 from nilearn import input_data
 
 spheres_masker = input_data.NiftiSpheresMasker(
-    seeds=coords, smoothing_fwhm=6, radius=5.,
+    seeds=coords, smoothing_fwhm=4, radius=5.,
     detrend=True, standardize=True, low_pass=0.1, high_pass=0.01, t_r=2.5)
 
 ###############################################################################


### PR DESCRIPTION
In #1953 the smoothing in the `plot_sphere_based_connectome.py` example was changed from 6mm to 4mm, but only for the fist (dosenbach) atlas, not the second (power). Since @emdupre and @KamalakerDadi can't figure out why that happened, we make this consistent by reverting to 4mm for both atlases.