### PR TITLE
[doc] improve documentation re: using index_img with slice()

### DIFF
--- a/examples/plot_3d_and_4d_niimg.py
+++ b/examples/plot_3d_and_4d_niimg.py
@@ -94,8 +94,8 @@ selected_volumes = image.index_img(rsn, slice(3, 5))
 
 ###############################################################################
 # If you're new to Python, one thing to note is that the slice constructor
-# uses 0-based indexing. This is standard in Python, but it may be unfamilar
-# if you're transitioning from another programming language.
+# uses 0-based indexing. You can confirm this by matching these slices
+# to the previous plot above.
 
 for img in image.iter_img(selected_volumes):
     plotting.plot_stat_map(img)

--- a/examples/plot_3d_and_4d_niimg.py
+++ b/examples/plot_3d_and_4d_niimg.py
@@ -86,15 +86,19 @@ for img in image.iter_img(rsn):
 # ---------------------------------------------
 #
 # If we want to plot selected volumes in this 4D file, we can use index_img
-# with the slice() constructor to select the desired volumes. 
+# with the `slice` constructor to select the desired volumes. 
 # 
 # Afterwards, we'll use iter_img to loop through them following the same 
 # formula as before.
 selected_volumes = image.index_img(rsn, slice(3, 5))
 
+###############################################################################
+# If you're new to Python, one thing to note is that the slice constructor
+# uses 0-based indexing. This is standard in Python, but it may be unfamilar
+# if you're transitioning from another programming language.
+
 for img in image.iter_img(selected_volumes):
-    plotting.plot_stat_map(img, threshold=3, display_mode="z", cut_coords=1,
-                           colorbar=False)
+    plotting.plot_stat_map(img)
 
 
 ###############################################################################

--- a/examples/plot_3d_and_4d_niimg.py
+++ b/examples/plot_3d_and_4d_niimg.py
@@ -82,6 +82,22 @@ for img in image.iter_img(rsn):
 
 
 ###############################################################################
+# Looping through selected volumes in a 4D file
+# ---------------------------------------------
+#
+# If we want to plot selected volumes in this 4D file, we can use index_img
+# with the slice() constructor to select the desired volumes. 
+# 
+# Afterwards, we'll use iter_img to loop through them following the same 
+# formula as before.
+selected_volumes = image.index_img(rsn, slice(3, 5))
+
+for img in image.iter_img(selected_volumes):
+    plotting.plot_stat_map(img, threshold=3, display_mode="z", cut_coords=1,
+                           colorbar=False)
+
+
+###############################################################################
 # plotting.show is useful to force the display of figures when running
 # outside IPython
 plotting.show()

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -615,6 +615,10 @@ def index_img(imgs, index):
 
     >>> full_timeseries = datasets.fetch_development_fmri(n_subjects=1,
     ...                                                   verbose=0).func
+    <BLANKLINE>
+    Dataset created in .../development_fmri # doctest:+ELLIPSIS
+    <BLANKLINE>
+
     >>> print(load_img(full_timeseries).shape)
     (50, 59, 50, 168)
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -599,7 +599,7 @@ def index_img(imgs, index):
     First we concatenate two mni152 images to create a 4D-image::
 
      >>> from nilearn import datasets
-     >>> from nilearn.image import concat_imgs, index_img
+     >>> from nilearn.image import concat_imgs, index_img, load_img
      >>> joint_mni_image = concat_imgs([datasets.load_mni152_template(),
      ...                                datasets.load_mni152_template()])
      >>> print(joint_mni_image.shape)
@@ -610,6 +610,16 @@ def index_img(imgs, index):
      >>> single_mni_image = index_img(joint_mni_image, 1)
      >>> print(single_mni_image.shape)
      (91, 109, 91)
+
+    We can also select multiple frames using the `slice` constructor::
+
+    >>> full_timeseries = datasets.fetch_development_fmri(n_subjects=1).func
+    >>> print(load_img(full_timeseries).shape)
+    (50, 59, 50, 168)
+
+    >>> first_ten_frames = index_img(func, slice(0, 10))
+    >>> print(first_ten_frames.shape)
+    (50, 59, 50, 10)
     """
     imgs = check_niimg_4d(imgs)
     # duck-type for pandas arrays, and select the 'values' attr

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -599,7 +599,7 @@ def index_img(imgs, index):
     First we concatenate two mni152 images to create a 4D-image::
 
      >>> from nilearn import datasets
-     >>> from nilearn.image import concat_imgs, index_img, load_img
+     >>> from nilearn.image import concat_imgs, index_img
      >>> joint_mni_image = concat_imgs([datasets.load_mni152_template(),
      ...                                datasets.load_mni152_template()])
      >>> print(joint_mni_image.shape)

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -613,17 +613,12 @@ def index_img(imgs, index):
 
     We can also select multiple frames using the `slice` constructor::
 
-    >>> full_timeseries = datasets.fetch_development_fmri(n_subjects=1,
-    ...                                                   verbose=0).func
-    <BLANKLINE>
-    Dataset created in .../development_fmri # doctest:+ELLIPSIS
-    <BLANKLINE>
-
-    >>> print(load_img(full_timeseries).shape)
+    >>> full_timeseries = datasets.fetch_development_fmri(n_subjects=1).func # doctest: +SKIP
+    >>> print(load_img(full_timeseries).shape) # doctest: +SKIP
     (50, 59, 50, 168)
 
-    >>> first_ten_frames = index_img(func, slice(0, 10))
-    >>> print(first_ten_frames.shape)
+    >>> first_ten_frames = index_img(full_timeseries, slice(0, 10)) # doctest: +SKIP
+    >>> print(first_ten_frames.shape) # doctest: +SKIP
     (50, 59, 50, 10)
     """
     imgs = check_niimg_4d(imgs)

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -613,13 +613,13 @@ def index_img(imgs, index):
 
     We can also select multiple frames using the `slice` constructor::
 
