### PR TITLE
[wip] Harmonize datasets.fetch_atlas output attributes 

### DIFF
--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -99,9 +99,11 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
     lateralized: boolean, optional
         If True, returns an atlas with distinct regions for right and left
         hemispheres.
+
     data_dir: string, optional
         Path of the data directory. Use to forec data storage in a non-
         standard location. Default: None (meaning: default)
+
     url: string, optional
         Download URL of the dataset. Overwrite the default URL.
 
@@ -109,8 +111,9 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
     -------
     data: sklearn.datasets.base.Bunch
         dictionary-like object, contains:
-        - Cortical ROIs, lateralized or not (maps)
-        - Labels of the ROIs (labels)
+        - maps: str, path to atlas, lateralized or not
+        - labels: list, labesl for ROIs
+        - labels_index: list, index corresponding to atlas labels 
 
     References
     ----------
@@ -121,6 +124,7 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
     Destrieux, C., et al. "A sulcal depth-based anatomical parcellation
     of the cerebral cortex." NeuroImage 47 (2009): S151.
     """
+    print('TEST!!!')
     if url is None:
         url = "https://www.nitrc.org/frs/download.php/7739/"
 
@@ -140,7 +144,10 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
     files_ = _fetch_files(data_dir, files, resume=resume,
                           verbose=verbose)
 
-    params = dict(maps=files_[1], labels=np.recfromcsv(files_[0]))
+    labels = np.recfromcsv(files_[0])
+    params = dict(maps=files_[1],
+                  labels_index=labels.field(0).tolist(),
+                  labels = labels.field(1).tolist())
 
     with open(files_[2], 'r') as rst_file:
         params['description'] = rst_file.read()

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1311,9 +1311,13 @@ def fetch_atlas_schaefer_2018(n_rois=400, yeo_networks=7, resolution_mm=1,
     labels_file, atlas_file = _fetch_files(data_dir, files, resume=resume,
                                            verbose=verbose)
 
-    labels = np.genfromtxt(labels_file, usecols=1, dtype="S", delimiter="\t")
-    fdescr = _get_dataset_descr(dataset_name)
+    labels = np.genfromtxt(labels_file, usecols=1, dtype="S", delimiter="\t"
+        ).tolist()
+    labels.insert(0,'Background')
+    labels_idx = range(len(labels))
+    fdescr = _get_dataset_descr(dataset_name).decode('utf-8')
 
     return Bunch(maps=atlas_file,
                  labels=labels,
-                 description=fdescr)
+                 description=fdescr,
+                 labels_index=labels_idx)

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -287,6 +287,8 @@ def fetch_atlas_harvard_oxford(atlas_name, data_dir=None,
     if lateralized:
         return Bunch(maps=atlas_img, labels=names, labels_index=labels_idx)
 
+
+    atlas_img = check_niimg(atlas_img)
     # Build a mask of both halves of the brain
     middle_ind = (atlas.shape[0] - 1) // 2
     # Put zeros on the median plane
@@ -301,8 +303,10 @@ def fetch_atlas_harvard_oxford(atlas_name, data_dir=None,
     new_atlas = atlas.copy()
     # Assumes that the background label is zero.
     new_names = [names[0]]
-    for label, name in zip(labels[1:], names[1:]):
+    new_labels = [0]
+    for label, name in zip(labels_idx[1:], names[1:]):
         new_label += 1
+        new_labels.append(new_label)
         left_elements = (left_atlas == label).sum()
         right_elements = (right_atlas == label).sum()
         n_elements = float(left_elements + right_elements)
@@ -314,11 +318,12 @@ def fetch_atlas_harvard_oxford(atlas_name, data_dir=None,
         new_atlas[right_atlas == label] = new_label
         new_names.append(name + ', left part')
         new_label += 1
+        new_labels.append(new_label)
         new_atlas[left_atlas == label] = new_label
         new_names.append(name + ', right part')
 
     atlas_img = new_img_like(atlas_img, new_atlas, atlas_img.affine)
-    return Bunch(maps=atlas_img, labels=new_names)
+    return Bunch(maps=atlas_img, labels=new_names, labels_index=new_labels)
 
 
 def fetch_atlas_msdl(data_dir=None, url=None, resume=True, verbose=1):

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -678,7 +678,9 @@ def fetch_atlas_aal(version='SPM12', data_dir=None, url=None, resume=True,
         labels.append(label.find('name').text)
 
     params = {'description': fdescr, 'maps': atlas_img,
-              'labels': labels, 'labels_index': indices}
+              'labels': labels, 'labels_index': indices,
+              'indices': indices # for legacy calls
+              } 
 
     return Bunch(**params)
 

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -368,7 +368,7 @@ def fetch_atlas_msdl(data_dir=None, url=None, resume=True, verbose=1):
                                 category=FutureWarning)
         region_coords = csv_data[['x', 'y', 'z']].tolist()
     net_names = [net_name.strip() for net_name in csv_data['net_name'].tolist()]
-    fdescr = _get_dataset_descr(dataset_name)
+    fdescr = _get_dataset_descr(dataset_name).decode('utf-8')
 
     return Bunch(maps=files[1], labels=labels, region_coords=region_coords,
                  networks=net_names, description=fdescr)

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -124,7 +124,6 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
     Destrieux, C., et al. "A sulcal depth-based anatomical parcellation
     of the cerebral cortex." NeuroImage 47 (2009): S151.
     """
