### PR TITLE
[MRG] Fix/surf plot thresholds

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,8 +23,8 @@ Fixes
 - add_contours now accepts `threshold` argument for filled=False. Now
   `threshold` is equally applied when asked for fillings in the contours.
 - :func:`nilearn.plotting.plot_surf` and
-  :func:`nilearn.plotting.plot_surf_map` no longer threshold zero values when
-  no threshold is given.
+  :func:`nilearn.plotting.plot_surf_stat_map` no longer threshold zero values
+  when no threshold is given.
 - When :func:`nilearn.plotting.plot_surf_map` is used with a thresholded map
   but without a background map, the surface mesh is displayed in
   half-transparent grey to maintain a 3D perception.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -25,7 +25,7 @@ Fixes
 - :func:`nilearn.plotting.plot_surf` and
   :func:`nilearn.plotting.plot_surf_stat_map` no longer threshold zero values
   when no threshold is given.
-- When :func:`nilearn.plotting.plot_surf_map` is used with a thresholded map
+- When :func:`nilearn.plotting.plot_surf_stat_map` is used with a thresholded map
   but without a background map, the surface mesh is displayed in
   half-transparent grey to maintain a 3D perception.
 
@@ -1359,4 +1359,3 @@ Contributors (from ``git shortlog -ns 0.1``)::
      1  Matthias Ekman
      1  Michael Waskom
      1  Vincent Michel
-

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,12 @@ Fixes
   images have NaNs.
 - add_contours now accepts `threshold` argument for filled=False. Now
   `threshold` is equally applied when asked for fillings in the contours.
+- :func:`nilearn.plotting.plot_surf` and
+  :func:`nilearn.plotting.plot_surf_map` no longer threshold zero values when
+  no threshold is given.
+- When :func:`nilearn.plotting.plot_surf_map` is used with a thresholded map
+  but without a background map, the surface mesh is displayed in
+  half-transparent grey to maintain a 3D perception.
 
 0.5.1
 =====

--- a/examples/01_plotting/plot_surf_stat_map.py
+++ b/examples/01_plotting/plot_surf_stat_map.py
@@ -122,11 +122,11 @@ plotting.plot_surf_roi(fsaverage['pial_left'], roi_map=pcc_labels,
                        title='PCC Seed')
 
 ###############################################################################
-# Display unthresholded stat map  with dimmed background
+# Display unthresholded stat map with a slightly dimmed background
 plotting.plot_surf_stat_map(fsaverage['pial_left'], stat_map=stat_map,
                             hemi='left', view='medial', colorbar=True,
                             bg_map=fsaverage['sulc_left'], bg_on_data=True,
-                            darkness=.2, title='Correlation map')
+                            darkness=.3, title='Correlation map')
 
 ###############################################################################
 # Many different options are available for plotting, for example thresholding,
@@ -138,11 +138,22 @@ plotting.plot_surf_stat_map(fsaverage['pial_left'], stat_map=stat_map,
                             title='Threshold and colormap')
 
 ###############################################################################
+# Here the surface is plotted in a lateral view without a background map.
+# To capture 3D structure without depth information, the default is to plot a
+# half transparent surface.
+# Note that you can also control the transparency with a background map using
+# the alpha parameter.
+plotting.plot_surf_stat_map(fsaverage['pial_left'], stat_map=stat_map,
+                            hemi='left', view='lateral', colorbar=True,
+                            cmap='Spectral', threshold=.5,
+                            title='Plotting without background')
+
+###############################################################################
 # The plots can be saved to file, in which case the display is closed after
 # creating the figure
 plotting.plot_surf_stat_map(fsaverage['infl_left'], stat_map=stat_map,
                             hemi='left', bg_map=fsaverage['sulc_left'],
-                            bg_on_data=True, threshold=.6, colorbar=True,
+                            bg_on_data=True, threshold=.5, colorbar=True,
                             output_file='plot_surf_stat_map.png')
 
 plotting.show()

