### PR TITLE
[ENH] API: nilearn.stats.map_threshold to threshold_stats_img

### DIFF
--- a/doc/modules/reference.rst
+++ b/doc/modules/reference.rst
@@ -425,7 +425,7 @@ the :ref:`user guide <user_guide>` for more information and usage examples.
     expression_to_contrast_vector
     fdr_threshold
     cluster_level_inference
-    map_threshold
+    threshold_stats_img
 
 
 :mod:`nilearn.stats.first_level_model`

--- a/examples/05_glm_second_level_models/plot_oasis.py
+++ b/examples/05_glm_second_level_models/plot_oasis.py
@@ -79,8 +79,8 @@ ax.set_title('Second level design matrix', fontsize=12)
 ax.set_ylabel('maps')
 
 ##########################################################################
-# Next, we specify and fit the second-level model when loading the data and also
-# smooth a little bit to improve statistical behavior.
+# Next, we specify and fit the second-level model when loading the data and
+# also smooth a little bit to improve statistical behavior.
 
 from nilearn.stats.second_level_model import SecondLevelModel
 second_level_model = SecondLevelModel(smoothing_fwhm=2.0, mask_img=mask_img)
@@ -96,8 +96,8 @@ z_map = second_level_model.compute_contrast(second_level_contrast=[1, 0, 0],
 ###########################################################################
 # We threshold the second level contrast at uncorrected p < 0.001 and plot it.
 from nilearn import plotting
-from nilearn.stats import map_threshold
-_, threshold = map_threshold(
+from nilearn.stats import threshold_stats_img
+_, threshold = threshold_stats_img(
     z_map, alpha=.05, height_control='fdr')
 print('The FDR=.05-corrected threshold is: %.3g' % threshold)
 
@@ -108,12 +108,12 @@ display = plotting.plot_stat_map(
 plotting.show()
 
 ###########################################################################
-# We can also study the effect of sex by computing the contrast, thresholding it
-# and plot the resulting map.
+# We can also study the effect of sex by computing the contrast, thresholding
+# it and plot the resulting map.
 
 z_map = second_level_model.compute_contrast(second_level_contrast='sex',
                                             output_type='z_score')
-_, threshold = map_threshold(
+_, threshold = threshold_stats_img(
     z_map, alpha=.05, height_control='fdr')
 plotting.plot_stat_map(
     z_map, threshold=threshold, colorbar=True,

--- a/examples/05_glm_second_level_models/plot_second_level_association_test.py
+++ b/examples/05_glm_second_level_models/plot_second_level_association_test.py
@@ -64,8 +64,8 @@ z_map = model.compute_contrast('fluency', output_type='z_score')
 
 ###########################################################################
 # We compute the fdr-corrected p = 0.05 threshold for these data
-from nilearn.stats import map_threshold
-_, threshold = map_threshold(z_map, alpha=.05, height_control='fdr')
+from nilearn.stats import threshold_stats_img
+_, threshold = threshold_stats_img(z_map, alpha=.05, height_control='fdr')
 
 ###########################################################################
 # Let us plot the second level contrast at the computed thresholds

--- a/examples/05_glm_second_level_models/plot_thresholding.py
+++ b/examples/05_glm_second_level_models/plot_thresholding.py
@@ -1,8 +1,8 @@
-"""
-Statistical testing of a second-level analysis
+"""Statistical testing of a second-level analysis
 ==============================================
 
-Perform a one-sample t-test on a bunch of images (a.k.a. second-level analyis in fMRI) and threshold the resulting statistical map.
+Perform a one-sample t-test on a bunch of images (a.k.a. second-level
+analyis in fMRI) and threshold the resulting statistical map.
 
 This example is based on the so-called localizer dataset.
 It shows activation related to a mental computation task,
@@ -27,7 +27,8 @@ cmap_filenames = localizer_dataset.cmaps
 # Perform the second level analysis
 # ----------------------------------
 #
-# First, we define a design matrix for the model. As the model is trivial (one-sample test), the design matrix is just one column with ones.
+# First, we define a design matrix for the model. As the model is trivial
+# (one-sample test), the design matrix is just one column with ones.
 import pandas as pd
 design_matrix = pd.DataFrame([1] * n_samples, columns=['intercept'])
 
@@ -45,13 +46,13 @@ z_map = second_level_model.compute_contrast(output_type='z_score')
 #########################################################################
 # Threshold the resulting map:
 # false positive rate < .001, cluster size > 10 voxels.
-from nilearn.stats import map_threshold
-thresholded_map1, threshold1 = map_threshold(
+from nilearn.stats import threshold_stats_img
+thresholded_map1, threshold1 = threshold_stats_img(
     z_map, alpha=.001, height_control='fpr', cluster_threshold=10)
 
 #########################################################################
 # Now use FDR <.05 (False Discovery Rate) and no cluster-level threshold.
-thresholded_map2, threshold2 = map_threshold(
+thresholded_map2, threshold2 = threshold_stats_img(
     z_map, alpha=.05, height_control='fdr')
 print('The FDR=.05 threshold is %.3g' % threshold2)
 
@@ -59,7 +60,7 @@ print('The FDR=.05 threshold is %.3g' % threshold2)
 # Now use FWER <.05 (Family-Wise Error Rate) and no cluster-level
 # threshold.  As the data has not been intensively smoothed, we can
 # use a simple Bonferroni correction.
-thresholded_map3, threshold3 = map_threshold(
+thresholded_map3, threshold3 = threshold_stats_img(
     z_map, alpha=.05, height_control='bonferroni')
 print('The p<.05 Bonferroni-corrected threshold is %.3g' % threshold3)
 
@@ -72,7 +73,8 @@ from nilearn import plotting
 display = plotting.plot_stat_map(z_map, title='Raw z map')
 
 #########################################################################
-# Second, the p<.001 uncorrected-thresholded map (with only clusters > 10 voxels).
+# Second, the p<.001 uncorrected-thresholded map (with only clusters > 10
+# voxels).
 plotting.plot_stat_map(
     thresholded_map1, cut_coords=display.cut_coords, threshold=threshold1,
     title='Thresholded z map, fpr <.001, clusters > 10 voxels')

--- a/examples/plot_single_subject_single_run.py
+++ b/examples/plot_single_subject_single_run.py
@@ -1,5 +1,4 @@
-"""
-Intro to GLM Analysis: a single-session, single-subject fMRI dataset
+"""Intro to GLM Analysis: a single-session, single-subject fMRI dataset
 =====================================================================
 
 In this tutorial, we use a General Linear Model (GLM) to compare the fMRI
@@ -21,14 +20,17 @@ The dataset comes from an experiment conducted at the FIL by Geraint Rees
 under the direction of Karl Friston. It is provided by FIL methods
 group which develops the SPM software.
 
-According to SPM documentation, 96 scans were acquired (repetition time TR=7s) in one session. The paradigm consisted of alternating periods of stimulation and rest, lasting 42s each (that is, for 6 scans). The sesssion started with a rest block.
-Auditory stimulation consisted of bi-syllabic words presented binaurally at a
-rate of 60 per minute. The functional data starts at scan number 4, that is the
-image file ``fM00223_004``.
+According to SPM documentation, 96 scans were acquired (repetition time TR=7s)
+in one session. The paradigm consisted of alternating periods of stimulation
+and rest, lasting 42s each (that is, for 6 scans). The sesssion started with a
+rest block.  Auditory stimulation consisted of bi-syllabic words presented
+binaurally at a rate of 60 per minute. The functional data starts at scan
+number 4, that is the image file ``fM00223_004``.
 
-The whole brain BOLD/EPI images were acquired on a  2T Siemens
-MAGNETOM Vision system. Each scan consisted of 64 contiguous
-slices (64x64x64 3mm x 3mm x 3mm voxels). Acquisition of one scan took 6.05s, with the scan to scan repeat time (TR) set arbitrarily to 7s.
+The whole brain BOLD/EPI images were acquired on a 2T Siemens MAGNETOM Vision
+system. Each scan consisted of 64 contiguous slices (64x64x64 3mm x 3mm x 3mm
+voxels). Acquisition of one scan took 6.05s, with the scan to scan repeat time
+(TR) set arbitrarily to 7s.
 
 
 To run this example, you must launch IPython via ``ipython
@@ -216,8 +218,8 @@ plt.show()
 # alpha) at a certain level, e.g. 0.001: this means that there is 0.1% chance
 # of declaring an inactive voxel, active.
 
-from nilearn.stats import map_threshold
-_, threshold = map_threshold(z_map, alpha=.001, height_control='fpr')
+from nilearn.stats import threshold_stats_img
+_, threshold = threshold_stats_img(z_map, alpha=.001, height_control='fpr')
 print('Uncorrected p<0.001 threshold: %.3f' % threshold)
 plot_stat_map(z_map, bg_img=mean_img, threshold=threshold,
               display_mode='z', cut_coords=3, black_bg=True,
@@ -231,7 +233,8 @@ plt.show()
 # i.e. the probability of making only one false detection, say at
 # 5%. For that we use the so-called Bonferroni correction.
 
-_, threshold = map_threshold(z_map, alpha=.05, height_control='bonferroni')
+_, threshold = threshold_stats_img(
+    z_map, alpha=.05, height_control='bonferroni')
 print('Bonferroni-corrected, p<0.05 threshold: %.3f' % threshold)
 plot_stat_map(z_map, bg_img=mean_img, threshold=threshold,
               display_mode='z', cut_coords=3, black_bg=True,
@@ -244,7 +247,7 @@ plt.show()
 # false discoveries among detections. This is called the False
 # discovery rate.
 
-_, threshold = map_threshold(z_map, alpha=.05, height_control='fdr')
+_, threshold = threshold_stats_img(z_map, alpha=.05, height_control='fdr')
 print('False Discovery rate = 0.05 threshold: %.3f' % threshold)
 plot_stat_map(z_map, bg_img=mean_img, threshold=threshold,
               display_mode='z', cut_coords=3, black_bg=True,
@@ -258,7 +261,7 @@ plt.show()
 # cluster_threshold argument. Here clusters smaller than 10 voxels
 # will be discarded.
 
-clean_map, threshold = map_threshold(
+clean_map, threshold = threshold_stats_img(
     z_map, alpha=.05, height_control='fdr', cluster_threshold=10)
 plot_stat_map(clean_map, bg_img=mean_img, threshold=threshold,
               display_mode='z', cut_coords=3, black_bg=True,
@@ -313,7 +316,7 @@ z_map = fmri_glm.compute_contrast(effects_of_interest,
 # Note that the statistic has been converted to a z-variable, which
 # makes it easier to represent it.
 
-clean_map, threshold = map_threshold(
+clean_map, threshold = threshold_stats_img(
     z_map, alpha=.05, height_control='fdr', cluster_threshold=10)
 plot_stat_map(clean_map, bg_img=mean_img, threshold=threshold,
               display_mode='z', cut_coords=3, black_bg=True,

--- a/nilearn/reporting/glm_reporter.py
+++ b/nilearn/reporting/glm_reporter.py
@@ -35,7 +35,7 @@ from nilearn.reporting import (plot_contrast_matrix,
                                plot_design_matrix,
                                get_clusters_table,
                                )
-from nilearn.stats.thresholding import map_threshold
+from nilearn.stats.thresholding import threshold_stats_img
 
 
 HTML_TEMPLATE_ROOT_PATH = os.path.join(os.path.dirname(__file__),
@@ -694,7 +694,7 @@ def _make_stat_maps_contrast_clusters(stat_img, contrasts_plots, threshold,
         components_template_text = html_template_obj.read()
     for contrast_name, stat_map_img in stat_img.items():
         component_text_ = string.Template(components_template_text)
-        thresholded_stat_map, threshold = map_threshold(
+        thresholded_stat_map, threshold = threshold_stats_img(
             stat_img=stat_map_img,
             threshold=threshold,
             alpha=alpha,

--- a/nilearn/stats/__init__.py
+++ b/nilearn/stats/__init__.py
@@ -21,7 +21,7 @@ from nilearn.stats.regression import (
 from nilearn.stats.thresholding import (
     fdr_threshold,
     cluster_level_inference,
-    map_threshold,
+    threshold_stats_img,
 )
 
 from nilearn.stats import first_level_model
@@ -43,7 +43,7 @@ __all__ = [
     'SimpleRegressionResults',
     'fdr_threshold',
     'cluster_level_inference',
-    'map_threshold',
+    'threshold_stats_img',
     'first_level_model',
     'second_level_model',
 ]

--- a/nilearn/stats/thresholding.py
+++ b/nilearn/stats/thresholding.py
@@ -8,7 +8,6 @@ Author: Bertrand Thirion, 2015 -- 2019
 import warnings
 
 import numpy as np
-
 from scipy.ndimage import label
 from scipy.stats import norm
 
@@ -173,8 +172,9 @@ def cluster_level_inference(stat_img, mask_img=None,
     return proportion_true_discoveries_img
 
 
-def map_threshold(stat_img=None, mask_img=None, alpha=.001, threshold=3.,
-                  height_control='fpr', cluster_threshold=0, two_sided=True):
+def threshold_stats_img(stat_img=None, mask_img=None, alpha=.001, threshold=3.,
+                        height_control='fpr', cluster_threshold=0,
+                        two_sided=True):
     """ Compute the required threshold level and return the thresholded map
 
     Parameters


### PR DESCRIPTION
Closes gh-2490

Changes proposed in this pull request:
* Change function name from `nilearn.stats.map_threshold` to `nilearn.stats.threshold_stats_img`
* Various indentation fix (PEP8) with `nilearn.stats` example
