### PR TITLE
[NOMRG] delete part of circleci cache before saving

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,13 @@ commands:
   save_to_cache:
     description: "Caches the downloaded packages & buit docs."
     steps:
+      - run:
+          name: Delete part of cache to make it smaller
+          command: |
+            rm -rf ../nilearn_data/neurovault
+            rm -rf ../nilearn_data/brainomics_localizer
+            rm -rf ../nilearn_data/ABIDE_pcp
+            rm -rf ../nilearn_data/development_fmri
       - save_cache:
           key: v1-packages+datasets-{{ checksum "week_num" }}-{{ checksum ".circleci/packages-cache-timestamp" }}
           paths:


### PR DESCRIPTION
do not review or merge this is part of a discussion with circleci support

since the current size is 5.0 G which happens to be exactly a limit on circleci
system, the circleci support asked to try changing the cache size to help debug
why the cache is not always found.

