### PR TITLE
[FIX] t_r in examples using the development dataset

### DIFF
--- a/examples/03_connectivity/plot_adhd_spheres.py
+++ b/examples/03_connectivity/plot_adhd_spheres.py
@@ -40,7 +40,7 @@ from nilearn import input_data
 masker = input_data.NiftiSpheresMasker(
     dmn_coords, radius=8,
     detrend=True, standardize=True,
-    low_pass=0.1, high_pass=0.01, t_r=2.5,
+    low_pass=0.1, high_pass=0.01, t_r=2,
     memory='nilearn_cache', memory_level=1, verbose=2)
 
 func_filename = dataset.func[0]

--- a/examples/03_connectivity/plot_group_level_connectivity.py
+++ b/examples/03_connectivity/plot_group_level_connectivity.py
@@ -56,7 +56,7 @@ print('MSDL has {0} ROIs, part of the following networks :\n{1}.'.format(
 from nilearn import input_data
 
 masker = input_data.NiftiMapsMasker(
-    msdl_data.maps, resampling_target="data", t_r=2.5, detrend=True,
+    msdl_data.maps, resampling_target="data", t_r=2, detrend=True,
     low_pass=.1, high_pass=.01, memory='nilearn_cache', memory_level=1)
 
 ###############################################################################

--- a/examples/03_connectivity/plot_multi_subject_connectome.py
+++ b/examples/03_connectivity/plot_multi_subject_connectome.py
@@ -57,7 +57,7 @@ mem = Memory('nilearn_cache')
 
 masker = input_data.NiftiMapsMasker(
     msdl_atlas_dataset.maps, resampling_target="maps", detrend=True,
-    low_pass=None, high_pass=0.01, t_r=2.5, standardize=True,
+    low_pass=None, high_pass=0.01, t_r=2, standardize=True,
     memory='nilearn_cache', memory_level=1, verbose=2)
 masker.fit()
 

--- a/examples/03_connectivity/plot_seed_to_voxel_correlation.py
+++ b/examples/03_connectivity/plot_seed_to_voxel_correlation.py
@@ -62,7 +62,7 @@ from nilearn import input_data
 seed_masker = input_data.NiftiSpheresMasker(
     pcc_coords, radius=8,
     detrend=True, standardize=True,
-    low_pass=0.1, high_pass=0.01, t_r=2.,
+    low_pass=0.1, high_pass=0.01, t_r=2,
     memory='nilearn_cache', memory_level=1, verbose=0)
 
 ##########################################################################
@@ -79,7 +79,7 @@ seed_time_series = seed_masker.fit_transform(func_filename,
 brain_masker = input_data.NiftiMasker(
     smoothing_fwhm=6,
     detrend=True, standardize=True,
-    low_pass=0.1, high_pass=0.01, t_r=2.,
+    low_pass=0.1, high_pass=0.01, t_r=2,
     memory='nilearn_cache', memory_level=1, verbose=0)
 
 ##########################################################################

--- a/examples/03_connectivity/plot_sphere_based_connectome.py
+++ b/examples/03_connectivity/plot_sphere_based_connectome.py
@@ -58,7 +58,7 @@ from nilearn import input_data
 
 spheres_masker = input_data.NiftiSpheresMasker(
     seeds=coords, smoothing_fwhm=4, radius=5.,
-    detrend=True, standardize=True, low_pass=0.1, high_pass=0.01, t_r=2.5)
+    detrend=True, standardize=True, low_pass=0.1, high_pass=0.01, t_r=2)
 
 ###############################################################################
 # Voxel-wise time-series within each sphere are averaged. The resulting signal
@@ -126,7 +126,7 @@ coords = np.vstack((
 
 spheres_masker = input_data.NiftiSpheresMasker(
     seeds=coords, smoothing_fwhm=4, radius=4.5,
-    detrend=True, standardize=True, low_pass=0.1, high_pass=0.01, t_r=2.5)
+    detrend=True, standardize=True, low_pass=0.1, high_pass=0.01, t_r=2)
 
 timeseries = spheres_masker.fit_transform(fmri_filename,
                                           confounds=confounds_filename)


### PR DESCRIPTION
Fixes #2014 

The change in the examples from the adhd dataset to the fmri development dataset left the t_r at 2.5. The development dataset has a TR of 2.
This now has been changed in the examples