### PR TITLE
Enh/surface path globbing

### DIFF
--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -14,6 +14,7 @@ from sklearn.externals.joblib import Memory
 
 from .cache_mixin import cache
 from .niimg import _safe_get_data, load_niimg
+from .path_finding import _resolve_globbing
 from .compat import _basestring, izip
 
 from .exceptions import DimensionError
@@ -73,17 +74,6 @@ def _index_img(img, index):
     return new_img_like(
         img, img.get_data()[:, :, :, index], img.affine,
         copy_header=True)
-
-
-def _resolve_globbing(path):
-    if isinstance(path, _basestring):
-        path_list = sorted(glob.glob(os.path.expanduser(path)))
-        # Raise an error in case the niimgs list is empty.
-        if len(path_list) == 0:
-            raise ValueError("No files matching path: %s" % path)
-        path = path_list
-
-    return path
 
 
 def _iter_check_niimg(niimgs, ensure_ndim=None, atleast_4d=False,

--- a/nilearn/_utils/path_finding.py
+++ b/nilearn/_utils/path_finding.py
@@ -1,0 +1,16 @@
+"""
+Path finding utilities
+"""
+import glob
+import os.path
+from .compat import _basestring
+
+def _resolve_globbing(path):
+    if isinstance(path, _basestring):
+        path_list = sorted(glob.glob(os.path.expanduser(path)))
+        # Raise an error in case the list is empty.
+        if len(path_list) == 0:
+            raise ValueError("No files matching path: %s" % path)
+        path = path_list
+
+    return path

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -625,30 +625,30 @@ def _gifti_img_to_mesh(gifti_img):
                 nibabel.nifti1.intent_codes['NIFTI_INTENT_POINTSET'])[0].data
         except IndexError:
             raise ValueError(error_message.format(
-                     'NIFTI_INTENT_POINTSET', gifti_img.get_arrays_from_intent(
-                        nibabel.nifti1.intent_codes['NIFTI_INTENT_POINTSET'])))
+                'NIFTI_INTENT_POINTSET', gifti_img.get_arrays_from_intent(
+                    nibabel.nifti1.intent_codes['NIFTI_INTENT_POINTSET'])))
         try:
             faces = gifti_img.get_arrays_from_intent(
                 nibabel.nifti1.intent_codes['NIFTI_INTENT_TRIANGLE'])[0].data
         except IndexError:
             raise ValueError(error_message.format(
-                     'NIFTI_INTENT_TRIANGLE', gifti_img.get_arrays_from_intent(
-                        nibabel.nifti1.intent_codes['NIFTI_INTENT_TRIANGLE'])))
+                'NIFTI_INTENT_TRIANGLE', gifti_img.get_arrays_from_intent(
+                    nibabel.nifti1.intent_codes['NIFTI_INTENT_TRIANGLE'])))
     else:
         try:
             coords = gifti_img.getArraysFromIntent(
                 nibabel.nifti1.intent_codes['NIFTI_INTENT_POINTSET'])[0].data
         except IndexError:
             raise ValueError(error_message.format(
-                        'NIFTI_INTENT_POINTSET', gifti_img.getArraysFromIntent(
-                        nibabel.nifti1.intent_codes['NIFTI_INTENT_POINTSET'])))
+                'NIFTI_INTENT_POINTSET', gifti_img.getArraysFromIntent(
+                    nibabel.nifti1.intent_codes['NIFTI_INTENT_POINTSET'])))
         try:
             faces = gifti_img.getArraysFromIntent(
                 nibabel.nifti1.intent_codes['NIFTI_INTENT_TRIANGLE'])[0].data
         except IndexError:
             raise ValueError(error_message.format(
-                        'NIFTI_INTENT_TRIANGLE', gifti_img.getArraysFromIntent(
-                        nibabel.nifti1.intent_codes['NIFTI_INTENT_TRIANGLE'])))
+                'NIFTI_INTENT_TRIANGLE', gifti_img.getArraysFromIntent(
+                    nibabel.nifti1.intent_codes['NIFTI_INTENT_TRIANGLE'])))
 
     return coords, faces
 
