### PR TITLE
Fix tests pertaining to replace_parameters functionality

### DIFF
--- a/nilearn/plotting/tests/test_html_connectome.py
+++ b/nilearn/plotting/tests/test_html_connectome.py
@@ -133,12 +133,9 @@ def test_params_deprecation_view_connectome():
                                         4.2,
                                         )
     old_params = ['coords', 'threshold', 'cmap', 'marker_size']
-
-    raised_warning_messages = ''.join(
-        str(warning.message) for warning in raised_warnings)
-    print(raised_warning_messages)
-    for old_param_ in old_params:
-        assert warning_msgs[old_param_] in raised_warning_messages
+    for old_param_, raised_warning_ in zip(old_params, raised_warnings):
+        assert warning_msgs[old_param_] == str(raised_warning_.message)
+        assert raised_warning_.category is DeprecationWarning
 
 
 def test_get_markers():

--- a/nilearn/tests/test_helpers.py
+++ b/nilearn/tests/test_helpers.py
@@ -60,6 +60,7 @@ def test_replace_parameters():
     raised_warnings.sort(key=lambda mem: str(mem.message))
     for raised_warning_, expected_warning_ in zip(raised_warnings,
                                                   expected_warnings):
+        assert raised_warning_.category is DeprecationWarning
         assert str(raised_warning_.message) == expected_warning_
 
 
@@ -107,4 +108,5 @@ def test_future_warn_deprecated_params():
     for raised_warning_, expected_warning_ in zip(raised_warnings,
                                                   expected_warnings
                                                   ):
+        assert raised_warning_.category is DeprecationWarning
         assert str(raised_warning_.message) == expected_warning_


### PR DESCRIPTION
While attending to issue #2251 I noticed the tests are inadequate. They don;t check for warning category, only the message. This fixes that.