### PR TITLE
Restore Localizer fetchers interface for backwards compatibility

### DIFF
--- a/examples/01_plotting/plot_dim_plotting.py
+++ b/examples/01_plotting/plot_dim_plotting.py
@@ -21,9 +21,9 @@ from nilearn import datasets
 
 localizer_dataset = datasets.fetch_localizer_button_task()
 # Contrast map of motor task
-localizer_tmap_filename = localizer_dataset.tmaps[0]
+localizer_tmap_filename = localizer_dataset.tmap
 # Subject specific anatomical image
-localizer_anat_filename = localizer_dataset.anats[0]
+localizer_anat_filename = localizer_dataset.anat
 ###########################################################################
 # Plotting with enhancement of background image with dim=-.5
 # --------------------------------------------------------------------------

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -1073,7 +1073,7 @@ def fetch_localizer_calculation_task(n_subjects=1, data_dir=None, url=None,
     return data
 
 
-def fetch_localizer_button_task(n_subjects=None, data_dir=None, url=None,
+def fetch_localizer_button_task(data_dir=None, url=None,
                                 verbose=1):
     """Fetch left vs right button press contrast maps from the localizer.
 
@@ -1116,18 +1116,14 @@ def fetch_localizer_button_task(n_subjects=None, data_dir=None, url=None,
     nilearn.datasets.fetch_localizer_contrasts
 
     """
-    if n_subjects is None:
-        n_subjects = [2]
     data = fetch_localizer_contrasts(["left vs right button press"],
-                                     n_subjects=n_subjects,
+                                     n_subjects=[2],
                                      get_tmaps=True, get_masks=False,
                                      get_anats=True, data_dir=data_dir,
                                      url=url, resume=True, verbose=verbose)
-    # TODO: remove -> only here for compatibility
-    if len(data["tmaps"]) == 1:
-        setattr(data, "tmap", data["tmaps"][0])
-    if len(data["anats"]) == 1:
-        setattr(data, "anat", data["anats"][0])
+    # Additional keys for backward compatibility
+    data['tmap'] = data['tmaps'][0]
+    data['anat'] = data['anats'][0]
     return data
 
 

--- a/nilearn/datasets/tests/test_func.py
+++ b/nilearn/datasets/tests/test_func.py
@@ -281,12 +281,23 @@ def test_fetch_localizer_calculation_task():
 @with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 @with_setup(setup_localizer, teardown_localizer)
 def test_fetch_localizer_button_task():
-    # 2 subjects
-    dataset = func.fetch_localizer_button_task(
-        data_dir=tst.tmpdir,
-        verbose=1)
-    assert_true(isinstance(dataset.tmaps[0], _basestring))
-    assert_true(isinstance(dataset.anats[0], _basestring))
+    local_url = "file://" + tst.datadir
+
+    # Disabled: cannot be tested without actually fetching covariates CSV file
+    # Only one subject
+    dataset = func.fetch_localizer_button_task(data_dir=tst.tmpdir,
+                                               url=local_url,
+                                               verbose=1)
+
+    assert_true(isinstance(dataset.tmaps, list))
+    assert_true(isinstance(dataset.anats, list))
+
+    assert len(dataset.tmaps) == 1
+    assert len(dataset.anats) == 1
+
+    assert_true(isinstance(dataset.tmap, str))
+    assert_true(isinstance(dataset.anat, str))
+
     assert_not_equal(dataset.description, '')
 
 


### PR DESCRIPTION
Fixes #2181 

Making `fetch_localizer_button_task` & `fetch_localizer_calculation_task` backwards compatible.

 - TODO: fetch_localizer_calculation_task()
 - TOFIX: Example plot_dim_plotting.py is failing here & in pre PR 2097.