### PR TITLE
Argument version='det' in pauli 2017 atlas now works correctly

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,6 +24,7 @@ Fixes
 - `pip install nilearn` now installs the necessary dependencies.
 - :func:`nilearn.image.new_img_like` no longer attempts to copy non-iterable headers. (PR #2212)
 - Nilearn no longer raises ImportError for nose when Matplotlib is not installed.
+- The arg `version='det'` in :func:`nilearn.datasets.fetch_atlas_pauli_2017` now  works as expected.
 
 Contributors
 ------------
@@ -32,6 +33,7 @@ The following people contributed to this release (in alphabetical order)::
 
     Daniel Gomez (dangom)
     Kshitij Chawla (kchawla-pi)
+    Ryan Hammonds (ryanhammonds)
 
 0.6.0b0
 =======
@@ -1572,4 +1574,3 @@ Contributors (from ``git shortlog -ns 0.1``)::
      1  Matthias Ekman
      1  Michael Waskom
      1  Vincent Michel
-

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1199,9 +1199,10 @@ def fetch_atlas_pauli_2017(version='prob', data_dir=None, verbose=1):
     Parameters
     ----------
 
-    version: str, optional (default='prob')
-        Which version of the atlas should be download. This can be 'prob'
-        for the probabilistic atlas or 'det' for the deterministic atlas.
+    version: str, optional (default='pro')
+        Which version of the atlas should be download. This can be
+        'prob' for the probabilistic atlas or 'det' for the
+        deterministic atlas.
 
     data_dir : str, optional (default=None)
         Path of the data directory. Used to force data storage in a specified
@@ -1230,10 +1231,10 @@ def fetch_atlas_pauli_2017(version='prob', data_dir=None, verbose=1):
 
     if version == 'prob':
         url_maps = 'https://osf.io/w8zq2/download'
-        filename = 'pauli_2017_labels.nii.gz'
-    elif version == 'labels':
-        url_maps = 'https://osf.io/5mqfx/download'
         filename = 'pauli_2017_prob.nii.gz'
+    elif version == 'det':
+        url_maps = 'https://osf.io/5mqfx/download'
+        filename = 'pauli_2017_det.nii.gz'
     else:
         raise NotImplementedError('{} is no valid version for '.format(version) + \
                                   'the Pauli atlas')

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1199,7 +1199,7 @@ def fetch_atlas_pauli_2017(version='prob', data_dir=None, verbose=1):
     Parameters
     ----------
 
-    version: str, optional (default='pro')
+    version: str, optional (default='prob')
         Which version of the atlas should be download. This can be
         'prob' for the probabilistic atlas or 'det' for the
         deterministic atlas.

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -27,6 +27,8 @@ from nilearn._utils.compat import _basestring, _urllib
 from nilearn.datasets import utils, atlas
 from nilearn.image import get_data
 
+import pytest
+
 
 def setup_mock():
     return tst.setup_mock(utils, atlas)
@@ -555,7 +557,7 @@ def test_fetch_atlas_talairach(data_dir=tst.tmpdir):
 def test_fetch_atlas_pauli_2017():
     data_dir = os.path.join(tst.tmpdir, 'pauli_2017')
 
-    data = atlas.fetch_atlas_pauli_2017('labels', data_dir)
+    data = atlas.fetch_atlas_pauli_2017('det', data_dir)
     assert_equal(len(data.labels), 16)
 
     values = get_data(nibabel.load(data.maps))
@@ -563,6 +565,9 @@ def test_fetch_atlas_pauli_2017():
 
     data = atlas.fetch_atlas_pauli_2017('prob', data_dir)
     assert_equal(nibabel.load(data.maps).shape[-1], 16)
+
+    with pytest.raises(NotImplementedError):
+        atlas.fetch_atlas_pauli_2017('junk for testing', data_dir)
 
 @with_setup(tst.setup_tmpdata, tst.teardown_tmpdata)
 def test_fetch_atlas_schaefer_2018():


### PR DESCRIPTION
Argument version='det' for Pauli 2017 atlas in documentation was not implemented as described.