### PR TITLE
deprecate cobre fetcher

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,6 +26,12 @@ Fixes
   some corrections regarding its description were made in the docstring.
 
 
+Changes
+-------
+
+- :function:`nilearn.datasets.fetch_cobre` has been deprecated and will be
+  removed in release 0.9 .
+
 0.6.2
 ======
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -29,7 +29,7 @@ Fixes
 Changes
 -------
 
-- :function:`nilearn.datasets.fetch_cobre` has been deprecated and will be
+- :func:`nilearn.datasets.fetch_cobre` has been deprecated and will be
   removed in release 0.9 .
 
 0.6.2

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -9,9 +9,11 @@ import tempfile
 import urllib
 import warnings
 import gc
+import distutils
 
 import numpy as np
 import pytest
+import sklearn
 
 from ..datasets.utils import _fetch_files
 
@@ -47,6 +49,19 @@ except ImportError:
 
 
     memory_usage = memory_used = None
+
+
+def check_deprecation(func, match=None):
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        if distutils.version.LooseVersion(sklearn.__version__) < '0.22':
+            with pytest.deprecated_call():
+                result = func(*args, **kwargs)
+        else:
+            with pytest.warns(FutureWarning, match=match):
+                result = func(*args, **kwargs)
+        return result
+    return wrapped
 
 
 def assert_memory_less_than(memory_limit, tolerance,

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -18,7 +18,7 @@ import nibabel
 import pandas as pd
 from scipy.io import loadmat
 from scipy.io.matlab.miobase import MatReadError
-from sklearn.utils import Bunch
+from sklearn.utils import Bunch, deprecated
 
 from .utils import (_get_dataset_dir, _fetch_files, _get_dataset_descr,
                     _read_md5_sum_file, _tree, _filter_columns, _fetch_file, _uncompress_file)
@@ -1490,6 +1490,10 @@ def fetch_megatrawls_netmats(dimensionality=100, timeseries='eigen_regression',
         description=description)
 
 
+@deprecated("'fetch_cobre' has been deprecated and will be removed "
+            "in release 0.9 . "
+            "Please consider using a different datasets or downloading it "
+            "with a different tool than nilearn.")
 def fetch_cobre(n_subjects=10, data_dir=None, url=None, verbose=1):
     """Fetch COBRE datasets preprocessed using NIAK 0.17 under CentOS
     version 6.3 with Octave version 4.0.2 and the Minc toolkit version 0.3.18.

--- a/nilearn/datasets/tests/test_func.py
+++ b/nilearn/datasets/tests/test_func.py
@@ -20,6 +20,7 @@ from sklearn.utils import check_random_state
 from . import test_utils as tst
 
 from nilearn.datasets import utils, func
+from nilearn._utils.testing import check_deprecation
 
 from ..utils import _get_dataset_dir
 
@@ -501,8 +502,9 @@ def test_fetch_cobre(tmp_path, request_mocker):
     local_url = "file://" + dummy
 
     # All subjects
-    cobre_data = func.fetch_cobre(n_subjects=None, data_dir=str(tmp_path),
-                                  url=local_url)
+    cobre_data = check_deprecation(
+        func.fetch_cobre, "'fetch_cobre' has been deprecated")(
+            n_subjects=None, data_dir=str(tmp_path), url=local_url)
 
     phenotypic_names = ['func', 'confounds', 'phenotypic', 'description',
                         'desc_con', 'desc_phenotypic']


### PR DESCRIPTION
start addressing #2283 by deprecating cobre fetcher
it is not used in any example nor by other functions