### PR TITLE
MAINT: Updates for nibabel deprecation

### DIFF
--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -40,7 +40,7 @@ def _safe_get_data(img, ensure_finite=False):
     # that's why we invoke a forced call to the garbage collector
     gc.collect()
 
-    data = img.get_data()
+    data = np.asanyarray(img.dataobj)
     if ensure_finite:
         non_finite_mask = np.logical_not(np.isfinite(data))
         if non_finite_mask.sum() > 0: # any non_finite_mask values?
@@ -113,17 +113,18 @@ def load_niimg(niimg, dtype=None):
                         " not compatible with nibabel format:\n"
                         + short_repr(niimg))
 
-    dtype = _get_target_dtype(niimg.get_data().dtype, dtype)
+    data = np.asanyarray(niimg.dataobj)
+    dtype = _get_target_dtype(data.dtype, dtype)
 
     if dtype is not None:
         # Copyheader and set dtype in header if header exists
         if niimg.header is not None:
-            niimg = new_img_like(niimg, niimg.get_data().astype(dtype),
-                                niimg.affine, copy_header=True)
-            niimg.header.set_data_dtype(dtype)        
+            niimg = new_img_like(niimg, data.astype(dtype),
+                                 niimg.affine, copy_header=True)
+            niimg.header.set_data_dtype(dtype)
         else:
-            niimg = new_img_like(niimg, niimg.get_data().astype(dtype),
-                                niimg.affine)
+            niimg = new_img_like(niimg, data.astype(dtype),
+                                 niimg.affine)
 
     return niimg
 

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -207,7 +207,8 @@ def get_mask_bounds(img):
 
     """
     img = _utils.check_niimg_3d(img)
-    mask = _utils.numpy_conversions._asarray(img.get_data(), dtype=np.bool)
+    data = np.asanyarray(img.dataobj)
+    mask = _utils.numpy_conversions._asarray(data, dtype=np.bool)
     affine = img.affine
     (xmin, xmax), (ymin, ymax), (zmin, zmax) = get_bounds(mask.shape, affine)
     slices = ndimage.find_objects(mask)
@@ -444,7 +445,7 @@ def resample_img(img, target_affine=None, target_shape=None,
     # We now know that some resampling must be done.
     # The value of "copy" is of no importance: output is always a separate
     # array.
-    data = img.get_data()
+    data = np.asanyarray(img.dataobj)
 
     # Get a bounding box for the transformed data
     # Embed target_affine in 4x4 shape if necessary


### PR DESCRIPTION
This takes care of some of the deprecation warnings on latest `nibabel` of the form:
```
  File "/home/larsoner/python/nilearn/nilearn/image/resampling.py", line 448, in resample_img
    data = img.get_data()
  File "/home/larsoner/python/nibabel/nibabel/deprecator.py", line 161, in deprecated_func
    warnings.warn(message, warn_class, stacklevel=2)
DeprecationWarning: get_data() is deprecated in favor of get_fdata(), which has a more predictable return type. To obtain get_data() behavior going forward, use numpy.asanyarray(img.dataobj).

* deprecated from version: 3.0
* Will raise <class 'nibabel.deprecator.ExpiredDeprecationError'> as of version: 5.0
```
I only tackled the ones that I needed to get `plot_glass_brain` not to complain anymore. If this seems like the right approach (I just did what `nibabel` recommended) I can try to look for other instances using `git grep`.