### PR TITLE
Update Python version warnings

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,3 +1,14 @@
+0.6.0b1
+=======
+
+NEW
+---
+
+- **Support for Python3.5 wil be removed in the 0.7.x release.**
+  Users with a Python3.5 environment will be warned
+  at their first Nilearn import.
+
+
 0.6.0b0
 =======
 

--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -47,32 +47,21 @@ from .version import _check_module_dependencies, __version__
 # see also https://github.com/scikit-learn/scikit-learn/pull/15020
 os.environ.setdefault("KMP_INIT_AT_FORK", "FALSE")
 
-def _py2_deprecation_warning():
-    py2_warning = ('Python2 support is deprecated and will be removed in '
-                   'the next release. Consider switching to Python 3.6 or 3.7.'
-                   )
-    warnings.filterwarnings('once', message=py2_warning)
-    warnings.warn(message=py2_warning,
-                  category=DeprecationWarning,
-                  stacklevel=3,
-                  )
 
-def _py34_deprecation_warning():
-    py34_warning = ('Python 3.4 support is deprecated and will be removed in '
-                   'the next release. Consider switching to Python 3.6 or 3.7.'
-                   )
-    warnings.filterwarnings('once', message=py34_warning)
-    warnings.warn(message=py34_warning,
-                  category=DeprecationWarning,
+def _py35_deprecation_warning():
+    py35_warning = ('Python 3.5 support is deprecated and will be removed in '
+                    'a future release. Consider switching to Python 3.6 or 3.7'
+                    )
+    warnings.filterwarnings('once', message=py35_warning)
+    warnings.warn(message=py35_warning,
+                  category=FutureWarning,
                   stacklevel=3,
                   )
 
 
 def _python_deprecation_warnings():
-    if sys.version_info.major == 2:
-        _py2_deprecation_warning()
-    elif sys.version_info.major == 3 and sys.version_info.minor == 4:
-        _py34_deprecation_warning()
+    if sys.version_info.major == 3 and sys.version_info.minor == 5:
+        _py35_deprecation_warning()
 
 
 _check_module_dependencies()

--- a/nilearn/tests/test_init.py
+++ b/nilearn/tests/test_init.py
@@ -24,7 +24,6 @@ def test_python_deprecation_warnings():
             _python_deprecation_warnings()
 
 
-
 def test_warnings_filter_scope():
     """
     Tests that warnings generated at Nilearn import in Python 3.5 envs

--- a/nilearn/tests/test_init.py
+++ b/nilearn/tests/test_init.py
@@ -1,64 +1,40 @@
 import sys
 import warnings
 
-from nose.tools import assert_true
+import pytest
 
 # import time warnings don't interfere with warning's tests
 with warnings.catch_warnings(record=True):
-    from nilearn import _py34_deprecation_warning
-    from nilearn import _py2_deprecation_warning
+    from nilearn import _py35_deprecation_warning
     from nilearn import _python_deprecation_warnings
 
 
-def test_py2_deprecation_warning():
-    with warnings.catch_warnings(record=True) as raised_warnings:
-            _py2_deprecation_warning()
-    assert_true(raised_warnings[0].category is DeprecationWarning)
-    assert_true(
-            str(raised_warnings[0].message).startswith(
-                    'Python2 support is deprecated')
-            )
-
-
-def test_py34_deprecation_warning():
-    with warnings.catch_warnings(record=True) as raised_warnings:
-        _py34_deprecation_warning()
-    assert_true(raised_warnings[0].category is DeprecationWarning)
-    assert_true(
-            str(raised_warnings[0].message).startswith(
-            'Python 3.4 support is deprecated')
-            )
+def test_py35_deprecation_warning():
+    with pytest.warns(FutureWarning,
+                      match='Python 3.5 support is deprecated'
+                      ):
+        _py35_deprecation_warning()
 
 
 def test_python_deprecation_warnings():
-    with warnings.catch_warnings(record=True) as raised_warnings:
-        _python_deprecation_warnings()
-    if sys.version_info.major == 2:
-        assert_true(raised_warnings[0].category is DeprecationWarning)
-        assert_true(
-                str(raised_warnings[0].message).startswith(
-                        'Python2 support is deprecated')
-                )
-    elif sys.version_info.major == 3 and sys.version_info.minor == 4:
-        assert_true(raised_warnings[0].category is DeprecationWarning)
-        assert_true(
-                str(raised_warnings[0].message).startswith(
-                        'Python 3.4 support is deprecated')
-                )
-    else:
-        assert_true(len(raised_warnings) == 0)
+    if sys.version_info.major == 3 and sys.version_info.minor == 5:
+        with pytest.warns(FutureWarning,
+                          match='Python 3.5 support is deprecated'
+                          ):
+            _python_deprecation_warnings()
+
 
 
 def test_warnings_filter_scope():
     """
-    Tests that warnings generated at Nilearn import in Python 2, 3.4 envs
+    Tests that warnings generated at Nilearn import in Python 3.5 envs
     do not change the warnings filter for subsequent warnings.
     """
     with warnings.catch_warnings(record=True) as raised_warnings:
         warnings.warn('Dummy warning 1')  # Will be raised.
         warnings.filterwarnings("ignore", message="Dummy warning")
         warnings.warn('Dummy warning 2')  # Will not be raised.
-        import nilearn  # Irrespective of warning raised in py2, py3.4 ...
+        import nilearn  # Irrespective of warning raised in py3.5 ...
         warnings.warn('Dummy warning 3')  # ...this should not be raised.
     assert str(raised_warnings[0].message) == 'Dummy warning 1'
     assert str(raised_warnings[-1].message) != 'Dummy warning 3'

--- a/nilearn/tests/test_init.py
+++ b/nilearn/tests/test_init.py
@@ -33,7 +33,7 @@ def test_warnings_filter_scope():
         warnings.warn('Dummy warning 1')  # Will be raised.
         warnings.filterwarnings("ignore", message="Dummy warning")
         warnings.warn('Dummy warning 2')  # Will not be raised.
-        import nilearn  # Irrespective of warning raised in py3.5 ...
+        import nilearn  # noqa: F401 # Irrespective of warning raised in py3.5
         warnings.warn('Dummy warning 3')  # ...this should not be raised.
     assert str(raised_warnings[0].message) == 'Dummy warning 1'
     assert str(raised_warnings[-1].message) != 'Dummy warning 3'


### PR DESCRIPTION
Fixes #2213 

Remove warnings for Python2, 3.4 .
Add warning to for Python 3.5