### PR TITLE
Fixed colorbar aesthetics on a black backgroud

### DIFF
--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -876,9 +876,12 @@ class BaseSlicer(object):
 
         self._colorbar_ax.yaxis.tick_left()
         tick_color = 'w' if self._black_bg else 'k'
+        outline_color = 'w' if self._black_bg else 'k'
+
         for tick in self._colorbar_ax.yaxis.get_ticklabels():
             tick.set_color(tick_color)
         self._colorbar_ax.yaxis.set_tick_params(width=0)
+        self._cbar.outline.set_edgecolor(outline_color)
 
     def add_edges(self, img, color='r'):
         """ Plot the edges of a 3D map in all the views.

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -1201,13 +1201,12 @@ def plot_glass_brain(stat_map_img,
         return functools.partial(get_projector(display_mode),
                                  alpha=alpha, plot_abs=plot_abs)
 
-    brain_color = (0. if black_bg else 1.,) * 3
     display = _plot_img_with_bg(
         img=stat_map_img, output_file=output_file, display_mode=display_mode,
         figure=figure, axes=axes, title=title, annotate=annotate,
         black_bg=black_bg, threshold=threshold, cmap=cmap, colorbar=colorbar,
         display_factory=display_factory, vmin=vmin, vmax=vmax,
-        cbar_vmin=cbar_vmin, cbar_vmax=cbar_vmax, brain_color=brain_color,
+        cbar_vmin=cbar_vmin, cbar_vmax=cbar_vmax,
         resampling_interpolation=resampling_interpolation, **kwargs)
 
     if stat_map_img is None and 'l' in display.axes:


### PR DESCRIPTION
This PR deals with the aesthetics of colorbar on black backgrounds (issue #2485). For glass brain, plotting overlay for thresholded colorbar is set up to default gray color in the same way as for `plot_stat_map`. Additionally, this PR changes the outline of the colorbar for a black background as it should be changed to white in the same way as color of `tick_params`. Note, that this will also affect colorbar on other plotting functions when `black_bg=True`.

Plots after fix:
![image](https://user-images.githubusercontent.com/14907241/82730951-e7582e00-9d03-11ea-9afb-c79ab6858730.png)
![image](https://user-images.githubusercontent.com/14907241/82731037-59307780-9d04-11ea-8cdd-a95af413aa08.png)


