### PR TITLE
[MRG] Replac conda with pip in CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,39 +16,40 @@ matrix:
   fast_finish: true
   allow_failures:
     # allow_failures keyed to skipping tests.
-    - env: SKIPT_TESTS="true"
+    - env: SKIP_TESTS="true"
   include:
     # without matplotlib
     - name: "Python 3.5 minimum package versions"
       python: "3.5"
       env: DISTRIB="conda" PYTHON_VERSION="3.5"
            NUMPY_VERSION="1.11" SCIPY_VERSION="0.19" PANDAS_VERSION="*"
-           SCIKIT_LEARN_VERSION="0.19" COVERAGE="true" JOBLIB_VERSION="*"
+           SCIKIT_LEARN_VERSION="0.19" COVERAGE="true" JOBLIB_VERSION="0.11"
            LXML_VERSION="*"
     - name: "Python 3.5 latest package versions"
       python: "3.5"
       env: DISTRIB="conda" PYTHON_VERSION="3.5"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
-           JOBLIB_VERSION="0.11"
+           JOBLIB_VERSION=".11"
            LXML_VERSION="*"
     - name: "Python 3.6 latest package versions"
       python: "3.6"
       env: DISTRIB="conda" PYTHON_VERSION="3.6"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
-           JOBLIB_VERSION="*"
+           JOBLIB_VERSION="0.12"
            LXML_VERSION="*"
     - name: "Python 3.7 latest package versions"
       python: "3.7"
       env: DISTRIB="conda" PYTHON_VERSION="3.7"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
-           JOBLIB_VERSION="0.12" LXML_VERSION="*"
+           JOBLIB_VERSION="*" LXML_VERSION="*"
 
   # FLAKE8 linting on diff wrt common ancestor with upstream/master
     # Note: the python value is only there to trigger allow_failures
-    - python: 3.5
+    - name: Python 3.5 Flake8 no tests
+      python: 3.5
       env: DISTRIB="conda" PYTHON_VERSION="3.5" FLAKE8_VERSION="*" SKIP_TESTS="true"
 
 install: source continuous_integration/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
       env: DISTRIB="conda" PYTHON_VERSION="3.5"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
-           JOBLIB_VERSION=".11"
+           JOBLIB_VERSION="0.11"
            LXML_VERSION="*"
     - name: "Python 3.6 latest package versions"
       python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,9 @@ dist: xenial
 
 language: python
 
-#virtualenv:
-#  system_site_packages: true
-
 env:
   global:
-    - TEST_RUN_FOLDER="/tmp" # folder where the tests are run from
+    - TEST_RUN_FOLDER="/tmp"
 
 matrix:
   # Do not wait for the allowed_failures entry to finish before
@@ -37,8 +34,10 @@ matrix:
       env: DISTRIB="travisci" PYTHON_VERSION="3.6"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
-           JOBLIB_VERSION="0.12"
-           LXML_VERSION="*"
+           JOBLIB_VERSION="0.12" LXML_VERSION="*"
+      # joblib.Memory switches from keyword cachedir to location in version 0.12
+      # Making sure we get the deprecation warning.
+
     - name: "Python 3.7 latest package versions"
       python: "3.7"
       env: DISTRIB="travisci" PYTHON_VERSION="3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,21 +20,21 @@ matrix:
     - python: 3.5
   include:
     # without matplotlib
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5"
+    - env: DISTRIB="pip" PYTHON_VERSION="3.5"
            NUMPY_VERSION="1.11" SCIPY_VERSION="0.19" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="0.19" COVERAGE="true" JOBLIB_VERSION="*"
            LXML_VERSION="*"
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5"
+    - env: DISTRIB="pip" PYTHON_VERSION="3.5"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
            JOBLIB_VERSION="0.11"
            LXML_VERSION="*"
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6"
+    - env: DISTRIB="pip" PYTHON_VERSION="3.6"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
            JOBLIB_VERSION="*"
            LXML_VERSION="*"
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7"
+    - env: DISTRIB="pip" PYTHON_VERSION="3.7"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
            JOBLIB_VERSION="0.12" LXML_VERSION="*"
