### PR TITLE
[MRG,MAINT] Fix joblib import

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       NUMPY_VERSION: "*"
       SCIPY_VERSION: "*"
       SCIKIT_LEARN_VERSION: "*"
-      JOBLIB_VERSION: "*"_
+      JOBLIB_VERSION: "*"
       MATPLOTLIB_VERSION: "*"
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
       NUMPY_VERSION: "*"
       SCIPY_VERSION: "*"
       SCIKIT_LEARN_VERSION: "*"
+      JOBLIB_VERSION: "*"_
       MATPLOTLIB_VERSION: "*"
 
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,20 +22,22 @@ matrix:
     # without matplotlib
     - env: DISTRIB="conda" PYTHON_VERSION="3.5"
            NUMPY_VERSION="1.11" SCIPY_VERSION="0.19" PANDAS_VERSION="*"
-           SCIKIT_LEARN_VERSION="0.19" COVERAGE="true"
+           SCIKIT_LEARN_VERSION="0.19" COVERAGE="true" JOBLIB_VERSION="*"
            LXML_VERSION="*"
     - env: DISTRIB="conda" PYTHON_VERSION="3.5"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
+           JOBLIB_VERSION="0.11"
            LXML_VERSION="*"
     - env: DISTRIB="conda" PYTHON_VERSION="3.6"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
+           JOBLIB_VERSION="*"
            LXML_VERSION="*"
     - env: DISTRIB="conda" PYTHON_VERSION="3.7"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
-           LXML_VERSION="*"
+           JOBLIB_VERSION="0.12" LXML_VERSION="*"
 
   # FLAKE8 linting on diff wrt common ancestor with upstream/master
     # Note: the python value is only there to trigger allow_failures

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ The required dependencies to use the software are:
 * Numpy >= 1.11
 * SciPy >= 0.19
 * Scikit-learn >= 0.19
+* Joblib >= 0.11
 * Nibabel >= 2.0.2
 
 If you are using nilearn plotting functionalities or running the

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   # See similar fix which made for travis and circleci
   # https://github.com/nilearn/nilearn/pull/1525
   # Should be removed after a new matplotlib release 2.1.1
