### PR TITLE
Add high_pass to docs for make_first_level_design_matrix

### DIFF
--- a/nilearn/stats/first_level_model/design_matrix.py
+++ b/nilearn/stats/first_level_model/design_matrix.py
@@ -281,9 +281,8 @@ def make_first_level_design_matrix(
     drift_model : {'polynomial', 'cosine', None}, optional
         Specifies the desired drift model,
 
-    period_cut : float, optional
-        Cut period of the high-pass filter in seconds.
-        Used only if drift_model is 'cosine'.
+    high_pass : float, optional
+        high-pass frequency in case of a cosine model (in Hz).
 
     drift_order : int, optional
         Order of the drift model (in case it is polynomial).

--- a/nilearn/stats/first_level_model/design_matrix.py
+++ b/nilearn/stats/first_level_model/design_matrix.py
@@ -282,7 +282,7 @@ def make_first_level_design_matrix(
         Specifies the desired drift model,
 
     high_pass : float, optional
-        high-pass frequency in case of a cosine model (in Hz).
+        High-pass frequency in case of a cosine model (in Hz).
 
     drift_order : int, optional
         Order of the drift model (in case it is polynomial).


### PR DESCRIPTION
This argument is passed to `_make_drift`, so I replaced the text with the same description as is used in `_make_drift `.