@@ -42,7 +42,7 @@ matrix:
   # FLAKE8 linting on diff wrt common ancestor with upstream/master
     # Note: the python value is only there to trigger allow_failures
     - python: 3.5
-      env: DISTRIB="conda" PYTHON_VERSION="3.5" FLAKE8_VERSION="*" SKIP_TESTS="true"
+      env: DISTRIB="pip" PYTHON_VERSION="3.5" FLAKE8_VERSION="*" SKIP_TESTS="true"
 
 install: source continuous_integration/install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: xenial
 
 language: python
 
-virtualenv:
-  system_site_packages: true
+#virtualenv:
+#  system_site_packages: true
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 dist: xenial
 
 language: python
-python: "3.5"
 
 virtualenv:
   system_site_packages: true
@@ -16,25 +15,33 @@ matrix:
   # setting the status
   fast_finish: true
   allow_failures:
-    # allow_failures seems to be keyed on the python version.
-    - python: 3.5
+    # allow_failures keyed to skipping tests.
+    - env: SKIPT_TESTS="true"
   include:
     # without matplotlib
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5"
+    - name: "Python 3.5 minimum package versions"
+      python: "3.5"
+      env: DISTRIB="conda" PYTHON_VERSION="3.5"
            NUMPY_VERSION="1.11" SCIPY_VERSION="0.19" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="0.19" COVERAGE="true" JOBLIB_VERSION="*"
            LXML_VERSION="*"
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5"
+    - name: "Python 3.5 latest package versions"
+      python: "3.5"
+      env: DISTRIB="conda" PYTHON_VERSION="3.5"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
            JOBLIB_VERSION="0.11"
            LXML_VERSION="*"
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6"
+    - name: "Python 3.6 latest package versions"
+      python: "3.6"
+      env: DISTRIB="conda" PYTHON_VERSION="3.6"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
            JOBLIB_VERSION="*"
            LXML_VERSION="*"
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7"
+    - name: "Python 3.7 latest package versions"
+      python: "3.7"
+      env: DISTRIB="conda" PYTHON_VERSION="3.7"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
            JOBLIB_VERSION="0.12" LXML_VERSION="*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,21 +20,21 @@ matrix:
     - python: 3.5
   include:
     # without matplotlib
-    - env: DISTRIB="pip" PYTHON_VERSION="3.5"
+    - env: DISTRIB="conda" PYTHON_VERSION="3.5"
            NUMPY_VERSION="1.11" SCIPY_VERSION="0.19" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="0.19" COVERAGE="true" JOBLIB_VERSION="*"
            LXML_VERSION="*"
-    - env: DISTRIB="pip" PYTHON_VERSION="3.5"
+    - env: DISTRIB="conda" PYTHON_VERSION="3.5"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
            JOBLIB_VERSION="0.11"
            LXML_VERSION="*"
-    - env: DISTRIB="pip" PYTHON_VERSION="3.6"
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
            JOBLIB_VERSION="*"
            LXML_VERSION="*"
-    - env: DISTRIB="pip" PYTHON_VERSION="3.7"
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
            JOBLIB_VERSION="0.12" LXML_VERSION="*"
@@ -42,7 +42,7 @@ matrix:
   # FLAKE8 linting on diff wrt common ancestor with upstream/master
     # Note: the python value is only there to trigger allow_failures
     - python: 3.5
-      env: DISTRIB="pip" PYTHON_VERSION="3.5" FLAKE8_VERSION="*" SKIP_TESTS="true"
+      env: DISTRIB="conda" PYTHON_VERSION="3.5" FLAKE8_VERSION="*" SKIP_TESTS="true"
 
 install: source continuous_integration/install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,27 +21,27 @@ matrix:
     # without matplotlib
     - name: "Python 3.5 minimum package versions"
       python: "3.5"
