### PR TITLE
MAINT: sklearn Deprecations

### DIFF
--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -11,7 +11,7 @@ import warnings
 import gc
 
 import numpy as np
-from sklearn.utils.testing import assert_warns
+from numpy.testing import assert_warns  # noqa: F401
 
 from .compat import _basestring, _urllib
 from ..datasets.utils import _fetch_files

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -11,7 +11,7 @@ import shutil
 import nibabel as nb
 import numpy as np
 from numpy.lib import recfunctions
-from sklearn.datasets.base import Bunch
+from sklearn.utils import Bunch
 
 from .utils import _get_dataset_dir, _fetch_files, _get_dataset_descr
 from .._utils import check_niimg

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -9,8 +9,7 @@ import numpy as np
 import numbers
 
 import nibabel
-from sklearn.datasets.base import Bunch
-from sklearn.utils import deprecated
+from sklearn.utils import Bunch, deprecated
 
 from .utils import (_get_dataset_dir, _fetch_files, _get_dataset_descr,
                     _read_md5_sum_file, _tree, _filter_columns, _fetch_file)

--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -27,7 +27,7 @@ except ImportError:
     from collections import Container
 
 import numpy as np
-from sklearn.datasets.base import Bunch
+from sklearn.utils import Bunch
 from sklearn.feature_extraction import DictVectorizer
 
 from .._utils.compat import _basestring

--- a/nilearn/datasets/struct.py
+++ b/nilearn/datasets/struct.py
@@ -5,7 +5,7 @@ import warnings
 import os
 import numpy as np
 from scipy import ndimage
-from sklearn.datasets.base import Bunch
+from sklearn.utils import Bunch
 
 from .utils import (_get_dataset_dir, _fetch_files,
                     _get_dataset_descr, _uncompress_file)

--- a/nilearn/datasets/tests/test_neurovault.py
+++ b/nilearn/datasets/tests/test_neurovault.py
@@ -21,7 +21,7 @@ from functools import wraps
 import numpy as np
 from nose import SkipTest
 from nose.tools import (assert_true, assert_false, assert_equal, assert_raises)
-from sklearn.utils.testing import assert_warns
+from from nilearn._utils.testing import assert_warns
 
 from nilearn.datasets import neurovault
 

--- a/nilearn/datasets/tests/test_neurovault.py
+++ b/nilearn/datasets/tests/test_neurovault.py
@@ -21,7 +21,7 @@ from functools import wraps
 import numpy as np
 from nose import SkipTest
 from nose.tools import (assert_true, assert_false, assert_equal, assert_raises)
-from from nilearn._utils.testing import assert_warns
+from nilearn._utils.testing import assert_warns
 
 from nilearn.datasets import neurovault
 


### PR DESCRIPTION
On latest `sklearn` master takes care of warnings of the form:
```
E   FutureWarning: The sklearn.utils.testing module is  deprecated in version 0.22 and will be removed in version 0.24. The corresponding classes / functions should instead be imported from sklearn.utils. Anything that cannot be imported from sklearn.utils is now part of the private API.
```
and
```
E   FutureWarning: The sklearn.datasets.base module is  deprecated in version 0.22 and will be removed in version 0.24. The corresponding classes / functions should instead be imported from sklearn.datasets. Anything that cannot be imported from sklearn.datasets is now part of the private API.
```