-    >>> full_timeseries = datasets.fetch_development_fmri(n_subjects=1).func # doctest: +SKIP
-    >>> print(load_img(full_timeseries).shape) # doctest: +SKIP
-    (50, 59, 50, 168)
-
-    >>> first_ten_frames = index_img(full_timeseries, slice(0, 10)) # doctest: +SKIP
-    >>> print(first_ten_frames.shape) # doctest: +SKIP
-    (50, 59, 50, 10)
+     >>> full_timeseries = datasets.fetch_development_fmri(n_subjects=1).func # doctest: +SKIP
+     >>> print(load_img(full_timeseries).shape) # doctest: +SKIP
+     (50, 59, 50, 168)
+    
+     >>> first_ten_frames = index_img(full_timeseries, slice(0, 10)) # doctest: +SKIP
+     >>> print(first_ten_frames.shape) # doctest: +SKIP
+     (50, 59, 50, 10)
     """
     imgs = check_niimg_4d(imgs)
     # duck-type for pandas arrays, and select the 'values' attr

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -613,12 +613,13 @@ def index_img(imgs, index):
 
     We can also select multiple frames using the `slice` constructor::
 
-     >>> full_timeseries = datasets.fetch_development_fmri(
+     >>> functional_scan = datasets.fetch_development_fmri(
      ...    n_subjects=1, verbose=0).func # doctest: +ELLIPSIS
      <BLANKLINE>
      Dataset created in .../development_fmri
      <BLANKLINE>
-     >>> print(load_img(full_timeseries).shape)
+     >>> full_timeseries = load_img(functional_scan)
+     >>> print(full_timeseries.shape)
      (50, 59, 50, 168)
     
      >>> first_ten_frames = index_img(full_timeseries, slice(0, 10))

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -613,18 +613,14 @@ def index_img(imgs, index):
 
     We can also select multiple frames using the `slice` constructor::
 
-     >>> functional_scan = datasets.fetch_development_fmri(
-     ...    n_subjects=1, verbose=0).func # doctest: +ELLIPSIS
-     <BLANKLINE>
-     Dataset created in .../development_fmri
-     <BLANKLINE>
-     >>> full_timeseries = load_img(functional_scan)
-     >>> print(full_timeseries.shape)
-     (50, 59, 50, 168)
+     >>> five_mni_images = concat_imgs([datasets.load_mni152_template()] * 5)
+     >>> print(five_mni_images.shape)
+     (91, 109, 91, 5)
     
-     >>> first_ten_frames = index_img(full_timeseries, slice(0, 10))
-     >>> print(first_ten_frames.shape)
-     (50, 59, 50, 10)
+     >>> first_three_images = index_img(five_mni_images,
+     ...                                slice(0, 3))
+     >>> print(first_three_images.shape)
+     (91, 109, 91, 3)
     """
     imgs = check_niimg_4d(imgs)
     # duck-type for pandas arrays, and select the 'values' attr

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -613,12 +613,16 @@ def index_img(imgs, index):
 
     We can also select multiple frames using the `slice` constructor::
 
-     >>> full_timeseries = datasets.fetch_development_fmri(n_subjects=1).func # doctest: +SKIP
-     >>> print(load_img(full_timeseries).shape) # doctest: +SKIP
+     >>> full_timeseries = datasets.fetch_development_fmri(
+     ...    n_subjects=1, verbose=0).func # doctest: +ELLIPSIS
+     <BLANKLINE>
+     Dataset created in .../development_fmri
+     <BLANKLINE>
+     >>> print(load_img(full_timeseries).shape)
      (50, 59, 50, 168)
     
-     >>> first_ten_frames = index_img(full_timeseries, slice(0, 10)) # doctest: +SKIP
-     >>> print(first_ten_frames.shape) # doctest: +SKIP
+     >>> first_ten_frames = index_img(full_timeseries, slice(0, 10))
+     >>> print(first_ten_frames.shape)
      (50, 59, 50, 10)
     """
     imgs = check_niimg_4d(imgs)

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -613,7 +613,8 @@ def index_img(imgs, index):
 
     We can also select multiple frames using the `slice` constructor::
 
-    >>> full_timeseries = datasets.fetch_development_fmri(n_subjects=1).func
+    >>> full_timeseries = datasets.fetch_development_fmri(n_subjects=1,
+    ...                                                   verbose=0).func
     >>> print(load_img(full_timeseries).shape)
     (50, 59, 50, 168)
 


### PR DESCRIPTION
Addresses #2188 

* Adds a description of using the `slice()` constructor to the `nilearn.image.index_img` docstring *Examples* section
* Adds an example of using the `slice()` constructor to index a 4D image in the `plot_3d_and_4d` examples image

Updated outputs:

* Rendered [example](https://5074-1235740-gh.circle-artifacts.com/0/home/circleci/project/doc/_build/html/auto_examples/plot_3d_and_4d_niimg.html#sphx-glr-auto-examples-plot-3d-and-4d-niimg-py)
* Rendered [docstring](https://5074-1235740-gh.circle-artifacts.com/0/home/circleci/project/doc/_build/html/modules/generated/nilearn.image.index_img.html#nilearn-image-index-img)