### PR TITLE
[DOC] updated reference Seitzman 2018

### DIFF
--- a/nilearn/datasets/description/seitzman_2018.rst
+++ b/nilearn/datasets/description/seitzman_2018.rst
@@ -10,7 +10,7 @@ anatomy to generate novel functionally-constrained ROIs in the thalamus, basal g
 cerebellum. We validate these ROIs in three datasets via several anatomical and functional criteria, including known
 anatomical divisions and functions, as well as agreement with existing literature.
 Further, we demonstrate that combining these ROIs with established cortical ROIs recapitulates and extends
-previously described functional network organization." (Seitzman et. al, 2018)
+previously described functional network organization." (Seitzman et. al, 2018, 2020)
 
 
 
@@ -29,7 +29,10 @@ https://greenelab.wustl.edu/data_software
 ROI coordinates downloaded from:
 https://wustl.box.com/s/twpyb1pflj6vrlxgh3rohyqanxbdpelw
 
-
-Seitzman, B. A., Gratton, C., Marek, S., Raut, R. V., Dosenbach, N. U., Schlaggar, B. L., et al. (2018).
+Paper:
+Seitzman, B. A., Gratton, C., Marek, S., Raut, R. V., Dosenbach, N. U. F., Schlaggar, B. L., et al. (2020).
 A set of functionally-defined brain regions with improved representation of the subcortex and cerebellum.
-bioRxiv, 450452. http://doi.org/10.1101/450452
+NeuroImage, 206, 116290. http://doi.org/10.1016/j.neuroimage.2019.116290
+
+Preprint:
+Seitzman et al. (2018). http://doi.org/10.1101/450452


### PR DESCRIPTION
The preprint referenced in the docs is now published as a paper. I have added the paper reference, but have left the reference to the preprint in so that the year in the function name still makes sense. 