### PR TITLE
[ENH] bug fixing on Decoder module:

### DIFF
--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -186,7 +186,7 @@ def _parallel_fit(estimator, X, y, train, test, param_grid, is_classification,
         # Store best parameters and estimator coefficients
         if (best_score is None) or (score >= best_score):
             best_score = score
-            best_coef = estimator.coef_.reshape(1, -1)
+            best_coef = np.reshape(estimator.coef_, (1, -1))
             best_intercept = estimator.intercept_
             best_param = param
 
@@ -481,9 +481,11 @@ class _BaseDecoder(LinearModel, RegressorMixin, CacheMixin):
                                            self.is_classification)
         # Return a suitable screening percentile according to the mask image
         if hasattr(selector, 'percentile'):
-            self.screening_percentile = selector.percentile
+            self.screening_percentile_ = selector.percentile
+        else:
+            self.screening_percentile_ = self.screening_percentile
 
-        n_final_features = int(X.shape[1] * self.screening_percentile
+        n_final_features = int(X.shape[1] * self.screening_percentile_
                                * self.clustering_percentile / 10000)
         if n_final_features < 50:
             warnings.warn(

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -712,7 +712,7 @@ class Decoder(_BaseDecoder):
         The percentage of brain volume that will be kept with respect to a full
         MNI template. In particular, if it is lower than 100, a univariate
         feature selection based on the Anova F-value for the input data will be
-        perfomed. A float according to a percentile of the highest
+        performed. A float according to a percentile of the highest
         scores. Default: 20.
 
     scoring: str, callable or None, optional. Default: 'roc_auc'
@@ -846,7 +846,7 @@ class DecoderRegressor(_BaseDecoder):
         The percentage of brain volume that will be kept with respect to a full
         MNI template. In particular, if it is lower than 100, a univariate
         feature selection based on the Anova F-value for the input data will be
-        perfomed. A float according to a percentile of the highest
+        performed. A float according to a percentile of the highest
         scores. Default: 20.
 
     scoring: str, callable or None, optional. Default: 'r2'
@@ -990,7 +990,7 @@ class fREMRegressor(_BaseDecoder):
         The percentage of brain volume that will be kept with respect to a full
         MNI template. In particular, if it is lower than 100, a univariate
         feature selection based on the Anova F-value for the input data will be
-        perfomed. A float according to a percentile of the highest
+        performed. A float according to a percentile of the highest
         scores. Default: 20.
 
     scoring: str, callable or None, optional. Default: 'r2'
@@ -1146,7 +1146,7 @@ class fREMClassifier(_BaseDecoder):
         The percentage of brain volume that will be kept with respect to a full
         MNI template. In particular, if it is lower than 100, a univariate
         feature selection based on the Anova F-value for the input data will be
-        perfomed. A float according to a percentile of the highest
+        performed. A float according to a percentile of the highest
         scores. Default: 20.
 
     scoring: str, callable or None, optional. Default: 'roc_auc'

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -482,6 +482,8 @@ class _BaseDecoder(LinearModel, RegressorMixin, CacheMixin):
         # Return a suitable screening percentile according to the mask image
         if hasattr(selector, 'percentile'):
             self.screening_percentile_ = selector.percentile
+        elif self.screening_percentile is None:
+            self.screening_percentile_ = 100.0
         else:
             self.screening_percentile_ = self.screening_percentile
 

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -173,7 +173,7 @@ def test_decoder_binary_classification():
     assert accuracy_score(y, y_pred) > 0.95
 
     # check different screening_percentile value
-    for screening_percentile in [100, 20]:
+    for screening_percentile in [100, 20, None]:
         model = Decoder(mask=mask, screening_percentile=screening_percentile)
         model.fit(X, y)
         y_pred = model.predict(X)
@@ -212,7 +212,7 @@ def test_decoder_multiclass_classification():
     assert accuracy_score(y, y_pred) > 0.95
 
     # check different screening_percentile value
-    for screening_percentile in [100, 20]:
+    for screening_percentile in [100, 20, None]:
         model = Decoder(mask=mask, screening_percentile=screening_percentile)
         model.fit(X, y)
         y_pred = model.predict(X)
@@ -262,7 +262,7 @@ def test_decoder_regression():
     X = StandardScaler().fit_transform(X)
     X, mask = to_niimgs(X, [dim, dim, dim])
     for reg in regressors:
-        for screening_percentile in [100, 20, 1]:
+        for screening_percentile in [100, 20, 1, None]:
             model = DecoderRegressor(estimator=reg, mask=mask,
                                      screening_percentile=screening_percentile)
             model.fit(X, y)

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -50,10 +50,10 @@ classifiers = {'svc': (svc, 'C'),
                'logistic_l2': (logistic_l2, 'C'),
                'ridge_classifier': (ridge_classifier, [])}
 # Create a test dataset
-rand = np.random.RandomState(0)
-X = rand.rand(100, 10)
+rng = np.random.RandomState(0)
+X = rng.rand(100, 10)
 # Create different targets
-y_regression = rand.rand(100)
+y_regression = rng.rand(100)
 y_classification = np.hstack([[-1] * 50, [1] * 50])
 y_classification_str = np.hstack([['face'] * 50, ['house'] * 50])
 y_multiclass = np.hstack([[0] * 35, [1] * 30, [2] * 35])

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -260,9 +260,9 @@ def test_decoder_classification_string_label():
 
 
 def test_decoder_regression():
-    dim = 15
+    dim = 20
     X, y = make_regression(n_samples=200, n_features=dim**3,
-                           n_informative=dim, noise=0.2, random_state=42)
+                           n_informative=dim, noise=1.0, random_state=42)
     X = StandardScaler().fit_transform(X)
     X, mask = to_niimgs(X, [dim, dim, dim])
     for regressor_ in regressors:

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -260,13 +260,13 @@ def test_decoder_classification_string_label():
 
 
 def test_decoder_regression():
-    X, y = make_regression(n_samples=200, n_features=125,
-                           n_informative=5, noise=0.2, random_state=42)
+    dim = 15
+    X, y = make_regression(n_samples=200, n_features=dim**3,
+                           n_informative=dim, noise=0.2, random_state=42)
     X = StandardScaler().fit_transform(X)
-    # y = (y - y.mean()) / y.std()
-    X, mask = to_niimgs(X, [5, 5, 5])
+    X, mask = to_niimgs(X, [dim, dim, dim])
     for regressor_ in regressors:
-        for screening_percentile in [100, 20]:
+        for screening_percentile in [100, 20, 1]:
             model = DecoderRegressor(estimator=regressor_, mask=mask,
                                      screening_percentile=screening_percentile)
             model.fit(X, y)

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -287,7 +287,8 @@ def test_decoder_regression():
 
 def test_decoder_apply_mask():
     X_init, y = make_classification(n_samples=200, n_features=125, scale=3.0,
-                                    n_informative=5, n_classes=4, random_state=42)
+                                    n_informative=5, n_classes=4,
+                                    random_state=42)
     X, _ = to_niimgs(X_init, [5, 5, 5])
     model = Decoder(mask=NiftiMasker())
 


### PR DESCRIPTION
Closes #2414 and closes #2360 

Changes proposed in this pull request:

- Fixed screening_percentile be corrected twice when doing fit
- Better docstring on screening_percentile param
- Reshaping coefficients of fitted estimator inside parallel_fit to prevent RidgeCV from behaving weirdly
- Improvement for `test_decoder.py`: increase difficulty of `test_decoder_regression`, removed unnecessary varible definition 

