### PR TITLE
[FIX] Ignore all-zero voxels in permuted_ols null distribution generation

### DIFF
--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -220,7 +220,7 @@ def _permuted_ols_on_chunk(scores_original_data, tested_vars, target_vars,
                                                        confounding_vars))
         if two_sided_test:
             perm_scores = np.fabs(perm_scores)
-        h0_fmax_part[i] = np.amax(perm_scores, 0)
+        h0_fmax_part[i] = np.nanmax(perm_scores, axis=0)
         # find the rank of the original scores in h0_part
         # (when n_descriptors or n_perm are large, it can be quite long to
         #  find the rank of the original scores into the whole H0 distribution.

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -354,10 +354,9 @@ def permuted_ols(tested_vars, target_vars, confounding_vars=None,
     target_vars = np.asfortranarray(target_vars)  # efficient for chunking
     n_descriptors = target_vars.shape[1]
     if np.any(np.all(target_vars == 0, axis=0)):
-        warnings.warn("Some samples in 'target_vars' have zeros across all "
-                      "descriptors. "
-                      "These samples will be ignored during null distribution "
-                      "generation.")
+        warnings.warn("Some descriptors in 'target_vars' have zeros across all "
+                      "samples. These descriptors will be ignored during null "
+                      "distribution generation.")
 
     # check explanatory variates dimensions
     if tested_vars.ndim == 1:

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -353,6 +353,11 @@ def permuted_ols(tested_vars, target_vars, confounding_vars=None,
                             "s" if target_vars.ndim > 1 else ""))
     target_vars = np.asfortranarray(target_vars)  # efficient for chunking
     n_descriptors = target_vars.shape[1]
+    if np.any(np.all(target_vars == 0, axis=0)):
+        warnings.warn("Some samples in 'target_vars' have zeros across all "
+                      "descriptors. "
+                      "These samples will be ignored during null distribution "
+                      "generation.")
 
     # check explanatory variates dimensions
     if tested_vars.ndim == 1:


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #2556.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add a warning if any voxels in `target_vars` are all zeros across samples.
- Use `numpy.nanmax` instead of `numpy.amax` to get the permutation-wise maximum values, so that all-zero voxels are ignored.
