### PR TITLE
[WIP] ENH: Confounds for ConnectivityMeasure

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -17,10 +17,15 @@ NEW
   These two objects also leverage the `NiftiMaskers` to provide a direct
   interface with the Nifti files on disk.
 
+
 Fixes
 -----
 
 - :class:`nilearn.input_data.NiftiLabelsMasker` no longer ignores its `mask_img`
+
+- :class:`nilearn.connectome.ConnectivityMeasure` can now remove
+  confounds in its transform step.
+
 
 0.6.2
 ======

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -532,20 +532,21 @@ class ConnectivityMeasure(BaseEstimator, TransformerMixin):
                                     for cov in connectivities]
 
             connectivities = np.array(connectivities)
+
+            if confounds is not None and not self.vectorize:
+                error_message = ("'confounds' are provided but "
+                                 "vectorize=False. Confounds are only "
+                                 "cleaned on vectorized matrices as "
+                                 "second level connectome regression "
+                                 "but not on symmetric matrices.")
+                raise ValueError(error_message)
+
             if self.vectorize:
                 connectivities = sym_matrix_to_vec(
                     connectivities, discard_diagonal=self.discard_diagonal)
                 if confounds is not None:
-                    if not self.vectorize:
-                        error_message = ("'confounds' are provided but "
-                                         "vectorize=False. Confounds are only "
-                                         "cleaned on vectorized matrices as "
-                                         "second level connectome regression "
-                                         "but not on symmetric matrices.")
-                        raise ValueError(error_message)
-                    else:
-                        connectivities = signal.clean(connectivities,
-                                                      confounds=confounds)
+                    connectivities = signal.clean(connectivities,
+                                                  confounds=confounds)
 
         return connectivities
 

--- a/nilearn/connectome/tests/test_connectivity_matrices.py
+++ b/nilearn/connectome/tests/test_connectivity_matrices.py
@@ -590,3 +590,53 @@ def test_connectivity_measure_outputs():
     with pytest.raises(ValueError,
                        match='can not reconstruct connectivity matrices'):
         tangent_measure.inverse_transform(vectorized_displacements)
+
+
+def test_confounds_connectome_measure():
+    n_subjects = 10
+    n_features = 49
+
+    # Generate signals and compute covariances and apply confounds while
+    # computing covariances
+    signals = []
+    for k in range(n_subjects):
+        n_samples = 200 + k
+        signal, _, confounds = generate_signals(n_features=n_features,
+                                                n_confounds=5,
+                                                length=n_samples,
+                                                same_variance=False)
+        signals.append(signal)
+    correlation_measure = ConnectivityMeasure(kind='correlation',
+                                              vectorize=True)
+    # Clean confounds on 10 subjects with confounds filtered to 10 subjects in
+    # length
+    cleaned_vectors = correlation_measure.fit_transform(signals,
+                                                        confounds=confounds[0:10])
+    assert_true(abs(np.dot(confounds[0:10].T,
+                           cleaned_vectors).max()) < 1000 * np.finfo(np.float).eps)
+    assert_true(isinstance(cleaned_vectors, np.ndarray))
+
+    # Raising error for input confounds are not iterable
+    conn_measure = ConnectivityMeasure(vectorize=True)
+    assert_raises_regex(ValueError,
+                        "'confounds' input argument must be an iterable.",
+                        conn_measure._check_input,
+                        signals, confounds=1.)
+
+    assert_raises_regex(ValueError,
+                        "'confounds' input argument must be an iterable.",
+                        conn_measure._fit_transform,
+                        X=signals, do_fit=True, do_transform=True,
+                        confounds=1.)
+
+    assert_raises_regex(ValueError,
+                        "'confounds' input argument must be an iterable.",
+                        conn_measure.fit_transform,
+                        signals, None, 1.)
+    # Raising error for input confounds are given but not vectorize=True
+    conn_measure = ConnectivityMeasure(vectorize=False)
+    assert_raises_regex(ValueError,
+                        "'confounds' are provided but vectorize=False.",
+                        conn_measure.fit_transform,
+                        signals, None, confounds[0:10])
+>>>>>>> TST: confounds for connectivity measure

--- a/nilearn/connectome/tests/test_connectivity_matrices.py
+++ b/nilearn/connectome/tests/test_connectivity_matrices.py
@@ -639,4 +639,4 @@ def test_confounds_connectome_measure():
                         "'confounds' are provided but vectorize=False.",
                         conn_measure.fit_transform,
                         signals, None, confounds[0:10])
->>>>>>> TST: confounds for connectivity measure
+

--- a/nilearn/connectome/tests/test_connectivity_matrices.py
+++ b/nilearn/connectome/tests/test_connectivity_matrices.py
@@ -612,31 +612,20 @@ def test_confounds_connectome_measure():
     # length
     cleaned_vectors = correlation_measure.fit_transform(signals,
                                                         confounds=confounds[0:10])
-    assert_true(abs(np.dot(confounds[0:10].T,
-                           cleaned_vectors).max()) < 1000 * np.finfo(np.float).eps)
-    assert_true(isinstance(cleaned_vectors, np.ndarray))
+    zero_matrix = np.zeros((confounds.shape[1], cleaned_vectors.shape[1]))
+    assert_array_almost_equal(
+        np.dot(confounds[0:10].T, cleaned_vectors), zero_matrix)
+    assert(isinstance(cleaned_vectors, np.ndarray))
 
     # Raising error for input confounds are not iterable
     conn_measure = ConnectivityMeasure(vectorize=True)
-    assert_raises_regex(ValueError,
-                        "'confounds' input argument must be an iterable.",
-                        conn_measure._check_input,
-                        signals, confounds=1.)
-
-    assert_raises_regex(ValueError,
-                        "'confounds' input argument must be an iterable.",
-                        conn_measure._fit_transform,
-                        X=signals, do_fit=True, do_transform=True,
-                        confounds=1.)
-
-    assert_raises_regex(ValueError,
-                        "'confounds' input argument must be an iterable.",
-                        conn_measure.fit_transform,
-                        signals, None, 1.)
+    pytest.raises(ValueError, conn_measure._check_input, signals, confounds=1.)
+    pytest.raises(ValueError, conn_measure._fit_transform,
+                  X=signals, do_fit=True, do_transform=True,
+                  confounds=1.)
+    pytest.raises(ValueError, conn_measure.fit_transform, signals, None, 1.)
     # Raising error for input confounds are given but not vectorize=True
     conn_measure = ConnectivityMeasure(vectorize=False)
-    assert_raises_regex(ValueError,
-                        "'confounds' are provided but vectorize=False.",
-                        conn_measure.fit_transform,
-                        signals, None, confounds[0:10])
+    pytest.raises(ValueError, conn_measure.fit_transform,
+                  signals, None, confounds[0:10])
 


### PR DESCRIPTION
This PR enhances the ConnectivityMeasure object by implementing confounds to regress out from the vectorized matrices. This is called as Connectome-level regression for example, to clean Mean FD.