### PR TITLE
do not fail if metadata cannot be updated for an image

### DIFF
--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -1661,8 +1661,10 @@ def _update_image(image_info, download_params):
             'image_{0}_metadata.json'.format(image_info['id']))
         _write_metadata(image_info, metadata_file_path)
     except OSError:
-        warnings.warn("could not update metadata for image {}".format(
-            image_info["id"]))
+        warnings.warn(
+            "could not update metadata for image {}, "
+            "most likely because you do not have write "
+            "permissions to its metadata file".format(image_info["id"]))
     return image_info
 
 

--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -1651,19 +1651,23 @@ def _update_image(image_info, download_params):
     """
     if not download_params['write_ok']:
         return image_info
-    collection = _fetch_collection_for_image(
-        image_info, download_params)
-    image_info, collection = _download_image_terms(
-        image_info, collection, download_params)
-    metadata_file_path = os.path.join(
-        os.path.dirname(image_info['absolute_path']),
-        'image_{0}_metadata.json'.format(image_info['id']))
-    _write_metadata(image_info, metadata_file_path)
+    try:
+        collection = _fetch_collection_for_image(
+            image_info, download_params)
+        image_info, collection = _download_image_terms(
+            image_info, collection, download_params)
+        metadata_file_path = os.path.join(
+            os.path.dirname(image_info['absolute_path']),
+            'image_{0}_metadata.json'.format(image_info['id']))
+        _write_metadata(image_info, metadata_file_path)
+    except OSError:
+        warnings.warn("could not update metadata for image {}".format(
+            image_info["id"]))
     return image_info
 
 
 def _update(image_info, collection, download_params):
-    """Update local metadata for an image and its collection."""
+    "Update local metadata for an image and its collection."""
     image_info = _update_image(image_info, download_params)
     return image_info, collection
 


### PR DESCRIPTION
In some cases the neurovault fetcher tries to update the metadata. at the moment this can fail if the user has write permission for the neurovault data directory, but not for the metadata file of a particular image for some weird reason. this pr skips these updates with a warning