### PR TITLE
Fix: CanICA ensure valid percentile

### DIFF
--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -5,7 +5,7 @@ CanICA
 # Author: Alexandre Abraham, Gael Varoquaux,
 # License: BSD 3 clause
 
-import warnings as _warnings 
+import warnings as _warnings
 import numpy as np
 
 from operator import itemgetter
@@ -218,11 +218,13 @@ class CanICA(MultiPCA):
             abs_ica_maps = np.abs(ica_maps)
             percentile = 100. - (100. / len(ica_maps)) * ratio
             if percentile <= 0:
-                _warnings.warn("Critical threshold (= %s percentile). "
-                              "No threshold will be applied. "
-                              "Threshold should be decreased or "
-                              "number of components should be adjusted." %
-                              str(percentile), UserWarning)
+                _warnings.warn("Nilearn's decomposition module "
+                               "obtained a critical threshold "
+                               "(= %s percentile).\n"
+                               "No threshold will be applied. "
+                               "Threshold should be decreased or "
+                               "number of components should be adjusted." %
+                               str(percentile), UserWarning, stacklevel=4)
             else:
                 threshold = scoreatpercentile(abs_ica_maps, percentile)
                 ica_maps[abs_ica_maps < threshold] = 0.
@@ -234,7 +236,8 @@ class CanICA(MultiPCA):
             if component.max() < -component.min():
                 component *= -1
         if hasattr(self, "masker_"):
-            self.components_img_ = self.masker_.inverse_transform(self.components_)
+            self.components_img_ = self.masker_.inverse_transform(
+                self.components_)
 
     # Overriding MultiPCA._raw_fit overrides MultiPCA.fit behavior
     def _raw_fit(self, data):

--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -216,7 +216,7 @@ class CanICA(MultiPCA):
             abs_ica_maps = np.abs(ica_maps)
             threshold = scoreatpercentile(
                 abs_ica_maps,
-                100. - (100. / len(ica_maps)) * ratio)
+                np.maximum(0, 100. - (100. / len(ica_maps)) * ratio))
             ica_maps[abs_ica_maps < threshold] = 0.
         # We make sure that we keep the dtype of components
         self.components_ = ica_maps.astype(self.components_.dtype)

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -146,6 +146,14 @@ def test_threshold_bound():
     # is higher than number of components
     pytest.raises(ValueError, CanICA, n_components=4, threshold=5.)
 
+def test_percentile_range():
+    # Smoke test to ensure a valid percentile for determining
+    # the threshold
+    data, mask_img, components, rng = _make_canica_test_data()
+
+    # use large number of components to stress threshold
+    CanICA(n_components=30, random_state=rng, mask=mask_img)
+
 
 def test_masker_attributes_with_fit():
     # Test base module at sub-class

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+import warnings
 
 from numpy.testing import assert_array_almost_equal
 import nibabel
@@ -147,13 +148,17 @@ def test_threshold_bound():
     pytest.raises(ValueError, CanICA, n_components=4, threshold=5.)
 
 def test_percentile_range():
-    # Smoke test to ensure a valid percentile for determining
-    # the threshold
-    data, mask_img, components, rng = _make_canica_test_data()
-
-    # use large number of components to stress threshold
-    canica = CanICA(n_components=11, threshold=11.)
-    canica.fit(data)
+    # Smoke test to test warning in case ignored thresholds
+    rng = np.random.RandomState(0)                                           
+    edge_case = rng.randint(low = 1, high = 10) 
+    data, *_ = _make_canica_test_data()
+    
+    # stess thresholding via edge case
+    canica = CanICA(n_components=edge_case, threshold=float(edge_case))
+    with warnings.catch_warnings(record=True) as warning:
+        canica.fit(data)
+        assert len(warning) == 1  # ensure single warning
+        assert "Critical threshold" in str(warning[-1].message)
 
 def test_masker_attributes_with_fit():
     # Test base module at sub-class

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -147,18 +147,20 @@ def test_threshold_bound():
     # is higher than number of components
     pytest.raises(ValueError, CanICA, n_components=4, threshold=5.)
 
+
 def test_percentile_range():
     # Smoke test to test warning in case ignored thresholds
-    rng = np.random.RandomState(0)                                           
-    edge_case = rng.randint(low = 1, high = 10) 
+    rng = np.random.RandomState(0)
+    edge_case = rng.randint(low=1, high=10)
     data, *_ = _make_canica_test_data()
-    
+
     # stess thresholding via edge case
     canica = CanICA(n_components=edge_case, threshold=float(edge_case))
     with warnings.catch_warnings(record=True) as warning:
         canica.fit(data)
         assert len(warning) == 1  # ensure single warning
-        assert "Critical threshold" in str(warning[-1].message)
+        assert "critical threshold" in str(warning[-1].message)
+
 
 def test_masker_attributes_with_fit():
     # Test base module at sub-class

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -152,8 +152,8 @@ def test_percentile_range():
     data, mask_img, components, rng = _make_canica_test_data()
 
     # use large number of components to stress threshold
-    CanICA(n_components=30, random_state=rng, mask=mask_img)
-
+    canica = CanICA(n_components=11, threshold=11.)
+    canica.fit(data)
 
 def test_masker_attributes_with_fit():
     # Test base module at sub-class


### PR DESCRIPTION
# Description
The calculated threshold in `canica` may throw an error.
The reason is that the percentile of the threshold takes on an undefined value range.

# Approach
The range of the percentile used to calculate the threshold in `canica` is limited to [0,100].