### PR TITLE
Fix "%matplotlib inline" in notebook

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,3 +1,11 @@
+0.6.2
+======
+
+Fixes
+-----
+
+- More robust matplotlib backend selection
+
 0.6.1
 =====
 

--- a/nilearn/plotting/__init__.py
+++ b/nilearn/plotting/__init__.py
@@ -25,10 +25,13 @@ def _set_mpl_backend():
         # that the version is greater that the minimum required one
         _import_module_with_version_check('matplotlib',
                                           OPTIONAL_MATPLOTLIB_MIN_VERSION)
+        current_backend = matplotlib.get_backend().lower()
         # Set the backend to a non-interactive one for unices without X
+        if 'inline' in current_backend or 'nbagg' in current_backend:
+            return
         if (os.name == 'posix' and 'DISPLAY' not in os.environ
                 and not (sys.platform == 'darwin'
-                         and matplotlib.get_backend() == 'MacOSX')
+                         and 'macosx' in current_backend)
         ):
             matplotlib.use('Agg')
 

--- a/nilearn/plotting/__init__.py
+++ b/nilearn/plotting/__init__.py
@@ -26,9 +26,10 @@ def _set_mpl_backend():
         _import_module_with_version_check('matplotlib',
                                           OPTIONAL_MATPLOTLIB_MIN_VERSION)
         current_backend = matplotlib.get_backend().lower()
-        # Set the backend to a non-interactive one for unices without X
+        
         if 'inline' in current_backend or 'nbagg' in current_backend:
             return
+        # Set the backend to a non-interactive one for unices without X
         if (os.name == 'posix' and 'DISPLAY' not in os.environ
                 and not (sys.platform == 'darwin'
                          and 'macosx' in current_backend)

--- a/nilearn/plotting/__init__.py
+++ b/nilearn/plotting/__init__.py
@@ -26,7 +26,7 @@ def _set_mpl_backend():
         _import_module_with_version_check('matplotlib',
                                           OPTIONAL_MATPLOTLIB_MIN_VERSION)
         current_backend = matplotlib.get_backend().lower()
-        
+
         if 'inline' in current_backend or 'nbagg' in current_backend:
             return
         # Set the backend to a non-interactive one for unices without X


### PR DESCRIPTION
Before this, importing nilearn.plotting after running "%matplotlib inline" would reset the backend. Thanks @emdupre for spotting it.

I checked interactively with jupyter that it would fix the problem, but I don't think that we can do a test.