### PR TITLE
[FIX] Ensure nilearn.signal.clean will not modify original array

### DIFF
--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -482,13 +482,13 @@ def clean(signals, sessions=None, detrend=True, standardize='zscore',
                          "but you provided ensure_finite={0}"
                          .format(ensure_finite))
 
+    signals = signals.copy()
     if not isinstance(signals, np.ndarray):
         signals = as_ndarray(signals)
 
     if ensure_finite:
         mask = np.logical_not(np.isfinite(signals))
         if mask.any():
-            signals = signals.copy()
             signals[mask] = 0
 
     # Read confounds

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -287,7 +287,8 @@ def test_clean_detrending():
     y_clean = nisignal.clean(y, ensure_finite=True)
     assert np.any(np.isfinite(y_clean)), True
     # clean should not modify inputs
-    assert np.array_equal(y_orig, y)
+    # using assert_almost_equal instead of array_equal due to NaNs
+    np.testing.assert_almost_equal(y_orig, y, decimal=13)
 
     # test boolean is not given to signal.clean
     pytest.raises(TypeError, nisignal.clean, x, low_pass=False)

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -348,6 +348,25 @@ def test_clean_frequencies():
     assert np.array_equal(sx_orig, sx)
 
 
+def test_clean_sessions():
+    n_samples = 21
+    n_features = 501  # Must be higher than 500
+    signals, _, _ = generate_signals(n_features=n_features,
+                                     length=n_samples)
+    trends = generate_trends(n_features=n_features,
+                             length=n_samples)
+    x = signals + trends
+    x_orig = x.copy()
+    # Create session info
+    sessions = np.ones(n_samples)
+    sessions[0:n_samples // 2] = 0
+    x_detrended = nisignal.clean(x, standardize=False, detrend=True,
+                                 low_pass=None, high_pass=None,
+                                 sessions=sessions)
+    # clean should not modify inputs
+    assert np.array_equal(x_orig, x)
+
+
 def test_clean_confounds():
     signals, noises, confounds = generate_signals(n_features=41,
                                                   n_confounds=5, length=45)

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -335,12 +335,17 @@ def test_clean_frequencies():
     sx1 = np.sin(np.linspace(0, 100, 2000))
     sx2 = np.sin(np.linspace(0, 100, 2000))
     sx = np.vstack((sx1, sx2)).T
+    sx_orig = sx.copy()
     assert clean(sx, standardize=False, high_pass=0.002, low_pass=None,
                       t_r=2.5).max() > 0.1
     assert clean(sx, standardize=False, high_pass=0.2, low_pass=None,
                       t_r=2.5) .max() < 0.01
     assert clean(sx, standardize=False, low_pass=0.01, t_r=2.5).max() > 0.9
     pytest.raises(ValueError, clean, sx, low_pass=0.4, high_pass=0.5, t_r=2.5)
+
+    # clean should not modify inputs
+    sx_cleaned = clean(sx, standardize=False, detrend=False, low_pass=0.2, t_r=2.5)
+    assert np.array_equal(sx_orig, sx)
 
 
 def test_clean_confounds():


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #2281 and closes #2475.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:
- Copy the input array at the top of `nilearn.signal.clean` so that the original array will not be modified.
- Add tests to cover the cases reported in #2281 and #2475.
- Add more tests for the same issue interspersed throughout the testing functions for `nilearn.signal.clean`.
