### PR TITLE
Import HTMLDocument in its original module to preserve backwards compatibility

### DIFF
--- a/nilearn/plotting/js_plotting_utils.py
+++ b/nilearn/plotting/js_plotting_utils.py
@@ -12,7 +12,9 @@ import matplotlib as mpl
 import numpy as np
 from matplotlib import cm as mpl_cm
 
-from nilearn.reporting.html_document import HTMLDocument  # noqa
+from nilearn.reporting.html_document import (HTMLDocument,
+                                             set_max_img_views_before_warning,
+                                             )  # noqa
 from .._utils.extmath import fast_abs_percentile
 from .._utils.param_validation import check_threshold
 from .. import surface

--- a/nilearn/plotting/js_plotting_utils.py
+++ b/nilearn/plotting/js_plotting_utils.py
@@ -12,6 +12,7 @@ import matplotlib as mpl
 import numpy as np
 from matplotlib import cm as mpl_cm
 
+from nilearn.reporting.html_document import HTMLDocument  # noqa
 from .._utils.extmath import fast_abs_percentile
 from .._utils.param_validation import check_threshold
 from .. import surface

--- a/nilearn/plotting/js_plotting_utils.py
+++ b/nilearn/plotting/js_plotting_utils.py
@@ -12,9 +12,9 @@ import matplotlib as mpl
 import numpy as np
 from matplotlib import cm as mpl_cm
 
-from nilearn.reporting.html_document import (HTMLDocument,
-                                             set_max_img_views_before_warning,
-                                             )  # noqa
+# included here for backward compatibility
+from nilearn.reporting.html_document import (
+    HTMLDocument, set_max_img_views_before_warning,)  # noqa
 from .._utils.extmath import fast_abs_percentile
 from .._utils.param_validation import check_threshold
 from .. import surface

--- a/nilearn/plotting/tests/test_js_plotting_utils.py
+++ b/nilearn/plotting/tests/test_js_plotting_utils.py
@@ -309,3 +309,8 @@ def test_to_color_strings():
     colors = ['#0000ffff', '#ff0000ab', '#7f7f7f00']
     as_str = js_plotting_utils.to_color_strings(colors)
     assert as_str == ['#0000ff', '#ff0000', '#7f7f7f']
+
+
+def test_import_html_document_from_js_plotting():
+    from nilearn.plotting.js_plotting_utils import (
+        HTMLDocument, set_max_img_views_before_warning)  #noqa


### PR DESCRIPTION
Fixes #2158 