### PR TITLE
[MRG] Replace _basestring compatibility shim with str datatype

### DIFF
--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -19,7 +19,6 @@ MEMORY_CLASSES = (Memory, )
 
 import nilearn
 
-from .compat import _basestring
 
 __CACHE_CHECKED = dict()
 
@@ -42,7 +41,7 @@ def _check_memory(memory, verbose=0):
     """
     if memory is None:
         memory = Memory(cachedir=None, verbose=verbose)
-    if isinstance(memory, _basestring):
+    if isinstance(memory, str):
         cache_dir = memory
         if nilearn.EXPAND_PATH_WILDCARDS:
             cache_dir = os.path.expanduser(cache_dir)
@@ -217,7 +216,7 @@ def cache(func, memory, func_memory_level=None, memory_level=None,
 
     if memory is not None and (func_memory_level is None or
                                memory_level >= func_memory_level):
-        if isinstance(memory, _basestring):
+        if isinstance(memory, str):
             memory = Memory(cachedir=memory, verbose=verbose)
         if not isinstance(memory, MEMORY_CLASSES):
             raise TypeError("'memory' argument must be a string or a "

--- a/nilearn/_utils/compat.py
+++ b/nilearn/_utils/compat.py
@@ -17,7 +17,6 @@ if sys.version_info[0] == 3:
     from base64 import encodebytes
 
     _encodebytes = encodebytes
-    _basestring = str
     cPickle = pickle
     StringIO = io.StringIO
     BytesIO = io.BytesIO
@@ -39,7 +38,6 @@ else:
     from base64 import encodestring
 
     _encodebytes = encodestring
-    _basestring = basestring
     cPickle = cPickle
     StringIO = BytesIO = StringIO.StringIO
     izip = itertools.izip

--- a/nilearn/_utils/logger.py
+++ b/nilearn/_utils/logger.py
@@ -6,7 +6,6 @@
 import inspect
 
 from sklearn.base import BaseEstimator
-from .compat import _basestring
 
 
 # The technique used in the log() function only applies to CPython, because
@@ -102,7 +101,7 @@ def _compose_err_msg(msg, **kwargs):
     """
     updated_msg = msg
     for k, v in sorted(kwargs.items()):
-        if isinstance(v, _basestring):  # print only str-like arguments
+        if isinstance(v, str):  # print only str-like arguments
             updated_msg += "\n" + k + ": " + v
 
     return updated_msg

--- a/nilearn/_utils/ndimage.py
+++ b/nilearn/_utils/ndimage.py
@@ -6,7 +6,6 @@ N-dimensional image manipulation
 
 import numpy as np
 from scipy import ndimage
-from .._utils.compat import _basestring
 ###############################################################################
 # Operating on connected components
 ###############################################################################
@@ -40,7 +39,7 @@ def largest_connected_component(volume):
 
     """
     if (hasattr(volume, "get_data") or hasattr(
-            volume, "get_fdata") or isinstance(volume, _basestring)):
+            volume, "get_fdata") or isinstance(volume, str)):
         raise ValueError('Please enter a valid numpy array. For images use\
                          largest_connected_component_img')
     # Get the new byteorder to handle issues like "Big-endian buffer not

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -11,8 +11,6 @@ import collections.abc
 import numpy as np
 import nibabel
 
-from .compat import str
-
 
 def _get_data(img):
     # copy-pasted from https://github.com/nipy/nibabel/blob/de44a105c1267b07ef9e28f6c35b31f851d5a005/nibabel/dataobj_images.py#L204

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -11,7 +11,7 @@ import collections.abc
 import numpy as np
 import nibabel
 
-from .compat import _basestring
+from .compat import str
 
 
 def _get_data(img):
@@ -116,7 +116,7 @@ def load_niimg(niimg, dtype=None):
     """
     from ..image import new_img_like  # avoid circular imports
 
-    if isinstance(niimg, _basestring):
+    if isinstance(niimg, str):
         # data is a filename, we load it
         niimg = nibabel.load(niimg)
     elif not isinstance(niimg, nibabel.spatialimages.SpatialImage):
@@ -163,7 +163,7 @@ def copy_img(img):
 def _repr_niimgs(niimgs):
     """ Pretty printing of niimg or niimgs.
     """
-    if isinstance(niimgs, _basestring):
+    if isinstance(niimgs, str):
         return niimgs
     if isinstance(niimgs, collections.abc.Iterable):
         return '[%s]' % ', '.join(_repr_niimgs(niimg) for niimg in niimgs)

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -15,7 +15,7 @@ from nilearn._utils.compat import Memory
 from .cache_mixin import cache
 from .niimg import _safe_get_data, load_niimg
 from .path_finding import _resolve_globbing
-from .compat import _basestring, izip
+from .compat import izip
 
 from .exceptions import DimensionError
 from .niimg import _get_data
