### PR TITLE
[NO MRG] Replace GraphLassoCV (deprecated since skl0.20) with GraphicalLassoCV

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+branch = True
+source = nilearn
+parallel = True
+omit =
+	plot_.*.py
+	conf\.py
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
 
 install: source continuous_integration/install.sh
 
-before_script: make clean
+before_script: make  clean
 
 script: source continuous_integration/test_script.sh
 

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,9 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-    pwd
     pytest -s -vv --duration=0
 	# $(TEST_RUNNER) -s $(TEST_RUNNER_OPTIONS)
 test-doc:
-    pwd
     pytest -s -vv --duration=0
 	# $(TEST_RUNNER) -s --with-doctest --doctest-tests --doctest-extension=rst \
 	# --doctest-extension=inc --doctest-fixtures=_fixture `find doc/ -name '*.rst'`

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@
 
 PYTHON ?= python
 CYTHON ?= cython
-TEST_RUNNER ?= pytest
-TEST_RUNNER_OPTIONS := --durations=0 -vv
 CTAGS ?= ctags
 
 all: clean test doc-noplot
@@ -31,15 +29,15 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	python -m $(TEST_RUNNER) --pyargs nilearn --cov=nilearn
+	python -m pytest --pyargs nilearn --cov=nilearn
 
 test-doc:
-	$(TEST_RUNNER) -s --doctest-glob='*.rst' `find doc/ -name '*.rst'`
+	pytest --doctest-glob='*.rst' `find doc/ -name '*.rst'`
 
 
 test-coverage:
 	rm -rf coverage .coverage
-	$(PYTEST) --pyargs nilearn --showlocals -vv --cov=nilearn --cov-report=html:coverage
+	pytest --pyargs nilearn --showlocals --cov=nilearn --cov-report=html:coverage
 
 test: test-code test-doc
 

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	python -m pytest /tmp/nilearn/ -s -vv --durations=0
+	python -m pytest -s -vv --durations=0
 test-doc:
-	python -m pytest /tmp/nilearn/ -s -vv --durations=0
+	python -m pytest -s -vv --durations=0
 
 test-coverage:
 	rm -rf coverage .coverage

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,7 @@ test-code:
 	python -m $(TEST_RUNNER) --pyargs nilearn --cov=nilearn -s -vv --durations=0
 
 test-doc:
-	$(TEST_RUNNER) -s --with-doctest --doctest-tests --doctest-extension=rst \
-	--doctest-extension=inc --doctest-fixtures=_fixture `find doc/ -name '*.rst'`
+	$(TEST_RUNNER) -s --doctest-glob='*.rst'
 
 
 test-coverage:

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,14 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	$(TEST_RUNNER) nilearn $(TEST_RUNNER_OPTIONS)
+    pwd
+    pytest -s -vv --duration=0
+	# $(TEST_RUNNER) -s $(TEST_RUNNER_OPTIONS)
 test-doc:
-	$(TEST_RUNNER) -s --with-doctest --doctest-tests --doctest-extension=rst \
-	--doctest-extension=inc --doctest-fixtures=_fixture `find doc/ -name '*.rst'`
+    pwd
+    pytest -s -vv --duration=0
+	# $(TEST_RUNNER) -s --with-doctest --doctest-tests --doctest-extension=rst \
+	# --doctest-extension=inc --doctest-fixtures=_fixture `find doc/ -name '*.rst'`
 
 test-coverage:
 	rm -rf coverage .coverage

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-    pytest -s -vv --duration=0
+	pytest -s -vv --duration=0
 test-doc:
-    pytest -s -vv --duration=0
+	pytest -s -vv --duration=0
 
 test-coverage:
 	rm -rf coverage .coverage

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,11 @@ inplace:
 
 test-code:
     pytest -s -vv --duration=0
-	# $(TEST_RUNNER) -s $(TEST_RUNNER_OPTIONS)
+#	$(TEST_RUNNER) -s $(TEST_RUNNER_OPTIONS)
 test-doc:
     pytest -s -vv --duration=0
