### PR TITLE
Improved nifti masker documentation

### DIFF
--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -80,9 +80,9 @@ class NiftiMasker(BaseMasker, CacheMixin, ReportMixin):
         Mask for the data. If not given, a mask is computed in the fit step.
         Optional parameters (mask_args and mask_strategy) can be set to
         fine tune the mask extraction. If the mask and the images have different
-	resolutions, the images are resampled to the mask resolution. If target_shape
-	and/or target_affine are provided, the mask is resampled first. After this,
-	the images are resampled to the resampled mask. 
+        resolutions, the images are resampled to the mask resolution. If target_shape
+        and/or target_affine are provided, the mask is resampled first. 
+        After this, images are resampled to the resampled mask. 
 
     sessions : numpy array, optional
         Add a session level to the preprocessing. Each session will be

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -79,7 +79,10 @@ class NiftiMasker(BaseMasker, CacheMixin, ReportMixin):
         See http://nilearn.github.io/manipulating_images/input_output.html
         Mask for the data. If not given, a mask is computed in the fit step.
         Optional parameters (mask_args and mask_strategy) can be set to
-        fine tune the mask extraction.
+        fine tune the mask extraction. If the mask and the images have different
+	resolutions, the images are resampled to the mask resolution. If target_shape
+	and/or target_affine are provided, the mask is resampled first. After this,
+	the images are resampled to the resampled mask. 
 
     sessions : numpy array, optional
         Add a session level to the preprocessing. Each session will be

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -82,7 +82,7 @@ class NiftiMasker(BaseMasker, CacheMixin, ReportMixin):
         fine tune the mask extraction. If the mask and the images have different
         resolutions, the images are resampled to the mask resolution. If target_shape
         and/or target_affine are provided, the mask is resampled first. 
-        After this, images are resampled to the resampled mask. 
+        After this, the images are resampled to the resampled mask. 
 
     sessions : numpy array, optional
         Add a session level to the preprocessing. Each session will be


### PR DESCRIPTION
I added an explanation for the resampling processes in `NiftiMasker`. Before this, it was not clear what happens in the background, when you provide a mask image and images of different resolution and how this does interact with target_shape and target_affine.

See [this post](https://neurostars.org/t/how-does-niftimasker-work-when-dealing-with-mask-and-data-images-of-different-resolutions/4892) on neurostars.org where I originally asked the question. Pinging @jeromedockes here, because he gave an answer to my question and might be interested to know about this pull request.

This pull request is related to issue #355, where I made a comment.