### PR TITLE
Update Schaefer parcelation to v0.14.3

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -66,8 +66,9 @@ Fixes
 - :func:`nilearn.plotting.plot_matrix` providing labels=None, False, or an empty list now correctly disables labels.
 - :func:`nilearn.datasets.fetch_surf_nki_enhanced` is now downloading the correct
   left and right functional surface data for each subject
-- :func:`nilearn.datasets.fetch_atlas_schaefer_2018` now downloads from release version 0.14.3 (instead of 0.8.1) by
-  default, which includes corrected region label names.
+- :func:`nilearn.datasets.fetch_atlas_schaefer_2018` now downloads from release
+  version 0.14.3 (instead of 0.8.1) by default, which includes corrected region label
+  names along with 700 and 900 region parcelations.
 
 0.5.2
 =====

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -66,6 +66,8 @@ Fixes
 - :func:`nilearn.plotting.plot_matrix` providing labels=None, False, or an empty list now correctly disables labels.
 - :func:`nilearn.datasets.fetch_surf_nki_enhanced` is now downloading the correct
   left and right functional surface data for each subject
+- :func:`nilearn.datasets.fetch_atlas_schaefer_2018` now downloads from release version 0.14.3 (instead of 0.8.1) by
+  default, which includes corrected region label names.
 
 0.5.2
 =====

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1275,7 +1275,7 @@ def fetch_atlas_schaefer_2018(n_rois=400, yeo_networks=7, resolution_mm=1,
     ----------
     n_rois: int
         number of regions of interest {100, 200, 300, 400 (default), 500, 600,
-        800, 1000}
+        700, 800, 900, 1000}
 
     yeo_networks: int
         ROI annotation according to yeo networks {7 (default), 17}
@@ -1328,7 +1328,7 @@ def fetch_atlas_schaefer_2018(n_rois=400, yeo_networks=7, resolution_mm=1,
     label names. For more details, see
     https://github.com/ThomasYeoLab/CBIG/blob/master/stable_projects/brain_parcellation/Schaefer2018_LocalGlobal/Parcellations/Updates/Update_20190916_README.md
     """
-    valid_n_rois = [100, 200, 300, 400, 500, 600, 800, 1000]
+    valid_n_rois = list(range(100, 1100, 100))
     valid_yeo_networks = [7, 17]
     valid_resolution_mm = [1, 2]
     if n_rois not in valid_n_rois:

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1307,7 +1307,7 @@ def fetch_atlas_schaefer_2018(n_rois=400, yeo_networks=7, resolution_mm=1,
     References
     ----------
     For more information on this dataset, see
-    https://github.com/ThomasYeoLab/CBIG/tree/v0.14.3-Schaefer2018_LocalGlobal/stable_projects/brain_parcellation/Schaefer2018_LocalGlobal
+    https://github.com/ThomasYeoLab/CBIG/tree/v0.14.3-Update_Yeo2011_Schaefer2018_labelname/stable_projects/brain_parcellation/Schaefer2018_LocalGlobal/Parcellations
 
     Schaefer A, Kong R, Gordon EM, Laumann TO, Zuo XN, Holmes AJ,
     Eickhoff SB, Yeo BTT. Local-Global parcellation of the human

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1307,7 +1307,7 @@ def fetch_atlas_schaefer_2018(n_rois=400, yeo_networks=7, resolution_mm=1,
     References
     ----------
     For more information on this dataset, see
-    https://github.com/ThomasYeoLab/CBIG/tree/v0.8.1-Schaefer2018_LocalGlobal/stable_projects/brain_parcellation/Schaefer2018_LocalGlobal
+    https://github.com/ThomasYeoLab/CBIG/tree/v0.14.3-Schaefer2018_LocalGlobal/stable_projects/brain_parcellation/Schaefer2018_LocalGlobal
 
     Schaefer A, Kong R, Gordon EM, Laumann TO, Zuo XN, Holmes AJ,
     Eickhoff SB, Yeo BTT. Local-Global parcellation of the human
@@ -1320,6 +1320,13 @@ def fetch_atlas_schaefer_2018(n_rois=400, yeo_networks=7, resolution_mm=1,
     intrinsic functional connectivity. J Neurophysiol 106(3):1125-65, 2011.
 
     Licence: MIT.
+
+    Notes
+    -----
+    Release v0.14.3 of the Schaefer 2018 parcellation is used by
+    default. Versions prior to v0.14.3 are known to contain erroneous region
+    label names. For more details, see
+    https://github.com/ThomasYeoLab/CBIG/blob/master/stable_projects/brain_parcellation/Schaefer2018_LocalGlobal/Parcellations/Updates/Update_20190916_README.md
     """
     valid_n_rois = [100, 200, 300, 400, 500, 600, 800, 1000]
     valid_yeo_networks = [7, 17]
@@ -1338,9 +1345,9 @@ def fetch_atlas_schaefer_2018(n_rois=400, yeo_networks=7, resolution_mm=1,
 
     if base_url is None:
         base_url = ('https://raw.githubusercontent.com/ThomasYeoLab/CBIG/'
-                    'v0.8.1-Schaefer2018_LocalGlobal/stable_projects/'
-                    'brain_parcellation/Schaefer2018_LocalGlobal/'
-                    'Parcellations/MNI/'
+                    'v0.14.3-Update_Yeo2011_Schaefer2018_labelname/'
+                    'stable_projects/brain_parcellation/'
+                    'Schaefer2018_LocalGlobal/Parcellations/MNI/'
                     )
 
     files = []

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -565,7 +565,7 @@ def test_fetch_atlas_pauli_2017():
 
 @with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_atlas_schaefer_2018():
-    valid_n_rois = [100, 200, 300, 400, 500, 600, 800, 1000]
+    valid_n_rois = list(range(100, 1100, 100))
     valid_yeo_networks = [7, 17]
     valid_resolution_mm = [1, 2]
 


### PR DESCRIPTION
Addresses #2137. `base_url=None` in `fetch_atlas_schaefer_2018` downloads the most recent Schaefer parcelation version, v0.14.3. Previously this downloaded v0.8.1. Using v0.14.3 ensures that users will get the correct atlas label names by default. I added a note to the docstring as well. 

When I was going through [the updates](https://github.com/ThomasYeoLab/CBIG/tree/master/stable_projects/brain_parcellation/Schaefer2018_LocalGlobal#updates), I also noticed that 700 and 900 region parcelations have been available since v0.10.2. Although this was not discussed in #2137,  I've updated `fetch_atlas_schaefer_2018` to include these as options for the `n_rois` parameter; `n_rois` now takes values 100-1000 in increments of 100. 