### PR TITLE
[NOMRG] Release 0.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="3.4"
            NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.17"
            SCIKIT_LEARN_VERSION="0.18" MATPLOTLIB_VERSION="1.5.1"
-           SETUPTOOLS="30.3.0"
     # Most recent versions
     - env: DISTRIB="conda" PYTHON_VERSION="3.5"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="3.4"
            NUMPY_VERSION="1.11.2" SCIPY_VERSION="0.17"
            SCIKIT_LEARN_VERSION="0.18" MATPLOTLIB_VERSION="1.5.1"
+           SETUPTOOLS="30.3.0"
     # Most recent versions
     - env: DISTRIB="conda" PYTHON_VERSION="3.5"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -67,7 +67,6 @@ create_new_conda_env() {
     chmod +x ~/miniconda.sh && ~/miniconda.sh -b
     export PATH=$HOME/miniconda3/bin:$PATH
     echo $PATH
-    conda update --quiet --yes conda
 
     # Configure the conda environment and put it in the path using the
     # provided versions

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -62,7 +62,7 @@ create_new_conda_env() {
 
     # Use the miniconda installer for faster download / install of conda
     # itself
-    wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh \
         -O ~/miniconda.sh
     chmod +x ~/miniconda.sh && ~/miniconda.sh -b
     export PATH=$HOME/miniconda3/bin:$PATH

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -228,7 +228,7 @@ htmlhelp_basename = 'PythonScientic'
 # [howto/manual]).
 latex_documents = [
   ('index', 'nilearn.tex', u'NeuroImaging with scikit-learn',
-   ur"""Gaël Varoquaux and Alexandre Abraham"""
+   'Gaël Varoquaux and Alexandre Abraham'
    + r"\\\relax ~\\\relax http://nilearn.github.io",
    'manual'),
 

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -177,7 +177,7 @@ preparation::
 
    >>> from nilearn import input_data
    >>> masker = input_data.NiftiMasker()
-   >>> masker # doctest: +ELLIPSIS
+   >>> masker # doctest: +ELLIPSIS +WHITESPACE
    NiftiMasker(detrend=False, dtype=None, high_pass=None, low_pass=None,
          mask_args=None, mask_img=None, mask_strategy='background',
          memory=Memory(location=None), memory_level=1, sample_mask=None,

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -177,7 +177,7 @@ preparation::
 
    >>> from nilearn import input_data
    >>> masker = input_data.NiftiMasker()
-   >>> masker
+   >>> masker # doctest: +ELLIPSIS +SKIP
    NiftiMasker(detrend=False, dtype=None, high_pass=None, low_pass=None,
          mask_args=None, mask_img=None, mask_strategy='background',
          memory=Memory(location=None), memory_level=1, sample_mask=None,

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -180,7 +180,7 @@ preparation::
    >>> masker # doctest: +ELLIPSIS
    NiftiMasker(detrend=False, dtype=None, high_pass=None, low_pass=None,
          mask_args=None, mask_img=None, mask_strategy='background',
-         memory=Memory(...), memory_level=1, sample_mask=None,
+         memory=Memory(location=None), memory_level=1, sample_mask=None,
          sessions=None, smoothing_fwhm=None, standardize=False, t_r=None,
          target_affine=None, target_shape=None, verbose=0)
 

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -177,7 +177,7 @@ preparation::
 
    >>> from nilearn import input_data
    >>> masker = input_data.NiftiMasker()
-   >>> masker # doctest: +ELLIPSIS +WHITESPACE
+   >>> masker
    NiftiMasker(detrend=False, dtype=None, high_pass=None, low_pass=None,
          mask_args=None, mask_img=None, mask_strategy='background',
          memory=Memory(location=None), memory_level=1, sample_mask=None,

--- a/doc/themes/nilearn/layout.html
+++ b/doc/themes/nilearn/layout.html
@@ -261,7 +261,9 @@ $(function () {
 
 <h4> News </h4>
   <ul>
-      <li><p> <strong>April 12th 2019</strong>: Nilearn 0.5.2 released
+      <li><p> <strong>August 22nd 2019</strong>: Nilearn 0.5.3 released
+      </p></li>
+      <li><p> <strong>April 17th 2019</strong>: Nilearn 0.5.2 released
       </p></li>
       <li><p> <strong>April 12th 2019</strong>: Nilearn 0.5.1 released
       </p></li>

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,5 +1,6 @@
 0.5.3
 =====
+
 **Released 22 Aug 2019**
 
 NEW
@@ -17,6 +18,14 @@ Fixes
 - NotImplementedError in Nilearn for ax.set_axes()
   (Matplotlib 3.1 dropped support for ax.set_axes())
 
+Contributors
+------------
+
+The following people contributed to this release::
+
+    Jerome Dockes (jeromedockes)
+    Kshitij Chawla (kchawla-pi)
+
 0.5.2
 =====
 
@@ -32,8 +41,9 @@ Contributors
 
 The following people contributed to this release::
 
-    Jerome Dockes (jeromedockes)
-    Kshitij Chawla (kchawla-pi)
+    11  Kshitij Chawla (kchawla-pi)
+     3  Gael Varoquaux
+     2  Alexandre Gramfort
 
 0.5.1
 =====

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,7 +1,6 @@
-0.5.2
+0.5.3
 =====
-
-**Released April 2019**
+**Released 22 Aug 2019**
 
 NEW
 ---
@@ -15,6 +14,17 @@ NEW
 Fixes
 -----
 
+- NotImplementedError in Nilearn for ax.set_axes()
+  (Matplotlib 3.1 dropped support for ax.set_axes())
+
+0.5.2
+=====
+
+**Released 17 April 2019**
+
+Fixes
+-----
+
 - Plotting ``.mgz`` files in MNE broke in ``0.5.1`` and has been fixed.
 
 Contributors
@@ -22,9 +32,8 @@ Contributors
 
 The following people contributed to this release::
 
-    11  Kshitij Chawla (kchawla-pi)
-     3  Gael Varoquaux
-     2  Alexandre Gramfort
+    Jerome Dockes (jeromedockes)
+    Kshitij Chawla (kchawla-pi)
 
 0.5.1
 =====

--- a/examples/01_plotting/plot_surface_projection_strategies.py
+++ b/examples/01_plotting/plot_surface_projection_strategies.py
@@ -61,7 +61,6 @@ ball_sample_points = surface._ball_sample_locations(
 for sample_points in [line_sample_points, ball_sample_points]:
     fig = plt.figure()
     ax = plt.subplot(projection='3d')
-    ax.set_aspect(1)
 
     ax.plot_trisurf(x, y, z, triangles=triangulation.triangles)
 

--- a/examples/02_decoding/plot_haxby_stimuli.py
+++ b/examples/02_decoding/plot_haxby_stimuli.py
@@ -7,7 +7,6 @@ and Overlapping Representations of Faces and Objects in Ventral Temporal
 Cortex" (Science 2001)
 """
 
-from scipy.misc import imread
 import matplotlib.pyplot as plt
 
 from nilearn import datasets
@@ -27,8 +26,8 @@ for stim_type in sorted(stimulus_information.keys()):
     for i in range(48):
         plt.subplot(6, 8, i + 1)
         try:
-            plt.imshow(imread(file_names[i]), cmap=plt.cm.gray)
-        except:
+            plt.imshow(plt.imread(file_names[i]), cmap=plt.cm.gray)
+        except Exception:
             # just go to the next one if the file is not present
             pass
         plt.axis("off")

--- a/nilearn/decoding/tests/test_graph_net.py
+++ b/nilearn/decoding/tests/test_graph_net.py
@@ -2,7 +2,7 @@ from nose.tools import assert_true
 import numpy as np
 import scipy as sp
 from numpy.testing import assert_almost_equal
-from sklearn.utils import extmath
+from scipy import linalg
 from sklearn.utils import check_random_state
 from nilearn.decoding.objective_functions import _gradient, _div
 from nilearn.decoding.space_net_solvers import (
@@ -167,12 +167,12 @@ def test__squared_loss_derivative_lipschitz_constant():
     for _ in range(20):
         x_1 = rng.rand(*w.shape) * rng.randint(1000)
         x_2 = rng.rand(*w.shape) * rng.randint(1000)
-        gradient_difference = extmath.norm(
+        gradient_difference = linalg.norm(
             _squared_loss_and_spatial_grad_derivative(X, y, x_1, mask,
                                                       grad_weight)
             - _squared_loss_and_spatial_grad_derivative(X, y, x_2, mask,
                                                         grad_weight))
-        point_difference = extmath.norm(x_1 - x_2)
+        point_difference = linalg.norm(x_1 - x_2)
         assert_true(
             gradient_difference <= lipschitz_constant * point_difference)
 
@@ -186,12 +186,12 @@ def test_logistic_derivative_lipschitz_constant():
     for _ in range(20):
         x_1 = rng.rand((w.shape[0] + 1)) * rng.randint(1000)
         x_2 = rng.rand((w.shape[0] + 1)) * rng.randint(1000)
-        gradient_difference = extmath.norm(
+        gradient_difference = linalg.norm(
             _logistic_data_loss_and_spatial_grad_derivative(
                 X, y, x_1, mask, grad_weight)
             - _logistic_data_loss_and_spatial_grad_derivative(
                 X, y, x_2, mask, grad_weight))
-        point_difference = extmath.norm(x_1 - x_2)
+        point_difference = linalg.norm(x_1 - x_2)
         assert_true(
             gradient_difference <= lipschitz_constant * point_difference)
 
@@ -224,12 +224,12 @@ def test_tikhonov_regularization_vs_graph_net():
         screening_percentile=100., standardize=False)
     graph_net.fit(X_, y.copy())
     coef_ = graph_net.coef_[0]
-    graph_net_perf = 0.5 / y.size * extmath.norm(
+    graph_net_perf = 0.5 / y.size * linalg.norm(
         np.dot(X, coef_) - y) ** 2\
-        + 0.5 * extmath.norm(np.dot(G, coef_)) ** 2
-    optimal_model_perf = 0.5 / y.size * extmath.norm(
+        + 0.5 * linalg.norm(np.dot(G, coef_)) ** 2
+    optimal_model_perf = 0.5 / y.size * linalg.norm(
         np.dot(X, optimal_model) - y) ** 2\
-        + 0.5 * extmath.norm(np.dot(G, optimal_model)) ** 2
+        + 0.5 * linalg.norm(np.dot(G, optimal_model)) ** 2
     assert_almost_equal(graph_net_perf, optimal_model_perf, decimal=1)
 
 

--- a/nilearn/decoding/tests/test_space_net.py
+++ b/nilearn/decoding/tests/test_space_net.py
@@ -4,8 +4,8 @@ from nose import SkipTest
 from nose.tools import (assert_equal, assert_true, assert_false,
                         assert_raises)
 import numpy as np
+from scipy import linalg
 from sklearn.datasets import load_iris
-from sklearn.utils import extmath
 from sklearn.linear_model import Lasso
 from sklearn.utils import check_random_state
 from sklearn.linear_model import LogisticRegression
@@ -241,7 +241,7 @@ def test_lasso_vs_graph_net():
                              penalty="graph-net", max_iter=100)
     lasso.fit(X_, y)
     graph_net.fit(X, y)
-    lasso_perf = 0.5 / y.size * extmath.norm(np.dot(
+    lasso_perf = 0.5 / y.size * linalg.norm(np.dot(
         X_, lasso.coef_) - y) ** 2 + np.sum(np.abs(lasso.coef_))
     graph_net_perf = 0.5 * ((graph_net.predict(X) - y) ** 2).mean()
     np.testing.assert_almost_equal(graph_net_perf, lasso_perf, decimal=3)

--- a/nilearn/plotting/data/html/connectome_plot_template.html
+++ b/nilearn/plotting/data/html/connectome_plot_template.html
@@ -3,7 +3,8 @@
 
 <head>
     <title>connectome plot</title>
-    <meta charset="UTF-8" /> $INSERT_JS_LIBRARIES_HERE
+    <meta charset="UTF-8" />
+    $INSERT_JS_LIBRARIES_HERE
     <script>
         var connectomeInfo = $INSERT_CONNECTOME_JSON_HERE;
         var data = [];
@@ -155,7 +156,7 @@
         <option value="bottom">view: Bottom</option>
         <option value="custom">view: -</option>
     </select>
-    <input id="opacity-range" type="range" min="0" max="100" value="30"></input>
+    <input id="opacity-range" type="range" min="0" max="100" value="30"/>
 
 </body>
 

--- a/nilearn/plotting/data/html/stat_map_template.html
+++ b/nilearn/plotting/data/html/stat_map_template.html
@@ -1,24 +1,26 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="en">
 <head>
+    <title>slice viewer</title>
+    <meta charset="UTF-8" />
 </head>
 <body>
   <div id="div_viewer">
     <!-- this is the canvas that will feature the brain slices -->
     <canvas id="3Dviewer">
     <!-- load a hidden version of the sprite image that includes all (sagital) brain slices -->
-    <img id="spriteImg" class="hidden" src="data:image/png;base64, $bg_base64" alt="background" />
+    <img id="spriteImg" class="hidden" src="data:image/png;base64,$bg_base64" alt="background" />
     <!-- the colormap -->
-    <img id="colorMap" class="hidden" src="data:image/png;base64, $cm_base64" alt="colormap">
+    <img id="colorMap" class="hidden" src="data:image/png;base64,$cm_base64" alt="colormap">
     <!-- another sprite image, with an overlay-->
-    <img id="overlayImg" class="hidden" src="data:image/png;base64, $stat_map_base64" alt="overlay">
+    <img id="overlayImg" class="hidden" src="data:image/png;base64,$stat_map_base64" alt="overlay">
+    </canvas>
   </div>
 
-  <script type="text/javascript" >
+  <script>
     $js_jquery
   </script>
-  <script type="text/javascript">
+  <script>
     $js_brainsprite
   </script>
 

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -4,6 +4,7 @@ Visualizing 3D stat maps in a Brainsprite viewer
 import os
 import json
 from io import BytesIO
+from base64 import b64encode
 
 import numpy as np
 from matplotlib.image import imsave
@@ -19,7 +20,6 @@ from .._utils.niimg_conversions import check_niimg_3d
 from .._utils.param_validation import check_threshold
 from .._utils.extmath import fast_abs_percentile
 from .._utils.niimg import _safe_get_data
-from .._utils.compat import _encodebytes
 from ..datasets import load_mni152_template
 
 
@@ -101,7 +101,7 @@ def _bytesIO_to_base64(handle_io):
         Returns: data
     """
     handle_io.seek(0)
-    data = _encodebytes(handle_io.read()).decode('utf-8')
+    data = b64encode(handle_io.read()).decode('utf-8')
     handle_io.close()
     return data
 

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -187,7 +187,6 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
             figure = axes.get_figure()
         axes.set_xlim(*limits)
         axes.set_ylim(*limits)
-    axes.set_aspect(.74)
     axes.view_init(elev=elev, azim=azim)
     axes.set_axis_off()
 

--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -106,7 +106,7 @@ def test_save_sprite():
     sprite_base64 = html_stat_map._bytesIO_to_base64(sprite_io)
 
     # Check the sprite is correct
-    assert sprite_base64 == '////AP////8=\n'
+    assert sprite_base64 == '////AP////8='
 
 
 def test_save_cmap():
@@ -121,7 +121,7 @@ def test_save_cmap():
     cmap_base64 = html_stat_map._bytesIO_to_base64(cmap_io)
 
     # Check the colormap is correct
-    assert cmap_base64 == '//////////8=\n'
+    assert cmap_base64 == '//////////8='
 
 
 def test_mask_stat_map():

--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -100,13 +100,14 @@ def test_save_sprite():
     # Save the sprite using BytesIO
     sprite_io = BytesIO()
     html_stat_map._save_sprite(data, sprite_io, vmin=0, vmax=1,
-                               mask=mask, format='raw')
+                               mask=mask, format='png')
 
     # Load the sprite back in base64
     sprite_base64 = html_stat_map._bytesIO_to_base64(sprite_io)
 
     # Check the sprite is correct
-    assert sprite_base64 == '////AP////8='
+    assert sprite_base64.startswith('iVBORw0KG')
+    assert sprite_base64.endswith('ABJRU5ErkJggg==')
 
 
 def test_save_cmap():
@@ -115,13 +116,14 @@ def test_save_cmap():
 
     # Save the cmap using BytesIO
     cmap_io = BytesIO()
-    html_stat_map._save_cm(cmap_io, 'cold_hot', format='raw', n_colors=2)
+    html_stat_map._save_cm(cmap_io, 'cold_hot', format='png', n_colors=2)
 
     # Load the colormap back in base64
     cmap_base64 = html_stat_map._bytesIO_to_base64(cmap_io)
 
     # Check the colormap is correct
-    assert cmap_base64 == '//////////8='
+    assert cmap_base64.startswith('iVBORw0KG')
+    assert cmap_base64.endswith('ElFTkSuQmCC')
 
 
 def test_mask_stat_map():

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -21,7 +21,7 @@ nilearn version, required package versions, and utilities for checking
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.5.2'
+__version__ = '0.5.3'
 
 _NILEARN_INSTALL_MSG = 'See %s for installation information.' % (
     'http://nilearn.github.io/introduction.html#installation')


### PR DESCRIPTION
The removal of ax.set_axes() from Matplotlib 3.1 is inconvenience to users and must be patched up. This branch aims to do that. Some other changes need to be made to make sure the CIs pass since the environment since 0.5.2 has changed. 

It is not intended to be merged into `master`. All the changes made here are already present in `master`, excepet the `whats_new`, which I will do separately.

This won't be merged with `master` so no need to resolved conflicts. I intend to push from this branch to PyPI.