### PR TITLE
MNT: Rename setattr_on_read -> auto_attr

### DIFF
--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -19,7 +19,7 @@ import numpy as np
 import pandas as pd
 from joblib import Memory, Parallel, delayed
 from nibabel import Nifti1Image
-from nibabel.onetime import setattr_on_read
+from nibabel.onetime import auto_attr
 from sklearn.base import BaseEstimator, TransformerMixin, clone
 
 from nilearn._utils import CacheMixin
@@ -667,7 +667,7 @@ class FirstLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
 
             return output
 
-    @setattr_on_read
+    @auto_attr
     def residuals(self):
         """Transform voxelwise residuals to the same shape
         as the input Nifti1Image(s)
@@ -680,7 +680,7 @@ class FirstLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
         return self._get_voxelwise_model_attribute('resid',
                                                    result_as_time_series=True)
 
-    @setattr_on_read
+    @auto_attr
     def predicted(self):
         """Transform voxelwise predicted values to the same shape
         as the input Nifti1Image(s)
@@ -693,7 +693,7 @@ class FirstLevelModel(BaseEstimator, TransformerMixin, CacheMixin):
         return self._get_voxelwise_model_attribute('predicted',
                                                    result_as_time_series=True)
 
-    @setattr_on_read
+    @auto_attr
     def r_square(self):
         """Transform voxelwise r-squared values to the same shape
         as the input Nifti1Image(s)

--- a/nilearn/glm/model.py
+++ b/nilearn/glm/model.py
@@ -7,7 +7,7 @@ import warnings
 
 import numpy as np
 
-from nibabel.onetime import setattr_on_read
+from nibabel.onetime import auto_attr
 from scipy.linalg import inv
 from scipy.stats import t as t_distribution
 
@@ -78,7 +78,7 @@ class LikelihoodModelResults(object):
         # put this as a parameter of LikelihoodModel
         self.df_residuals = self.df_total - self.df_model
 
-    @setattr_on_read
+    @auto_attr
     def df_resid(self):
         warnings.warn("'df_resid' from LikelihoodModelResults "
                       "has been deprecated and will be removed. "
@@ -86,7 +86,7 @@ class LikelihoodModelResults(object):
                       FutureWarning)
         return self.df_residuals
 
-    @setattr_on_read
+    @auto_attr
     def logL(self):
         """
         The maximized log-likelihood

--- a/nilearn/glm/regression.py
+++ b/nilearn/glm/regression.py
@@ -22,7 +22,7 @@ import warnings
 
 import numpy as np
 
-from nibabel.onetime import setattr_on_read
+from nibabel.onetime import auto_attr
 from numpy.linalg import matrix_rank
 import scipy.linalg as spl
 
@@ -95,7 +95,7 @@ class OLSModel(object):
         self.df_model = matrix_rank(self.design, eps)
         self.df_residuals = self.df_total - self.df_model
 
-    @setattr_on_read
+    @auto_attr
     def df_resid(self):
         warnings.warn("'df_resid' from OLSModel"
                       "has been deprecated and will be removed. "
@@ -103,7 +103,7 @@ class OLSModel(object):
                       FutureWarning)
         return self.df_residuals
 
-    @setattr_on_read
+    @auto_attr
     def wdesign(self):
         warnings.warn("'wdesign' from OLSModel"
                       "has been deprecated and will be removed. "
@@ -307,7 +307,7 @@ class RegressionResults(LikelihoodModelResults):
         self.whitened_residuals = whitened_residuals
         self.whitened_design = model.whitened_design
 
-    @setattr_on_read
+    @auto_attr
     def wdesign(self):
         warnings.warn("'wdesign' from RegressionResults"
                       "has been deprecated and will be removed. "
@@ -315,7 +315,7 @@ class RegressionResults(LikelihoodModelResults):
                       FutureWarning)
         return self.whitened_design
 
-    @setattr_on_read
+    @auto_attr
     def wY(self):
         warnings.warn("'wY' from RegressionResults "
                       "has been deprecated and will be removed. "
@@ -324,7 +324,7 @@ class RegressionResults(LikelihoodModelResults):
                       )
         return self.whitened_Y
 
-    @setattr_on_read
+    @auto_attr
     def wresid(self):
         warnings.warn("'wresid' from RegressionResults "
                       "has been deprecated and will be removed. "
@@ -333,7 +333,7 @@ class RegressionResults(LikelihoodModelResults):
                       )
         return self.whitened_residuals
 
-    @setattr_on_read
+    @auto_attr
     def resid(self):
         warnings.warn("'resid' from RegressionResults "
                       "has been deprecated and will be removed. "
@@ -342,14 +342,14 @@ class RegressionResults(LikelihoodModelResults):
                       )
         return self.residuals
 
-    @setattr_on_read
+    @auto_attr
     def residuals(self):
         """
         Residuals from the fit.
         """
         return self.Y - self.predicted
 
-    @setattr_on_read
+    @auto_attr
     def norm_resid(self):
         warnings.warn("'norm_resid' from RegressionResults "
                       "has been deprecated and will be removed. "
@@ -358,7 +358,7 @@ class RegressionResults(LikelihoodModelResults):
                       )
         return self.normalized_residuals
 
-    @setattr_on_read
+    @auto_attr
     def normalized_residuals(self):
         """
         Residuals, normalized to have unit length.
@@ -378,7 +378,7 @@ class RegressionResults(LikelihoodModelResults):
         """
         return self.residuals * positive_reciprocal(np.sqrt(self.dispersion))
 
-    @setattr_on_read
+    @auto_attr
     def predicted(self):
         """ Return linear predictor values from a design matrix.
         """
@@ -387,20 +387,20 @@ class RegressionResults(LikelihoodModelResults):
         X = self.whitened_design
         return np.dot(X, beta)
 
-    @setattr_on_read
+    @auto_attr
     def SSE(self):
         """Error sum of squares. If not from an OLS model this is "pseudo"-SSE.
         """
         return (self.whitened_residuals ** 2).sum(0)
 
-    @setattr_on_read
+    @auto_attr
     def r_square(self):
         """Proportion of explained variance.
         If not from an OLS model this is "pseudo"-R2.
         """
         return np.var(self.predicted, 0) / np.var(self.whitened_Y, 0)
 
-    @setattr_on_read
+    @auto_attr
     def MSE(self):
         """ Mean square (error) """
         return self.SSE / self.df_residuals
@@ -449,7 +449,7 @@ class SimpleRegressionResults(LikelihoodModelResults):
         """
         return Y - self.predicted
 
-    @setattr_on_read
+    @auto_attr
     def df_resid(self):
         warnings.warn("The attribute 'df_resid' from OLSModel"
                       "has been deprecated and will be removed. "


### PR DESCRIPTION
nibabel.onetime.setattr_on_read has been renamed to [auto_attr](https://nipy.org/nibabel/reference/nibabel.onetime.html#auto-attr).

Deprecation is [mentioned in a comment](https://github.com/nipy/nibabel/blob/516434c086b64aae03c69b6549548e5556760002/nibabel/onetime.py#L174-L179), but not raised as a warning. I'll plan to tag it with a `DeprecationWarning` in an upcoming release, but might as well change it here first.