### PR TITLE
[MRG] Moving nilearn.decoding.objective_functions._unmask to nilearn.masking._unmask_from_to_3d_array

### DIFF
--- a/nilearn/decoding/objective_functions.py
+++ b/nilearn/decoding/objective_functions.py
@@ -218,31 +218,6 @@ def _gradient_id(img, l1_ratio=.5):
     return gradient
 
 
-def _unmask(w, mask):
-    """Unmask an image into whole brain, with off-mask voxels set to 0.
-
-    Parameters
-    ----------
-    w : ndarray, shape (n_features,)
-      The image to be unmasked.
-
-    mask : ndarray, shape (nx, ny, nz)
-      The mask used in the unmasking operation. It is required that
-      mask.sum() == n_features.
-
-    Returns
-    -------
-    out : 3d of same shape as `mask`.
-        The unmasked version of `w`
-    """
-
-    if mask.sum() != len(w):
-        raise ValueError("Expecting mask.sum() == len(w).")
-    out = np.zeros(mask.shape, dtype=w.dtype)
-    out[mask] = w
-    return out
-
-
 def _sigmoid(t, copy=True):
     """Helper function: return 1. / (1 + np.exp(-t))"""
     if copy:

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -34,7 +34,7 @@ from sklearn.model_selection import check_cv
 from sklearn.linear_model.base import _preprocess_data as center_data
 from .._utils.compat import _basestring
 from .._utils.cache_mixin import CacheMixin
-from .objective_functions import _unmask
+from nilearn.masking import _unmask_from_to_3d_array
 from .space_net_solvers import (tvl1_solver, _graph_net_logistic,
                                 _graph_net_squared_loss)
 
@@ -103,9 +103,9 @@ def _univariate_feature_screening(
         sX = np.empty(X.shape)
         for sample in range(sX.shape[0]):
             sX[sample] = ndimage.gaussian_filter(
-                _unmask(X[sample].copy(),  # avoid modifying X
-                        mask), (smoothing_fwhm, smoothing_fwhm,
-                                smoothing_fwhm))[mask]
+                _unmask_from_to_3d_array(X[sample].copy(),  # avoid modifying X
+                                         mask), (smoothing_fwhm, smoothing_fwhm,
+                                                 smoothing_fwhm))[mask]
     else:
         sX = X
 

--- a/nilearn/decoding/tests/test_objective_functions.py
+++ b/nilearn/decoding/tests/test_objective_functions.py
@@ -8,7 +8,7 @@ from scipy.optimize import check_grad
 from sklearn.utils import check_random_state
 from nilearn.decoding.objective_functions import (
     _gradient_id, _logistic, _div_id,
-    _logistic_loss_grad, _unmask)
+    _logistic_loss_grad)
 from nilearn.decoding.space_net import BaseSpaceNet
 from nose.tools import raises
 
@@ -82,15 +82,3 @@ def test_grad_div_adjoint_arbitrary_ndim_():
 @raises(ValueError)
 def test_baseestimator_invalid_l1_ratio():
     BaseSpaceNet(l1_ratios=2.)
-
-
-def test_unmask(size=5):
-    rng = check_random_state(42)
-    for ndim in range(1, 4):
-        shape = [size] * ndim
-        mask = np.zeros(shape).astype(np.bool)
-        mask[rng.rand(*shape) > .8] = 1
-        support = rng.randn(mask.sum())
-        full = _unmask(support, mask)
-        np.testing.assert_array_equal(full.shape, shape)
-        np.testing.assert_array_equal(full[mask], support)

--- a/nilearn/decoding/tests/test_same_api.py
+++ b/nilearn/decoding/tests/test_same_api.py
@@ -9,9 +9,10 @@ import numpy as np
 import nibabel
 from sklearn.datasets import load_iris
 from sklearn.utils import check_random_state
