### PR TITLE
[FIX] Patch non-resolving OSF download links

### DIFF
--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -920,6 +920,9 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
 
     # Build data URLs that will be fetched
     files = {}
+    # Download from the relevant OSF project, using hashes generated
+    # from the OSF API. Note the trailing slash. For more info, see:
+    # https://gist.github.com/emdupre/3cb4d564511d495ea6bf89c6a577da74
     root_url = "https://osf.io/download/{0}/"
     if isinstance(n_subjects, numbers.Number):
         subject_mask = np.arange(1, n_subjects + 1)
@@ -1957,6 +1960,9 @@ def _fetch_development_fmri_functional(participants, data_dir, url, resume,
                                 verbose=verbose)
 
     if url is None:
+        # Download from the relevant OSF project, using hashes generated
+        # from the OSF API. Note the trailing slash. For more info, see:
+        # https://gist.github.com/emdupre/3cb4d564511d495ea6bf89c6a577da74
         url = 'https://osf.io/download/{}/'
 
     confounds = '{}_task-pixar_desc-confounds_regressors.tsv'

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -920,7 +920,7 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
 
     # Build data URLs that will be fetched
     files = {}
-    root_url = "https://files.de-1.osf.io/v1/resources/vhtf6/providers/osfstorage/{0}"
+    root_url = "https://osf.io/download/{0}/"
     if isinstance(n_subjects, numbers.Number):
         subject_mask = np.arange(1, n_subjects + 1)
         subject_id_max = "S%02d" % n_subjects
@@ -1957,7 +1957,7 @@ def _fetch_development_fmri_functional(participants, data_dir, url, resume,
                                 verbose=verbose)
 
     if url is None:
-        url = 'https://osf.io/download/{}'
+        url = 'https://osf.io/download/{}/'
 
     confounds = '{}_task-pixar_desc-confounds_regressors.tsv'
     func = '{0}_task-pixar_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz'

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -920,7 +920,7 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
 
     # Build data URLs that will be fetched
     files = {}
-    root_url = "https://osf.io/download/{0}"
+    root_url = "https://files.de-1.osf.io/v1/resources/vhtf6/providers/osfstorage/{0}"
     if isinstance(n_subjects, numbers.Number):
         subject_mask = np.arange(1, n_subjects + 1)
         subject_id_max = "S%02d" % n_subjects


### PR DESCRIPTION
To troubleshoot #2285.

The original resource we're requesting returns a 308 error. Trying with a 302 link, since it _might_ redirect on its own and we can still query it systematically. See:

![Screenshot from 2020-01-20 11-33-18](https://user-images.githubusercontent.com/15017191/72743001-cbd3ef80-3b78-11ea-9176-2d4f536e383f.png)

@kchawla-pi did OSF admin get back in touch with you ?