### PR TITLE
[MRG] set config to print_changed_only=False for doctests

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -403,6 +403,7 @@ estimator object, for instance an SVC (`support vector classifier
 <http://scikit-learn.org/stable/modules/svm.html>`_).
 It is first created with the relevant parameters::
 
+    >>> import sklearn; sklearn.set_config(print_changed_only=False)
     >>> from sklearn.svm import SVC
     >>> svc = SVC(kernel='linear', C=1.)
 

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -188,6 +188,7 @@ Common data preparation steps: smoothing, filtering, resampling
 :class:`NiftiMasker` comes with many parameters that enable data
 preparation::
 
+   >>> import sklearn; sklearn.set_config(print_changed_only=False)
    >>> from nilearn import input_data
    >>> masker = input_data.NiftiMasker()
    >>> masker # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE


### PR DESCRIPTION
since the scikit-learn release 0.23 (12 may 2020), by default estimator's `__repr__` only show parameters that are different from the default values:

https://scikit-learn.org/stable/whats_new/v0.23.html#miscellaneous
https://github.com/scikit-learn/scikit-learn/pull/17061

this causes some of nilearn's doctests to fail; this PR sets sklearn's config to
the old behaviour for the affected files. 
(note that for the NiftiMasker at least the doctest in question is meant to show
the parameters to the reader so in this particular case the old behaviour is
indeed what we want)