### PR TITLE
Deliberate failure introduced to test Checks API

### DIFF
--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -97,9 +97,10 @@ EXPAND_PATH_WILDCARDS = True
 # This  is used in nilearn._utils.cache_mixin
 CHECK_CACHE_VERSION = True
 
+[].update('JUNK')  # Deliberate failure introduced to test Checks API
+
 # list all submodules available in nilearn and version
 __all__ = ['datasets', 'decoding', 'decomposition', 'connectome',
            'image', 'input_data', 'masking', 'mass_univariate', 'plotting',
            'regions', 'signal', 'stats', 'surface',
            'parcellations', '__version__']
-


### PR DESCRIPTION
At the request of one of Nilearn's maintainers, @kchawla-pi , this PR has been created to fail deliberately, to verify that the Checks API allows people without write access to retrigger failing CIs.

Update: No they do not.