### PR TITLE
changing surface mesh from a list to a namedtuple

### DIFF
--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -38,13 +38,14 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
 
     Parameters
     ----------
-    surf_mesh : str or list of two numpy.ndarray
+    surf_mesh : str or list of two numpy.ndarray or Mesh
         Surface mesh geometry, can be a file (valid formats are
         .gii or Freesurfer specific files such as .orig, .pial,
         .sphere, .white, .inflated) or
         a list of two Numpy arrays, the first containing the x-y-z coordinates
         of the mesh vertices, the second containing the indices
-        (into coords) of the mesh faces.
+        (into coords) of the mesh faces, or a Mesh object with
+        "coordinates" and "faces" attributes.
 
     surf_map : str or numpy.ndarray, optional
         Data to be displayed on the surface mesh. Can be a file (valid formats
@@ -513,13 +514,14 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
 
     Parameters
     ----------
-    surf_mesh : str or list of two numpy.ndarray
+    surf_mesh : str or list of two numpy.ndarray or Mesh
         Surface mesh geometry, can be a file (valid formats are
         .gii or Freesurfer specific files such as .orig, .pial,
         .sphere, .white, .inflated) or
         a list of two Numpy arrays, the first containing the x-y-z
         coordinates of the mesh vertices, the second containing the
-        indices (into coords) of the mesh faces
+        indices (into coords) of the mesh faces, or a Mesh object
+        with "coordinates" and "faces" attributes.
 
     stat_map : str or numpy.ndarray
         Statistical map to be displayed on the surface mesh, can
@@ -877,13 +879,14 @@ def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
 
     Parameters
     ----------
-    surf_mesh : str or list of two numpy.ndarray
+    surf_mesh : str or list of two numpy.ndarray or Mesh
         Surface mesh geometry, can be a file (valid formats are
         .gii or Freesurfer specific files such as .orig, .pial,
         .sphere, .white, .inflated) or
         a list of two Numpy arrays, the first containing the x-y-z
         coordinates of the mesh vertices, the second containing the indices
-        (into coords) of the mesh faces
+        (into coords) of the mesh faces, or a Mesh object with
+        "coordinates" and "faces" attributes.
 
     roi_map : str or numpy.ndarray or list of numpy.ndarray
         ROI map to be displayed on the surface mesh, can be a file

--- a/nilearn/surface/__init__.py
+++ b/nilearn/surface/__init__.py
@@ -3,7 +3,7 @@ Functions for surface manipulation.
 """
 
 from .surface import (vol_to_surf, load_surf_data,
-                      load_surf_mesh, check_mesh_and_data)
+                      load_surf_mesh, check_mesh_and_data, Mesh)
 
 __all__ = ['vol_to_surf', 'load_surf_data', 'load_surf_mesh',
-           'check_mesh_and_data']
+           'check_mesh_and_data', 'Mesh']

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -478,11 +478,12 @@ def vol_to_surf(img, surf_mesh,
     img : Niimg-like object, 3d or 4d.
         See http://nilearn.github.io/manipulating_images/input_output.html
 
-    surf_mesh : str or numpy.ndarray
+    surf_mesh : str or numpy.ndarray or Mesh
         Either a file containing surface mesh geometry (valid formats
         are .gii or Freesurfer specific files such as .orig, .pial,
         .sphere, .white, .inflated) or two Numpy arrays organized in a list,
-        tuple or a namedtuple with the fields "coordinates" and "faces".
+        tuple or a namedtuple with the fields "coordinates" and "faces", or
+        a Mesh object with "coordinates" and "faces" attributes.
 
     radius : float, optional
         The size (in mm) of the neighbourhood from which samples are drawn
@@ -814,15 +815,16 @@ def load_surf_mesh(surf_mesh):
 
     Parameters
     ----------
-    surf_mesh : str or numpy.ndarray
+    surf_mesh : str or numpy.ndarray or Mesh
         Either a file containing surface mesh geometry (valid formats
         are .gii .gii.gz or Freesurfer specific files such as .orig, .pial,
         .sphere, .white, .inflated) or two Numpy arrays organized in a list,
-        tuple or a namedtuple with the fields "coordinates" and "faces"
+        tuple or a namedtuple with the fields "coordinates" and "faces", or a
+        Mesh object with "coordinates" and "faces" attributes.
 
     Returns
     --------
-    mesh : namedtuple
+    mesh : Mesh
         With the fields "coordinates" and "faces", each containing a
         numpy.ndarray
 
@@ -877,7 +879,7 @@ def load_surf_mesh(surf_mesh):
                               'array containing  the indices (into coords) of '
                               'the mesh faces. The input was a list with '
                               '%r elements.') % len(surf_mesh))
-    elif (hasattr(surf_mesh, "faces") & hasattr(surf_mesh,"coordinates")):
+    elif (hasattr(surf_mesh, "faces") and hasattr(surf_mesh,"coordinates")):
         coords, faces = surf_mesh.coordinates, surf_mesh.faces
         mesh = Mesh(coordinates=coords, faces=faces)
 

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -879,7 +879,7 @@ def load_surf_mesh(surf_mesh):
                               'array containing  the indices (into coords) of '
                               'the mesh faces. The input was a list with '
                               '%r elements.') % len(surf_mesh))
-    elif (hasattr(surf_mesh, "faces") and hasattr(surf_mesh,"coordinates")):
+    elif (hasattr(surf_mesh, "faces") and hasattr(surf_mesh, "coordinates")):
         coords, faces = surf_mesh.coordinates, surf_mesh.faces
         mesh = Mesh(coordinates=coords, faces=faces)
 
@@ -922,7 +922,7 @@ def check_mesh_and_data(mesh, data):
     mesh = load_surf_mesh(mesh)
     data = load_surf_data(data)
     # Check that mesh coordinates has a number of nodes
-    # equals to the size of the data.
+    # equal to the size of the data.
     if len(data) != len(mesh.coordinates):
         raise ValueError(
             'Mismatch between number of nodes in mesh ({}) and '

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -921,8 +921,18 @@ def check_mesh_and_data(mesh, data):
     """Load surface mesh and data, check that they have compatible shapes."""
     mesh = load_surf_mesh(mesh)
     data = load_surf_data(data)
+    # Check that mesh coordinates has a number of nodes
+    # equals to the size of the data.
     if len(data) != len(mesh.coordinates):
         raise ValueError(
             'Mismatch between number of nodes in mesh ({}) and '
             'size of surface data ({})'.format(len(mesh.coordinates),len(data)))
+    # Check that the indices of faces are consistent with the
+    # mesh coordinates. That is, we shouldn't have an index
+    # larger or equal to the length of the coordinates array.
+    if mesh.faces.max() >= len(mesh.coordinates):
+        raise ValueError(
+            "Mismatch between the indices of faces and the number of nodes. "
+            "Maximum face index is {} while coordinates array has length {}.".format(
+                mesh.faces.max(), len(mesh.coordinates)))
     return mesh, data

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -926,7 +926,7 @@ def check_mesh_and_data(mesh, data):
     if len(data) != len(mesh.coordinates):
         raise ValueError(
             'Mismatch between number of nodes in mesh ({}) and '
-            'size of surface data ({})'.format(len(mesh.coordinates),len(data)))
+            'size of surface data ({})'.format(len(mesh.coordinates), len(data)))
     # Check that the indices of faces are consistent with the
     # mesh coordinates. That is, we shouldn't have an index
     # larger or equal to the length of the coordinates array.

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -30,6 +30,9 @@ from nilearn._utils.path_finding import _resolve_globbing
 from nilearn import _utils
 from nilearn.image import get_data
 
+# Create a namedtuple object for meshes
+Mesh = namedtuple("mesh", ["coordinates", "faces"])
+
 
 def _uniform_ball_cloud(n_points=20, dim=3, n_monte_carlo=50000):
     """Get points uniformly spaced in the unit ball."""
@@ -478,10 +481,8 @@ def vol_to_surf(img, surf_mesh,
     surf_mesh : str or numpy.ndarray
         Either a file containing surface mesh geometry (valid formats
         are .gii or Freesurfer specific files such as .orig, .pial,
-        .sphere, .white, .inflated) or a list of two Numpy arrays,
-        the first containing the x-y-z coordinates of the mesh
-        vertices, the second containing the indices (into coords)
-        of the mesh faces.
+        .sphere, .white, .inflated) or two Numpy arrays organized in a list,
+        tuple or a namedtuple with the fields "coordinates" and "faces".
 
     radius : float, optional
         The size (in mm) of the neighbourhood from which samples are drawn
@@ -826,8 +827,6 @@ def load_surf_mesh(surf_mesh):
         numpy.ndarray
 
     """
-    # Create a named tuple
-    Mesh = namedtuple("mesh", ["coordinates", "faces"])
 
     # if input is a filename, try to load it
     if isinstance(surf_mesh, str):

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -621,11 +621,22 @@ def test_check_mesh():
 
 
 def test_check_mesh_and_data():
-    mesh = generate_surf()
+    coords, faces = generate_surf()
+    mesh = Mesh(coords, faces)
     data = mesh[0][:, 0]
     m, d = surface.check_mesh_and_data(mesh, data)
     assert (m[0] == mesh[0]).all()
     assert (m[1] == mesh[1]).all()
     assert (d == data).all()
+    # Generate faces such that max index is larger than
+    # the length of coordinates array.
+    rng = np.random.RandomState(42)
+    wrong_faces = rng.randint(coords.shape[0] + 1, size=(30, 3))
+    wrong_mesh = Mesh(coords, wrong_faces)
+    # Check that check_mesh_and_data raises an error with the resulting wrong mesh
+    with pytest.raises(ValueError, match="Mismatch between the indices of faces and the number of nodes."):
+        surface.check_mesh_and_data(wrong_mesh, data)
+    # Alter the data and check that an error is raised
     data = mesh[0][::2, 0]
-    pytest.raises(ValueError, surface.check_mesh_and_data, mesh, data)
+    with pytest.raises(ValueError, match="Mismatch between number of nodes in mesh"):
+        surface.check_mesh_and_data(mesh, data)

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -33,6 +33,21 @@ currdir = os.path.dirname(os.path.abspath(__file__))
 datadir = os.path.join(currdir, 'data')
 
 
+class MeshLikeObject(object):
+    """Class with attributes coordinates and
+    faces to be used for testing purposes.
+    """
+    def __init__(self, coordinates, faces):
+        self._coordinates = coordinates
+        self._faces = faces
+    @property
+    def coordinates(self):
+        return self._coordinates
+    @property
+    def faces(self):
+        return self._faces
+
+
 def test_load_surf_data_array():
     # test loading and squeezing data from numpy array
     data_flat = np.zeros((20, ))
@@ -150,10 +165,22 @@ def test_load_surf_mesh():
     mesh = Mesh(coords, faces)
     assert_array_equal(mesh.coordinates, coords)
     assert_array_equal(mesh.faces, faces)
+    # Call load_surf_mesh with a Mesh as argument
     loaded_mesh = load_surf_mesh(mesh)
     assert isinstance(loaded_mesh, Mesh)
     assert_array_equal(mesh.coordinates, loaded_mesh.coordinates)
     assert_array_equal(mesh.faces, loaded_mesh.faces)
+
+    mesh_like = MeshLikeObject(coords, faces)
+    assert_array_equal(mesh_like.coordinates, coords)
+    assert_array_equal(mesh_like.faces, faces)
+    # Call load_surf_mesh with an object having
+    # coordinates and faces attributes
+    loaded_mesh = load_surf_mesh(mesh_like)
+    assert isinstance(loaded_mesh, Mesh)
+    assert_array_equal(mesh_like.coordinates, loaded_mesh.coordinates)
+    assert_array_equal(mesh_like.faces, loaded_mesh.faces)
+
 
 def test_load_surf_mesh_list():
     # test if correct list is returned

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -20,6 +20,7 @@ from nilearn import datasets
 from nilearn import image
 from nilearn.image import resampling
 from nilearn.image.tests.test_resampling import rotation
+from nilearn.surface import Mesh
 from nilearn.surface import surface
 from nilearn.surface import load_surf_data, load_surf_mesh, vol_to_surf
 from nilearn.surface.surface import (_gifti_img_to_mesh,
@@ -143,6 +144,16 @@ def test_load_surf_data_file_error():
             load_surf_data(filename_wrong)
         os.remove(filename_wrong)
 
+
+def test_load_surf_mesh():
+    coords, faces = generate_surf()
+    mesh = Mesh(coords, faces)
+    assert_array_equal(mesh.coordinates, coords)
+    assert_array_equal(mesh.faces, faces)
+    loaded_mesh = load_surf_mesh(mesh)
+    assert isinstance(loaded_mesh, Mesh)
+    assert_array_equal(mesh.coordinates, loaded_mesh.coordinates)
+    assert_array_equal(mesh.faces, loaded_mesh.faces)
 
 def test_load_surf_mesh_list():
     # test if correct list is returned


### PR DESCRIPTION
Updates of surface handling as discussed in #2171

Changes proposed in this pull request:
- Changing the representation of a surface mesh from a list to a named tuple

Additional changes towards a surface object that contains both mesh and data are to follow
