### PR TITLE
BUG: Escape chars

### DIFF
--- a/nilearn/_utils/stats.py
+++ b/nilearn/_utils/stats.py
@@ -391,7 +391,7 @@ def get_bids_files(main_path, file_tag='*', file_type='*', sub_label='*',
 
 
 def parse_bids_filename(img_path):
-    """Returns dictionary with parsed information from file path
+    r"""Return dictionary with parsed information from file path.
 
     Parameters
     ----------

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -2505,7 +2505,7 @@ def _prepare_downloaded_spm_auditory_data(subject_dir):
     _subject_data = {}
     _subject_data['func'] = sorted(
         [subject_data[x] for x in subject_data.keys()
-         if re.match('^fM00223_0\d\d\.img$',  # noqa:W605
+         if re.match(r'^fM00223_0\d\d\.img$',
                      os.path.basename(x))])
 
     # volumes for this dataset of shape (64, 64, 64, 1); let's fix this
@@ -2517,7 +2517,7 @@ def _prepare_downloaded_spm_auditory_data(subject_dir):
             nib.save(vol, x)
 
     _subject_data['anat'] = [subject_data[x] for x in subject_data.keys()
-                             if re.match('^sM00223_002\.img$',  # noqa:W605
+                             if re.match(r'^sM00223_002\.img$',
                                          os.path.basename(x))][0]
 
     # ... same thing for anat

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -226,9 +226,9 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
 
     if surf_map is not None:
         surf_map_data = load_surf_data(surf_map)
-        if len(surf_map_data.shape) is not 1:
+        if surf_map_data.ndim != 1:
             raise ValueError('surf_map can only have one dimension but has'
-                             '%i dimensions' % len(surf_map_data.shape))
+                             '%i dimensions' % surf_map_data.ndim)
         if surf_map_data.shape[0] != coords.shape[0]:
             raise ValueError('The surf_map does not have the same number '
                              'of vertices as the mesh.')
@@ -520,9 +520,9 @@ def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
 
     mesh = load_surf_mesh(surf_mesh)
 
-    if len(roi.shape) is not 1:
+    if roi.ndim != 1:
         raise ValueError('roi_map can only have one dimension but has '
-                         '%i dimensions' % len(roi.shape))
+                         '%i dimensions' % roi.ndim)
     if roi.shape[0] != mesh[0].shape[0]:
         raise ValueError('roi_map does not have the same number of vertices '
                          'as the mesh. If you have a list of indices for the '


### PR DESCRIPTION
Running some code over in MNE with `warnings.simplefilter('error')` I found a few warnings that could be fixed involving escape chars and literal int comparisons.