@@ -680,7 +680,7 @@ def load_surf_mesh(surf_mesh):
         if len(file_list) == 1:
             surf_mesh = file_list[0]
         elif len(file_list) > 1:
-        #empty list is handled inside _resolve_globbing function
+            # empty list is handled inside _resolve_globbing function
             raise ValueError(("More than one file matching path: %s \n"
                              "load_surf_mesh can only load one file at a time")
                              % surf_mesh)
@@ -701,10 +701,10 @@ def load_surf_mesh(surf_mesh):
         else:
             raise ValueError(('The input type is not recognized. %r was given '
                               'while valid inputs are one of the following '
-                              'file formats: .gii, .gii.gz, Freesurfer specific'
-                              ' files such as .orig, .pial, .sphere, .white, '
-                              '.inflated or a list containing two Numpy '
-                              'arrays [vertex coordinates, face indices]'
+                              'file formats: .gii, .gii.gz, Freesurfer '
+                              'specific files such as .orig, .pial, .sphere, '
+                              '.white, .inflated or a list containing two '
+                              'Numpy arrays [vertex coordinates, face indices]'
                               ) % surf_mesh)
     elif isinstance(surf_mesh, (list, tuple)):
         try:

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -615,7 +615,8 @@ def load_surf_data(surf_data):
                 data[:, f] = data1D
             except ValueError:
                 raise ValueError('When more than one file is given as input, '
-                                 'all files must have the same shape.')
+                                 'all files must cotain data of the same '
+                                 'shape.')
 
     # if the input is a numpy array
     elif isinstance(surf_data, np.ndarray):

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -22,6 +22,7 @@ from nibabel import gifti
 from ..image import load_img
 from ..image import resampling
 from .._utils.compat import _basestring
+from .._utils.path_finding import _resolve_globbing
 from .. import _utils
 
 