--- a/examples/01_plotting/plot_surf_stat_map.py
+++ b/examples/01_plotting/plot_surf_stat_map.py
@@ -126,14 +126,7 @@ plotting.plot_surf_roi(fsaverage['pial_left'], roi_map=pcc_labels,
 plotting.plot_surf_stat_map(fsaverage['pial_left'], stat_map=stat_map,
                             hemi='left', view='medial', colorbar=True,
                             bg_map=fsaverage['sulc_left'], bg_on_data=True,
-                            darkness=.5, title='Correlation map')
-
-###############################################################################
-# Display unthresholded stat map without background map, transparency is
-# automatically set to .5, but can also be controlled with the alpha parameter
-plotting.plot_surf_stat_map(fsaverage['pial_left'], stat_map=stat_map,
-                            hemi='left', view='medial', colorbar=True,
-                            title='Plotting without background')
+                            darkness=.2, title='Correlation map')
 
 ###############################################################################
 # Many different options are available for plotting, for example thresholding,

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -214,8 +214,9 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
                 raise ValueError('The bg_map does not have the same number '
                                  'of vertices as the mesh.')
             bg_faces = np.mean(bg_data[faces], axis=1)
-            bg_faces = bg_faces - bg_faces.min()
-            bg_faces = bg_faces / bg_faces.max()
+            if bg_faces.min() != bg_faces.max():
+                bg_faces = bg_faces - bg_faces.min()
+                bg_faces = bg_faces / bg_faces.max()
             # control background darkness
             bg_faces *= darkness
             face_colors = plt.cm.gray_r(bg_faces)

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -414,7 +414,7 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
     display = plot_surf(
         surf_mesh, surf_map=stat_map, bg_map=bg_map, hemi=hemi, view=view,
         avg_method='mean', threshold=threshold, cmap=cmap, colorbar=colorbar,
-        alpha=alpha, bg_on_data=bg_on_data, darkness=1, vmax=vmax, vmin=vmin,
+        alpha=alpha, bg_on_data=bg_on_data, darkness=darkness, vmax=vmax, vmin=vmin,
         title=title, output_file=output_file, axes=axes, figure=figure,
         cbar_vmin=cbar_vmin, cbar_vmax=cbar_vmax, **kwargs)
 

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -247,7 +247,7 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
 
             # treshold if inidcated
             if threshold is None:
-                kept_indices = np.where(surf_map_faces)[0]
+                kept_indices = np.arange(surf_map_faces.shape[0])
             else:
                 kept_indices = np.where(np.abs(surf_map_faces) >= threshold)[0]
 

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -205,20 +205,21 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
     face_colors = np.ones((faces.shape[0], 4))
 
     if bg_map is None:
-        bg_map = np.ones(coords.shape[0]) * 0.5
+        bg_data = np.ones(coords.shape[0]) * 0.5
 
     else:
         bg_data = load_surf_data(bg_map)
         if bg_data.shape[0] != coords.shape[0]:
             raise ValueError('The bg_map does not have the same number '
                              'of vertices as the mesh.')
-        bg_faces = np.mean(bg_data[faces], axis=1)
-        if bg_faces.min() != bg_faces.max():
-            bg_faces = bg_faces - bg_faces.min()
-            bg_faces = bg_faces / bg_faces.max()
-        # control background darkness
-        bg_faces *= darkness
-        face_colors = plt.cm.gray_r(bg_faces)
+
+    bg_faces = np.mean(bg_data[faces], axis=1)
+    if bg_faces.min() != bg_faces.max():
+        bg_faces = bg_faces - bg_faces.min()
+        bg_faces = bg_faces / bg_faces.max()
+    # control background darkness
+    bg_faces *= darkness
+    face_colors = plt.cm.gray_r(bg_faces)
 
     # modify alpha values of background
     face_colors[:, 3] = alpha * face_colors[:, 3]

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -75,7 +75,7 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
         If 'auto' is chosen, alpha will default to .5 when no bg_map
         is passed and to 1 if a bg_map is passed.
 