-      env: DISTRIB="conda" PYTHON_VERSION="3.5"
+      env: DISTRIB="travisci" PYTHON_VERSION="3.5"
            NUMPY_VERSION="1.11" SCIPY_VERSION="0.19" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="0.19" COVERAGE="true" JOBLIB_VERSION="0.11"
            LXML_VERSION="*"
     - name: "Python 3.5 latest package versions"
       python: "3.5"
-      env: DISTRIB="conda" PYTHON_VERSION="3.5"
+      env: DISTRIB="travisci" PYTHON_VERSION="3.5"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
            JOBLIB_VERSION="0.11"
            LXML_VERSION="*"
     - name: "Python 3.6 latest package versions"
       python: "3.6"
-      env: DISTRIB="conda" PYTHON_VERSION="3.6"
+      env: DISTRIB="travisci" PYTHON_VERSION="3.6"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
            JOBLIB_VERSION="0.12"
            LXML_VERSION="*"
     - name: "Python 3.7 latest package versions"
       python: "3.7"
-      env: DISTRIB="conda" PYTHON_VERSION="3.7"
+      env: DISTRIB="travisci" PYTHON_VERSION="3.7"
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
            JOBLIB_VERSION="*" LXML_VERSION="*"
@@ -50,7 +50,7 @@ matrix:
     # Note: the python value is only there to trigger allow_failures
     - name: Python 3.5 Flake8 no tests
       python: 3.5