+from nilearn.masking import _unmask_from_to_3d_array
 from nilearn.decoding.objective_functions import (
     _squared_loss, _squared_loss_grad, _logistic_loss_lipschitz_constant,
-    spectral_norm_squared, _unmask)
+    spectral_norm_squared)
 from nilearn.decoding.space_net_solvers import (
     _squared_loss_and_spatial_grad,
     _logistic_derivative_lipschitz_constant,
@@ -52,7 +53,8 @@ def to_niimgs(X, dim):
     mask[:X.shape[-1]] = 1
     assert_equal(mask.sum(), X.shape[1])
     mask = mask.reshape(dim)
-    X = np.rollaxis(np.array([_unmask(x, mask) for x in X]), 0, start=4)
+    X = np.rollaxis(
+        np.array([_unmask_from_to_3d_array(x, mask) for x in X]), 0, start=4)
     affine = np.eye(4)
     return nibabel.Nifti1Image(X, affine), nibabel.Nifti1Image(
         mask.astype(np.float), affine)

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -70,7 +70,7 @@ def _extrapolate_out_mask(data, mask, iterations=1):
     """
     if iterations > 1:
         data, mask = _extrapolate_out_mask(data, mask,
-                                          iterations=iterations - 1)
+                                           iterations=iterations - 1)
     new_mask = ndimage.binary_dilation(mask)
     larger_mask = np.zeros(np.array(mask.shape) + 2, dtype=np.bool)
     larger_mask[1:-1, 1:-1, 1:-1] = mask
@@ -82,7 +82,7 @@ def _extrapolate_out_mask(data, mask, iterations=1):
     outer_shell[1:-1, 1:-1, 1:-1] = np.logical_xor(new_mask, mask)
     outer_shell_x, outer_shell_y, outer_shell_z = np.where(outer_shell)
     extrapolation = list()
-    for i, j, k in [(1, 0, 0), (-1, 0, 0), 
+    for i, j, k in [(1, 0, 0), (-1, 0, 0),
                     (0, 1, 0), (0, -1, 0),
                     (0, 0, 1), (0, 0, -1)]:
         this_x = outer_shell_x + i
@@ -173,7 +173,7 @@ def _post_process_mask(mask, affine, opening=2, connected=True,
     mask_any = mask.any()
     if not mask_any:
         warnings.warn("Computed an empty mask. %s" % warning_msg,
-            MaskWarning, stacklevel=2)
+                      MaskWarning, stacklevel=2)
     if connected and mask_any:
         mask = largest_connected_component(mask)
     if opening:
@@ -259,9 +259,9 @@ def compute_epi_mask(epi_img, lower_cutoff=0.2, upper_cutoff=0.85,
     # Delayed import to avoid circular imports
     from .image.image import _compute_mean
     mean_epi, affine = cache(_compute_mean, memory)(epi_img,
-                                     target_affine=target_affine,
-                                     target_shape=target_shape,
-                                     smooth=(1 if opening else False))
+                                                    target_affine=target_affine,
+                                                    target_shape=target_shape,
+                                                    smooth=(1 if opening else False))
 
     if ensure_finite:
         # Get rid of memmapping
@@ -284,8 +284,8 @@ def compute_epi_mask(epi_img, lower_cutoff=0.2, upper_cutoff=0.85,
     mask = mean_epi >= threshold
 
     mask, affine = _post_process_mask(mask, affine, opening=opening,
-        connected=connected, warning_msg="Are you sure that input "
-            "data are EPI images not detrended. ")
+                                      connected=connected, warning_msg="Are you sure that input "
+                                      "data are EPI images not detrended. ")
     return new_img_like(epi_img, mask, affine)
 
 
@@ -370,9 +370,9 @@ def compute_multi_epi_mask(epi_imgs, lower_cutoff=0.2, upper_cutoff=0.85,
 
 
 def compute_background_mask(data_imgs, border_size=2,
-                     connected=False, opening=False,
-                     target_affine=None, target_shape=None,
-                     memory=None, verbose=0):
+                            connected=False, opening=False,
+                            target_affine=None, target_shape=None,
+                            memory=None, verbose=0):
     """ Compute a brain mask for the images by guessing the value of the
     background from the border of the image.
 
@@ -426,8 +426,8 @@ def compute_background_mask(data_imgs, border_size=2,
     # Delayed import to avoid circular imports
     from .image.image import _compute_mean
     data, affine = cache(_compute_mean, memory)(data_imgs,
-                target_affine=target_affine, target_shape=target_shape,
-                smooth=False)
+                                                target_affine=target_affine, target_shape=target_shape,
+                                                smooth=False)
 
     background = np.median(get_border_data(data, border_size))
     if np.isnan(background):
@@ -438,16 +438,16 @@ def compute_background_mask(data_imgs, border_size=2,
         mask = data != background
 
     mask, affine = _post_process_mask(mask, affine, opening=opening,
-        connected=connected, warning_msg="Are you sure that input "
-            "images have a homogeneous background.")
+                                      connected=connected, warning_msg="Are you sure that input "
+                                      "images have a homogeneous background.")
     return new_img_like(data_imgs, mask, affine)
 
 
 def compute_multi_background_mask(data_imgs, border_size=2, upper_cutoff=0.85,
-                           connected=True, opening=2, threshold=0.5,
-                           target_affine=None, target_shape=None,
-                           exclude_zeros=False, n_jobs=1,
-                           memory=None, verbose=0):
+                                  connected=True, opening=2, threshold=0.5,
+                                  target_affine=None, target_shape=None,
+                                  exclude_zeros=False, n_jobs=1,
+                                  memory=None, verbose=0):
     """ Compute a common mask for several sessions or subjects of data.
 
     Uses the mask-finding algorithms to extract masks for each session
@@ -502,12 +502,12 @@ def compute_multi_background_mask(data_imgs, border_size=2, upper_cutoff=0.85,
                         'image or a list of images' % data_imgs)
     masks = Parallel(n_jobs=n_jobs, verbose=verbose)(
         delayed(compute_background_mask)(img,
-                                  border_size=border_size,
-                                  connected=connected,
-                                  opening=opening,
-                                  target_affine=target_affine,
-                                  target_shape=target_shape,
-                                  memory=memory)
+                                         border_size=border_size,
+                                         connected=connected,
+                                         opening=opening,
+                                         target_affine=target_affine,
+                                         target_shape=target_shape,
+                                         memory=memory)
         for img in data_imgs)
 
     mask = intersect_masks(masks, connected=connected, threshold=threshold)
@@ -863,3 +863,30 @@ def unmask(X, mask_img, order="F"):
                         "got shape: %s" % str(X.shape))
 
     return new_img_like(mask_img, unmasked, affine)
+
+
+def _unmask_from_to_3d_array(w, mask):
+    """Unmask an image into whole brain, with off-mask voxels set to 0. Used as
+    a stand-alone function in low-level decoding (SpaceNet) and clustering (ReNA)
+    functions.
+
+    Parameters
+    ----------
+    w : ndarray, shape (n_features,)
+      The image to be unmasked.
+
+    mask : ndarray, shape (nx, ny, nz)
+      The mask used in the unmasking operation. It is required that
+      mask.sum() == n_features.
+
+    Returns
+    -------
+    out : 3d of same shape as `mask`.
+        The unmasked version of `w`
+    """
+
+    if mask.sum() != len(w):
+        raise ValueError("Expecting mask.sum() == len(w).")
+    out = np.zeros(mask.shape, dtype=w.dtype)
+    out[mask] = w
+    return out


### PR DESCRIPTION
Renaming stand-alone _unmask function for SpaceNet to _unmask_from_to_3d_array and moving it in nilearn/masking.py with the relevant tests and import changes.

The goal is to use this function later to refactor ReNA for PR#1983