### PR TITLE
Joblib cache now cleaned with 'make clean' for doc building

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -37,6 +37,7 @@ clean:
 	-rm -rf auto_examples/
 	-rm -rf generated/*
 	-rm -rf modules/generated/*
+	-rm -rf ../examples/**/nilearn_cache
 
 sym_links:
 	# Make sym-links to share the cache across various example


### PR DESCRIPTION
Fixes #2258 