-    print('TEST!!!')
     if url is None:
         url = "https://www.nitrc.org/frs/download.php/7739/"
 

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -972,7 +972,7 @@ def fetch_atlas_surf_destrieux(data_dir=None, url=None,
         url = "https://www.nitrc.org/frs/download.php/"
 
     dataset_name = 'destrieux_surface'
-    fdescr = _get_dataset_descr(dataset_name)
+    fdescr = _get_dataset_descr(dataset_name).decode('utf-8')
     data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,
                                 verbose=verbose)
 
@@ -1185,7 +1185,7 @@ def fetch_atlas_pauli_2017(version='prob', data_dir=None, verbose=1):
     if version == 'prob':
         url_maps = 'https://osf.io/w8zq2/download'
         filename = 'pauli_2017_labels.nii.gz'
-    elif version == 'labels':
+    elif version == 'det':
         url_maps = 'https://osf.io/5mqfx/download'
         filename = 'pauli_2017_prob.nii.gz'
     else:

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -511,7 +511,7 @@ def fetch_atlas_smith_2009(data_dir=None, mirror='origin', url=None,
 
     keys = ['rsn20', 'rsn10', 'rsn70', 'bm20', 'bm10', 'bm70']
     params = dict(zip(keys, files_))
-    params['description'] = fdescr
+    params['description'] = fdescr.decode('utf-8')
 
     return Bunch(**params)
 

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -507,11 +507,11 @@ def fetch_atlas_smith_2009(data_dir=None, mirror='origin', url=None,
     files_ = _fetch_files(data_dir, files, resume=resume,
                           verbose=verbose)
 
-    fdescr = _get_dataset_descr(dataset_name)
+    fdescr = _get_dataset_descr(dataset_name).decode('utf-8')
 
     keys = ['rsn20', 'rsn10', 'rsn70', 'bm20', 'bm10', 'bm70']
     params = dict(zip(keys, files_))
-    params['description'] = fdescr.decode('utf-8')
+    params['description'] = fdescr
 
     return Bunch(**params)
 
@@ -666,19 +666,19 @@ def fetch_atlas_aal(version='SPM12', data_dir=None, url=None, resume=True,
     atlas_img, labels_file = _fetch_files(data_dir, filenames, resume=resume,
                                           verbose=verbose)
 
-    fdescr = _get_dataset_descr(dataset_name)
+    fdescr = _get_dataset_descr(dataset_name).decode('utf-8')
 
     # We return the labels contained in the xml file as a dictionary
     xml_tree = xml.etree.ElementTree.parse(labels_file)
     root = xml_tree.getroot()
-    labels = []
-    indices = []
+    labels = ['Background']
+    indices = [0]
     for label in root.getiterator('label'):
         indices.append(label.find('index').text)
         labels.append(label.find('name').text)
 
     params = {'description': fdescr, 'maps': atlas_img,
-              'labels': labels, 'indices': indices}
+              'labels': labels, 'labels_index': indices}
 
     return Bunch(**params)
 


### PR DESCRIPTION
The goal is to ensure that, once fetched, the atlas objects all have consistent attributes. These attributes would have the same name, same data type, and refer to the same or similar objects. At a minimum, that would be:
* description: utf-8 encode string, a description of the atlas
* maps: string, path to the atlas file
* labels: list, string labels corresponding to each atlas label
* labels_index: list, int labels corresponding to each unique value in the atlas (or each index along the 4th dimension)

Other attributes are permissible, as is redundancy (for backwards compatibility), as long as these attributes are present. 

This is related to issues #930 (closed), #1489  and #1635 , and PR #1608 