### PR TITLE
[WIP] Rename test to deduplicate name in test_signal

### DIFF
--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -444,7 +444,7 @@ def test_clean_confounds():
                                    np.zeros((20, 2)))
 
 
-def test_clean_frequencies():
+def test_clean_frequencies_using_power_spectrum_density():
 
     # Create signal
     sx = np.array([np.sin(np.linspace(0, 100, 100) * 1.5),


### PR DESCRIPTION
Some how there are two tests in `test_signal.py` with the same name, which means one of the test is overridden by another during collection and never run. This can be fixed by giving the tests unique names.

The purpose of the second test & hence it's name needs to be determined & decided.
@jeromedockes 