@@ -617,7 +618,7 @@ def _gifti_img_to_mesh(gifti_img):
     error_message = ('The surf_mesh input is not recognized. Valid Freesurfer '
                      'surface mesh inputs are .pial, .inflated, .sphere, '
                      '.orig, .white. You provided input which have no '
-                     '{0} or of empty value={1}') 
+                     '{0} or of empty value={1}')
     if LooseVersion(nibabel.__version__) >= LooseVersion('2.1.0'):
         try:
             coords = gifti_img.get_arrays_from_intent(
@@ -674,6 +675,16 @@ def load_surf_mesh(surf_mesh):
     """
     # if input is a filename, try to load it
     if isinstance(surf_mesh, _basestring):
+        # resolve globbing
+        file_list = _resolve_globbing(surf_mesh)
+        if len(file_list) == 1:
+            surf_mesh = file_list[0]
+        elif len(file_list) > 1:
+        #empty list is handled inside _resolve_globbing function
+            raise ValueError(("More than one file matching path: %s \n"
+                             "load_surf_mesh can only load one file at a time")
+                             % surf_mesh)
+
         if (surf_mesh.endswith('orig') or surf_mesh.endswith('pial') or
                 surf_mesh.endswith('white') or surf_mesh.endswith('sphere') or
                 surf_mesh.endswith('inflated')):

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -13,10 +13,8 @@ from nose.tools import assert_true, assert_raises
 from nilearn._utils.testing import assert_raises_regex, assert_warns
 
 import numpy as np
-<<<<<<< HEAD
 from scipy.spatial import Delaunay
-=======
->>>>>>> master
+
 
 import nibabel as nb
 from nibabel import gifti
@@ -268,7 +266,7 @@ def test_load_surf_mesh_file_error():
 
 
 def test_load_surf_mesh_file_glob():
-    mesh = _generate_surf()
+    mesh = generate_surf()
     fname1 = tempfile.mktemp(suffix='.pial')
     nb.freesurfer.write_geometry(fname1, mesh[0], mesh[1])
     fname2 = tempfile.mktemp(suffix='.pial')

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -14,7 +14,6 @@ from nilearn._utils.testing import assert_raises_regex, assert_warns
 
 import numpy as np
 from scipy.spatial import Delaunay
-import sklearn
 
 import nibabel as nb
 from nibabel import gifti
@@ -271,25 +270,25 @@ def test_load_surf_mesh_file_error():
 
 
 def test_load_surf_mesh_file_glob():
-     mesh = _generate_surf()
-     fname1 = tempfile.mktemp(suffix='.pial')
-     nb.freesurfer.write_geometry(fname1, mesh[0], mesh[1])
-     fname2 = tempfile.mktemp(suffix='.pial')
-     nb.freesurfer.write_geometry(fname2, mesh[0], mesh[1])
+    mesh = _generate_surf()
+    fname1 = tempfile.mktemp(suffix='.pial')
+    nb.freesurfer.write_geometry(fname1, mesh[0], mesh[1])
+    fname2 = tempfile.mktemp(suffix='.pial')
+    nb.freesurfer.write_geometry(fname2, mesh[0], mesh[1])
 
-     assert_raises_regex(ValueError, 'More than one file matching path',
-                         load_surf_mesh,
-                         os.path.join(os.path.dirname(fname1),"*.pial"))
-     assert_raises_regex(ValueError, 'No files matching path',
-                         load_surf_mesh,
-                         os.path.join(os.path.dirname(fname1),
-                         "*.unlikelysuffix" ))
-     assert_equal(len(load_surf_mesh(fname1)), 2)
-     assert_array_almost_equal(load_surf_mesh(fname1)[0], mesh[0])
-     assert_array_almost_equal(load_surf_mesh(fname1)[1], mesh[1])
+    assert_raises_regex(ValueError, 'More than one file matching path',
+                        load_surf_mesh,
+                        os.path.join(os.path.dirname(fname1), "*.pial"))
+    assert_raises_regex(ValueError, 'No files matching path',
+                        load_surf_mesh,
+                        os.path.join(os.path.dirname(fname1),
+                                     "*.unlikelysuffix"))
+    assert_equal(len(load_surf_mesh(fname1)), 2)
+    assert_array_almost_equal(load_surf_mesh(fname1)[0], mesh[0])
+    assert_array_almost_equal(load_surf_mesh(fname1)[1], mesh[1])
 
-     os.remove(fname1)
-     os.remove(fname2)
+    os.remove(fname1)
+    os.remove(fname2)
 
 
 def _flat_mesh(x_s, y_s, z=0):

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -266,8 +266,30 @@ def test_load_surf_mesh_file_error():
         nb.freesurfer.write_geometry(filename_wrong, mesh[0], mesh[1])
         assert_raises_regex(ValueError,
                             'input type is not recognized',
-                            load_surf_data, filename_wrong)
+                            load_surf_mesh, filename_wrong)
         os.remove(filename_wrong)
+
+
+def test_load_surf_mesh_file_glob():
+     mesh = _generate_surf()
+     fname1 = tempfile.mktemp(suffix='.pial')
+     nb.freesurfer.write_geometry(fname1, mesh[0], mesh[1])
+     fname2 = tempfile.mktemp(suffix='.pial')
+     nb.freesurfer.write_geometry(fname2, mesh[0], mesh[1])
+
+     assert_raises_regex(ValueError, 'More than one file matching path',
+                         load_surf_mesh,
+                         os.path.join(os.path.dirname(fname1),"*.pial"))
+     assert_raises_regex(ValueError, 'No files matching path',
+                         load_surf_mesh,
+                         os.path.join(os.path.dirname(fname1),
+                         "*.unlikelysuffix" ))
+     assert_equal(len(load_surf_mesh(fname1)), 2)
+     assert_array_almost_equal(load_surf_mesh(fname1)[0], mesh[0])
+     assert_array_almost_equal(load_surf_mesh(fname1)[1], mesh[1])
+
+     os.remove(fname1)
+     os.remove(fname2)
 
 
 def _flat_mesh(x_s, y_s, z=0):


### PR DESCRIPTION
Enables and tests globbing in load_surf_mesh and load_surf_data (#1989)

- For load_surf_data, if several files are given they are concatenated and returned as a 2D array

- For load_surf_mesh, only one file at a time can be loaded, if globbing returns several files an error occurs