### PR TITLE
CI: Test pre-release versions of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ matrix:
     # allow_failures keyed to python 3.5 & skipping tests.
     - python: "3.5"
       env: DISTRIB="travisci" PYTHON_VERSION="3.5" FLAKE8_VERSION="*" SKIP_TESTS="true"
+    - python: "3.7"
+      env: DISTRIB="travisci" PIP_FLAGS="--pre" COVERAGE="true"
+           NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
+           SCIKIT_LEARN_VERSION="*" JOBLIB_VERSION="*" LXML_VERSION="*"
   include:
     - name: "Python 3.5 minimum package versions without Matplotlib"
       python: "3.5"
@@ -44,6 +48,12 @@ matrix:
            NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
            SCIKIT_LEARN_VERSION="*" MATPLOTLIB_VERSION="*" COVERAGE="true"
            JOBLIB_VERSION="*" LXML_VERSION="*"
+
+    - name: "Python 3.7 pre-release checks"
+      python: "3.7"
+      env: DISTRIB="travisci" PIP_FLAGS="--pre" COVERAGE="true"
+           NUMPY_VERSION="*" SCIPY_VERSION="*" PANDAS_VERSION="*"
+           SCIKIT_LEARN_VERSION="*" JOBLIB_VERSION="*" LXML_VERSION="*"
 
   # FLAKE8 linting on diff wrt common ancestor with upstream/master
     # Note: the python value is only there to trigger allow_failures

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -57,7 +57,7 @@ echo_requirements_string() {
 
 create_new_travisci_env() {
     REQUIREMENTS=$(echo_requirements_string)
-    pip install ${REQUIREMENTS}
+    pip install $PIP_FLAGS ${REQUIREMENTS}
     pip install pytest pytest-cov
 
     if [[ "$INSTALL_MKL" == "true" ]]; then
@@ -97,5 +97,5 @@ fi
 # numpy not installed when skipping the tests so we do not want to run
 # setup.py install
 if [[ "$SKIP_TESTS" != "true" ]]; then
-    python setup.py install
+    pip install $PIP_FLAGS .
 fi


### PR DESCRIPTION
Fixes #1728 
I noticed that you aren't testing pre-releases (I was checking to see if the nibabel RC was causing problems). I've found it very helpful to see when changes coming down the pipeline (particularly from numpy) are going to break compatibility.

This PR adds an optional `PIP_FLAGS` environment variable that will be added to `pip install` commands for requirements and nilearn.

Feel free to merge if this seems useful. I can also just use the Travis results for this PR to see if we're breaking anything.