-      env: DISTRIB="conda" PYTHON_VERSION="3.5" FLAKE8_VERSION="*" SKIP_TESTS="true"
+      env: DISTRIB="travisci" PYTHON_VERSION="3.5" FLAKE8_VERSION="*" SKIP_TESTS="true"
 
 install: source continuous_integration/install.sh
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -71,14 +71,14 @@ create_new_conda_env() {
     # provided versions
     REQUIREMENTS=$(print_conda_requirements)
     echo "conda requirements string: $REQUIREMENTS"
-    conda create -n --quiet --yes testenv python==$PYTHON_VERSION
+    conda create -n --yes testenv python==$PYTHON_VERSION
     source activate testenv
-    pip install --quiet $REQUIREMENTS
-    pip install --quiet pytest pytest-cov
+    pip install $REQUIREMENTS
+    pip install pytest pytest-cov
 
     if [[ "$INSTALL_MKL" == "true" ]]; then
         # Make sure that MKL is used
-        pip install --quiet mkl
+        pip install mkl
     fi
 }
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -35,8 +35,7 @@ print_conda_requirements() {
     #   - for scikit-learn, SCIKIT_LEARN_VERSION is used
     TO_INSTALL_ALWAYS="pip nose pytest"
     REQUIREMENTS="$TO_INSTALL_ALWAYS"
-    TO_INSTALL_MAYBE="python numpy scipy matplotlib scikit-learn pandas \
-flake8 lxml joblib"
+    TO_INSTALL_MAYBE="numpy scipy matplotlib scikit-learn pandas flake8 lxml joblib"
     for PACKAGE in $TO_INSTALL_MAYBE; do
         # Capitalize package name and add _VERSION
         PACKAGE_VERSION_VARNAME="${PACKAGE^^}_VERSION"
@@ -72,7 +71,7 @@ create_new_conda_env() {
     # provided versions
     REQUIREMENTS=$(print_conda_requirements)
     echo "conda requirements string: $REQUIREMENTS"
-    conda create -n testenv --quiet --yes
+    conda create -n --quiet --yes testenv python==$PYTHON_VERSION
     source activate testenv
     pip install --quiet $REQUIREMENTS
     pip install --quiet pytest pytest-cov

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -20,12 +20,12 @@ create_new_venv() {
     # virtualenv but we want to be in control of the numpy version
     # we are using for example through apt-get install
     deactivate
-    virtualenv --system-site-packages testvenv
+    python -m venv --clear --system-site-packages testvenv
     source testvenv/bin/activate
     pip install nose pytest
 }
 
-print_conda_requirements() {
+print_pip_requirements() {
     # Echo a conda requirement string for example
     # "pip nose python='2.7.3 scikit-learn=*". It has a hardcoded
     # list of possible packages to install and looks at _VERSION
@@ -70,8 +70,8 @@ create_new_conda_env() {
 
     # Configure the conda environment and put it in the path using the
     # provided versions
-    REQUIREMENTS=$(print_conda_requirements)
-    echo "conda requirements string: $REQUIREMENTS"
+    REQUIREMENTS=$(print_pip_requirements)
+    echo "pip requirements string: $REQUIREMENTS"
     source testvenv/bin/activate
     pip install --quiet $REQUIREMENTS
     pip install pytest pytest-cov --quiet
@@ -90,27 +90,26 @@ create_new_conda_env() {
     fi
 }
 
-if [[ "$DISTRIB" == "neurodebian" ]]; then
-    create_new_venv
-    pip install nose-timer
-    bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
-    sudo apt-get install -qq python-scipy python-nose python-nibabel python-sklearn python-joblib
+create_new_venv
+pip install nose-timer
+bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
+sudo apt-get install -qq python-scipy python-nose python-nibabel python-sklearn python-joblib
 
-elif [[ "$DISTRIB" == "conda" ]]; then
-    create_new_conda_env
-    pip install nose-timer
-    # Note: nibabel is in setup.py install_requires so nibabel will
-    # always be installed eventually. Defining NIBABEL_VERSION is only
-    # useful if you happen to want a specific nibabel version rather
-    # than the latest available one.
-    if [ -n "$NIBABEL_VERSION" ]; then
-        pip install nibabel=="$NIBABEL_VERSION"
-    fi
-
-else
-    echo "Unrecognized distribution ($DISTRIB); cannot setup CI environment."
-    exit 1
-fi
+#else
+#    create_new_conda_env
+#    pip install nose-timer
+#    # Note: nibabel is in setup.py install_requires so nibabel will
+#    # always be installed eventually. Defining NIBABEL_VERSION is only
+#    # useful if you happen to want a specific nibabel version rather
+#    # than the latest available one.
+#    if [ -n "$NIBABEL_VERSION" ]; then
+#        pip install nibabel=="$NIBABEL_VERSION"
+#    fi
+#
+#else
+#    echo "Unrecognized distribution ($DISTRIB); cannot setup CI environment."
+#    exit 1
+#fi
 
 pip install psutil memory_profiler
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -56,27 +56,27 @@ print_conda_requirements() {
 }
 
 create_new_conda_env() {
-    # Skip Travis related code on circle ci.
-    if [ -z $CIRCLECI ]; then
-        # Deactivate the travis-provided virtual environment and setup a
-        # conda-based environment instead
-        deactivate
-    fi
-
-    # Use the miniconda installer for faster download / install of conda
-    # itself
-    wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh \
-        -O ~/miniconda.sh
-    chmod +x ~/miniconda.sh && ~/miniconda.sh -b
-    export PATH=$HOME/miniconda3/bin:$PATH
-    echo $PATH
-
-    # Configure the conda environment and put it in the path using the
-    # provided versions
+#    # Skip Travis related code on circle ci.
+#    if [ -z $CIRCLECI ]; then
+#        # Deactivate the travis-provided virtual environment and setup a
+#        # conda-based environment instead
+#        deactivate
+#    fi
+#
+#    # Use the miniconda installer for faster download / install of conda
+#    # itself
+#    wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh \
+#        -O ~/miniconda.sh
+#    chmod +x ~/miniconda.sh && ~/miniconda.sh -b
+#    export PATH=$HOME/miniconda3/bin:$PATH
+#    echo $PATH
+#
+#    # Configure the conda environment and put it in the path using the
+#    # provided versions
     REQUIREMENTS=$(print_conda_requirements)
-    echo "conda requirements string: $REQUIREMENTS"
-    conda create -n testenv python==$PYTHON_VERSION --yes
-    source activate testenv
+#    echo "conda requirements string: $REQUIREMENTS"
+#    conda create -n testenv python==$PYTHON_VERSION --yes
+#    source activate testenv
     pip install $REQUIREMENTS
     pip install pytest pytest-cov
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -62,23 +62,26 @@ create_new_conda_env() {
 
     # Use the miniconda installer for faster download / install of conda
     # itself
-    wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh \
-        -O ~/miniconda.sh
-    chmod +x ~/miniconda.sh && ~/miniconda.sh -b
-    export PATH=$HOME/miniconda3/bin:$PATH
-    echo $PATH
+	# wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh \
+    #    -O ~/miniconda.sh
+    # chmod +x ~/miniconda.sh && ~/miniconda.sh -b
+    # export PATH=$HOME/miniconda3/bin:$PATH
+    # echo $PATH
 
     # Configure the conda environment and put it in the path using the
     # provided versions
     REQUIREMENTS=$(print_conda_requirements)
     echo "conda requirements string: $REQUIREMENTS"
-    conda create -n testenv --quiet --yes $REQUIREMENTS
-    source activate testenv
-    conda install pytest pytest-cov --yes
+    source testvenv/bin/activate
+    pip install --quiet $REQUIREMENTS
+    pip install pytest pytest-cov --quiet
+   # conda create -n testenv --quiet --yes $REQUIREMENTS
+   # source activate testenv
+   # conda install pytest pytest-cov --yes
 
     if [[ "$INSTALL_MKL" == "true" ]]; then
         # Make sure that MKL is used
-        conda install --quiet --yes mkl
+        pip install mkl
     elif [[ -z $CIRCLECI ]]; then
         # Travis doesn't use MKL but circle ci does for speeding up examples
         # generation in the html documentation.

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -45,7 +45,11 @@ print_conda_requirements() {
         # version to install
         PACKAGE_VERSION="${!PACKAGE_VERSION_VARNAME}"
         if [ -n "$PACKAGE_VERSION" ]; then
-            REQUIREMENTS="$REQUIREMENTS $PACKAGE==$PACKAGE_VERSION"
+            if [ "$PACKAGE_VERSION" == "*" ]; then
+                REQUIREMENTS="$REQUIREMENTS $PACKAGE"
+            else
+                REQUIREMENTS="$REQUIREMENTS $PACKAGE==$PACKAGE_VERSION"
+            fi
         fi
     done
     echo $REQUIREMENTS

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -25,7 +25,7 @@ create_new_venv() {
     pip install nose pytest
 }
 
-print_conda_requirements() {
+echo_requirements_string() {
     # Echo a conda requirement string for example
     # "pip nose python='2.7.3 scikit-learn=*". It has a hardcoded
     # list of possible packages to install and looks at _VERSION
@@ -55,8 +55,8 @@ print_conda_requirements() {
     echo $REQUIREMENTS
 }
 
-create_new_conda_env() {
-    REQUIREMENTS=$(print_conda_requirements)
+create_new_travisci_env() {
+    REQUIREMENTS=$(echo_requirements_string)
     pip install $REQUIREMENTS
     pip install pytest pytest-cov
 
@@ -72,8 +72,8 @@ if [[ "$DISTRIB" == "neurodebian" ]]; then
     bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
     sudo apt-get install -qq python-scipy python-nose python-nibabel python-sklearn python-joblib
 
-elif [[ "$DISTRIB" == "conda" ]]; then
-    create_new_conda_env
+elif [[ "$DISTRIB" == "travisci" ]]; then
+    create_new_travisci_env
     pip install nose-timer
     # Note: nibabel is in setup.py install_requires so nibabel will
     # always be installed eventually. Defining NIBABEL_VERSION is only

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -44,8 +44,8 @@ echo_requirements_string() {
         # dereference $PACKAGE_VERSION_VARNAME to figure out the
         # version to install
         PACKAGE_VERSION="${!PACKAGE_VERSION_VARNAME}"
-        if [ -n "$PACKAGE_VERSION" ]; then
-            if [ "$PACKAGE_VERSION" == "*" ]; then
+        if [[ -n "$PACKAGE_VERSION" ]]; then
+            if [[ "$PACKAGE_VERSION" == "*" ]]; then
                 REQUIREMENTS="$REQUIREMENTS $PACKAGE"
             else
                 REQUIREMENTS="$REQUIREMENTS $PACKAGE==$PACKAGE_VERSION"
@@ -57,7 +57,7 @@ echo_requirements_string() {
 
 create_new_travisci_env() {
     REQUIREMENTS=$(echo_requirements_string)
-    pip install $REQUIREMENTS
+    pip install ${REQUIREMENTS}
     pip install pytest pytest-cov
 
     if [[ "$INSTALL_MKL" == "true" ]]; then
@@ -79,7 +79,7 @@ elif [[ "$DISTRIB" == "travisci" ]]; then
     # always be installed eventually. Defining NIBABEL_VERSION is only
     # useful if you happen to want a specific nibabel version rather
     # than the latest available one.
-    if [ -n "$NIBABEL_VERSION" ]; then
+    if [[ -n "$NIBABEL_VERSION" ]]; then
         pip install nibabel=="$NIBABEL_VERSION"
     fi
 

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -26,7 +26,7 @@ create_new_venv() {
 }
 
 echo_requirements_string() {
-    # Echo a conda requirement string for example
+    # Echo a requirement string for example
     # "pip nose python='2.7.3 scikit-learn=*". It has a hardcoded
     # list of possible packages to install and looks at _VERSION
     # environment variables to know whether to install a given package and

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -71,7 +71,7 @@ create_new_conda_env() {
     # provided versions
     REQUIREMENTS=$(print_conda_requirements)
     echo "conda requirements string: $REQUIREMENTS"
-    conda create -n --yes testenv python==$PYTHON_VERSION
+    conda create -n testenv python==$PYTHON_VERSION --yes
     source activate testenv
     pip install $REQUIREMENTS
     pip install pytest pytest-cov

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -45,7 +45,7 @@ print_conda_requirements() {
         # version to install
         PACKAGE_VERSION="${!PACKAGE_VERSION_VARNAME}"
         if [ -n "$PACKAGE_VERSION" ]; then
-            REQUIREMENTS="$REQUIREMENTS $PACKAGE=$PACKAGE_VERSION"
+            REQUIREMENTS="$REQUIREMENTS $PACKAGE==$PACKAGE_VERSION"
         fi
     done
     echo $REQUIREMENTS

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -56,27 +56,7 @@ print_conda_requirements() {
 }
 
 create_new_conda_env() {
-#    # Skip Travis related code on circle ci.
-#    if [ -z $CIRCLECI ]; then
-#        # Deactivate the travis-provided virtual environment and setup a
-#        # conda-based environment instead
-#        deactivate
-#    fi
-#
-#    # Use the miniconda installer for faster download / install of conda
-#    # itself
-#    wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh \
-#        -O ~/miniconda.sh
-#    chmod +x ~/miniconda.sh && ~/miniconda.sh -b
-#    export PATH=$HOME/miniconda3/bin:$PATH
-#    echo $PATH
-#
-#    # Configure the conda environment and put it in the path using the
-#    # provided versions
     REQUIREMENTS=$(print_conda_requirements)
-#    echo "conda requirements string: $REQUIREMENTS"
-#    conda create -n testenv python==$PYTHON_VERSION --yes
-#    source activate testenv
     pip install $REQUIREMENTS
     pip install pytest pytest-cov
 


### PR DESCRIPTION
Fixes #2115 

Conda has become unreliable for use with CIs. Replacing it with alternatives such as pip and apt seems a prudent long term solution.