### PR TITLE
[MRG] import norm from scipy.linalg not sklearn.utils.extmath

### DIFF
--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -177,7 +177,7 @@ preparation::
 
    >>> from nilearn import input_data
    >>> masker = input_data.NiftiMasker()
-   >>> masker # doctest: +ELLIPSIS
+   >>> masker # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
    NiftiMasker(detrend=False, dtype=None, high_pass=None, low_pass=None,
          mask_args=None, mask_img=None, mask_strategy='background',
          memory=Memory(...), memory_level=1, sample_mask=None,

--- a/nilearn/decoding/tests/test_graph_net.py
+++ b/nilearn/decoding/tests/test_graph_net.py
@@ -2,7 +2,7 @@ from nose.tools import assert_true
 import numpy as np
 import scipy as sp
 from numpy.testing import assert_almost_equal
-from sklearn.utils import extmath
+from scipy import linalg
 from sklearn.utils import check_random_state
 from nilearn.decoding.objective_functions import _gradient, _div
 from nilearn.decoding.space_net_solvers import (
@@ -167,12 +167,12 @@ def test__squared_loss_derivative_lipschitz_constant():
     for _ in range(20):
         x_1 = rng.rand(*w.shape) * rng.randint(1000)
         x_2 = rng.rand(*w.shape) * rng.randint(1000)
-        gradient_difference = extmath.norm(
+        gradient_difference = linalg.norm(
             _squared_loss_and_spatial_grad_derivative(X, y, x_1, mask,
                                                       grad_weight)
             - _squared_loss_and_spatial_grad_derivative(X, y, x_2, mask,
                                                         grad_weight))
-        point_difference = extmath.norm(x_1 - x_2)
+        point_difference = linalg.norm(x_1 - x_2)
         assert_true(
             gradient_difference <= lipschitz_constant * point_difference)
 
@@ -186,12 +186,12 @@ def test_logistic_derivative_lipschitz_constant():
     for _ in range(20):
         x_1 = rng.rand((w.shape[0] + 1)) * rng.randint(1000)
         x_2 = rng.rand((w.shape[0] + 1)) * rng.randint(1000)
-        gradient_difference = extmath.norm(
+        gradient_difference = linalg.norm(
             _logistic_data_loss_and_spatial_grad_derivative(
                 X, y, x_1, mask, grad_weight)
             - _logistic_data_loss_and_spatial_grad_derivative(
                 X, y, x_2, mask, grad_weight))
-        point_difference = extmath.norm(x_1 - x_2)
+        point_difference = linalg.norm(x_1 - x_2)
         assert_true(
             gradient_difference <= lipschitz_constant * point_difference)
 
@@ -224,12 +224,12 @@ def test_tikhonov_regularization_vs_graph_net():
         screening_percentile=100., standardize=False)
     graph_net.fit(X_, y.copy())
     coef_ = graph_net.coef_[0]
-    graph_net_perf = 0.5 / y.size * extmath.norm(
+    graph_net_perf = 0.5 / y.size * linalg.norm(
         np.dot(X, coef_) - y) ** 2\
-        + 0.5 * extmath.norm(np.dot(G, coef_)) ** 2
-    optimal_model_perf = 0.5 / y.size * extmath.norm(
+        + 0.5 * linalg.norm(np.dot(G, coef_)) ** 2
+    optimal_model_perf = 0.5 / y.size * linalg.norm(
         np.dot(X, optimal_model) - y) ** 2\
-        + 0.5 * extmath.norm(np.dot(G, optimal_model)) ** 2
+        + 0.5 * linalg.norm(np.dot(G, optimal_model)) ** 2
     assert_almost_equal(graph_net_perf, optimal_model_perf, decimal=1)
 
 

--- a/nilearn/decoding/tests/test_space_net.py
+++ b/nilearn/decoding/tests/test_space_net.py
@@ -4,8 +4,8 @@ from nose import SkipTest
 from nose.tools import (assert_equal, assert_true, assert_false,
                         assert_raises)
 import numpy as np
+from scipy import linalg
 from sklearn.datasets import load_iris
-from sklearn.utils import extmath
 from sklearn.linear_model import Lasso
 from sklearn.utils import check_random_state
 from sklearn.linear_model import LogisticRegression
@@ -241,7 +241,7 @@ def test_lasso_vs_graph_net():
                              penalty="graph-net", max_iter=100)
     lasso.fit(X_, y)
     graph_net.fit(X, y)
-    lasso_perf = 0.5 / y.size * extmath.norm(np.dot(
+    lasso_perf = 0.5 / y.size * linalg.norm(np.dot(
         X_, lasso.coef_) - y) ** 2 + np.sum(np.abs(lasso.coef_))
     graph_net_perf = 0.5 * ((graph_net.predict(X) - y) ** 2).mean()
     np.testing.assert_almost_equal(graph_net_perf, lasso_perf, decimal=3)


### PR DESCRIPTION
fixes #2056 : sklearn.utils.extmath.norm deprecated in 0.19 and removed in 0.21