### PR TITLE
[MRG] Replace GraphLasso* with GraphicalLasso*

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -287,7 +287,7 @@ intersphinx_mapping = {
     'numpy': ('http://docs.scipy.org/doc/numpy', None),
     'scipy': ('http://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('http://matplotlib.org/', None),
-    'sklearn': ('http://scikit-learn.org/', None),
+    'sklearn': ('http://scikit-learn.org/latest', None),
     'nibabel': ('http://nipy.org/nibabel', None),
     'pandas': ('http://pandas.pydata.org', None),
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -287,7 +287,7 @@ intersphinx_mapping = {
     'numpy': ('http://docs.scipy.org/doc/numpy', None),
     'scipy': ('http://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('http://matplotlib.org/', None),
-    'sklearn': ('http://scikit-learn.org/0.18', None),
+    'sklearn': ('http://scikit-learn.org/', None),
     'nibabel': ('http://nipy.org/nibabel', None),
     'pandas': ('http://pandas.pydata.org', None),
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -287,7 +287,7 @@ intersphinx_mapping = {
     'numpy': ('http://docs.scipy.org/doc/numpy', None),
     'scipy': ('http://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('http://matplotlib.org/', None),
-    'sklearn': ('http://scikit-learn.org/latest', None),
+    'sklearn': ('http://scikit-learn.org/stable/', None),
     'nibabel': ('http://nipy.org/nibabel', None),
     'pandas': ('http://pandas.pydata.org', None),
 }

--- a/doc/connectivity/connectome_extraction.rst
+++ b/doc/connectivity/connectome_extraction.rst
@@ -49,12 +49,12 @@ conditioned on all the others.
 
 
 To recover well the interaction structure, a **sparse inverse covariance
-estimator** is necessary. The GraphLasso, implemented in scikit-learn's
-estimator :class:`sklearn.covariance.GraphLassoCV` is a good, simple
+estimator** is necessary. The GraphicalLasso, implemented in scikit-learn's
+estimator :class:`sklearn.covariance.GraphicalLassoCV` is a good, simple
 solution. To use it, you need to create an estimator object::
 
-    >>> from sklearn.covariance import GraphLassoCV
-    >>> estimator = GraphLassoCV()
+    >>> from sklearn.covariance import GraphicalLassoCV
+    >>> estimator = GraphicalLassoCV()
 
 And then you can fit it on the activation time series, for instance
 extracted in :ref:`the previous section <functional_connectomes>`::
@@ -95,7 +95,7 @@ of the estimator::
     The parameter controlling the sparsity is set by `cross-validation
     <http://scikit-learn.org/stable/modules/cross_validation.html>`_
     scheme. If you want to specify it manually, use the estimator
-    :class:`sklearn.covariance.GraphLasso`.
+    :class:`sklearn.covariance.GraphicalLasso`.
 
 .. topic:: **Full example**
 
@@ -126,7 +126,7 @@ differing connection values across subjects.
 
 For this, nilearn provides the
 :class:`nilearn.connectome.GroupSparseCovarianceCV`
-estimator. Its usage is similar to the GraphLassoCV object, but it takes
+estimator. Its usage is similar to the GraphicalLassoCV object, but it takes
 a list of time series::
 
     >>> estimator.fit([time_series_1, time_series_2, ...])  # doctest: +SKIP
@@ -186,7 +186,7 @@ with different precision matrices, but sharing a common sparsity pattern:
 10 brain regions, for 20 subjects.
 
 A single-subject estimation can be performed using the
-:class:`sklearn.covariance.GraphLassoCV` estimator from scikit-learn.
+:class:`sklearn.covariance.GraphicalLassoCV` estimator from scikit-learn.
 
 It is also possible to fit a graph lasso on data from every subject all
 together.

--- a/doc/developers/group_sparse_covariance.rst
+++ b/doc/developers/group_sparse_covariance.rst
@@ -369,7 +369,7 @@ used), then a tighter grid near the found maximum is computed, and so
 on. This allows for a very precise determination of the maximum
 location while reducing a lot the required evaluation number. The code
 is very close to what is done in
-:class:`sklearn.covariance.GraphLassoCV`.
+:class:`sklearn.covariance.GraphicalLassoCV`.
 
 
 Warm restart

--- a/examples/03_connectivity/plot_inverse_covariance_connectome.py
+++ b/examples/03_connectivity/plot_inverse_covariance_connectome.py
@@ -51,9 +51,13 @@ time_series = masker.fit_transform(data.func[0],
 ##############################################################################
 # Compute the sparse inverse covariance
 # --------------------------------------
-from sklearn.covariance import GraphicalLassoCV
-estimator = GraphicalLassoCV()
+try:
+    from sklearn.covariance import GraphicalLassoCV
+except ImportError:
+    # for Scitkit-Learn < v0.20.0
+    from sklearn.covariance import GraphLassoCV as GraphicalLassoCV
 
+estimator = GraphicalLassoCV()
 estimator.fit(time_series)
 
 ##############################################################################

--- a/examples/03_connectivity/plot_inverse_covariance_connectome.py
+++ b/examples/03_connectivity/plot_inverse_covariance_connectome.py
@@ -51,8 +51,8 @@ time_series = masker.fit_transform(data.func[0],
 ##############################################################################
 # Compute the sparse inverse covariance
 # --------------------------------------
-from sklearn.covariance import GraphLassoCV
-estimator = GraphLassoCV()
+from sklearn.covariance import GraphicalLassoCV
+estimator = GraphicalLassoCV()
 
 estimator.fit(time_series)
 

--- a/examples/03_connectivity/plot_multi_subject_connectome.py
+++ b/examples/03_connectivity/plot_multi_subject_connectome.py
@@ -84,8 +84,13 @@ from nilearn.connectome import GroupSparseCovarianceCV
 gsc = GroupSparseCovarianceCV(verbose=2)
 gsc.fit(subject_time_series)
 
-from sklearn import covariance
-gl = covariance.GraphicalLassoCV(verbose=2)
+try:
+    from sklearn.covariance import GraphicalLassoCV
+except ImportError:
+    # for Scitkit-Learn < v0.20.0
+    from sklearn.covariance import GraphLassoCV as GraphicalLassoCV
+
+gl = GraphicalLassoCV(verbose=2)
 gl.fit(np.concatenate(subject_time_series))
 
 

--- a/examples/03_connectivity/plot_multi_subject_connectome.py
+++ b/examples/03_connectivity/plot_multi_subject_connectome.py
@@ -85,7 +85,7 @@ gsc = GroupSparseCovarianceCV(verbose=2)
 gsc.fit(subject_time_series)
 
 from sklearn import covariance
-gl = covariance.GraphLassoCV(verbose=2)
+gl = covariance.GraphicalLassoCV(verbose=2)
 gl.fit(np.concatenate(subject_time_series))
 
 
@@ -102,10 +102,10 @@ plotting.plot_connectome(gl.covariance_,
                          display_mode="lzr")
 plotting.plot_connectome(-gl.precision_, atlas_region_coords,
                          edge_threshold='90%',
-                         title="Sparse inverse covariance (GraphLasso)",
+                         title="Sparse inverse covariance (GraphicalLasso)",
                          display_mode="lzr",
                          edge_vmax=.5, edge_vmin=-.5)
-plot_matrices(gl.covariance_, gl.precision_, "GraphLasso", labels)
+plot_matrices(gl.covariance_, gl.precision_, "GraphicalLasso", labels)
 
 title = "GroupSparseCovariance"
 plotting.plot_connectome(-gsc.precisions_[..., 0],

--- a/examples/03_connectivity/plot_simulated_connectome.py
+++ b/examples/03_connectivity/plot_simulated_connectome.py
@@ -49,7 +49,12 @@ for n in range(n_displayed):
 
 
 # Fit one graph lasso per subject
-from sklearn.covariance import GraphicalLassoCV
+try:
+    from sklearn.covariance import GraphicalLassoCV
+except ImportError:
+    # for Scitkit-Learn < v0.20.0
+    from sklearn.covariance import GraphLassoCV as GraphicalLassoCV
+
 gl = GraphicalLassoCV(verbose=1)
 
 for n, subject in enumerate(subjects[:n_displayed]):

--- a/examples/03_connectivity/plot_simulated_connectome.py
+++ b/examples/03_connectivity/plot_simulated_connectome.py
@@ -49,8 +49,8 @@ for n in range(n_displayed):
 
 
 # Fit one graph lasso per subject
-from sklearn.covariance import GraphLassoCV
-gl = GraphLassoCV(verbose=1)
+from sklearn.covariance import GraphicalLassoCV
+gl = GraphicalLassoCV(verbose=1)
 
 for n, subject in enumerate(subjects[:n_displayed]):
     gl.fit(subject)

--- a/examples/03_connectivity/plot_sphere_based_connectome.py
+++ b/examples/03_connectivity/plot_sphere_based_connectome.py
@@ -211,13 +211,13 @@ print('time series has {0} samples'.format(timeseries.shape[0]))
 ###############################################################################
 # in which situation the graphical lasso **sparse inverse covariance**
 # estimator captures well the covariance **structure**.
-from sklearn.covariance import GraphLassoCV
+from sklearn.covariance import GraphicalLassoCV
 
-covariance_estimator = GraphLassoCV(cv=3, verbose=1)
+covariance_estimator = GraphicalLassoCV(cv=3, verbose=1)
 
 
 ###############################################################################
-# We just fit our regions signals into the `GraphLassoCV` object
+# We just fit our regions signals into the `GraphicalLassoCV` object
 covariance_estimator.fit(timeseries)
 
 
@@ -271,7 +271,7 @@ spheres_masker = input_data.NiftiSpheresMasker(
 timeseries = spheres_masker.fit_transform(func_filename,
                                           confounds=confounds_filename)
 
-covariance_estimator = GraphLassoCV()
+covariance_estimator = GraphicalLassoCV()
 covariance_estimator.fit(timeseries)
 matrix = covariance_estimator.covariance_
 
@@ -321,7 +321,7 @@ spheres_masker = input_data.NiftiSpheresMasker(
 timeseries = spheres_masker.fit_transform(func_filename,
                                           confounds=confounds_filename)
 
-covariance_estimator = GraphLassoCV()
+covariance_estimator = GraphicalLassoCV()
 covariance_estimator.fit(timeseries)
 matrix = covariance_estimator.covariance_
 

--- a/examples/03_connectivity/plot_sphere_based_connectome.py
+++ b/examples/03_connectivity/plot_sphere_based_connectome.py
@@ -211,7 +211,11 @@ print('time series has {0} samples'.format(timeseries.shape[0]))
 ###############################################################################
 # in which situation the graphical lasso **sparse inverse covariance**
 # estimator captures well the covariance **structure**.
-from sklearn.covariance import GraphicalLassoCV
+try:
+    from sklearn.covariance import GraphicalLassoCV
+except ImportError:
+    # for Scitkit-Learn < v0.20.0
+    from sklearn.covariance import GraphLassoCV as GraphicalLassoCV
 
 covariance_estimator = GraphicalLassoCV(cv=3, verbose=1)
 

--- a/nilearn/connectome/group_sparse_cov.py
+++ b/nilearn/connectome/group_sparse_cov.py
@@ -891,7 +891,7 @@ class GroupSparseCovarianceCV(BaseEstimator, CacheMixin):
     See also
     --------
     GroupSparseCovariance,
-    sklearn.covariance.GraphLassoCV
+    sklearn.covariance.GraphicalLassoCV
 
     Notes
     -----


### PR DESCRIPTION
For issue #2069

Since the usage is in examples & documentation, it is improbable that users will run it in the oldest support Scikitlearn version. CIrcleCI uses the latest versions. Hence not accommodating the older version immediately. Will reasses based on feedback.