-  - "conda install pip numpy scipy scikit-learn nose wheel matplotlib -y -q"
+  - "conda install pip numpy scipy scikit-learn joblib nose wheel matplotlib -y -q"
 
   # Install other nilearn dependencies
   - "pip install nibabel coverage nose-timer"

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -36,7 +36,7 @@ print_conda_requirements() {
     TO_INSTALL_ALWAYS="pip nose"
     REQUIREMENTS="$TO_INSTALL_ALWAYS"
     TO_INSTALL_MAYBE="python numpy scipy matplotlib scikit-learn pandas \
-flake8 lxml"
+flake8 lxml joblib"
     for PACKAGE in $TO_INSTALL_MAYBE; do
         # Capitalize package name and add _VERSION
         PACKAGE_VERSION_VARNAME="${PACKAGE^^}_VERSION"
@@ -90,7 +90,7 @@ if [[ "$DISTRIB" == "neurodebian" ]]; then
     create_new_venv
     pip install nose-timer
     bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
-    sudo apt-get install -qq python-scipy python-nose python-nibabel python-sklearn
+    sudo apt-get install -qq python-scipy python-nose python-nibabel python-sklearn python-joblib
 
 elif [[ "$DISTRIB" == "conda" ]]; then
     create_new_conda_env

--- a/continuous_integration/show-python-packages-versions.py
+++ b/continuous_integration/show-python-packages-versions.py
@@ -1,6 +1,6 @@
 import sys
 
-DEPENDENCIES = ['numpy', 'scipy', 'sklearn', 'matplotlib', 'nibabel']
+DEPENDENCIES = ['numpy', 'scipy', 'sklearn', 'joblib', 'matplotlib', 'nibabel']
 
 
 def print_package_version(package_name, indent='  '):

--- a/doc/install_doc_component.html
+++ b/doc/install_doc_component.html
@@ -53,7 +53,8 @@ $(document).ready(function(){
        as an alternative.</p>
 
       <p>Nilearn requires a Python installation and the following
-      dependencies: ipython, scipy, scikit-learn, matplotlib and nibabel.</p>
+          dependencies: ipython, scipy, scikit-learn, joblib, matplotlib
+          and nibabel.</p>
 
       <p class="emphasize">Second: open a Command Prompt</p>
       <p><strong>(Press "Win-R", type "cmd" and press "Enter". This will open
@@ -83,7 +84,8 @@ $(document).ready(function(){
       it will save you time and trouble.</p>
 
       <p>Nilearn requires a Python installation and the following
-      dependencies: ipython, scipy, scikit-learn, matplotlib and nibabel.</p>
+          dependencies: ipython, scipy, scikit-learn, joblib,
+          matplotlib and nibabel.</p>
 
       <p class="emphasize">Second: open a Terminal</p>
       <p><strong>(Navigate to /Applications/Utilities and double-click on
@@ -114,7 +116,8 @@ $(document).ready(function(){
       <p>Install or ask your system administrator to install the following
       packages using the distribution package manager: <strong>ipython</strong>
       , <strong>scipy</strong>, <strong>scikit-learn</strong> (sometimes called <cite>sklearn</cite>,
-      or <cite>python-sklearn</cite>), <strong>matplotlib</strong> (sometimes
+          or <cite>python-sklearn</cite>), <strong>joblib</strong>,
+          <strong>matplotlib</strong> (sometimes
       called <cite>python-matplotlib</cite>) and <strong>nibabel</strong>
       (sometimes called <cite>python-nibabel</cite>).</p>
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -13,6 +13,8 @@ NEW
  | - Scikit-learn -- v0.19
  | - Scipy -- v0.19
 
+- joblib is now a dependency
+
 - Parcellation method ReNA: Fast agglomerative clustering based on recursive
   nearest neighbor grouping.
   Yields very fast & accurate models, without creation of giant

--- a/examples/03_connectivity/plot_multi_subject_connectome.py
+++ b/examples/03_connectivity/plot_multi_subject_connectome.py
@@ -52,7 +52,7 @@ from nilearn import image
 from nilearn import input_data
 
 # A "memory" to avoid recomputation
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 mem = Memory('nilearn_cache')
 
 masker = input_data.NiftiMapsMasker(

--- a/examples/03_connectivity/plot_multi_subject_connectome.py
+++ b/examples/03_connectivity/plot_multi_subject_connectome.py
@@ -52,7 +52,7 @@ from nilearn import image
 from nilearn import input_data
 
 # A "memory" to avoid recomputation
-from nilearn._utils.compat.joblib import Memory
+from nilearn._utils.compat import Memory
 mem = Memory('nilearn_cache')
 
 masker = input_data.NiftiMapsMasker(

--- a/examples/03_connectivity/plot_multi_subject_connectome.py
+++ b/examples/03_connectivity/plot_multi_subject_connectome.py
@@ -52,7 +52,7 @@ from nilearn import image
 from nilearn import input_data
 
 # A "memory" to avoid recomputation
-from joblib import Memory
+from nilearn._utils.compat.joblib import Memory
 mem = Memory('nilearn_cache')
 
 masker = input_data.NiftiMapsMasker(

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -13,7 +13,7 @@ from distutils.version import LooseVersion
 import nibabel
 import sklearn
 
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 
 MEMORY_CLASSES = (Memory, )
 

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -13,15 +13,9 @@ from distutils.version import LooseVersion
 import nibabel
 import sklearn
 
-from nilearn._utils.compat.joblib import Memory
+from nilearn._utils.compat import Memory
 
 MEMORY_CLASSES = (Memory, )
-
-try:
-    from nilearn._utils.compat.joblib import Memory as JoblibMemory
-    MEMORY_CLASSES = (Memory, JoblibMemory)
-except ImportError:
-    pass
 
 import nilearn
 

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -13,12 +13,12 @@ from distutils.version import LooseVersion
 import nibabel
 import sklearn
 
-from joblib import Memory
+from nilearn._utils.compat.joblib import Memory
 
 MEMORY_CLASSES = (Memory, )
 
 try:
-    from joblib import Memory as JoblibMemory
+    from nilearn._utils.compat.joblib import Memory as JoblibMemory
     MEMORY_CLASSES = (Memory, JoblibMemory)
 except ImportError:
     pass

--- a/nilearn/_utils/compat.py
+++ b/nilearn/_utils/compat.py
@@ -7,6 +7,7 @@ import hashlib
 from distutils.version import LooseVersion
 
 import nibabel
+import sklearn
 
 
 if sys.version_info[0] == 3:
@@ -66,3 +67,9 @@ else:
         m = hashlib.md5()
         m.update(string)
         return m.hexdigest()
+
+
+if sklearn.__version__ < '0.21':
+    from sklearn.utils.compat import joblib
+else:
+    import joblib

--- a/nilearn/_utils/compat.py
+++ b/nilearn/_utils/compat.py
@@ -70,7 +70,7 @@ else:
 
 
 if sklearn.__version__ < '0.21':
-    from sklearn.utils.compat import joblib
+    from sklearn.externals import joblib
 else:
     import joblib
 

--- a/nilearn/_utils/compat.py
+++ b/nilearn/_utils/compat.py
@@ -73,3 +73,9 @@ if sklearn.__version__ < '0.21':
     from sklearn.utils.compat import joblib
 else:
     import joblib
+
+Memory = joblib.Memory
+Parallel = joblib.Parallel
+hash = joblib.hash
+delayed = joblib.delayed
+cpu_count = joblib.cpu_count

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -10,7 +10,7 @@ import glob
 import nilearn as ni
 import numpy as np
 import itertools
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 
 from .cache_mixin import cache
 from .niimg import _safe_get_data, load_niimg

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -10,7 +10,7 @@ import glob
 import nilearn as ni
 import numpy as np
 import itertools
-from joblib import Memory
+from nilearn._utils.compat.joblib import Memory
 
 from .cache_mixin import cache
 from .niimg import _safe_get_data, load_niimg

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -10,7 +10,7 @@ import glob
 import nilearn as ni
 import numpy as np
 import itertools
-from nilearn._utils.compat.joblib import Memory
+from nilearn._utils.compat import Memory
 
 from .cache_mixin import cache
 from .niimg import _safe_get_data, load_niimg

--- a/nilearn/connectome/group_sparse_cov.py
+++ b/nilearn/connectome/group_sparse_cov.py
@@ -15,7 +15,7 @@ import scipy.linalg
 
 from sklearn.base import BaseEstimator
 from sklearn.covariance import empirical_covariance
-from joblib import Memory, delayed, Parallel
+from nilearn._utils.compat.joblib import Memory, delayed, Parallel
 from sklearn.model_selection import check_cv
 from sklearn.utils.extmath import fast_logdet
 

--- a/nilearn/connectome/group_sparse_cov.py
+++ b/nilearn/connectome/group_sparse_cov.py
@@ -15,7 +15,7 @@ import scipy.linalg
 
 from sklearn.base import BaseEstimator
 from sklearn.covariance import empirical_covariance
-from nilearn._utils.compat.joblib import Memory, delayed, Parallel
+from nilearn._utils.compat import Memory, delayed, Parallel
 from sklearn.model_selection import check_cv
 from sklearn.utils.extmath import fast_logdet
 

--- a/nilearn/connectome/group_sparse_cov.py
+++ b/nilearn/connectome/group_sparse_cov.py
@@ -15,7 +15,7 @@ import scipy.linalg
 
 from sklearn.base import BaseEstimator
 from sklearn.covariance import empirical_covariance
-from sklearn.externals.joblib import Memory, delayed, Parallel
+from joblib import Memory, delayed, Parallel
 from sklearn.model_selection import check_cv
 from sklearn.utils.extmath import fast_logdet
 

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -16,7 +16,7 @@ import warnings
 
 import numpy as np
 
-from nilearn._utils.compat.joblib import Parallel, delayed, cpu_count
+from nilearn._utils.compat import Parallel, delayed, cpu_count
 from sklearn import svm
 from sklearn.base import BaseEstimator
 from sklearn.exceptions import ConvergenceWarning

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -16,7 +16,7 @@ import warnings
 
 import numpy as np
 
-from sklearn.externals.joblib import Parallel, delayed, cpu_count
+from joblib import Parallel, delayed, cpu_count
 from sklearn import svm
 from sklearn.base import BaseEstimator
 from sklearn.exceptions import ConvergenceWarning

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -16,7 +16,7 @@ import warnings
 
 import numpy as np
 
-from joblib import Parallel, delayed, cpu_count
+from nilearn._utils.compat.joblib import Parallel, delayed, cpu_count
 from sklearn import svm
 from sklearn.base import BaseEstimator
 from sklearn.exceptions import ConvergenceWarning

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -24,7 +24,7 @@ from sklearn.utils import check_array
 from sklearn.linear_model.base import LinearModel
 from sklearn.feature_selection import (SelectPercentile, f_regression,
                                        f_classif)
-from nilearn._utils.compat.joblib import Memory, Parallel, delayed
+from nilearn._utils.compat import Memory, Parallel, delayed
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.metrics import accuracy_score
 from ..input_data.masker_validation import check_embedded_nifti_masker

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -24,7 +24,7 @@ from sklearn.utils import check_array
 from sklearn.linear_model.base import LinearModel
 from sklearn.feature_selection import (SelectPercentile, f_regression,
                                        f_classif)
-from sklearn.externals.joblib import Memory, Parallel, delayed
+from joblib import Memory, Parallel, delayed
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.metrics import accuracy_score
 from ..input_data.masker_validation import check_embedded_nifti_masker

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -24,7 +24,7 @@ from sklearn.utils import check_array
 from sklearn.linear_model.base import LinearModel
 from sklearn.feature_selection import (SelectPercentile, f_regression,
                                        f_classif)
-from joblib import Memory, Parallel, delayed
+from nilearn._utils.compat.joblib import Memory, Parallel, delayed
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.metrics import accuracy_score
 from ..input_data.masker_validation import check_embedded_nifti_masker

--- a/nilearn/decoding/tests/test_searchlight.py
+++ b/nilearn/decoding/tests/test_searchlight.py
@@ -100,10 +100,10 @@ def test_searchlight():
     rand = np.random.RandomState(0)
     data = rand.rand(5, 5, 5)
     data_img = nibabel.Nifti1Image(data, affine=np.eye(4))
-    imgs = [data_img, data_img, data_img, data_img, data_img, data_img]
+    imgs = [data_img] * 12
 
     # labels
-    y = [0, 1, 0, 1, 0, 1]
+    y = [0, 1] * 6
 
     # run searchlight on list of 3D images
     sl = searchlight.SearchLight(mask_img)

--- a/nilearn/decomposition/base.py
+++ b/nilearn/decomposition/base.py
@@ -14,7 +14,7 @@ from scipy import linalg
 import sklearn
 import nilearn
 from sklearn.base import BaseEstimator, TransformerMixin
-from joblib import Memory, Parallel, delayed
+from nilearn._utils.compat.joblib import Memory, Parallel, delayed
 from sklearn.linear_model import LinearRegression
 from sklearn.utils import check_random_state
 from sklearn.utils.extmath import randomized_svd, svd_flip

--- a/nilearn/decomposition/base.py
+++ b/nilearn/decomposition/base.py
@@ -14,7 +14,7 @@ from scipy import linalg
 import sklearn
 import nilearn
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.externals.joblib import Memory, Parallel, delayed
+from joblib import Memory, Parallel, delayed
 from sklearn.linear_model import LinearRegression
 from sklearn.utils import check_random_state
 from sklearn.utils.extmath import randomized_svd, svd_flip

--- a/nilearn/decomposition/base.py
+++ b/nilearn/decomposition/base.py
@@ -14,7 +14,7 @@ from scipy import linalg
 import sklearn
 import nilearn
 from sklearn.base import BaseEstimator, TransformerMixin
-from nilearn._utils.compat.joblib import Memory, Parallel, delayed
+from nilearn._utils.compat import Memory, Parallel, delayed
 from sklearn.linear_model import LinearRegression
 from sklearn.utils import check_random_state
 from sklearn.utils.extmath import randomized_svd, svd_flip

--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -10,7 +10,7 @@ from operator import itemgetter
 import numpy as np
 from scipy.stats import scoreatpercentile
 from sklearn.decomposition import fastica
-from sklearn.externals.joblib import Memory, delayed, Parallel
+from joblib import Memory, delayed, Parallel
 from sklearn.utils import check_random_state
 
 from .multi_pca import MultiPCA

--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -10,7 +10,7 @@ from operator import itemgetter
 import numpy as np
 from scipy.stats import scoreatpercentile
 from sklearn.decomposition import fastica
-from joblib import Memory, delayed, Parallel
+from nilearn._utils.compat.joblib import Memory, delayed, Parallel
 from sklearn.utils import check_random_state
 
 from .multi_pca import MultiPCA

--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -10,7 +10,7 @@ from operator import itemgetter
 import numpy as np
 from scipy.stats import scoreatpercentile
 from sklearn.decomposition import fastica
-from nilearn._utils.compat.joblib import Memory, delayed, Parallel
+from nilearn._utils.compat import Memory, delayed, Parallel
 from sklearn.utils import check_random_state
 
 from .multi_pca import MultiPCA

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -15,7 +15,7 @@ from distutils.version import LooseVersion
 import numpy as np
 import sklearn
 from sklearn.decomposition import dict_learning_online
-from joblib import Memory
+from nilearn._utils.compat.joblib import Memory
 from sklearn.linear_model import Ridge
 
 from .base import BaseDecomposition

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -15,7 +15,7 @@ from distutils.version import LooseVersion
 import numpy as np
 import sklearn
 from sklearn.decomposition import dict_learning_online
-from nilearn._utils.compat.joblib import Memory
+from nilearn._utils.compat import Memory
 from sklearn.linear_model import Ridge
 
 from .base import BaseDecomposition

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -15,7 +15,7 @@ from distutils.version import LooseVersion
 import numpy as np
 import sklearn
 from sklearn.decomposition import dict_learning_online
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 from sklearn.linear_model import Ridge
 
 from .base import BaseDecomposition

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -3,7 +3,7 @@ PCA dimension reduction on multiple subjects.
 This is a good initialization method for ICA.
 """
 import numpy as np
-from joblib import Memory
+from nilearn._utils.compat.joblib import Memory
 from sklearn.utils.extmath import randomized_svd
 
 from .base import BaseDecomposition

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -3,7 +3,7 @@ PCA dimension reduction on multiple subjects.
 This is a good initialization method for ICA.
 """
 import numpy as np
-from nilearn._utils.compat.joblib import Memory
+from nilearn._utils.compat import Memory
 from sklearn.utils.extmath import randomized_svd
 
 from .base import BaseDecomposition

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -3,7 +3,7 @@ PCA dimension reduction on multiple subjects.
 This is a good initialization method for ICA.
 """
 import numpy as np
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 from sklearn.utils.extmath import randomized_svd
 
 from .base import BaseDecomposition

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -14,7 +14,7 @@ from scipy import ndimage
 from scipy.stats import scoreatpercentile
 import copy
 import nibabel
-from joblib import Parallel, delayed
+from nilearn._utils.compat.joblib import Parallel, delayed
 
 from .. import signal
 from .._utils import (check_niimg_4d, check_niimg_3d, check_niimg, as_ndarray,

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -14,7 +14,7 @@ from scipy import ndimage
 from scipy.stats import scoreatpercentile
 import copy
 import nibabel
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 
 from .. import signal
 from .._utils import (check_niimg_4d, check_niimg_3d, check_niimg, as_ndarray,

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -14,7 +14,7 @@ from scipy import ndimage
 from scipy.stats import scoreatpercentile
 import copy
 import nibabel
-from nilearn._utils.compat.joblib import Parallel, delayed
+from nilearn._utils.compat import Parallel, delayed
 
 from .. import signal
 from .._utils import (check_niimg_4d, check_niimg_3d, check_niimg, as_ndarray,

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -10,7 +10,7 @@ import abc
 import numpy as np
 
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 
 from .. import masking
 from .. import image

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -10,7 +10,7 @@ import abc
 import numpy as np
 
 from sklearn.base import BaseEstimator, TransformerMixin
-from nilearn._utils.compat.joblib import Memory
+from nilearn._utils.compat import Memory
 
 from .. import masking
 from .. import image

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -10,7 +10,7 @@ import abc
 import numpy as np
 
 from sklearn.base import BaseEstimator, TransformerMixin
-from joblib import Memory
+from nilearn._utils.compat.joblib import Memory
 
 from .. import masking
 from .. import image

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -8,7 +8,7 @@ import collections
 import itertools
 import warnings
 
-from joblib import Memory, Parallel, delayed
+from nilearn._utils.compat.joblib import Memory, Parallel, delayed
 
 from .. import _utils
 from .. import image

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -8,7 +8,7 @@ import collections
 import itertools
 import warnings
 
-from nilearn._utils.compat.joblib import Memory, Parallel, delayed
+from nilearn._utils.compat import Memory, Parallel, delayed
 
 from .. import _utils
 from .. import image

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -8,7 +8,7 @@ import collections
 import itertools
 import warnings
 
-from sklearn.externals.joblib import Memory, Parallel, delayed
+from joblib import Memory, Parallel, delayed
 
 from .. import _utils
 from .. import image

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -4,7 +4,7 @@ Transformer for computing ROI signals.
 
 import numpy as np
 
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 
 from .. import _utils
 from .._utils import logger, CacheMixin, _compose_err_msg

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -4,7 +4,7 @@ Transformer for computing ROI signals.
 
 import numpy as np
 
-from joblib import Memory
+from nilearn._utils.compat.joblib import Memory
 
 from .. import _utils
 from .._utils import logger, CacheMixin, _compose_err_msg

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -4,7 +4,7 @@ Transformer for computing ROI signals.
 
 import numpy as np
 
-from nilearn._utils.compat.joblib import Memory
+from nilearn._utils.compat import Memory
 
 from .. import _utils
 from .._utils import logger, CacheMixin, _compose_err_msg

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -3,7 +3,7 @@ Transformer for computing ROI signals.
 """
 
 import numpy as np
-from joblib import Memory
+from nilearn._utils.compat.joblib import Memory
 
 from .. import _utils
 from .._utils import logger, CacheMixin

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -3,7 +3,7 @@ Transformer for computing ROI signals.
 """
 
 import numpy as np
-from nilearn._utils.compat.joblib import Memory
+from nilearn._utils.compat import Memory
 
 from .. import _utils
 from .._utils import logger, CacheMixin

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -3,7 +3,7 @@ Transformer for computing ROI signals.
 """
 
 import numpy as np
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 
 from .. import _utils
 from .._utils import logger, CacheMixin

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -6,7 +6,7 @@ Transformer used to apply basic transformations on MRI data.
 
 from copy import copy as copy_object
 
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 
 from .base_masker import BaseMasker, filter_and_extract
 from .. import _utils

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -6,7 +6,7 @@ Transformer used to apply basic transformations on MRI data.
 
 from copy import copy as copy_object
 
-from nilearn._utils.compat.joblib import Memory
+from nilearn._utils.compat import Memory
 
 from .base_masker import BaseMasker, filter_and_extract
 from .. import _utils

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -6,7 +6,7 @@ Transformer used to apply basic transformations on MRI data.
 
 from copy import copy as copy_object
 
-from joblib import Memory
+from nilearn._utils.compat.joblib import Memory
 
 from .base_masker import BaseMasker, filter_and_extract
 from .. import _utils

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -7,7 +7,7 @@ Mask nifti images by spherical volumes for seed-region analyses
 import numpy as np
 import warnings
 from sklearn import neighbors
-from joblib import Memory
+from nilearn._utils.compat.joblib import Memory
 
 from ..image.resampling import coord_transform
 from .._utils.niimg_conversions import _safe_get_data

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -7,7 +7,7 @@ Mask nifti images by spherical volumes for seed-region analyses
 import numpy as np
 import warnings
 from sklearn import neighbors
-from nilearn._utils.compat.joblib import Memory
+from nilearn._utils.compat import Memory
 
 from ..image.resampling import coord_transform
 from .._utils.niimg_conversions import _safe_get_data

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -7,7 +7,7 @@ Mask nifti images by spherical volumes for seed-region analyses
 import numpy as np
 import warnings
 from sklearn import neighbors
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 
 from ..image.resampling import coord_transform
 from .._utils.niimg_conversions import _safe_get_data

--- a/nilearn/input_data/tests/test_masker_validation.py
+++ b/nilearn/input_data/tests/test_masker_validation.py
@@ -3,7 +3,7 @@ import nibabel
 import numpy as np
 
 from sklearn.base import BaseEstimator
-from joblib import Memory
+from nilearn._utils.compat.joblib import Memory
 
 from nilearn._utils.testing import assert_warns
 from nilearn.input_data.masker_validation import check_embedded_nifti_masker

--- a/nilearn/input_data/tests/test_masker_validation.py
+++ b/nilearn/input_data/tests/test_masker_validation.py
@@ -3,7 +3,7 @@ import nibabel
 import numpy as np
 
 from sklearn.base import BaseEstimator
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 
 from nilearn._utils.testing import assert_warns
 from nilearn.input_data.masker_validation import check_embedded_nifti_masker

--- a/nilearn/input_data/tests/test_masker_validation.py
+++ b/nilearn/input_data/tests/test_masker_validation.py
@@ -3,7 +3,7 @@ import nibabel
 import numpy as np
 
 from sklearn.base import BaseEstimator
-from nilearn._utils.compat.joblib import Memory
+from nilearn._utils.compat import Memory
 
 from nilearn._utils.testing import assert_warns
 from nilearn.input_data.masker_validation import check_embedded_nifti_masker

--- a/nilearn/input_data/tests/test_multi_nifti_masker.py
+++ b/nilearn/input_data/tests/test_multi_nifti_masker.py
@@ -14,7 +14,7 @@ from nibabel import Nifti1Image
 from nose import SkipTest
 from nose.tools import assert_true, assert_false, assert_raises, assert_equal
 from numpy.testing import assert_array_equal
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 
 from nilearn._utils.exceptions import DimensionError
 from nilearn._utils.testing import assert_raises_regex, write_tmp_imgs
@@ -116,7 +116,7 @@ def test_3d_images():
 
 
 def test_joblib_cache():
-    from sklearn.externals.joblib import hash
+    from joblib import hash
     # Dummy mask
     mask = np.zeros((40, 40, 40))
     mask[20, 20, 20] = 1

--- a/nilearn/input_data/tests/test_multi_nifti_masker.py
+++ b/nilearn/input_data/tests/test_multi_nifti_masker.py
@@ -14,7 +14,7 @@ from nibabel import Nifti1Image
 from nose import SkipTest
 from nose.tools import assert_true, assert_false, assert_raises, assert_equal
 from numpy.testing import assert_array_equal
-from joblib import Memory
+from nilearn._utils.compat.joblib import Memory
 
 from nilearn._utils.exceptions import DimensionError
 from nilearn._utils.testing import assert_raises_regex, write_tmp_imgs
@@ -116,7 +116,7 @@ def test_3d_images():
 
 
 def test_joblib_cache():
-    from joblib import hash
+    from nilearn._utils.compat.joblib import hash
     # Dummy mask
     mask = np.zeros((40, 40, 40))
     mask[20, 20, 20] = 1

--- a/nilearn/input_data/tests/test_multi_nifti_masker.py
+++ b/nilearn/input_data/tests/test_multi_nifti_masker.py
@@ -14,7 +14,7 @@ from nibabel import Nifti1Image
 from nose import SkipTest
 from nose.tools import assert_true, assert_false, assert_raises, assert_equal
 from numpy.testing import assert_array_equal
-from nilearn._utils.compat.joblib import Memory
+from nilearn._utils.compat import Memory
 
 from nilearn._utils.exceptions import DimensionError
 from nilearn._utils.testing import assert_raises_regex, write_tmp_imgs
@@ -116,7 +116,7 @@ def test_3d_images():
 
 
 def test_joblib_cache():
-    from nilearn._utils.compat.joblib import hash
+    from nilearn._utils.compat import hash
     # Dummy mask
     mask = np.zeros((40, 40, 40))
     mask[20, 20, 20] = 1

--- a/nilearn/input_data/tests/test_nifti_masker.py
+++ b/nilearn/input_data/tests/test_nifti_masker.py
@@ -233,7 +233,7 @@ def test_sessions():
 
 
 def test_joblib_cache():
-    from nilearn._utils.compat.joblib import hash, Memory
+    from nilearn._utils.compat import hash, Memory
     mask = np.zeros((40, 40, 40))
     mask[20, 20, 20] = 1
     mask_img = Nifti1Image(mask, np.eye(4))

--- a/nilearn/input_data/tests/test_nifti_masker.py
+++ b/nilearn/input_data/tests/test_nifti_masker.py
@@ -233,7 +233,7 @@ def test_sessions():
 
 
 def test_joblib_cache():
-    from joblib import hash, Memory
+    from nilearn._utils.compat.joblib import hash, Memory
     mask = np.zeros((40, 40, 40))
     mask[20, 20, 20] = 1
     mask_img = Nifti1Image(mask, np.eye(4))

--- a/nilearn/input_data/tests/test_nifti_masker.py
+++ b/nilearn/input_data/tests/test_nifti_masker.py
@@ -233,7 +233,7 @@ def test_sessions():
 
 
 def test_joblib_cache():
-    from sklearn.externals.joblib import hash, Memory
+    from joblib import hash, Memory
     mask = np.zeros((40, 40, 40))
     mask[20, 20, 20] = 1
     mask_img = Nifti1Image(mask, np.eye(4))

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -8,7 +8,7 @@ import numbers
 
 import numpy as np
 from scipy import ndimage
-from joblib import Parallel, delayed
+from nilearn._utils.compat.joblib import Parallel, delayed
 
 from . import _utils
 from .image import new_img_like

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -8,7 +8,7 @@ import numbers
 
 import numpy as np
 from scipy import ndimage
-from nilearn._utils.compat.joblib import Parallel, delayed
+from nilearn._utils.compat import Parallel, delayed
 
 from . import _utils
 from .image import new_img_like

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -8,7 +8,7 @@ import numbers
 
 import numpy as np
 from scipy import ndimage
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 
 from . import _utils
 from .image import new_img_like

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -8,7 +8,7 @@ import warnings
 import numpy as np
 from scipy import linalg
 from sklearn.utils import check_random_state
-import joblib as joblib
+from nilearn._utils.compat import joblib
 
 
 def normalize_matrix_on_axis(m, axis=0):

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -8,7 +8,7 @@ import warnings
 import numpy as np
 from scipy import linalg
 from sklearn.utils import check_random_state
-import sklearn.externals.joblib as joblib
+import joblib as joblib
 
 
 def normalize_matrix_on_axis(m, axis=0):

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from sklearn.base import clone
 from sklearn.feature_extraction import image
-from sklearn.externals.joblib import Memory, delayed, Parallel
+from joblib import Memory, delayed, Parallel
 
 from .rena_clustering import ReNA
 from ..decomposition.multi_pca import MultiPCA

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from sklearn.base import clone
 from sklearn.feature_extraction import image
-from nilearn._utils.compat.joblib import Memory, delayed, Parallel
+from nilearn._utils.compat import Memory, delayed, Parallel
 
 from .rena_clustering import ReNA
 from ..decomposition.multi_pca import MultiPCA

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from sklearn.base import clone
 from sklearn.feature_extraction import image
-from joblib import Memory, delayed, Parallel
+from nilearn._utils.compat.joblib import Memory, delayed, Parallel
 
 from .rena_clustering import ReNA
 from ..decomposition.multi_pca import MultiPCA

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy import ndimage
 from scipy.stats import scoreatpercentile
 
-from nilearn._utils.compat.joblib import Memory
+from nilearn._utils.compat import Memory
 
 from .. import masking
 from ..input_data import NiftiMapsMasker

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy import ndimage
 from scipy.stats import scoreatpercentile
 
-from joblib import Memory
+from nilearn._utils.compat.joblib import Memory
 
 from .. import masking
 from ..input_data import NiftiMapsMasker

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy import ndimage
 from scipy.stats import scoreatpercentile
 
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 
 from .. import masking
 from ..input_data import NiftiMapsMasker

--- a/nilearn/regions/rena_clustering.py
+++ b/nilearn/regions/rena_clustering.py
@@ -8,9 +8,9 @@ import numpy as np
 import warnings
 from scipy.sparse import csgraph, coo_matrix, dia_matrix
 try:
-    from nilearn._utils.compat.joblib import Memory
+    from nilearn._utils.compat import Memory
 except ImportError:
-    from nilearn._utils.compat.joblib import Memory
+    from nilearn._utils.compat import Memory
 from sklearn.base import TransformerMixin, ClusterMixin
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_is_fitted

--- a/nilearn/regions/rena_clustering.py
+++ b/nilearn/regions/rena_clustering.py
@@ -8,9 +8,9 @@ import numpy as np
 import warnings
 from scipy.sparse import csgraph, coo_matrix, dia_matrix
 try:
-    from joblib import Memory
+    from nilearn._utils.compat.joblib import Memory
 except ImportError:
-    from joblib import Memory
+    from nilearn._utils.compat.joblib import Memory
 from sklearn.base import TransformerMixin, ClusterMixin
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_is_fitted

--- a/nilearn/regions/rena_clustering.py
+++ b/nilearn/regions/rena_clustering.py
@@ -8,7 +8,7 @@ import numpy as np
 import warnings
 from scipy.sparse import csgraph, coo_matrix, dia_matrix
 try:
-    from sklearn.externals.joblib import Memory
+    from joblib import Memory
 except ImportError:
     from joblib import Memory
 from sklearn.base import TransformerMixin, ClusterMixin

--- a/nilearn/regions/tests/test_rena_clustering.py
+++ b/nilearn/regions/tests/test_rena_clustering.py
@@ -1,9 +1,9 @@
 import numpy as np
 from nose.tools import assert_equal, assert_not_equal, assert_raises
 try:
-    from joblib import Memory
+    from nilearn._utils.compat.joblib import Memory
 except ImportError:
-    from joblib import Memory
+    from nilearn._utils.compat.joblib import Memory
 from nilearn._utils.data_gen import generate_fake_fmri
 from nilearn.regions.rena_clustering import ReNA
 from nilearn.input_data import NiftiMasker

--- a/nilearn/regions/tests/test_rena_clustering.py
+++ b/nilearn/regions/tests/test_rena_clustering.py
@@ -1,9 +1,9 @@
 import numpy as np
 from nose.tools import assert_equal, assert_not_equal, assert_raises
 try:
-    from nilearn._utils.compat.joblib import Memory
+    from nilearn._utils.compat import Memory
 except ImportError:
-    from nilearn._utils.compat.joblib import Memory
+    from nilearn._utils.compat import Memory
 from nilearn._utils.data_gen import generate_fake_fmri
 from nilearn.regions.rena_clustering import ReNA
 from nilearn.input_data import NiftiMasker

--- a/nilearn/regions/tests/test_rena_clustering.py
+++ b/nilearn/regions/tests/test_rena_clustering.py
@@ -1,7 +1,7 @@
 import numpy as np
 from nose.tools import assert_equal, assert_not_equal, assert_raises
 try:
-    from sklearn.externals.joblib import Memory
+    from joblib import Memory
 except ImportError:
     from joblib import Memory
 from nilearn._utils.data_gen import generate_fake_fmri

--- a/nilearn/tests/test_cache_mixin.py
+++ b/nilearn/tests/test_cache_mixin.py
@@ -10,7 +10,7 @@ from distutils.version import LooseVersion
 
 import sklearn
 from nose.tools import assert_false, assert_true, assert_equal
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 
 import nilearn
 from nilearn._utils import cache_mixin, CacheMixin

--- a/nilearn/tests/test_cache_mixin.py
+++ b/nilearn/tests/test_cache_mixin.py
@@ -10,7 +10,7 @@ from distutils.version import LooseVersion
 
 import sklearn
 from nose.tools import assert_false, assert_true, assert_equal
-from nilearn._utils.compat.joblib import Memory
+from nilearn._utils.compat import Memory
 
 import nilearn
 from nilearn._utils import cache_mixin, CacheMixin

--- a/nilearn/tests/test_cache_mixin.py
+++ b/nilearn/tests/test_cache_mixin.py
@@ -10,7 +10,7 @@ from distutils.version import LooseVersion
 
 import sklearn
 from nose.tools import assert_false, assert_true, assert_equal
-from joblib import Memory
+from nilearn._utils.compat.joblib import Memory
 
 import nilearn
 from nilearn._utils import cache_mixin, CacheMixin

--- a/nilearn/tests/test_niimg.py
+++ b/nilearn/tests/test_niimg.py
@@ -6,7 +6,7 @@ from nose.tools import assert_equal
 import nibabel as nb
 from nibabel import Nifti1Image
 from nibabel.tmpdirs import InTemporaryDirectory
-from sklearn.externals import joblib
+import joblib
 
 from nilearn.image import new_img_like
 from nilearn._utils import niimg

--- a/nilearn/tests/test_niimg.py
+++ b/nilearn/tests/test_niimg.py
@@ -6,7 +6,7 @@ from nose.tools import assert_equal
 import nibabel as nb
 from nibabel import Nifti1Image
 from nibabel.tmpdirs import InTemporaryDirectory
-import joblib
+from nilearn._utils.compat import joblib
 
 from nilearn.image import new_img_like
 from nilearn._utils import niimg

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -41,6 +41,10 @@ REQUIRED_MODULE_METADATA = (
         'min_version': '0.19',
         'required_at_installation': True,
         'install_info': _NILEARN_INSTALL_MSG}),
+    ('joblib', {
+        'min_version': '0.11',
+        'required_at_installation': True,
+        'install_info': _NILEARN_INSTALL_MSG}),
     ('nibabel', {
         'min_version': '2.0.2',
         'required_at_installation': False}))

--- a/requirements-build-docs.txt
+++ b/requirements-build-docs.txt
@@ -17,4 +17,5 @@ pandas
 nose-timer
 nibabel
 scikit-learn
+joblib
 matplotlib

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,6 @@ boto3
 patsy
 scipy
 scikit-learn
+joblib
 pandas
 matplotlib


### PR DESCRIPTION
sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23

this PR is to import joblib directly rather than from sklearn.externals

this adds joblib as a dependency to nilearn