-    bg_on_stat: bool, default is False
+    bg_on_data: bool, default is False
         If True, and a bg_map is specified, the surf_data data is multiplied
         by the background image, so that e.g. sulcal depth is visible beneath
         the surf_data.
@@ -200,98 +200,97 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
     # reduce viewing distance to remove space around mesh
     axes.dist = 8
 
-    # If depth_map and/or surf_map are provided, map these onto the surface
     # set_facecolors function of Poly3DCollection is used as passing the
     # facecolors argument to plot_trisurf does not seem to work
-    if bg_map is not None or surf_map is not None:
+    face_colors = np.ones((faces.shape[0], 4))
 
-        face_colors = np.ones((faces.shape[0], 4))
-        # face_colors[:, :3] = .5*face_colors[:, :3]  # why this?
+    if bg_map is None:
+        bg_map = np.ones(coords.shape[0]) * 0.5
 
-        if bg_map is not None:
-            bg_data = load_surf_data(bg_map)
-            if bg_data.shape[0] != coords.shape[0]:
-                raise ValueError('The bg_map does not have the same number '
-                                 'of vertices as the mesh.')
-            bg_faces = np.mean(bg_data[faces], axis=1)
-            if bg_faces.min() != bg_faces.max():
-                bg_faces = bg_faces - bg_faces.min()
-                bg_faces = bg_faces / bg_faces.max()
-            # control background darkness
-            bg_faces *= darkness
-            face_colors = plt.cm.gray_r(bg_faces)
+    else:
+        bg_data = load_surf_data(bg_map)
+        if bg_data.shape[0] != coords.shape[0]:
+            raise ValueError('The bg_map does not have the same number '
+                             'of vertices as the mesh.')
+        bg_faces = np.mean(bg_data[faces], axis=1)
+        if bg_faces.min() != bg_faces.max():
+            bg_faces = bg_faces - bg_faces.min()
+            bg_faces = bg_faces / bg_faces.max()
+        # control background darkness
+        bg_faces *= darkness
+        face_colors = plt.cm.gray_r(bg_faces)
 
-        # modify alpha values of background
-        face_colors[:, 3] = alpha * face_colors[:, 3]
-        # should it be possible to modify alpha of surf data as well?
+    # modify alpha values of background
+    face_colors[:, 3] = alpha * face_colors[:, 3]
+    # should it be possible to modify alpha of surf data as well?
 
-        if surf_map is not None:
-            surf_map_data = load_surf_data(surf_map)
-            if len(surf_map_data.shape) is not 1:
-                raise ValueError('surf_map can only have one dimension but has'
-                                 '%i dimensions' % len(surf_map_data.shape))
-            if surf_map_data.shape[0] != coords.shape[0]:
-                raise ValueError('The surf_map does not have the same number '
-                                 'of vertices as the mesh.')
+    if surf_map is not None:
+        surf_map_data = load_surf_data(surf_map)
+        if len(surf_map_data.shape) is not 1:
+            raise ValueError('surf_map can only have one dimension but has'
+                             '%i dimensions' % len(surf_map_data.shape))
+        if surf_map_data.shape[0] != coords.shape[0]:
+            raise ValueError('The surf_map does not have the same number '
+                             'of vertices as the mesh.')
 
-            # create face values from vertex values by selected avg methods
-            if avg_method == 'mean':
-                surf_map_faces = np.mean(surf_map_data[faces], axis=1)
-            elif avg_method == 'median':
-                surf_map_faces = np.median(surf_map_data[faces], axis=1)
+        # create face values from vertex values by selected avg methods
+        if avg_method == 'mean':
+            surf_map_faces = np.mean(surf_map_data[faces], axis=1)
+        elif avg_method == 'median':
+            surf_map_faces = np.median(surf_map_data[faces], axis=1)
 
