### PR TITLE
Update Azure VM host versions (obsolete, near discontinuation)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
 
 - job: 'run_tests_on_windows'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   strategy:
     matrix:
       Python35:
@@ -87,7 +87,7 @@ jobs:
 
 - job: 'test_installing_on_macos'
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.15'
   strategy:
     matrix:
       Python36:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,7 +125,7 @@ jobs:
 
 - job: 'test_installing_on_windows'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   strategy:
     matrix:
       Python36:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
 
 - job: 'run_tests_on_windows'
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'vs2017-win2016'
   strategy:
     matrix:
       Python35:
@@ -87,7 +87,7 @@ jobs:
 
 - job: 'test_installing_on_macos'
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-latest'
   strategy:
     matrix:
       Python36:
@@ -125,7 +125,7 @@ jobs:
 
 - job: 'test_installing_on_windows'
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'vs2017-win2016'
   strategy:
     matrix:
       Python36:


### PR DESCRIPTION
Certain VMs used for testing are now obsolete and will be discontinued in the near future and hence are being updated.