### PR TITLE
[DOC] update whats_new to reference #2013

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -38,7 +38,17 @@ NEW
   functional connectivity. Similar example in
   `examples/03_connectivity/plot_group_level_connectivity.py` simplified.
 
-- the Localizer dataset now follows the BIDS organization.
+- Merged `examples/03_connectivity/plot_adhd_spheres.py` and
+  `examples/03_connectivity/plot_sphere_based_connectome.py` to remove
+  duplication across examples. The improved
+  `examples/03_connectivity/plot_sphere_based_connectome.py` contains
+  concepts previously reviewed in both examples.
+- Similarly, merged `examples/03_connectivity/plot_compare_decomposition.py`
+  and `examples/03_connectivity/plot_canica_analysis.py` into an improved
+  `examples/03_connectivity/plot_compare_decomposition.py`.
+
+- The Localizer dataset now follows the BIDS organization.
+
 
 Changes
 -------


### PR DESCRIPTION
Closes https://github.com/nilearn/nilearn/issues/1986.

Updates `whats_new.rst` to reference #2013 example consolidation by @illdopejake.