-            # if no vmin/vmax are passed figure them out from data
-            if vmin is None:
-                vmin = np.nanmin(surf_map_faces)
-            if vmax is None:
-                vmax = np.nanmax(surf_map_faces)
+        # if no vmin/vmax are passed figure them out from data
+        if vmin is None:
+            vmin = np.nanmin(surf_map_faces)
+        if vmax is None:
+            vmax = np.nanmax(surf_map_faces)
 
-            # treshold if inidcated
-            if threshold is None:
-                kept_indices = np.arange(surf_map_faces.shape[0])
-            else:
-                kept_indices = np.where(np.abs(surf_map_faces) >= threshold)[0]
+        # treshold if inidcated
+        if threshold is None:
+            kept_indices = np.arange(surf_map_faces.shape[0])
+        else:
+            kept_indices = np.where(np.abs(surf_map_faces) >= threshold)[0]
 
-            surf_map_faces = surf_map_faces - vmin
-            surf_map_faces = surf_map_faces / (vmax - vmin)
+        surf_map_faces = surf_map_faces - vmin
+        surf_map_faces = surf_map_faces / (vmax - vmin)
 
-            # multiply data with background if indicated
-            if bg_on_data:
-                face_colors[kept_indices] = cmap(surf_map_faces[kept_indices])\
-                    * face_colors[kept_indices]
-            else:
-                face_colors[kept_indices] = cmap(surf_map_faces[kept_indices])
+        # multiply data with background if indicated
+        if bg_on_data:
+            face_colors[kept_indices] = cmap(surf_map_faces[kept_indices])\
+                * face_colors[kept_indices]
+        else:
+            face_colors[kept_indices] = cmap(surf_map_faces[kept_indices])
 
-            if colorbar:
-                our_cmap = get_cmap(cmap)
-                norm = Normalize(vmin=vmin, vmax=vmax)
+        if colorbar:
+            our_cmap = get_cmap(cmap)
+            norm = Normalize(vmin=vmin, vmax=vmax)
 
-                nb_ticks = 5
-                ticks = np.linspace(vmin, vmax, nb_ticks)
-                bounds = np.linspace(vmin, vmax, our_cmap.N)
+            nb_ticks = 5
+            ticks = np.linspace(vmin, vmax, nb_ticks)
+            bounds = np.linspace(vmin, vmax, our_cmap.N)
 
-                if threshold is not None:
-                    cmaplist = [our_cmap(i) for i in range(our_cmap.N)]
-                    # set colors to grey for absolute values < threshold
-                    istart = int(norm(-threshold, clip=True) *
-                                 (our_cmap.N - 1))
-                    istop = int(norm(threshold, clip=True) *
-                                (our_cmap.N - 1))
-                    for i in range(istart, istop):
-                        cmaplist[i] = (0.5, 0.5, 0.5, 1.)
-                    our_cmap = LinearSegmentedColormap.from_list(
-                        'Custom cmap', cmaplist, our_cmap.N)
+            if threshold is not None:
+                cmaplist = [our_cmap(i) for i in range(our_cmap.N)]
+                # set colors to grey for absolute values < threshold
+                istart = int(norm(-threshold, clip=True) *
+                             (our_cmap.N - 1))
+                istop = int(norm(threshold, clip=True) *
+                            (our_cmap.N - 1))
+                for i in range(istart, istop):
+                    cmaplist[i] = (0.5, 0.5, 0.5, 1.)
+                our_cmap = LinearSegmentedColormap.from_list(
+                    'Custom cmap', cmaplist, our_cmap.N)
 
