### PR TITLE
Fix nilearn under scikit-learn 0.24

### DIFF
--- a/nilearn/_utils/param_validation.py
+++ b/nilearn/_utils/param_validation.py
@@ -191,4 +191,4 @@ def check_feature_screening(screening_percentile, mask_img,
         screening_percentile_ = _adjust_screening_percentile(
             screening_percentile, mask_img, verbose=verbose)
 
-        return SelectPercentile(f_test, int(screening_percentile_))
+        return SelectPercentile(f_test, percentile=int(screening_percentile_))

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -19,23 +19,20 @@ import warnings
 import numpy as np
 from joblib import Parallel, delayed
 from sklearn import clone
-from sklearn.base import RegressorMixin
 from sklearn.linear_model import LogisticRegression
-from sklearn.linear_model.base import LinearModel
-from sklearn.linear_model.ridge import RidgeClassifierCV, RidgeCV, _BaseRidgeCV
+from sklearn.linear_model import LinearRegression
+from sklearn.linear_model import RidgeClassifierCV, RidgeCV
 from sklearn.model_selection import (LeaveOneGroupOut, ParameterGrid,
                                      ShuffleSplit, StratifiedShuffleSplit,
                                      check_cv)
 from sklearn.preprocessing import LabelBinarizer
-from sklearn.svm import SVR, LinearSVC
-from sklearn.svm.bounds import l1_min_c
+from sklearn.svm import SVR, LinearSVC, l1_min_c
 from sklearn.utils.extmath import safe_sparse_dot
 from sklearn.utils.validation import check_is_fitted, check_X_y
 
 from nilearn._utils import CacheMixin
 from nilearn._utils.cache_mixin import _check_memory
-from nilearn._utils.param_validation import (_adjust_screening_percentile,
-                                             check_feature_screening)
+from nilearn._utils.param_validation import check_feature_screening
 from nilearn.input_data.masker_validation import check_embedded_nifti_masker
 from nilearn.regions.rena_clustering import ReNA
 
@@ -103,7 +100,8 @@ def _check_param_grid(estimator, X, y, param_grid=None):
         # define loss function
         if isinstance(estimator, LogisticRegression):
             loss = 'log'
-        elif isinstance(estimator, (LinearSVC, _BaseRidgeCV, SVR)):
+        elif isinstance(estimator,
+                        (LinearSVC, RidgeCV, RidgeClassifierCV, SVR)):
             loss = 'squared_hinge'
         else:
             raise ValueError(
@@ -116,7 +114,7 @@ def _check_param_grid(estimator, X, y, param_grid=None):
         else:
             min_c = 0.5
 
-        if not isinstance(estimator, _BaseRidgeCV):
+        if not isinstance(estimator, (RidgeCV, RidgeClassifierCV)):
             param_grid['C'] = np.array([2, 20, 200]) * min_c
         else:
             param_grid = {}
@@ -199,7 +197,7 @@ def _parallel_fit(estimator, X, y, train, test, param_grid, is_classification,
     return class_index, best_coef, best_intercept, best_param, best_score
 
 
-class _BaseDecoder(LinearModel, RegressorMixin, CacheMixin):
+class _BaseDecoder(LinearRegression, CacheMixin):
     """A wrapper for popular classification/regression strategies in
     neuroimaging.
 

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -943,7 +943,7 @@ class BaseSpaceNet(LinearRegression, CacheMixin):
 
         # handle regression (least-squared loss)
         if not self.is_classif:
-            return LinearModel.predict(self, X)
+            return LinearRegression.predict(self, X)
 
         # prediction proper
         scores = self.decision_function(X)

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -18,10 +18,9 @@ import sys
 from functools import partial
 import numpy as np
 from scipy import stats, ndimage
-from sklearn.base import RegressorMixin
 from sklearn.utils.extmath import safe_sparse_dot
 from sklearn.utils import check_array
-from sklearn.linear_model.base import LinearModel
+from sklearn.linear_model import LinearRegression
 from sklearn.feature_selection import (SelectPercentile, f_regression,
                                        f_classif)
 from joblib import Memory, Parallel, delayed
@@ -31,7 +30,11 @@ from ..input_data.masker_validation import check_embedded_nifti_masker
 from .._utils.param_validation import _adjust_screening_percentile
 from sklearn.utils import check_X_y
 from sklearn.model_selection import check_cv
-from sklearn.linear_model.base import _preprocess_data as center_data
+try:
+    from sklearn.linear_model._base import _preprocess_data as center_data
+except ImportError:
+    # Sklearn < 0.23
+    from sklearn.linear_model.base import _preprocess_data as center_data
 from .._utils.cache_mixin import CacheMixin
 from nilearn.masking import _unmask_from_to_3d_array
 from .space_net_solvers import (tvl1_solver, _graph_net_logistic,
@@ -448,7 +451,7 @@ def path_scores(solver, X, y, mask, alphas, l1_ratios, train, test,
             y_train_mean, key)
 
 
-class BaseSpaceNet(LinearModel, RegressorMixin, CacheMixin):
+class BaseSpaceNet(LinearRegression, CacheMixin):
     """
     Regression and classification learners with sparsity and spatial priors
 
@@ -904,7 +907,8 @@ class BaseSpaceNet(LinearModel, RegressorMixin, CacheMixin):
         """
         # handle regression (least-squared loss)
         if not self.is_classif:
-            return LinearModel.decision_function(self, X)
+            raise ValueError(
+                'There is no decision_function in classification')
 
         X = check_array(X)
         n_features = self.coef_.shape[1]


### PR DESCRIPTION
Do not import from modules that have been made private and moved

Currently, nilearn does not run on sklearn 0.24. This PR fixes it.