### PR TITLE
[MRG] numpy warning changed in 1.19

### DIFF
--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -479,7 +479,7 @@ def test_resampling_nan():
 
         # check 3x3 transformation matrix
         target_affine = np.eye(3)[axis_permutation]
-        with pytest.warns(RuntimeWarning):
+        with pytest.warns(Warning, match=r"\bnan\b"):
             resampled_img = resample_img(source_img,
                                          target_affine=target_affine)
 

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -479,7 +479,7 @@ def test_resampling_nan():
 
         # check 3x3 transformation matrix
         target_affine = np.eye(3)[axis_permutation]
-        with pytest.warns(Warning, match=r"\bnan\b"):
+        with pytest.warns(Warning, match=r"(\bnan\b|invalid value)"):
             resampled_img = resample_img(source_img,
                                          target_affine=target_affine)
 


### PR DESCRIPTION
fix test failing because numpy warning type changed in 1.19 release
see e.g. https://github.com/nilearn/nilearn/pull/2529#issuecomment-650832712