### PR TITLE
Fix: load_surf_mesh and vol_to_surf offset vertices coords by CRAS

### DIFF
--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -713,7 +713,8 @@ def load_surf_mesh(surf_mesh):
                 surf_mesh.endswith('white') or surf_mesh.endswith('sphere') or
                 surf_mesh.endswith('inflated')):
             coords, faces, header = fs.io.read_geometry(surf_mesh, read_metadata=True)
-            coords += header['cras']
+            if 'cras' in header:
+                coords += header['cras']
         elif surf_mesh.endswith('gii'):
             if LooseVersion(nibabel.__version__) >= LooseVersion('2.1.0'):
                 gifti_img = nibabel.load(surf_mesh)

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -712,7 +712,8 @@ def load_surf_mesh(surf_mesh):
         if (surf_mesh.endswith('orig') or surf_mesh.endswith('pial') or
                 surf_mesh.endswith('white') or surf_mesh.endswith('sphere') or
                 surf_mesh.endswith('inflated')):
-            coords, faces = fs.io.read_geometry(surf_mesh)
+            coords, faces, header = fs.io.read_geometry(surf_mesh, read_metadata=True)
+            coords += header['cras']
         elif surf_mesh.endswith('gii'):
             if LooseVersion(nibabel.__version__) >= LooseVersion('2.1.0'):
                 gifti_img = nibabel.load(surf_mesh)


### PR DESCRIPTION
There is offset between Freesurfer coordinate space and orig T1 space named CRAS. The issue misleads [`vol_to_surf`](https://github.com/nilearn/nilearn/blob/4e1ccac93753ffb2eced2d7cbb20d91688d21fab/nilearn/surface/surface.py#L386) when it try to project voxels from volume (.nii file) in T1 space onto surface (.orig, .pial, .white, .sphere, or .inflated) extracted by Freesurfer from the same volume (or at least from the volume in the same T1 space):
we observe some shift between volume and surface
![plot_surf_stat_map-before](https://user-images.githubusercontent.com/1339345/68902720-20f31f80-074a-11ea-93c3-75e16813e888.png)
instead of uniform distribution of voxels intensity near the cortex
![plot_surf_stat_map-after](https://user-images.githubusercontent.com/1339345/68902740-2b151e00-074a-11ea-92a4-362686391875.png)
It is easily solved by CRAS offsetting vertices coords loaded by [`load_surf_mesh`](https://github.com/nilearn/nilearn/blob/4e1ccac93753ffb2eced2d7cbb20d91688d21fab/nilearn/surface/surface.py#L681). It seems this does [not apply to .gii](https://neurostars.org/t/resample-volume-and-surface-to-same-orientation/4069/4) files.
