### PR TITLE
BUG: NiftiLabelsMasker inverse_transform without transform

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -25,6 +25,8 @@ Fixes
 - :func:`nilearn.image.new_img_like` no longer attempts to copy non-iterable headers. (PR #2212)
 - Nilearn no longer raises ImportError for nose when Matplotlib is not installed.
 - The arg `version='det'` in :func:`nilearn.datasets.fetch_atlas_pauli_2017` now  works as expected.
+- :func:`nilearn.input_data.NiftiLabelsMasker.inverse_transform` now works without the need to call
+  transform first.
 
 Contributors
 ------------

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -215,7 +215,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             mask_data, mask_affine = masking._load_mask_img(self.mask_img_)
 
         if not hasattr(self, '_resampled_labels_img_'):
-            # obviates need for .transform() to run .inverse_transform()
+            # obviates need to run .transform() before .inverse_transform()
             self._resampled_labels_img_ = self.labels_img_
 
         return self

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -214,6 +214,9 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
 
             mask_data, mask_affine = masking._load_mask_img(self.mask_img_)
 
+        if not hasattr(self, '_resampled_labels_img_'):
+            self._resampled_labels_img_ = self.labels_img_
+
         return self
 
     def fit_transform(self, imgs, confounds=None):

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -215,6 +215,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             mask_data, mask_affine = masking._load_mask_img(self.mask_img_)
 
         if not hasattr(self, '_resampled_labels_img_'):
+            # obviates need for transform() to run reverse_transform()
             self._resampled_labels_img_ = self.labels_img_
 
         return self

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -215,7 +215,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             mask_data, mask_affine = masking._load_mask_img(self.mask_img_)
 
         if not hasattr(self, '_resampled_labels_img_'):
-            # obviates need for transform() to run reverse_transform()
+            # obviates need for .transform() to run .inverse_transform()
             self._resampled_labels_img_ = self.labels_img_
 
         return self

--- a/nilearn/input_data/tests/test_nifti_labels_masker.py
+++ b/nilearn/input_data/tests/test_nifti_labels_masker.py
@@ -66,6 +66,11 @@ def test_nifti_labels_masker():
     signals11 = masker11.fit().transform(fmri11_img)
     assert_equal(signals11.shape, (length, n_regions))
 
+    # No exception should be raised either
+    masker11 = NiftiLabelsMasker(labels11_img, resampling_target=None)
+    masker11.fit()
+    masker11.inverse_transform(signals11)
+
     masker11 = NiftiLabelsMasker(labels11_img, mask_img=mask11_img,
                                  resampling_target=None)
     signals11 = masker11.fit().transform(fmri11_img)

--- a/nilearn/input_data/tests/test_nifti_maps_masker.py
+++ b/nilearn/input_data/tests/test_nifti_maps_masker.py
@@ -105,6 +105,11 @@ def test_nifti_maps_masker():
     assert_equal(fmri11_img_r.shape, fmri11_img.shape)
     np.testing.assert_almost_equal(fmri11_img_r.affine, fmri11_img.affine)
 
+    # Now try on a masker that has never seen the call to "transform"
+    masker2 = NiftiMapsMasker(labels11_img, resampling_target=None)
+    masker2.fit()
+    fmri11_img_rr = masker2.inverse_transform(signals11)
+
     # Test with data and atlas of different shape: the atlas should be
     # resampled to the data
     shape22 = (5, 5, 6)
@@ -115,9 +120,10 @@ def test_nifti_maps_masker():
                                         length=length)
     masker = NiftiMapsMasker(labels11_img, mask_img=mask21_img)
 
-    masker.fit_transform(fmri22_img)
+    signals = masker.fit_transform(fmri22_img)
     np.testing.assert_array_equal(masker._resampled_maps_img_.affine,
                                   affine2)
+
 
 
 def test_nifti_maps_masker_with_nans():

--- a/nilearn/input_data/tests/test_nifti_maps_masker.py
+++ b/nilearn/input_data/tests/test_nifti_maps_masker.py
@@ -108,7 +108,7 @@ def test_nifti_maps_masker():
     # Now try on a masker that has never seen the call to "transform"
     masker2 = NiftiMapsMasker(labels11_img, resampling_target=None)
     masker2.fit()
-    fmri11_img_rr = masker2.inverse_transform(signals11)
+    masker2.inverse_transform(signals11)
 
     # Test with data and atlas of different shape: the atlas should be
     # resampled to the data
@@ -120,10 +120,9 @@ def test_nifti_maps_masker():
                                         length=length)
     masker = NiftiMapsMasker(labels11_img, mask_img=mask21_img)
 
-    signals = masker.fit_transform(fmri22_img)
+    masker.fit_transform(fmri22_img)
     np.testing.assert_array_equal(masker._resampled_maps_img_.affine,
                                   affine2)
-
 
 
 def test_nifti_maps_masker_with_nans():


### PR DESCRIPTION
Get NiftiLabelsMasker.inverse_transform to work even without calling
transform.

Fixes #2192

Ping @banilo : this should fix your problem.