@@ -155,7 +155,7 @@ def _iter_check_niimg(niimgs, ensure_ndim=None, atleast_4d=False,
             raise
         except TypeError as exc:
             img_name = ''
-            if isinstance(niimg, _basestring):
+            if isinstance(niimg, str):
                 img_name = " (%s) " % niimg
 
             exc.args = (('Error encountered while loading image #%d%s'
@@ -227,7 +227,7 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False, dtype=None,
     """
     from ..image import new_img_like  # avoid circular imports
 
-    if isinstance(niimg, _basestring):
+    if isinstance(niimg, str):
         if wildcards and ni.EXPAND_PATH_WILDCARDS:
             # Ascending sorting + expand user path
             filenames = sorted(glob.glob(os.path.expanduser(niimg)))
@@ -253,7 +253,7 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False, dtype=None,
             raise ValueError("File not found: '%s'" % niimg)
 
     # in case of an iterable
-    if hasattr(niimg, "__iter__") and not isinstance(niimg, _basestring):
+    if hasattr(niimg, "__iter__") and not isinstance(niimg, str):
         if return_iterator:
             return _iter_check_niimg(niimg, ensure_ndim=ensure_ndim,
                                      dtype=dtype)
@@ -459,7 +459,7 @@ def concat_niimgs(niimgs, dtype=np.float32, ensure_ndim=None,
             memory=memory, memory_level=memory_level))):
 
         if verbose > 0:
-            if isinstance(niimg, _basestring):
+            if isinstance(niimg, str):
                 nii_str = "image " + niimg
             else:
                 nii_str = "image #" + str(index)

--- a/nilearn/_utils/numpy_conversions.py
+++ b/nilearn/_utils/numpy_conversions.py
@@ -6,7 +6,6 @@ Validation and conversion utilities for numpy.
 
 import csv
 import numpy as np
-from .compat import _basestring
 
 
 def _asarray(arr, dtype=None, order=None):
@@ -149,7 +148,7 @@ def csv_to_array(csv_path, delimiters=' \t,;', **kwargs):
     array: numpy.ndarray
         An array containing the data loaded from the CSV file.
     """
-    if not isinstance(csv_path, _basestring):
+    if not isinstance(csv_path, str):
         raise TypeError('CSV must be a file path. Got a CSV of type: %s' %
                         type(csv_path))
 

--- a/nilearn/_utils/param_validation.py
+++ b/nilearn/_utils/param_validation.py
@@ -9,7 +9,6 @@ import numbers
 from sklearn.feature_selection import (SelectPercentile, f_regression,
                                        f_classif)
 
-from .compat import _basestring
 from .niimg import _get_data
 
 
@@ -47,7 +46,7 @@ def check_threshold(threshold, data, percentile_func, name='threshold'):
         returns the score of the percentile on the data or
         returns threshold as it is if given threshold is not a string percentile.
     """
-    if isinstance(threshold, _basestring):
+    if isinstance(threshold, str):
         message = ('If "{0}" is given as string it '
                    'should be a number followed by the percent '
                    'sign, e.g. "25.3%"').format(name)

--- a/nilearn/_utils/path_finding.py
+++ b/nilearn/_utils/path_finding.py
@@ -3,10 +3,10 @@ Path finding utilities
 """
 import glob
 import os.path
-from .compat import _basestring
+from .compat import str
 
 def _resolve_globbing(path):
-    if isinstance(path, _basestring):
+    if isinstance(path, str):
         path_list = sorted(glob.glob(os.path.expanduser(path)))
         # Raise an error in case the list is empty.
         if len(path_list) == 0:

--- a/nilearn/_utils/path_finding.py
+++ b/nilearn/_utils/path_finding.py
@@ -3,7 +3,7 @@ Path finding utilities
 """
 import glob
 import os.path
-from .compat import str
+
 
 def _resolve_globbing(path):
     if isinstance(path, str):

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -12,7 +12,7 @@ import gc
 import numpy as np
 import pytest
 
-from .compat import _basestring, _urllib
+from .compat import str, _urllib
 from ..datasets.utils import _fetch_files
 
 
@@ -191,7 +191,7 @@ class mock_request(object):
 def wrap_chunk_read_(_chunk_read_):
     def mock_chunk_read_(response, local_file, initial_size=0, chunk_size=8192,
                          report_hook=None, verbose=0):
-        if not isinstance(response, _basestring):
+        if not isinstance(response, str):
             return _chunk_read_(response, local_file,
                                 initial_size=initial_size,
                                 chunk_size=chunk_size,

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -12,7 +12,7 @@ import gc
 import numpy as np
 import pytest
 
-from .compat import str, _urllib
+from .compat import _urllib
 from ..datasets.utils import _fetch_files
 
 

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -15,7 +15,6 @@ from sklearn.utils import Bunch
 
 from .utils import _get_dataset_dir, _fetch_files, _get_dataset_descr
 from .._utils import check_niimg
-from .._utils.compat import _basestring
 from ..image import new_img_like, get_data
 
 _TALAIRACH_LEVELS = ['hemisphere', 'lobe', 'gyrus', 'tissue', 'ba']
@@ -471,7 +470,7 @@ def fetch_atlas_smith_2009(data_dir=None, mirror='origin', url=None,
             'bm70.nii.gz'
     ]
 
-    if isinstance(url, _basestring):
+    if isinstance(url, str):
         url = [url] * len(files)
 
     files = [(f, u + f, {}) for f, u in zip(files, url)]

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -14,7 +14,7 @@ from sklearn.utils import Bunch
 from .utils import (_get_dataset_dir, _fetch_files, _get_dataset_descr,
                     _read_md5_sum_file, _tree, _filter_columns, _fetch_file)
 from .._utils import check_niimg
-from .._utils.compat import BytesIO, _basestring
+from .._utils.compat import BytesIO
 from .._utils.numpy_conversions import csv_to_array
 from nilearn.image import get_data
 
@@ -746,7 +746,7 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
     nilearn.datasets.fetch_localizer_button_task
 
     """
-    if isinstance(contrasts, _basestring):
+    if isinstance(contrasts, str):
         raise ValueError('Contrasts should be a list of strings, but '
                          'a single string was given: "%s"' % contrasts)
     if n_subjects is None:
@@ -1143,7 +1143,7 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
     """
     # People keep getting it wrong and submiting a string instead of a
     # list of strings. We'll make their life easy
-    if isinstance(derivatives, _basestring):
+    if isinstance(derivatives, str):
         derivatives = [derivatives, ]
 
     # Parameter check

--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -30,7 +30,6 @@ import numpy as np
 from sklearn.utils import Bunch
 from sklearn.feature_extraction import DictVectorizer
 
-from .._utils.compat import _basestring
 from .utils import _fetch_file, _get_dataset_dir, _get_dataset_descr
 
 
@@ -654,7 +653,7 @@ class Pattern(_SpecialValue):
         self.flags_ = flags
 
     def __eq__(self, other):
-        if not isinstance(other, _basestring) or re.match(
+        if not isinstance(other, str) or re.match(
                 self.pattern_, other, self.flags_) is None:
             return False
         return True
@@ -1295,7 +1294,7 @@ def _remove_none_strings(metadata):
     """
     metadata = metadata.copy()
     for key, value in metadata.items():
-        if (isinstance(value, _basestring) and
+        if (isinstance(value, str) and
                 re.match(r'($|n/?a$|none|null)', value, re.IGNORECASE)):
             metadata[key] = None
     return metadata
@@ -2049,7 +2048,7 @@ def _split_terms(terms, available_on_server):
     terms_ = dict(terms)
     server_terms = dict([(k, terms_.pop(k)) for k in
                          available_on_server if k in terms_ and
-                         (isinstance(terms_[k], _basestring) or
+                         (isinstance(terms_[k], str) or
                           isinstance(terms_[k], int))])
     return terms_, server_terms
 

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -17,7 +17,7 @@ from numpy.testing import assert_array_equal
 
 from . import test_utils as tst
 
-from nilearn._utils.compat import _basestring, _urllib
+from nilearn._utils.compat import _urllib
 
 from nilearn.datasets import utils, atlas
 from nilearn.image import get_data
@@ -195,7 +195,7 @@ def test_fail_fetch_atlas_harvard_oxford(tmp_path):
     # file to retrieve labels.
     ho_wo_symm = atlas.fetch_atlas_harvard_oxford(target_atlas,
                                                   data_dir=str(tmp_path))
-    assert isinstance(ho_wo_symm.maps, _basestring)
+    assert isinstance(ho_wo_symm.maps, str)
     assert isinstance(ho_wo_symm.labels, list)
     assert ho_wo_symm.labels[0] == "Background"
     assert ho_wo_symm.labels[1] == "R1"
@@ -358,20 +358,20 @@ def test_fetch_atlas_msdl(tmp_path, request_mocker):
     assert isinstance(dataset.labels, list)
     assert isinstance(dataset.region_coords, list)
     assert isinstance(dataset.networks, list)
-    assert isinstance(dataset.maps, _basestring)
+    assert isinstance(dataset.maps, str)
     assert len(tst.mock_url_request.urls) == 1
     assert dataset.description != ''
 
 
 def test_fetch_atlas_yeo_2011(tmp_path, request_mocker):
     dataset = atlas.fetch_atlas_yeo_2011(data_dir=str(tmp_path), verbose=0)
-    assert isinstance(dataset.anat, _basestring)
-    assert isinstance(dataset.colors_17, _basestring)
-    assert isinstance(dataset.colors_7, _basestring)
-    assert isinstance(dataset.thick_17, _basestring)
-    assert isinstance(dataset.thick_7, _basestring)
-    assert isinstance(dataset.thin_17, _basestring)
-    assert isinstance(dataset.thin_7, _basestring)
+    assert isinstance(dataset.anat, str)
+    assert isinstance(dataset.colors_17, str)
+    assert isinstance(dataset.colors_7, str)
+    assert isinstance(dataset.thick_17, str)
+    assert isinstance(dataset.thick_7, str)
+    assert isinstance(dataset.thin_17, str)
+    assert isinstance(dataset.thin_7, str)
     assert len(tst.mock_url_request.urls) == 1
     assert dataset.description != ''
 
@@ -384,7 +384,7 @@ def test_fetch_atlas_aal(tmp_path, request_mocker):
                        "<metadata>"
                        "</metadata>")
     dataset = atlas.fetch_atlas_aal(data_dir=str(tmp_path), verbose=0)
-    assert isinstance(dataset.maps, _basestring)
+    assert isinstance(dataset.maps, str)
     assert isinstance(dataset.labels, list)
     assert isinstance(dataset.indices, list)
     assert len(tst.mock_url_request.urls) == 1
@@ -557,7 +557,7 @@ def test_fetch_atlas_schaefer_2018(tmp_path):
                                                data_dir=str(tmp_path),
                                                verbose=0)
         assert data.description != ''
-        assert isinstance(data.maps, _basestring)
+        assert isinstance(data.maps, str)
         assert isinstance(data.labels, np.ndarray)
         assert len(data.labels) == n_rois
         assert data.labels[0].astype(str).startswith("{}Networks".

--- a/nilearn/datasets/tests/test_func.py
+++ b/nilearn/datasets/tests/test_func.py
@@ -19,8 +19,6 @@ from . import test_utils as tst
 
 from nilearn.datasets import utils, func
 
-from nilearn._utils.compat import _basestring
-
 
 @pytest.fixture()
 def request_mocker():
@@ -118,7 +116,7 @@ def test_fetch_haxby(tmp_path, request_mocker):
     assert len(haxby.mask_house_little) == len(subjects)
     assert len(haxby.anat) == len(subjects)
     assert haxby.anat[2] is None
-    assert isinstance(haxby.mask, _basestring)
+    assert isinstance(haxby.mask, str)
     assert len(haxby.mask_face) == len(subjects)
     assert len(haxby.session_target) == len(subjects)
     assert len(haxby.mask_vt) == len(subjects)
@@ -196,9 +194,9 @@ def test_miyawaki2008(tmp_path, request_mocker):
     dataset = func.fetch_miyawaki2008(data_dir=str(tmp_path), verbose=0)
     assert len(dataset.func) == 32
     assert len(dataset.label) == 32
-    assert isinstance(dataset.mask, _basestring)
+    assert isinstance(dataset.mask, str)
     assert len(dataset.mask_roi) == 38
-    assert isinstance(dataset.background, _basestring)
+    assert isinstance(dataset.background, str)
     assert len(tst.mock_url_request.urls) == 1
     assert dataset.description != ''
 
@@ -213,7 +211,7 @@ def test_fetch_localizer_contrasts(tmp_path, request_mocker, localizer_mocker):
     assert not hasattr(dataset, 'anats')
     assert not hasattr(dataset, 'tmaps')
     assert not hasattr(dataset, 'masks')
-    assert isinstance(dataset.cmaps[0], _basestring)
+    assert isinstance(dataset.cmaps[0], str)
     assert isinstance(dataset.ext_vars, np.recarray)
     assert len(dataset.cmaps) == 2
     assert dataset.ext_vars.size == 2
@@ -225,7 +223,7 @@ def test_fetch_localizer_contrasts(tmp_path, request_mocker, localizer_mocker):
         data_dir=str(tmp_path),
         verbose=1)
     assert isinstance(dataset.ext_vars, np.recarray)
-    assert isinstance(dataset.cmaps[0], _basestring)
+    assert isinstance(dataset.cmaps[0], str)
     assert len(dataset.cmaps) == 2 * 2  # two contrasts are fetched
     assert dataset.ext_vars.size == 2
 
@@ -239,10 +237,10 @@ def test_fetch_localizer_contrasts(tmp_path, request_mocker, localizer_mocker):
         get_tmaps=True,
         verbose=1)
     assert isinstance(dataset.ext_vars, np.recarray)
-    assert isinstance(dataset.anats[0], _basestring)
-    assert isinstance(dataset.cmaps[0], _basestring)
-    assert isinstance(dataset.masks[0], _basestring)
-    assert isinstance(dataset.tmaps[0], _basestring)
+    assert isinstance(dataset.anats[0], str)
+    assert isinstance(dataset.cmaps[0], str)
+    assert isinstance(dataset.masks[0], str)
+    assert isinstance(dataset.tmaps[0], str)
     assert dataset.ext_vars.size == 1
     assert len(dataset.anats) == 1
     assert len(dataset.cmaps) == 1
@@ -270,7 +268,7 @@ def test_fetch_localizer_calculation_task(tmp_path, request_mocker,
         data_dir=str(tmp_path),
         verbose=1)
     assert isinstance(dataset.ext_vars, np.recarray)
-    assert isinstance(dataset.cmaps[0], _basestring)
+    assert isinstance(dataset.cmaps[0], str)
     assert dataset.ext_vars.size == 2
     assert len(dataset.cmaps) == 2
     assert dataset.description != ''
@@ -515,7 +513,7 @@ def test_fetch_cobre(tmp_path, request_mocker):
     assert isinstance(cobre_data.func, list)
     # test confounds files in a list
     assert isinstance(cobre_data.confounds, list)
-    assert isinstance(cobre_data.func[0], _basestring)
+    assert isinstance(cobre_data.func[0], str)
     # returned phenotypic data will be an array
     assert isinstance(cobre_data.phenotypic, np.recarray)
 

--- a/nilearn/datasets/tests/test_struct.py
+++ b/nilearn/datasets/tests/test_struct.py
@@ -11,7 +11,6 @@ import nibabel
 import numpy as np
 import pytest
 
-from nilearn._utils.compat import _basestring
 from nilearn.datasets import utils, struct
 
 from . import test_utils as tst
@@ -88,16 +87,16 @@ def test_get_dataset_dir(tmp_path):
 
 def test_fetch_icbm152_2009(tmp_path, request_mocker):
     dataset = struct.fetch_icbm152_2009(data_dir=str(tmp_path), verbose=0)
-    assert isinstance(dataset.csf, _basestring)
-    assert isinstance(dataset.eye_mask, _basestring)
-    assert isinstance(dataset.face_mask, _basestring)
-    assert isinstance(dataset.gm, _basestring)
-    assert isinstance(dataset.mask, _basestring)
-    assert isinstance(dataset.pd, _basestring)
-    assert isinstance(dataset.t1, _basestring)
-    assert isinstance(dataset.t2, _basestring)
-    assert isinstance(dataset.t2_relax, _basestring)
-    assert isinstance(dataset.wm, _basestring)
+    assert isinstance(dataset.csf, str)
+    assert isinstance(dataset.eye_mask, str)
+    assert isinstance(dataset.face_mask, str)
+    assert isinstance(dataset.gm, str)
+    assert isinstance(dataset.mask, str)
+    assert isinstance(dataset.pd, str)
+    assert isinstance(dataset.t1, str)
+    assert isinstance(dataset.t2, str)
+    assert isinstance(dataset.t2_relax, str)
+    assert isinstance(dataset.wm, str)
     assert len(tst.mock_url_request.urls) == 1
     assert dataset.description != ''
 
@@ -113,20 +112,20 @@ def test_fetch_oasis_vbm(tmp_path, request_mocker):
                                      verbose=0)
     assert len(dataset.gray_matter_maps) == 403
     assert len(dataset.white_matter_maps) == 403
-    assert isinstance(dataset.gray_matter_maps[0], _basestring)
-    assert isinstance(dataset.white_matter_maps[0], _basestring)
+    assert isinstance(dataset.gray_matter_maps[0], str)
+    assert isinstance(dataset.white_matter_maps[0], str)
     assert isinstance(dataset.ext_vars, np.recarray)
-    assert isinstance(dataset.data_usage_agreement, _basestring)
+    assert isinstance(dataset.data_usage_agreement, str)
     assert len(tst.mock_url_request.urls) == 3
 
     dataset = struct.fetch_oasis_vbm(data_dir=str(tmp_path), url=local_url,
                                      dartel_version=False, verbose=0)
     assert len(dataset.gray_matter_maps) == 415
     assert len(dataset.white_matter_maps) == 415
-    assert isinstance(dataset.gray_matter_maps[0], _basestring)
-    assert isinstance(dataset.white_matter_maps[0], _basestring)
+    assert isinstance(dataset.gray_matter_maps[0], str)
+    assert isinstance(dataset.white_matter_maps[0], str)
     assert isinstance(dataset.ext_vars, np.recarray)
-    assert isinstance(dataset.data_usage_agreement, _basestring)
+    assert isinstance(dataset.data_usage_agreement, str)
     assert len(tst.mock_url_request.urls) == 4
     assert dataset.description != ''
 

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -15,7 +15,7 @@ import tarfile
 import warnings
 import zipfile
 
-from .._utils.compat import _basestring, cPickle, _urllib, md5_hash
+from .._utils.compat import cPickle, _urllib, md5_hash
 
 
 def _format_time(t):
@@ -394,7 +394,7 @@ def _filter_column(array, col, criteria):
     except:
         raise KeyError('Filtering criterion %s does not exist' % col)
 
-    if (not isinstance(criteria, _basestring) and
+    if (not isinstance(criteria, str) and
         not isinstance(criteria, bytes) and
         not isinstance(criteria, tuple) and
             isinstance(criteria, collections.abc.Iterable)):
@@ -415,7 +415,7 @@ def _filter_column(array, col, criteria):
         return np.logical_and(filter, array[col] >= criteria[0])
 
     # Handle strings with different encodings
-    if isinstance(criteria, (_basestring, bytes)):
+    if isinstance(criteria, (str, bytes)):
         criteria = np.array(criteria).astype(array[col].dtype)
 
     return array[col] == criteria

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -24,7 +24,6 @@ from sklearn.exceptions import ConvergenceWarning
 from .. import masking
 from ..image.resampling import coord_transform
 from ..input_data.nifti_spheres_masker import _apply_mask_and_get_affinity
-from .._utils.compat import str
 from .._utils import check_niimg_4d
 from sklearn.model_selection import cross_val_score
 

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -24,7 +24,7 @@ from sklearn.exceptions import ConvergenceWarning
 from .. import masking
 from ..image.resampling import coord_transform
 from ..input_data.nifti_spheres_masker import _apply_mask_and_get_affinity
-from .._utils.compat import _basestring
+from .._utils.compat import str
 from .._utils import check_niimg_4d
 from sklearn.model_selection import cross_val_score
 
@@ -307,7 +307,7 @@ class SearchLight(BaseEstimator):
             mask_img=self.mask_img)
 
         estimator = self.estimator
-        if isinstance(estimator, _basestring):
+        if isinstance(estimator, str):
             estimator = ESTIMATOR_CATALOG[estimator]()
 
         scores = search_light(X, y, estimator, A, groups,

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -32,7 +32,6 @@ from .._utils.param_validation import _adjust_screening_percentile
 from sklearn.utils import check_X_y
 from sklearn.model_selection import check_cv
 from sklearn.linear_model.base import _preprocess_data as center_data
-from .._utils.compat import _basestring
 from .._utils.cache_mixin import CacheMixin
 from nilearn.masking import _unmask_from_to_3d_array
 from .space_net_solvers import (tvl1_solver, _graph_net_logistic,
@@ -746,7 +745,7 @@ class BaseSpaceNet(LinearModel, RegressorMixin, CacheMixin):
         """
         # misc
         self.check_params()
-        if self.memory is None or isinstance(self.memory, _basestring):
+        if self.memory is None or isinstance(self.memory, str):
             self.memory_ = Memory(self.memory,
                                   verbose=max(0, self.verbose - 1))
         else:

--- a/nilearn/decomposition/base.py
+++ b/nilearn/decomposition/base.py
@@ -21,7 +21,6 @@ from sklearn.utils.extmath import randomized_svd, svd_flip
 from .._utils.cache_mixin import CacheMixin, cache
 from .._utils.niimg import _safe_get_data
 from .._utils.niimg_conversions import _resolve_globbing
-from .._utils.compat import str
 from ..input_data import NiftiMapsMasker
 from ..input_data.masker_validation import check_embedded_nifti_masker
 

--- a/nilearn/decomposition/base.py
+++ b/nilearn/decomposition/base.py
@@ -21,7 +21,7 @@ from sklearn.utils.extmath import randomized_svd, svd_flip
 from .._utils.cache_mixin import CacheMixin, cache
 from .._utils.niimg import _safe_get_data
 from .._utils.niimg_conversions import _resolve_globbing
-from .._utils.compat import _basestring
+from .._utils.compat import str
 from ..input_data import NiftiMapsMasker
 from ..input_data.masker_validation import check_embedded_nifti_masker
 
@@ -373,11 +373,11 @@ class BaseDecomposition(BaseEstimator, CacheMixin, TransformerMixin):
         """
         # Base fit for decomposition estimators : compute the embedded masker
 
-        if isinstance(imgs, _basestring):
+        if isinstance(imgs, str):
             if nilearn.EXPAND_PATH_WILDCARDS and glob.has_magic(imgs):
                 imgs = _resolve_globbing(imgs)
 
-        if isinstance(imgs, _basestring) or not hasattr(imgs, '__iter__'):
+        if isinstance(imgs, str) or not hasattr(imgs, '__iter__'):
             # these classes are meant for list of 4D images
             # (multi-subject), we want it to work also on a single
             # subject, so we hack it.

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -21,7 +21,6 @@ from .._utils import (check_niimg_4d, check_niimg_3d, check_niimg, as_ndarray,
                       _repr_niimgs)
 from .._utils.niimg_conversions import _index_img, _check_same_fov
 from .._utils.niimg import _safe_get_data, _get_data
-from .._utils.compat import _basestring
 from .._utils.param_validation import check_threshold
 
 
@@ -273,7 +272,7 @@ def smooth_img(imgs, fwhm):
     # Use hasattr() instead of isinstance to workaround a Python 2.6/2.7 bug
     # See http://bugs.python.org/issue7624
     if hasattr(imgs, "__iter__") \
-       and not isinstance(imgs, _basestring):
+       and not isinstance(imgs, str):
         single_img = False
     else:
         single_img = True
@@ -517,7 +516,7 @@ def mean_img(imgs, target_affine=None, target_shape=None,
     nilearn.image.math_img : For more general operations on images
 
     """
-    if (isinstance(imgs, _basestring) or
+    if (isinstance(imgs, str) or
             not isinstance(imgs, collections.abc.Iterable)):
         imgs = [imgs, ]
 
@@ -691,7 +690,7 @@ def new_img_like(ref_niimg, data, affine=None, copy_header=False):
     """
     # Hand-written loading code to avoid too much memory consumption
     orig_ref_niimg = ref_niimg
-    if (not isinstance(ref_niimg, _basestring)
+    if (not isinstance(ref_niimg, str)
             and not hasattr(ref_niimg, 'get_data')
             and not hasattr(ref_niimg, 'get_fdata')
             and hasattr(ref_niimg, '__iter__')):
@@ -699,7 +698,7 @@ def new_img_like(ref_niimg, data, affine=None, copy_header=False):
     if not ((hasattr(ref_niimg, 'get_data')
              or hasattr(ref_niimg, 'get_fdata'))
               and hasattr(ref_niimg, 'affine')):
-        if isinstance(ref_niimg, _basestring):
+        if isinstance(ref_niimg, str):
             ref_niimg = nibabel.load(ref_niimg)
         else:
             raise TypeError(('The reference image should be a niimg, %r '
@@ -1089,7 +1088,7 @@ def largest_connected_component_img(imgs):
     """
     from .._utils.ndimage import largest_connected_component
 
-    if hasattr(imgs, "__iter__") and not isinstance(imgs, _basestring):
+    if hasattr(imgs, "__iter__") and not isinstance(imgs, str):
         single_img = False
     else:
         single_img = True

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -15,7 +15,6 @@ from scipy import ndimage, linalg
 
 from .image import crop_img
 from .. import _utils
-from .._utils.compat import _basestring
 from .._utils.niimg import _get_data
 
 ###############################################################################
@@ -416,7 +415,7 @@ def resample_img(img, target_affine=None, target_shape=None,
                    "or 'nearest' but it was set to '{0}'").format(interpolation)
         raise ValueError(message)
 
-    if isinstance(img, _basestring):
+    if isinstance(img, str):
         # Avoid a useless copy
         input_img_is_string = True
     else:

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -18,7 +18,6 @@ from .. import signal
 from .. import _utils
 from .._utils.cache_mixin import CacheMixin, cache
 from .._utils.class_inspect import enclosing_scope_name
-from .._utils.compat import _basestring
 
 
 def filter_and_extract(imgs, extraction_function,
@@ -57,7 +56,7 @@ def filter_and_extract(imgs, extraction_function,
 
     # If we have a string (filename), we won't need to copy, as
     # there will be no side effect
-    if isinstance(imgs, _basestring):
+    if isinstance(imgs, str):
         copy = False
 
     if verbose > 0:

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -15,7 +15,7 @@ from .. import image
 from .. import masking
 from .._utils import CacheMixin
 from .._utils.class_inspect import get_params
-from .._utils.compat import str, izip
+from .._utils.compat import izip
 from .._utils.niimg_conversions import _iter_check_niimg
 from .nifti_masker import NiftiMasker, filter_and_mask
 from nilearn.image import get_data

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -15,7 +15,7 @@ from .. import image
 from .. import masking
 from .._utils import CacheMixin
 from .._utils.class_inspect import get_params
-from .._utils.compat import _basestring, izip
+from .._utils.compat import str, izip
 from .._utils.niimg_conversions import _iter_check_niimg
 from .nifti_masker import NiftiMasker, filter_and_mask
 from nilearn.image import get_data
@@ -177,7 +177,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
             if self.verbose > 0:
                 print("[%s.fit] Computing mask" % self.__class__.__name__)
             if not isinstance(imgs, collections.abc.Iterable) \
-                    or isinstance(imgs, _basestring):
+                    or isinstance(imgs, str):
                 raise ValueError("[%s.fit] For multiple processing, you should"
                                  " provide a list of data "
                                  "(e.g. Nifti1Image objects or filenames)."
@@ -322,6 +322,6 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         """
         self._check_fitted()
         if not hasattr(imgs, '__iter__') \
-                or isinstance(imgs, _basestring):
+                or isinstance(imgs, str):
             return self.transform_single_imgs(imgs)
         return self.transform_imgs(imgs, confounds, n_jobs=self.n_jobs)

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -395,7 +395,7 @@ class GlassBrainAxes(BaseAxes):
 
         # Allow markers only in their respective hemisphere when appropriate
         if self.direction in 'lr':
-            if not isinstance(marker_color, _utils.compat.str) and \
+            if not isinstance(marker_color, str) and \
                     not isinstance(marker_color, np.ndarray):
                 marker_color = np.asarray(marker_color)
             relevant_coords = []
@@ -412,7 +412,7 @@ class GlassBrainAxes(BaseAxes):
             # making any selection in 'l' or 'r' color.
             # More likely that user wants to display all nodes to be in
             # same color.
-            if not isinstance(marker_color, _utils.compat.str) and \
+            if not isinstance(marker_color, str) and \
                     len(marker_color) != 1:
                 marker_color = marker_color[relevant_coords]
 

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -395,7 +395,7 @@ class GlassBrainAxes(BaseAxes):
 
         # Allow markers only in their respective hemisphere when appropriate
         if self.direction in 'lr':
-            if not isinstance(marker_color, _utils.compat._basestring) and \
+            if not isinstance(marker_color, _utils.compat.str) and \
                     not isinstance(marker_color, np.ndarray):
                 marker_color = np.asarray(marker_color)
             relevant_coords = []
@@ -412,7 +412,7 @@ class GlassBrainAxes(BaseAxes):
             # making any selection in 'l' or 'r' color.
             # More likely that user wants to display all nodes to be in
             # same color.
-            if not isinstance(marker_color, _utils.compat._basestring) and \
+            if not isinstance(marker_color, _utils.compat.str) and \
                     len(marker_color) != 1:
                 marker_color = marker_color[relevant_coords]
 

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -22,7 +22,7 @@ from scipy import sparse
 from nibabel.spatialimages import SpatialImage
 
 from .._utils.numpy_conversions import as_ndarray
-from .._utils.compat import _basestring
+from .._utils.compat import str
 from .._utils.niimg import _safe_get_data
 
 import matplotlib
@@ -887,7 +887,7 @@ def plot_prob_atlas(maps_img, bg_img=MNI152TEMPLATE, view_type='auto',
         threshold = "%f%%" % (100 * (1 - .2 * correction_factor / n_maps))
 
     if (isinstance(threshold, collections.abc.Iterable) and
-            not isinstance(threshold, _basestring)):
+            not isinstance(threshold, str)):
         threshold = [thr for thr in threshold]
         if len(threshold) != n_maps:
             raise TypeError('The list of values to threshold '

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -22,7 +22,6 @@ from scipy import sparse
 from nibabel.spatialimages import SpatialImage
 
 from .._utils.numpy_conversions import as_ndarray
-from .._utils.compat import str
 from .._utils.niimg import _safe_get_data
 
 import matplotlib

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -13,7 +13,7 @@ from matplotlib.cm import ScalarMappable, get_cmap
 from matplotlib.colors import Normalize, LinearSegmentedColormap
 
 from ..surface import load_surf_data, load_surf_mesh
-from .._utils.compat import _basestring
+from .._utils.compat import str
 from .img_plotting import _get_colorbar_and_data_ranges, _crop_colorbar
 
 
@@ -174,7 +174,7 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
         cmap = plt.cm.get_cmap(plt.rcParamsDefault['image.cmap'])
     else:
         # if cmap is given as string, translate to matplotlib cmap
-        if isinstance(cmap, _basestring):
+        if isinstance(cmap, str):
             cmap = plt.cm.get_cmap(cmap)
 
     # initiate figure and 3d axes

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -13,7 +13,6 @@ from matplotlib.cm import ScalarMappable, get_cmap
 from matplotlib.colors import Normalize, LinearSegmentedColormap
 
 from ..surface import load_surf_data, load_surf_mesh
-from .._utils.compat import str
 from .img_plotting import _get_colorbar_and_data_ranges, _crop_colorbar
 
 

--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -11,7 +11,7 @@ from nilearn.plotting import html_stat_map
 from nilearn.image import new_img_like
 from nilearn.image import get_data
 from ..js_plotting_utils import colorscale
-from ..._utils.compat import _basestring
+from ..._utils.compat import str
 
 
 def _check_html(html_view, title=None):
@@ -253,9 +253,9 @@ def test_json_view_data():
         cmap='cold_hot', colorbar=True)
 
     # Check the presence of critical fields
-    assert isinstance(json_view['bg_base64'], _basestring)
-    assert isinstance(json_view['stat_map_base64'], _basestring)
-    assert isinstance(json_view['cm_base64'], _basestring)
+    assert isinstance(json_view['bg_base64'], str)
+    assert isinstance(json_view['stat_map_base64'], str)
+    assert isinstance(json_view['cm_base64'], str)
 
     return json_view, data
 

--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -11,7 +11,6 @@ from nilearn.plotting import html_stat_map
 from nilearn.image import new_img_like
 from nilearn.image import get_data
 from ..js_plotting_utils import colorscale
-from ..._utils.compat import str
 
 
 def _check_html(html_view, title=None):

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -11,7 +11,6 @@ from nilearn._utils.compat import Memory, delayed, Parallel
 from .rena_clustering import ReNA
 from ..decomposition.multi_pca import MultiPCA
 from ..input_data import NiftiLabelsMasker
-from .._utils.compat import _basestring
 from .._utils.niimg import _safe_get_data
 from .._utils.niimg_conversions import _iter_check_niimg
 
@@ -60,7 +59,7 @@ def _check_parameters_transform(imgs, confounds):
     as a list.
     """
     if not isinstance(imgs, (list, tuple)) or \
-            isinstance(imgs, _basestring):
+            isinstance(imgs, str):
         imgs = [imgs, ]
         single_subject = True
     elif isinstance(imgs, (list, tuple)) and len(imgs) == 1:
@@ -73,7 +72,7 @@ def _check_parameters_transform(imgs, confounds):
 
     if confounds is not None:
         if not isinstance(confounds, (list, tuple)) or \
-                isinstance(confounds, _basestring):
+                isinstance(confounds, str):
             confounds = [confounds, ]
 
     if len(confounds) != len(imgs):

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -18,7 +18,6 @@ from ..image import new_img_like, resample_img
 from ..image.image import _smooth_array, threshold_img
 from .._utils.niimg_conversions import concat_niimgs, _check_same_fov
 from .._utils.niimg import _safe_get_data
-from .._utils.compat import _basestring
 from .._utils.ndimage import _peak_local_max
 from .._utils.segmentation import _random_walker
 
@@ -392,7 +391,7 @@ class RegionExtractor(NiftiMapsMasker):
                        "either of these {0}").format(list_of_strategies)
             raise ValueError(message)
 
-        if self.threshold is None or isinstance(self.threshold, _basestring):
+        if self.threshold is None or isinstance(self.threshold, str):
             raise ValueError("The given input to threshold is not valid. "
                              "Please submit a valid number specific to either of "
                              "the strategy in {0}".format(list_of_strategies))
@@ -502,7 +501,7 @@ def connected_label_regions(labels_img, min_size=None, connect_diag=True,
 
     if labels is not None:
         if (not isinstance(labels, collections.abc.Iterable) or
-                isinstance(labels, _basestring)):
+                isinstance(labels, str)):
             labels = [labels, ]
         if len(unique_labels) != len(labels):
             raise ValueError("The number of labels: {0} provided as input "

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -14,7 +14,6 @@ import numpy as np
 from scipy import stats, linalg, signal as sp_signal
 from sklearn.utils import gen_even_slices, as_float_array
 
-from ._utils.compat import _basestring
 from ._utils.numpy_conversions import csv_to_array, as_ndarray
 
 NP_VERSION = distutils.version.LooseVersion(np.version.short_version).version
@@ -475,7 +474,7 @@ def clean(signals, sessions=None, detrend=True, standardize='zscore',
                         "high_pass='{0}'".format(high_pass))
 
     if not isinstance(confounds,
-                      (list, tuple, _basestring, np.ndarray, type(None))):
+                      (list, tuple, str, np.ndarray, type(None))):
         raise TypeError("confounds keyword has an unhandled type: %s"
                         % confounds.__class__)
 
@@ -500,7 +499,7 @@ def clean(signals, sessions=None, detrend=True, standardize='zscore',
 
         all_confounds = []
         for confound in confounds:
-            if isinstance(confound, _basestring):
+            if isinstance(confound, str):
                 filename = confound
                 confound = csv_to_array(filename)
                 if np.isnan(confound.flat[0]):

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -22,7 +22,6 @@ from nibabel import freesurfer as fs
 
 from ..image import load_img
 from ..image import resampling
-from .._utils.compat import _basestring
 from .._utils.path_finding import _resolve_globbing
 from .. import _utils
 from nilearn.image import get_data
@@ -574,7 +573,7 @@ def load_surf_data(surf_data):
         An array containing surface data
     """
     # if the input is a filename, load it
-    if isinstance(surf_data, _basestring):
+    if isinstance(surf_data, str):
 
         # resolve globbing
         file_list = _resolve_globbing(surf_data)
@@ -698,7 +697,7 @@ def load_surf_mesh(surf_mesh):
         the second containing the indices (into coords) of the mesh faces.
     """
     # if input is a filename, try to load it
-    if isinstance(surf_mesh, _basestring):
+    if isinstance(surf_mesh, str):
         # resolve globbing
         file_list = _resolve_globbing(surf_mesh)
         if len(file_list) == 1:


### PR DESCRIPTION
Now that Nilearn no longer supports Python2, we can directly use the `str` datatype instead of couching it behind _basestring.
This PR does that.