### PR TITLE
Add check for vmin, vmax in plot_surf_roi

### DIFF
--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -515,7 +515,11 @@ def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
     # messages in case of wrong inputs
 
     roi = load_surf_data(roi_map)
-    vmin, vmax = np.min(roi), 1 + np.max(roi)
+    # vmin, vmax = np.min(roi), 1 + np.max(roi)
+    if vmin is None:
+        vmin = np.min(roi)
+    if vmax is None:
+        vmax = 1 + np.max(roi)
 
     mesh = load_surf_mesh(surf_mesh)
 


### PR DESCRIPTION
Passed vmin, vmax values were being overwritten by default values. Added check to use default vmin, vmax if no parameters are passed.