### PR TITLE
Fix small cosmetics on docs + CSS for the download links

### DIFF
--- a/doc/themes/nilearn/static/nature.css_t
+++ b/doc/themes/nilearn/static/nature.css_t
@@ -1707,8 +1707,8 @@ div.sg-report iframe {
 /* gallery download note */
 
 div.body div.sphx-glr-download-link-note {
-    text-align: left;
     float: left;
+    text-align: left;
     border-radius: 4px;
     color: #006801;
     background-color: #dff0d8;
@@ -1718,12 +1718,22 @@ div.body div.sphx-glr-download-link-note {
     width: 43ex;
 }
 
+@media (min-width: 1200px) {
+  div.body div.sphx-glr-download-link-note {
+    /* Flush to the left: 50% of viewport width 
+     * minus half of the bodywrapper width,
+     * minus the half width of the sphinxsidebar */
+    float: none;
+    margin-left: calc(32em - 50vw + 123px);
+    margin-bottom: -10ex;
+}
+
 @media (min-width: 1420px) {
   div.body div.sphx-glr-download-link-note {
-    float: none;
     position: absolute;
     left: 5px;
     width: 15ex;
+    margin-left: 0px;
   }
 }
 

--- a/doc/themes/nilearn/static/nature.css_t
+++ b/doc/themes/nilearn/static/nature.css_t
@@ -1730,6 +1730,10 @@ div.body div.sphx-glr-download-link-note {
 @media (min-width: 1550px) {
     div.body div.sphx-glr-download-link-note {
 	width: 20ex;
+	/* 47% of viewport width minus half of the bodywrapper width,
+	 * minus the half width of the sphinxsidebar, minus the width of this
+	 * div */
+	margin-left: calc(47vw - 31em - 123px - 20ex);
     }
 }
 

--- a/doc/themes/nilearn/static/nature.css_t
+++ b/doc/themes/nilearn/static/nature.css_t
@@ -420,12 +420,6 @@ div.body p.sphx-glr-script-out {
     margin: -.9ex 0ex;
 }
 
-div.body div.sphx-glr-download-link-note {
-    max-width: 8em;
-    float: right;
-    margin-right: -1em;
-}
-
 div.bodywrapper {
     margin: 0 246px 0 auto;
     /*border-right: 1px solid #EEE;*/
@@ -1155,6 +1149,7 @@ span.example-links {
   display: block;
 }
 
+
 div#logo-banner {
     background-color: white;
     padding: 10px 10px 15px 15px;
@@ -1713,9 +1708,28 @@ div.sg-report iframe {
 
 div.body div.sphx-glr-download-link-note {
     text-align: left;
-    float: none;
-    margin: 10px 0 -10px 0;
+    float: left;
     border-radius: 4px;
-    padding: 5px;
+    color: #006801;
+    background-color: #dff0d8;
+    border: 0.2em solid rgba(79, 173, 117, 0.35);
+    padding: 4px;
     max-width: 100%;
+    width: 43ex;
 }
+
+@media (min-width: 1420px) {
+  div.body div.sphx-glr-download-link-note {
+    float: none;
+    position: absolute;
+    left: 5px;
+    width: 15ex;
+  }
+}
+
+@media (min-width: 1550px) {
+    div.body div.sphx-glr-download-link-note {
+	width: 20ex;
+    }
+}
+

--- a/doc/themes/nilearn/static/nature.css_t
+++ b/doc/themes/nilearn/static/nature.css_t
@@ -314,6 +314,9 @@ div.related ul {
     border-bottom: 2px solid #727272;
     margin: 0;
     padding-left: 10px;
+    white-space: nowrap;
+    overflow-y: hidden;
+    overflow-x: hidden;
 }
 
 div.related ul li {
@@ -333,7 +336,7 @@ div.related ul li#navbar-ecosystem {
     margin-right: 0.5em;
 }
 
-@media (max-width: 800px) {
+@media (max-width: 1000px) {
     div.related ul li#navbar-ecosystem {
 	display: none;
     }

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,7 +31,7 @@ Fixes
 Changes
 -------
 
-- Atlas :func:`nilearn.datasets.func.fetch_nyu_rest` has been deprecated and wil be removed in Nilearn 0.8.0 .
+- Atlas `nilearn.datasets.func.fetch_nyu_rest` has been deprecated and wil be removed in Nilearn 0.8.0 .
 
 Contributors
 ------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,7 +31,7 @@ Fixes
 Changes
 -------
 
-- Atlas func:`nilearn.datasets.func.fetch_nyu_rest` has been deprecated and wil be removed in Nilearn 0.8.0 .
+- Atlas :func:`nilearn.datasets.func.fetch_nyu_rest` has been deprecated and wil be removed in Nilearn 0.8.0 .
 
 Contributors
 ------------


### PR DESCRIPTION
The CSS changes are to make the download link both more visible and not too intrusive. They are illustrated below for different screen sizes:

![image](https://user-images.githubusercontent.com/208217/75368112-3de1d780-588f-11ea-8a7c-59c7630a2127.png)

![image](https://user-images.githubusercontent.com/208217/75367963-168b0a80-588f-11ea-98eb-4ed5c8b0d19e.png)

![image](https://user-images.githubusercontent.com/208217/75368165-4df9b700-588f-11ea-91a9-871d7b11553a.png)