-                # we need to create a proxy mappable
-                proxy_mappable = ScalarMappable(cmap=our_cmap, norm=norm)
-                proxy_mappable.set_array(surf_map_faces)
-                cax, kw = make_axes(axes, location='right', fraction=.1,
-                                    shrink=.6, pad=.0)
-                cbar = figure.colorbar(
-                    proxy_mappable, cax=cax, ticks=ticks,
-                    boundaries=bounds, spacing='proportional',
-                    format='%.2g', orientation='vertical')
-                _crop_colorbar(cbar, cbar_vmin, cbar_vmax)
+            # we need to create a proxy mappable
+            proxy_mappable = ScalarMappable(cmap=our_cmap, norm=norm)
+            proxy_mappable.set_array(surf_map_faces)
+            cax, kw = make_axes(axes, location='right', fraction=.1,
+                                shrink=.6, pad=.0)
+            cbar = figure.colorbar(
+                proxy_mappable, cax=cax, ticks=ticks,
+                boundaries=bounds, spacing='proportional',
+                format='%.2g', orientation='vertical')
+            _crop_colorbar(cbar, cbar_vmin, cbar_vmax)
 
         p3dcollec.set_facecolors(face_colors)
 

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -66,7 +66,7 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
         How to average vertex values to derive the face value, mean results
         in smooth, median in sharp boundaries.
 
-    threshold : a number, None, or 'auto', default is None.
+    threshold : a number or None, default is None.
         If None is given, the image is not thresholded.
         If a number is given, it is used to threshold the image, values
         below the threshold (in absolute value) are plotted as transparent.
@@ -344,7 +344,7 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
     view: {'lateral', 'medial', 'dorsal', 'ventral', 'anterior', 'posterior'}, default is 'lateral'
         View of the surface that is rendered.
 
-    threshold : a number, None, or 'auto', default is None
+    threshold : a number or None, default is None
         If None is given, the image is not thresholded.
         If a number is given, it is used to threshold the image,
         values below the threshold (in absolute value) are plotted
@@ -423,8 +423,8 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
 
 
 def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
-                  hemi='left', view='lateral', alpha='auto',
-                  vmin=None, vmax=None, cmap='gist_ncar',
+                  hemi='left', view='lateral', threshold=1e-14,
+                  alpha='auto', vmin=None, vmax=None, cmap='gist_ncar',
                   bg_on_data=False, darkness=1, title=None,
                   output_file=None, axes=None, figure=None, **kwargs):
     """ Plotting ROI on a surface mesh with optional background
@@ -457,8 +457,13 @@ def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
         stat_map in greyscale, most likely a sulcal depth map for
         realistic shading.
 
-    view: {'lateral', 'medial', 'dorsal', 'ventral', 'anterior', 'posterior'}, default is 'lateral'
+    view: {'lateral', 'medial', 'dorsal', 'ventral', 'anterior', 'posterior'},
+        default is 'lateral'
         View of the surface that is rendered.
+
+    threshold: a number or None
+        default is 1e-14 to threshold regions that are labelled 0. If you want
+        to use 0 as a label, set threshold to None.
 
     cmap : matplotlib colormap str or colormap object, default 'coolwarm'
         To use for plotting of the rois. Either a string which is a name
@@ -534,9 +539,10 @@ def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
     vmin, vmax = np.min(roi_map), 1 + np.max(roi_map)
     display = plot_surf(surf_mesh, surf_map=roi_map, bg_map=bg_map,
                         hemi=hemi, view=view, avg_method='median',
-                        cmap=cmap, alpha=alpha, bg_on_data=bg_on_data,
-                        darkness=darkness, vmin=vmin, vmax=vmax,
-                        title=title, output_file=output_file,
-                        axes=axes, figure=figure, **kwargs)
+                        threshold=threshold, cmap=cmap, alpha=alpha,
+                        bg_on_data=bg_on_data, darkness=darkness,
+                        vmin=vmin, vmax=vmax, title=title,
+                        output_file=output_file, axes=axes,
+                        figure=figure, **kwargs)
 
     return display


### PR DESCRIPTION
This addresses issues mentioned in #1738 
(and https://neurostars.org/t/thresholded-surface-plot-with-nilearn/2992).

- Accidental thresholding of zeros removed

- Changed behaviour when no background map. Instead of a solid grey background (which removes 3D structure of the surface) the default is to display thresholded maps on grey half-transparent background. This is also shown in the example plot_surf_stat_map now. 

- Some additional small bugs and inconsistencies were removed