-	# $(TEST_RUNNER) -s --with-doctest --doctest-tests --doctest-extension=rst \
-	# --doctest-extension=inc --doctest-fixtures=_fixture `find doc/ -name '*.rst'`
+#	$(TEST_RUNNER) -s --with-doctest --doctest-tests --doctest-extension=rst \
+#	--doctest-extension=inc --doctest-fixtures=_fixture `find doc/ -name '*.rst'`
 
 test-coverage:
 	rm -rf coverage .coverage

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	pytest -s -vv --duration=0
+	pytest nilearn -s -vv --duration=0
 test-doc:
-	pytest -s -vv --duration=0
+	pytest nilearn -s -vv --duration=0
 
 test-coverage:
 	rm -rf coverage .coverage

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	python -m pytest nilearn -s -vv --durations=0
+	python -m pytest --pyargs nilearn -s -vv --durations=0
 test-doc:
-	python -m pytest nilearn -s -vv --durations=0
+	python -m pytest --pyargs nilearn -s -vv --durations=0
 
 test-coverage:
 	rm -rf coverage .coverage

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	python -m pytest --pyargs nilearn -s -vv --durations=0
+	python -m pytest --pyargs nilearn -s -v --durations=0
 test-doc:
-	python -m pytest --pyargs nilearn -s -vv --durations=0
+	python -m pytest --pyargs nilearn -s -v --durations=0
 
 test-coverage:
 	rm -rf coverage .coverage

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	pytest nilearn -s -vv --duration=0
+	pytest nilearn/ -s -vv --duration=0
 test-doc:
-	pytest nilearn -s -vv --duration=0
+	pytest nilearn/ -s -vv --duration=0
 
 test-coverage:
 	rm -rf coverage .coverage

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,6 @@ PYTHON ?= python
 CYTHON ?= cython
 TEST_RUNNER ?= pytest
 TEST_RUNNER_OPTIONS := --duration=0 -vv
-# TEST_RUNNER ?= nosetests
-# TEST_RUNNER_OPTIONS := $(shell pip list | grep nose-timer > /dev/null && \
-#                       echo '--with-timer --timer-top-n 50')
 CTAGS ?= ctags
 
 all: clean test doc-noplot
@@ -35,11 +32,8 @@ inplace:
 
 test-code:
     pytest -s -vv --duration=0
-#	$(TEST_RUNNER) -s $(TEST_RUNNER_OPTIONS)
 test-doc:
     pytest -s -vv --duration=0
-#	$(TEST_RUNNER) -s --with-doctest --doctest-tests --doctest-extension=rst \
-#	--doctest-extension=inc --doctest-fixtures=_fixture `find doc/ -name '*.rst'`
 
 test-coverage:
 	rm -rf coverage .coverage

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 PYTHON ?= python
 CYTHON ?= cython
 TEST_RUNNER ?= pytest
-TEST_RUNNER_OPTIONS := --duration=0 -vv
+TEST_RUNNER_OPTIONS := --durations=0 -vv
 CTAGS ?= ctags
 
 all: clean test doc-noplot
@@ -31,16 +31,15 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	python -m $(TEST_RUNNER) --pyargs nilearn --cov=nilearn -s -vv --durations=0
+	python -m $(TEST_RUNNER) --pyargs nilearn --doctest-modules --cov=nilearn -s -vv --durations=0
 
 test-doc:
-	$(TEST_RUNNER) -s --doctest-glob='*.rst' --doctest-modules
+	$(TEST_RUNNER) -s --doctest-glob='*.rst' `find doc/ -name '*.rst'`
 
 
 test-coverage:
 	rm -rf coverage .coverage
-	$(TEST_RUNNER) -s --cov=nilearn --cover-html --cover-html-dir=coverage \
-	--cover-package=nilearn nilearn
+	$(PYTEST) --pyargs nilearn --showlocals -vv --cov=nilearn --cov-report=html:coverage
 
 test: test-code test-doc
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	python -m $(TEST_RUNNER) --pyargs nilearn --doctest-modules --cov=nilearn -s -vv --durations=0
+	python -m $(TEST_RUNNER) --pyargs nilearn --cov=nilearn
 
 test-doc:
 	$(TEST_RUNNER) -s --doctest-glob='*.rst' `find doc/ -name '*.rst'`

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,11 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	python -m $(TEST_RUNNER) --pyargs nilearn -s -v --durations=0
+	python -m $(TEST_RUNNER) --pyargs nilearn --cov=nilearn -s -v --durations=0
 test-doc:
-	python -m $(TEST_RUNNER) --pyargs nilearn -s -v --durations=0
+	$(NOSETESTS) -s --with-doctest --doctest-tests --doctest-extension=rst \
+	--doctest-extension=inc --doctest-fixtures=_fixture `find doc/ -name '*.rst'`
+
 
 test-coverage:
 	rm -rf coverage .coverage

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	pytest nilearn/ -s -vv --duration=0
+	python -m pytest -s -vv --duration=0
 test-doc:
-	pytest nilearn/ -s -vv --duration=0
+	python -m pytest -s -vv --duration=0
 
 test-coverage:
 	rm -rf coverage .coverage

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,10 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	python -m $(TEST_RUNNER) --pyargs nilearn --cov=nilearn -s -v --durations=0
+	python -m $(TEST_RUNNER) --pyargs nilearn --cov=nilearn -s -vv --durations=0
+
 test-doc:
-	$(NOSETESTS) -s --with-doctest --doctest-tests --doctest-extension=rst \
+	$(TEST_RUNNER) -s --with-doctest --doctest-tests --doctest-extension=rst \
 	--doctest-extension=inc --doctest-fixtures=_fixture `find doc/ -name '*.rst'`
 
 

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	python -m pytest -s -vv --durations=0
+	python -m pytest nilearn -s -vv --durations=0
 test-doc:
-	python -m pytest -s -vv --durations=0
+	python -m pytest nilearn -s -vv --durations=0
 
 test-coverage:
 	rm -rf coverage .coverage

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	$(TEST_RUNNER) nilearn TEST_RUNNER_OPTIONS
+	$(TEST_RUNNER) nilearn $(TEST_RUNNER_OPTIONS)
 test-doc:
 	$(TEST_RUNNER) -s --with-doctest --doctest-tests --doctest-extension=rst \
 	--doctest-extension=inc --doctest-fixtures=_fixture `find doc/ -name '*.rst'`

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	python -m pytest -s -vv --duration=0
+	python -m pytest /tmp/nilearn/ -s -vv --duration=0
 test-doc:
-	python -m pytest -s -vv --duration=0
+	python -m pytest /tmp/nilearn/ -s -vv --duration=0
 
 test-coverage:
 	rm -rf coverage .coverage

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,11 @@
 
 PYTHON ?= python
 CYTHON ?= cython
-NOSETESTS ?= nosetests
-NOSETESTS_OPTIONS := $(shell pip list | grep nose-timer > /dev/null && \
-                       echo '--with-timer --timer-top-n 50')
+TEST_RUNNER ?= pytest
+TEST_RUNNER_OPTIONS := --duration=0 -vv
+# TEST_RUNNER ?= nosetests
+# TEST_RUNNER_OPTIONS := $(shell pip list | grep nose-timer > /dev/null && \
+#                       echo '--with-timer --timer-top-n 50')
 CTAGS ?= ctags
 
 all: clean test doc-noplot
@@ -32,14 +34,14 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	$(NOSETESTS) -s nilearn $(NOSETESTS_OPTIONS)
+	$(TEST_RUNNER) nilearn TEST_RUNNER_OPTIONS
 test-doc:
-	$(NOSETESTS) -s --with-doctest --doctest-tests --doctest-extension=rst \
+	$(TEST_RUNNER) -s --with-doctest --doctest-tests --doctest-extension=rst \
 	--doctest-extension=inc --doctest-fixtures=_fixture `find doc/ -name '*.rst'`
 
 test-coverage:
 	rm -rf coverage .coverage
-	$(NOSETESTS) -s --with-coverage --cover-html --cover-html-dir=coverage \
+	$(TEST_RUNNER) -s --with-coverage --cover-html --cover-html-dir=coverage \
 	--cover-package=nilearn nilearn
 
 test: test-code test-doc

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test-code:
 	python -m $(TEST_RUNNER) --pyargs nilearn --cov=nilearn -s -vv --durations=0
 
 test-doc:
-	$(TEST_RUNNER) -s --doctest-glob='*.rst'
+	$(TEST_RUNNER) -s --doctest-glob='*.rst' --doctest-modules
 
 
 test-coverage:

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	python -m pytest /tmp/nilearn/ -s -vv --duration=0
+	python -m pytest /tmp/nilearn/ -s -vv --durations=0
 test-doc:
-	python -m pytest /tmp/nilearn/ -s -vv --duration=0
+	python -m pytest /tmp/nilearn/ -s -vv --durations=0
 
 test-coverage:
 	rm -rf coverage .coverage

--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,13 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	python -m pytest --pyargs nilearn -s -v --durations=0
+	python -m $(TEST_RUNNER) --pyargs nilearn -s -v --durations=0
 test-doc:
-	python -m pytest --pyargs nilearn -s -v --durations=0
+	python -m $(TEST_RUNNER) --pyargs nilearn -s -v --durations=0
 
 test-coverage:
 	rm -rf coverage .coverage
-	$(TEST_RUNNER) -s --with-coverage --cover-html --cover-html-dir=coverage \
+	$(TEST_RUNNER) -s --cov=nilearn --cover-html --cover-html-dir=coverage \
 	--cover-package=nilearn nilearn
 
 test: test-code test-doc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   # See similar fix which made for travis and circleci
   # https://github.com/nilearn/nilearn/pull/1525
   # Should be removed after a new matplotlib release 2.1.1
-  - "conda install pip numpy scipy scikit-learn nose wheel matplotlib -y -q"
+  - "conda install pip numpy scipy scikit-learn nose pytest wheel matplotlib -y -q"
 
   # Install other nilearn dependencies
   - "pip install nibabel coverage nose-timer"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
 
   - script: |
       pip install .
-      nosetests ./nilearn -v
+      pytest ./nilearn -v
     displayName: 'test'
 
   - task: PublishTestResults@2

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,0 @@
-try:
-    import matplotlib
-except ImportError:
-    collect_ignore = ["nilearn/plotting"]

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,4 @@
+try:
+    import matplotlib
+except ImportError:
+    collect_ignore = ["nilearn/plotting"]

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -121,5 +121,3 @@ fi
 if [[ "$SKIP_TESTS" != "true" ]]; then
     python setup.py install
 fi
