### PR TITLE
[MRG] fix TemplateNotFound error

### DIFF
--- a/doc/themes/nilearn/layout.html
+++ b/doc/themes/nilearn/layout.html
@@ -9,7 +9,7 @@
     :author: Jaques Grobler
     :license: BSD
 #}
-{% extends "sphinxdoc/layout.html" %}
+{% extends "basic/layout.html" %}
 
 {%- block doctype -%}
 <!DOCTYPE html>


### PR DESCRIPTION
the sphinxdoc/layout.html has been removed in latest sphinx release
before it extended basic/layout.html
