### PR TITLE
Removing fake sklearn import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ def list_required_packages():
         if package.startswith('sklearn'):
             package = package.replace('sklearn', 'scikit-learn')
         required_packages.append(package)
-    required_packages.append('sklearn')
     return required_packages
 
 


### PR DESCRIPTION
Tackling #2288, and its consequences as in #2481 (potential bugs with recent versions of scikit)

Now we don't use AppVeyor anymore, this should be useless