-
-find . -type f -name "nilearn"

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -33,7 +33,7 @@ print_conda_requirements() {
     # if yes which version to install. For example:
     #   - for numpy, NUMPY_VERSION is used
     #   - for scikit-learn, SCIKIT_LEARN_VERSION is used
-    TO_INSTALL_ALWAYS="pip nose"
+    TO_INSTALL_ALWAYS="pip nose pytest"
     REQUIREMENTS="$TO_INSTALL_ALWAYS"
     TO_INSTALL_MAYBE="python numpy scipy matplotlib scikit-learn pandas \
 flake8 lxml"

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -121,3 +121,5 @@ fi
 if [[ "$SKIP_TESTS" != "true" ]]; then
     python setup.py install
 fi
+
+find . -type f -name "nilearn"

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -22,7 +22,7 @@ create_new_venv() {
     deactivate
     virtualenv --system-site-packages testvenv
     source testvenv/bin/activate
-    pip install nose
+    pip install nose pytest
 }
 
 print_conda_requirements() {

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -75,6 +75,7 @@ create_new_conda_env() {
     echo "conda requirements string: $REQUIREMENTS"
     conda create -n testenv --quiet --yes $REQUIREMENTS
     source activate testenv
+    conda install pytest --yes
 
     if [[ "$INSTALL_MKL" == "true" ]]; then
         # Make sure that MKL is used

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -75,7 +75,7 @@ create_new_conda_env() {
     echo "conda requirements string: $REQUIREMENTS"
     conda create -n testenv --quiet --yes $REQUIREMENTS
     source activate testenv
-    conda install pytest --yes
+    conda install pytest pytest-cov --yes
 
     if [[ "$INSTALL_MKL" == "true" ]]; then
         # Make sure that MKL is used

--- a/doc/connectivity/connectome_extraction.rst
+++ b/doc/connectivity/connectome_extraction.rst
@@ -50,11 +50,11 @@ conditioned on all the others.
 
 To recover well the interaction structure, a **sparse inverse covariance
 estimator** is necessary. The GraphLasso, implemented in scikit-learn's
-estimator :class:`sklearn.covariance.GraphLassoCV` is a good, simple
+estimator :class:`sklearn.covariance.GraphicalLassoCV` is a good, simple
 solution. To use it, you need to create an estimator object::
 
-    >>> from sklearn.covariance import GraphLassoCV
-    >>> estimator = GraphLassoCV()
+    >>> from sklearn.covariance import GraphicalLassoCV
+    >>> estimator = GraphicalLassoCV()
 
 And then you can fit it on the activation time series, for instance
 extracted in :ref:`the previous section <functional_connectomes>`::
@@ -126,7 +126,7 @@ differing connection values across subjects.
 
 For this, nilearn provides the
 :class:`nilearn.connectome.GroupSparseCovarianceCV`
-estimator. Its usage is similar to the GraphLassoCV object, but it takes
+estimator. Its usage is similar to the GraphicalLassoCV object, but it takes
 a list of time series::
 
     >>> estimator.fit([time_series_1, time_series_2, ...])  # doctest: +SKIP
@@ -186,7 +186,7 @@ with different precision matrices, but sharing a common sparsity pattern:
 10 brain regions, for 20 subjects.
 
 A single-subject estimation can be performed using the
-:class:`sklearn.covariance.GraphLassoCV` estimator from scikit-learn.
+:class:`sklearn.covariance.GraphicalLassoCV` estimator from scikit-learn.
 
 It is also possible to fit a graph lasso on data from every subject all
 together.

--- a/doc/connectivity/connectome_extraction.rst
+++ b/doc/connectivity/connectome_extraction.rst
@@ -49,7 +49,7 @@ conditioned on all the others.
 
 
 To recover well the interaction structure, a **sparse inverse covariance
-estimator** is necessary. The GraphLasso, implemented in scikit-learn's
+estimator** is necessary. The GraphicalLasso, implemented in scikit-learn's
 estimator :class:`sklearn.covariance.GraphicalLassoCV` is a good, simple
 solution. To use it, you need to create an estimator object::
 
@@ -95,7 +95,7 @@ of the estimator::
     The parameter controlling the sparsity is set by `cross-validation
     <http://scikit-learn.org/stable/modules/cross_validation.html>`_
     scheme. If you want to specify it manually, use the estimator
-    :class:`sklearn.covariance.GraphLasso`.
+    :class:`sklearn.covariance.GraphicalLasso`.
 
 .. topic:: **Full example**
 

--- a/doc/developers/group_sparse_covariance.rst
+++ b/doc/developers/group_sparse_covariance.rst
@@ -369,7 +369,7 @@ used), then a tighter grid near the found maximum is computed, and so
 on. This allows for a very precise determination of the maximum
 location while reducing a lot the required evaluation number. The code
 is very close to what is done in
-:class:`sklearn.covariance.GraphLassoCV`.
+:class:`sklearn.covariance.GraphicalLassoCV`.
 
 
 Warm restart

--- a/examples/03_connectivity/plot_inverse_covariance_connectome.py
+++ b/examples/03_connectivity/plot_inverse_covariance_connectome.py
@@ -51,8 +51,8 @@ time_series = masker.fit_transform(data.func[0],
 ##############################################################################
 # Compute the sparse inverse covariance
 # --------------------------------------
-from sklearn.covariance import GraphLassoCV
-estimator = GraphLassoCV()
+from sklearn.covariance import GraphicalLassoCV
+estimator = GraphicalLassoCV()
 
 estimator.fit(time_series)
 

--- a/examples/03_connectivity/plot_multi_subject_connectome.py
+++ b/examples/03_connectivity/plot_multi_subject_connectome.py
@@ -102,10 +102,10 @@ plotting.plot_connectome(gl.covariance_,
                          display_mode="lzr")
 plotting.plot_connectome(-gl.precision_, atlas_region_coords,
                          edge_threshold='90%',
-                         title="Sparse inverse covariance (GraphLasso)",
+                         title="Sparse inverse covariance (GraphicalLasso)",
                          display_mode="lzr",
                          edge_vmax=.5, edge_vmin=-.5)
-plot_matrices(gl.covariance_, gl.precision_, "GraphLasso", labels)
+plot_matrices(gl.covariance_, gl.precision_, "GraphicalLasso", labels)
 
 title = "GroupSparseCovariance"
 plotting.plot_connectome(-gsc.precisions_[..., 0],

--- a/examples/03_connectivity/plot_multi_subject_connectome.py
+++ b/examples/03_connectivity/plot_multi_subject_connectome.py
@@ -85,7 +85,7 @@ gsc = GroupSparseCovarianceCV(verbose=2)
 gsc.fit(subject_time_series)
 
 from sklearn import covariance
-gl = covariance.GraphLassoCV(verbose=2)
+gl = covariance.GraphicalLassoCV(verbose=2)
 gl.fit(np.concatenate(subject_time_series))
 
 

--- a/examples/03_connectivity/plot_simulated_connectome.py
+++ b/examples/03_connectivity/plot_simulated_connectome.py
@@ -49,8 +49,8 @@ for n in range(n_displayed):
 
 
 # Fit one graph lasso per subject
-from sklearn.covariance import GraphLassoCV
-gl = GraphLassoCV(verbose=1)
+from sklearn.covariance import GraphicalLassoCV
+gl = GraphicalLassoCV(verbose=1)
 
 for n, subject in enumerate(subjects[:n_displayed]):
     gl.fit(subject)

--- a/examples/03_connectivity/plot_sphere_based_connectome.py
+++ b/examples/03_connectivity/plot_sphere_based_connectome.py
@@ -211,13 +211,13 @@ print('time series has {0} samples'.format(timeseries.shape[0]))
 ###############################################################################
 # in which situation the graphical lasso **sparse inverse covariance**
 # estimator captures well the covariance **structure**.
-from sklearn.covariance import GraphLassoCV
+from sklearn.covariance import GraphicalLassoCV
 
-covariance_estimator = GraphLassoCV(cv=3, verbose=1)
+covariance_estimator = GraphicalLassoCV(cv=3, verbose=1)
 
 
 ###############################################################################
-# We just fit our regions signals into the `GraphLassoCV` object
+# We just fit our regions signals into the `GraphicalLassoCV` object
 covariance_estimator.fit(timeseries)
 
 
@@ -271,7 +271,7 @@ spheres_masker = input_data.NiftiSpheresMasker(
 timeseries = spheres_masker.fit_transform(func_filename,
                                           confounds=confounds_filename)
 
-covariance_estimator = GraphLassoCV()
+covariance_estimator = GraphicalLassoCV()
 covariance_estimator.fit(timeseries)
 matrix = covariance_estimator.covariance_
 
@@ -321,7 +321,7 @@ spheres_masker = input_data.NiftiSpheresMasker(
 timeseries = spheres_masker.fit_transform(func_filename,
                                           confounds=confounds_filename)
 
-covariance_estimator = GraphLassoCV()
+covariance_estimator = GraphicalLassoCV()
 covariance_estimator.fit(timeseries)
 matrix = covariance_estimator.covariance_
 

--- a/nilearn/conftest.py
+++ b/nilearn/conftest.py
@@ -14,7 +14,7 @@ else:
 
 
 def pytest_collection_modifyitems(items):
-    
+
     # numpy changed the str/repr formatting of numpy arrays in 1.14. We want to
     # run doctests only for numpy >= 1.14.Adapted from scikit-learn
     if LooseVersion(np.__version__) < LooseVersion('1.14'):
@@ -22,7 +22,7 @@ def pytest_collection_modifyitems(items):
         skip_doctests = True
     else:
         skip_doctests = False
-        
+
     if skip_doctests:
         skip_marker = pytest.mark.skip(reason=reason)
         for item in items:

--- a/nilearn/conftest.py
+++ b/nilearn/conftest.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     collect_ignore = ['plotting']
 else:
-    matplotlib
+    matplotlib  # Prevents flake8 erring due to unused entities.
 
 
 def pytest_collection_modifyitems(items):

--- a/nilearn/conftest.py
+++ b/nilearn/conftest.py
@@ -1,6 +1,30 @@
+from distutils.version import LooseVersion
+
+import numpy as np
+import pytest
+
+from _pytest.doctest import DoctestItem
+
 try:
     import matplotlib
 except ImportError:
     collect_ignore = ['plotting']
 else:
     matplotlib
+
+
+def pytest_collection_modifyitems(items):
+    
+    # numpy changed the str/repr formatting of numpy arrays in 1.14. We want to
+    # run doctests only for numpy >= 1.14.Adapted from scikit-learn
+    if LooseVersion(np.__version__) < LooseVersion('1.14'):
+        reason = 'doctests are only run for numpy >= 1.14'
+        skip_doctests = True
+    else:
+        skip_doctests = False
+        
+    if skip_doctests:
+        skip_marker = pytest.mark.skip(reason=reason)
+        for item in items:
+            if isinstance(item, DoctestItem):
+                item.add_marker(skip_marker)

--- a/nilearn/conftest.py
+++ b/nilearn/conftest.py
@@ -1,0 +1,6 @@
+try:
+    import matplotlib
+except ImportError:
+    collect_ignore = ['plotting']
+else:
+    matplotlib

--- a/nilearn/connectome/group_sparse_cov.py
+++ b/nilearn/connectome/group_sparse_cov.py
@@ -891,7 +891,7 @@ class GroupSparseCovarianceCV(BaseEstimator, CacheMixin):
     See also
     --------
     GroupSparseCovariance,
-    sklearn.covariance.GraphLassoCV
+    sklearn.covariance.GraphicalLassoCV
 
     Notes
     -----

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -34,11 +34,11 @@ def normalize_matrix_on_axis(m, axis=0):
     ...     normalize_matrix_on_axis)
     >>> X = np.array([[0, 4], [1, 0]])
     >>> normalize_matrix_on_axis(X)
-    array([[ 0.,  1.],
-           [ 1.,  0.]])
+    array([[0., 1.],
+           [1., 0.]])
     >>> normalize_matrix_on_axis(X, axis=1)
-    array([[ 0.,  1.],
-           [ 1.,  0.]])
+    array([[0., 1.],
+           [1., 0.]])
 
     """
     if m.ndim > 2:

--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -228,8 +228,8 @@ def find_cut_slices(img, direction='z', n_cuts=7, spacing='auto'):
     large and all the activated regions are covered, cuts with a spacing
     less than 'spacing' will be returned.
 
-    Warning
-    -------
+    Warnings
+    --------
     If a non-diagonal img is given. This function automatically reorders
     img to get it back to diagonal. This is to avoid finding same cuts in
     the slices.

--- a/nilearn/tests/test_extmath.py
+++ b/nilearn/tests/test_extmath.py
@@ -15,7 +15,7 @@ def test_fast_abs_percentile():
     data = np.arange(100)
     rng.shuffle(data)
     for p in data:
-        yield nose.tools.assert_equal, fast_abs_percentile(data, p), p
+        nose.tools.assert_equal(fast_abs_percentile(data, p), p)
 
 
 def test_is_spd_with_non_symmetrical_matrix():

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
+junit_family = xunit2
+addopts = --doctest-modules -s -vv --durations=0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,7 @@
 nose
 pytest
+pytest-cov
 coverage
-boto3
-patsy
 scipy
 scikit-learn
 pandas

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 nose
+pytest
 coverage
 boto3
 patsy

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,9 +14,6 @@ with-doctest=1
 doctest-extension=rst
 ignore-files=(plot_.*.py|conf\.py)
 
-[tool:pytest]
-doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
-
 [wheel]
 universal=1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,17 +3,6 @@
 [bdist_rpm]
 doc-files = doc
 
-[nosetests]
-;verbosity = 2
-;detailed-errors = 1
-;with-coverage = 1
-;cover-package = nilearn
-#pdb = 1
-#pdb-failures = 1
-;with-doctest=1
-;doctest-extension=rst
-;ignore-files=(plot_.*.py|conf\.py)
-
 [wheel]
 universal=1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,15 +4,15 @@
 doc-files = doc
 
 [nosetests]
-verbosity = 2
-detailed-errors = 1
-with-coverage = 1
-cover-package = nilearn
+;verbosity = 2
+;detailed-errors = 1
+;with-coverage = 1
+;cover-package = nilearn
 #pdb = 1
 #pdb-failures = 1
-with-doctest=1
-doctest-extension=rst
-ignore-files=(plot_.*.py|conf\.py)
+;with-doctest=1
+;doctest-extension=rst
+;ignore-files=(plot_.*.py|conf\.py)
 
 [wheel]
 universal=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,9 @@ with-doctest=1
 doctest-extension=rst
 ignore-files=(plot_.*.py|conf\.py)
 
+[tool:pytest]
+doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
+
 [wheel]
 universal=1
 


### PR DESCRIPTION
For issue #2069 

Since the usage is in examples & documentation, it is improbable that users will run it in the oldest support Scikitlearn version. CIrcleCI uses the latest versions. Hence not including the older version immediately. Will reasses based on feedback.