### PR TITLE
Add copy=True parameter to threshold_img

### DIFF
--- a/examples/02_decoding/plot_miyawaki_encoding.py
+++ b/examples/02_decoding/plot_miyawaki_encoding.py
@@ -152,7 +152,7 @@ cut_score[cut_score < 0] = 0
 # bring the scores into the shape of the background brain
 score_map_img = masker.inverse_transform(cut_score)
 
-thresholded_score_map_img = threshold_img(score_map_img, threshold=1e-6)
+thresholded_score_map_img = threshold_img(score_map_img, threshold=1e-6, copy=False)
 
 ##############################################################################
 # Plotting the statistical map on a background brain, we mark four voxels

--- a/examples/04_manipulating_images/plot_extract_rois_statistical_maps.py
+++ b/examples/04_manipulating_images/plot_extract_rois_statistical_maps.py
@@ -28,12 +28,12 @@ from nilearn.image import threshold_img
 
 # Two types of strategies can be used from this threshold function
 # Type 1: strategy used will be based on scoreatpercentile
-threshold_percentile_img = threshold_img(tmap_filename, threshold='97%')
+threshold_percentile_img = threshold_img(tmap_filename, threshold='97%', copy=False)
 
 
 # Type 2: threshold strategy used will be based on image intensity
 # Here, threshold value should be within the limits i.e. less than max value.
-threshold_value_img = threshold_img(tmap_filename, threshold=3.0)
+threshold_value_img = threshold_img(tmap_filename, threshold=3.0, copy=False)
 
 ################################################################################
 # Visualization

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -172,8 +172,8 @@ def _smooth_array(arr, affine, fwhm=None, ensure_finite=True, copy=True):
         filtering.
 
     copy: bool
-        if True, input array is not modified. False by default: the filtering
-        is performed in-place.
+        if True, input array is not modified. True by default: the filtering
+        is not performed in-place.
 
     Returns
     -------
@@ -705,7 +705,7 @@ def new_img_like(ref_niimg, data, affine=None, copy_header=False):
     return klass(data, affine, header=header)
 
 
-def threshold_img(img, threshold, mask_img=None):
+def threshold_img(img, threshold, mask_img=None, copy=True):
     """ Threshold the given input image, mostly statistical or atlas images.
 
     Thresholding can be done based on direct image intensities or selection
@@ -732,6 +732,10 @@ def threshold_img(img, threshold, mask_img=None):
         Mask image applied to mask the input data.
         If None, no masking will be applied.
 
+    copy: bool
+        if True, input array is not modified. True by default: the filtering
+        is not performed in-place.
+
     Returns
     -------
     threshold_img: Nifti1Image
@@ -742,6 +746,8 @@ def threshold_img(img, threshold, mask_img=None):
 
     img = check_niimg(img)
     img_data = _safe_get_data(img, ensure_finite=True)
+    if copy:
+        img_data = img_data.copy()
     affine = img.affine
 
     if mask_img is not None:

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -499,6 +499,27 @@ def test_threshold_img():
         # when threshold is a percentile
         thr_maps_percent2 = threshold_img(img, threshold='2%')
 
+def test_threshold_img_copy():
+
+    img_zeros = Nifti1Image(np.zeros((10, 10, 10, 10)), np.eye(4))
+    img_ones = Nifti1Image(np.ones((10, 10, 10, 10)), np.eye(4))
+
+    # Check that copy does not mutate. It returns modified copy.
+    thresholded = threshold_img(img_ones, 2)  # threshold 2 > 1
+
+    # Original img_ones should have all ones.
+    assert_array_equal(img_ones.get_data(), np.ones((10, 10, 10, 10)))
+    # Thresholded should have all zeros.
+    assert_array_equal(thresholded.get_data(), np.zeros((10, 10, 10, 10)))
+
+    # Check that not copying does mutate.
+    img_to_mutate = Nifti1Image(np.ones((10, 10, 10, 10)), np.eye(4))
+    thresholded = threshold_img(img_to_mutate, 2, copy=False)
+    # Check that original mutates
+    assert_array_equal(img_to_mutate.get_data(), np.zeros((10, 10, 10, 10)))
+    # And that returned value is also thresholded.
+    assert_array_equal(img_to_mutate.get_data(), thresholded.get_data())
+
 
 def test_isnan_threshold_img_data():
     shape = (10, 10, 10)

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -403,7 +403,7 @@ class RegionExtractor(NiftiMapsMasker):
             else:
                 if self.thresholding_strategy == 'percentile':
                     self.threshold = "{0}%".format(self.threshold)
-                threshold_maps = threshold_img(maps_img, mask_img=self.mask_img,
+                threshold_maps = threshold_img(maps_img, mask_img=self.mask_img, copy=True,
                                                threshold=self.threshold)
 
         # connected component extraction


### PR DESCRIPTION
The threshold_img was not following the conventions of the other
image functions and was performing in-place thresholding without
offering the possibility to turn it off. This is now fixed.