### PR TITLE
CI: Use pkg_resources to list installed dependencies

### DIFF
--- a/continuous_integration/show-python-packages-versions.py
+++ b/continuous_integration/show-python-packages-versions.py
@@ -8,12 +8,14 @@ DEPENDENCIES = ['numpy', 'scipy', 'scikit-learn', 'joblib', 'matplotlib',
 def print_package_version(package_name, indent='  '):
     try:
         dist = pkg_resources.get_distribution(package_name)
-        provenance_info = '{0} installed in {1}'.format(dist.version,
-                                                        dist.location)
     except pkg_resources.DistributionNotFound:
         provenance_info = 'not installed'
+    else:
+        provenance_info = '{0} installed in {1}'.format(dist.version,
+                                                        dist.location)
 
     print('{0}{1}: {2}'.format(indent, package_name, provenance_info))
+
 
 if __name__ == '__main__':
     print('=' * 120)

--- a/continuous_integration/show-python-packages-versions.py
+++ b/continuous_integration/show-python-packages-versions.py
@@ -1,4 +1,5 @@
 import sys
+import pkg_resources
 
 DEPENDENCIES = ['numpy', 'scipy', 'scikit-learn', 'joblib', 'matplotlib',
                 'nibabel']
@@ -6,11 +7,10 @@ DEPENDENCIES = ['numpy', 'scipy', 'scikit-learn', 'joblib', 'matplotlib',
 
 def print_package_version(package_name, indent='  '):
     try:
-        package = __import__(package_name)
-        version = getattr(package, '__version__', None)
-        package_file = getattr(package, '__file__', )
-        provenance_info = '{0} from {1}'.format(version, package_file)
-    except ImportError:
+        dist = pkg_resources.get_distribution(package_name)
+        provenance_info = '{0} installed in {1}'.format(dist.version,
+                                                        dist.location)
+    except pkg_resources.DistributionNotFound:
         provenance_info = 'not installed'
 
     print('{0}{1}: {2}'.format(indent, package_name, provenance_info))


### PR DESCRIPTION
While reading outputs in #2224, it looked like scikit-learn was not installed, but this is because the import is `sklearn`.

[Example](https://travis-ci.org/nilearn/nilearn/jobs/615268943):

```
Dependencies versions
  numpy: 1.15.4 from /home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/numpy/__init__.py
  scipy: 1.3.2 from /home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/scipy/__init__.py
  scikit-learn: not installed
  joblib: 0.14.0 from /home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/joblib/__init__.py
  matplotlib: not installed
  nibabel: 3.0.0rc1 from /home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/nibabel/__init__.py
```

I looked around, and the `pkg_resources` package that comes with `setuptools` can retrieve information about installed packages based on their package name.

Was quick to do, so coded it up rather than start an issue first. New output locally looks like:

```
========================================================================================================================
Python 3.7.5 (default, Oct 25 2019, 10:52:18) 
[Clang 4.0.1 (tags/RELEASE_401/final)]
from: /System/Volumes/Data/anaconda3/envs/nilearn-dev/bin/python

Dependencies versions
  numpy: 1.17.4 installed in /System/Volumes/Data/anaconda3/envs/nilearn-dev/lib/python3.7/site-packages
  scipy: 1.3.2 installed in /System/Volumes/Data/anaconda3/envs/nilearn-dev/lib/python3.7/site-packages
  scikit-learn: 0.22rc2.post1 installed in /System/Volumes/Data/anaconda3/envs/nilearn-dev/lib/python3.7/site-packages
  joblib: 0.14.0 installed in /System/Volumes/Data/anaconda3/envs/nilearn-dev/lib/python3.7/site-packages
  matplotlib: not installed
  nibabel: 3.0.0rc1 installed in /System/Volumes/Data/anaconda3/envs/nilearn-dev/lib/python3.7/site-packages
========================================================================================================================
```