### PR TITLE
[WIP] Ensure that random number generation in tests is seeded & standardized

### DIFF
--- a/nilearn/decoding/tests/test_searchlight.py
+++ b/nilearn/decoding/tests/test_searchlight.py
@@ -80,8 +80,10 @@ def test_searchlight():
         # the groups variable should have no effect.
         gcv = cv
 
-    groups = np.random.permutation(np.arange(frames, dtype=int) >
-                                   (frames // 2))
+    groups = np.random.RandomState(42).permutation(
+        np.arange(frames, dtype=int) > (frames // 2)
+    )
+
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img, radius=1,
                                  n_jobs=n_jobs, scoring='accuracy', cv=gcv)
     sl.fit(data_img, cond, groups)

--- a/nilearn/glm/tests/test_contrasts.py
+++ b/nilearn/glm/tests/test_contrasts.py
@@ -27,8 +27,9 @@ def test_expression_to_contrast_vector():
 
 
 def test_Tcontrast():
+    rng = np.random.RandomState(42)
     n, p, q = 100, 80, 10
-    X, Y = np.random.randn(p, q), np.random.randn(p, n)
+    X, Y = rng.standard_normal(size=(p, q)), rng.standard_normal(size=(p, n))
     labels, results = run_glm(Y, X, 'ar1')
     con_val = np.eye(q)[0]
     z_vals = compute_contrast(labels, results, con_val).z_score()
@@ -37,8 +38,9 @@ def test_Tcontrast():
 
 
 def test_Fcontrast():
+    rng = np.random.RandomState(42)
     n, p, q = 100, 80, 10
-    X, Y = np.random.randn(p, q), np.random.randn(p, n)
+    X, Y = rng.standard_normal(size=(p, q)), rng.standard_normal(size=(p, n))
     for model in ['ols', 'ar1']:
         labels, results = run_glm(Y, X, model)
         for con_val in [np.eye(q)[0], np.eye(q)[:3]]:
@@ -49,8 +51,9 @@ def test_Fcontrast():
 
 
 def test_t_contrast_add():
+    rng = np.random.RandomState(42)
     n, p, q = 100, 80, 10
-    X, Y = np.random.randn(p, q), np.random.randn(p, n)
+    X, Y = rng.standard_normal(size=(p, q)), rng.standard_normal(size=(p, n))
     lab, res = run_glm(Y, X, 'ols')
     c1, c2 = np.eye(q)[0], np.eye(q)[1]
     con = compute_contrast(lab, res, c1) + compute_contrast(lab, res, c2)
@@ -60,8 +63,9 @@ def test_t_contrast_add():
 
 
 def test_fixed_effect_contrast():
+    rng = np.random.RandomState(42)
     n, p, q = 100, 80, 10
-    X, Y = np.random.randn(p, q), np.random.randn(p, n)
+    X, Y = rng.standard_normal(size=(p, q)), rng.standard_normal(size=(p, n))
     lab, res = run_glm(Y, X, 'ols')
     c1, c2 = np.eye(q)[0], np.eye(q)[1]
     con = _compute_fixed_effect_contrast([lab, lab], [res, res], [c1, c2])
@@ -89,8 +93,9 @@ def test_fixed_effect_contrast_nonzero_effect():
 
 
 def test_F_contrast_add():
+    rng = np.random.RandomState(42)
     n, p, q = 100, 80, 10
-    X, Y = np.random.randn(p, q), np.random.randn(p, n)
+    X, Y = rng.standard_normal(size=(p, q)), rng.standard_normal(size=(p, n))
     lab, res = run_glm(Y, X, 'ar1')
     c1, c2 = np.eye(q)[:2], np.eye(q)[2:4]
     con = compute_contrast(lab, res, c1) + compute_contrast(lab, res, c2)
@@ -107,8 +112,9 @@ def test_F_contrast_add():
 
 
 def test_contrast_mul():
+    rng = np.random.RandomState(42)
     n, p, q = 100, 80, 10
-    X, Y = np.random.randn(p, q), np.random.randn(p, n)
+    X, Y = rng.standard_normal(size=(p, q)), rng.standard_normal(size=(p, n))
     lab, res = run_glm(Y, X, 'ar1')
     for c1 in [np.eye(q)[0], np.eye(q)[:3]]:
         con1 = compute_contrast(lab, res, c1)
@@ -119,8 +125,9 @@ def test_contrast_mul():
 
 def test_contrast_values():
     # but this test is circular and should be removed
+    rng = np.random.RandomState(42)
     n, p, q = 100, 80, 10
-    X, Y = np.random.randn(p, q), np.random.randn(p, n)
+    X, Y = rng.standard_normal(size=(p, q)), rng.standard_normal(size=(p, n))
     lab, res = run_glm(Y, X, 'ar1', bins=1)
     # t test
     cval = np.eye(q)[0]
@@ -137,9 +144,10 @@ def test_contrast_values():
 
 
 def test_low_level_fixed_effects():
+    rng = np.random.RandomState(42)
     p = 100
     # X1 is some effects estimate, V1 their variance for "session 1"
-    X1, V1 = np.random.randn(p), np.ones(p)
+    X1, V1 = rng.standard_normal(size=p), np.ones(p)
     # same thing for a "session 2"
     X2, V2 = 2 * X1, 4 * V1
     # compute the fixed effects estimate, Xf, their variance Vf,

--- a/nilearn/glm/tests/test_dmtx.py
+++ b/nilearn/glm/tests/test_dmtx.py
@@ -54,10 +54,11 @@ def basic_paradigm():
 
 
 def modulated_block_paradigm():
+    rng = np.random.RandomState(42)
     conditions = ['c0', 'c0', 'c0', 'c1', 'c1', 'c1', 'c2', 'c2', 'c2']
     onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
-    durations = 5 + 5 * np.random.rand(len(onsets))
-    values = 1 + np.random.rand(len(onsets))
+    durations = 5 + 5 * rng.uniform(size=len(onsets))
+    values = 1 + rng.uniform(size=len(onsets))
     events = pd.DataFrame({'trial_type': conditions,
                            'onset': onsets,
                            'duration': durations,
@@ -66,10 +67,11 @@ def modulated_block_paradigm():
 
 
 def modulated_event_paradigm():
+    rng = np.random.RandomState(42)
     conditions = ['c0', 'c0', 'c0', 'c1', 'c1', 'c1', 'c2', 'c2', 'c2']
     onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
     durations = 1 * np.ones(9)
-    values = 1 + np.random.rand(len(onsets))
+    values = 1 + rng.uniform(size=len(onsets))
     events = pd.DataFrame({'trial_type': conditions,
                            'onset': onsets,
                            'duration': durations,
@@ -111,20 +113,21 @@ def test_design_matrix0():
 
 def test_design_matrix0c():
     # test design matrix creation when regressors are provided manually
+    rng = np.random.RandomState(42)
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
-    ax = np.random.randn(128, 4)
+    ax = rng.standard_normal(size=(128, 4))
     _, X, names = check_design_matrix(make_first_level_design_matrix(
         frame_times, drift_model='polynomial',
         drift_order=3, add_regs=ax))
     assert_almost_equal(X[:, 0], ax[:, 0])
-    ax = np.random.randn(127, 4)
+    ax = rng.standard_normal(size=(127, 4))
     with pytest.raises(
         AssertionError,
         match="Incorrect specification of additional regressors:."
     ):
         make_first_level_design_matrix(frame_times, add_regs=ax)
-    ax = np.random.randn(128, 4)
+    ax = rng.standard_normal(size=(128, 4))
     with pytest.raises(
         ValueError,
         match="Incorrect number of additional regressor names."
@@ -136,9 +139,10 @@ def test_design_matrix0c():
 
 def test_design_matrix0d():
     # test design matrix creation when regressors are provided manually
+    rng = np.random.RandomState(42)
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
-    ax = np.random.randn(128, 4)
+    ax = rng.standard_normal(size=(128, 4))
     _, X, names = check_design_matrix(make_first_level_design_matrix(
         frame_times, drift_model='polynomial', drift_order=3, add_regs=ax))
     assert len(names) == 8
@@ -338,11 +342,12 @@ def test_design_matrix14():
 
 def test_design_matrix15():
     # basic test based on basic_paradigm, plus user supplied regressors
+    rng = np.random.RandomState(42)
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     events = basic_paradigm()
     hrf_model = 'glover'
-    ax = np.random.randn(128, 4)
+    ax = rng.standard_normal(size=(128, 4))
     X, names = design_matrix_light(frame_times, events, hrf_model=hrf_model,
                                    drift_model='polynomial', drift_order=3,
                                    add_regs=ax)
@@ -352,11 +357,12 @@ def test_design_matrix15():
 
 def test_design_matrix16():
     # Check that additional regressors are put at the right place
+    rng = np.random.RandomState(42)
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     events = basic_paradigm()
     hrf_model = 'glover'
-    ax = np.random.randn(128, 4)
+    ax = rng.standard_normal(size=(128, 4))
     X, names = design_matrix_light(frame_times, events, hrf_model=hrf_model,
                                    drift_model='polynomial', drift_order=3,
                                    add_regs=ax)
@@ -413,11 +419,12 @@ def test_design_matrix20():
 
 def test_design_matrix21():
     # basic test on repeated names of user supplied regressors
+    rng = np.random.RandomState(42)
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
     events = basic_paradigm()
     hrf_model = 'glover'
-    ax = np.random.randn(128, 4)
+    ax = rng.standard_normal(size=(128, 4))
     with pytest.raises(ValueError):
         design_matrix_light(frame_times, events,
                             hrf_model=hrf_model, drift_model='polynomial',

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -217,8 +217,9 @@ def test_high_level_glm_different_design_matrices():
 
 
 def test_run_glm():
+    rng = np.random.RandomState(42)
     n, p, q = 100, 80, 10
-    X, Y = np.random.randn(p, q), np.random.randn(p, n)
+    X, Y = rng.standard_normal(size=(p, q)), rng.standard_normal(size=(p, n))
 
     # Ordinary Least Squares case
     labels, results = run_glm(Y, X, 'ols')
@@ -244,9 +245,10 @@ def test_run_glm():
 
 def test_scaling():
     """Test the scaling function"""
+    rng = np.random.RandomState(42)
     shape = (400, 10)
-    u = np.random.randn(*shape)
-    mean = 100 * np.random.rand(shape[1]) + 1
+    u = rng.standard_normal(size=shape)
+    mean = 100 * rng.uniform(size=shape[1]) + 1
     Y = u + mean
     Y_, mean_ = mean_scaling(Y)
     assert_almost_equal(Y_.mean(0), 0, 5)

--- a/nilearn/glm/tests/test_hemodynamic_models.py
+++ b/nilearn/glm/tests/test_hemodynamic_models.py
@@ -80,7 +80,8 @@ def test_resample_regressor_nl():
 
 def test_orthogonalize():
     """ test that the orthogonalization is OK """
-    X = np.random.randn(100, 5)
+    rng = np.random.RandomState(42)
+    X = rng.standard_normal(size=(100, 5))
     X = _orthogonalize(X)
     K = np.dot(X.T, X)
     K -= np.diag(np.diag(K))
@@ -89,7 +90,8 @@ def test_orthogonalize():
 
 def test_orthogonalize_trivial():
     """ test that the orthogonalization is OK """
-    X = np.random.randn(100)
+    rng = np.random.RandomState(42)
+    X = rng.standard_normal(size=100)
     Y = X.copy()
     X = _orthogonalize(X)
     assert_array_equal(Y, X)

--- a/nilearn/glm/tests/test_paradigm.py
+++ b/nilearn/glm/tests/test_paradigm.py
@@ -22,10 +22,11 @@ def basic_paradigm():
 
 
 def modulated_block_paradigm():
+    rng = np.random.RandomState(42)
     conditions = ['c0', 'c0', 'c0', 'c1', 'c1', 'c1', 'c2', 'c2', 'c2']
     onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
-    durations = 5 + 5 * np.random.rand(len(onsets))
-    values = np.random.rand(len(onsets))
+    durations = 5 + 5 * rng.uniform(size=len(onsets))
+    values = rng.uniform(size=len(onsets))
     events = pd.DataFrame({'name': conditions,
                            'onset': onsets,
                            'duration': durations,
@@ -34,10 +35,11 @@ def modulated_block_paradigm():
 
 
 def modulated_event_paradigm():
+    rng = np.random.RandomState(42)
     conditions = ['c0', 'c0', 'c0', 'c1', 'c1', 'c1', 'c2', 'c2', 'c2']
     onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
     durations = 1 * np.ones(9)
-    values = np.random.rand(len(onsets))
+    values = rng.uniform(size=len(onsets))
     events = pd.DataFrame({'name': conditions,
                            'onset': onsets,
                            'durations': durations,

--- a/nilearn/glm/tests/test_regression.py
+++ b/nilearn/glm/tests/test_regression.py
@@ -13,9 +13,9 @@ from numpy.testing import (assert_almost_equal,
 from nilearn.glm import OLSModel, ARModel
 
 
-RNG = np.random.RandomState(20110902)
-X = RNG.standard_normal((40, 10))
-Y = RNG.standard_normal((40,))
+RNG = np.random.RandomState(42)
+X = RNG.standard_normal(size=(40, 10))
+Y = RNG.standard_normal(size=(40,))
 
 
 def test_OLS():

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -346,10 +346,8 @@ def test_second_level_contrast_computation():
             model.compute_contrast(c1, None, None, '')
         # check that passing no explicit contrast when the design
         # matrix has more than one columns raises an error
-        X = pd.DataFrame(
-            np.random.RandomState(42).uniform(size=(4, 2)),
-            columns=["r1", "r2"],
-        )
+        rng = np.random.RandomState(42)
+        X = pd.DataFrame(rng.uniform(size=(4, 2)), columns=["r1", "r2"])
         model = model.fit(Y, design_matrix=X)
         with pytest.raises(ValueError):
             model.compute_contrast(None)
@@ -394,10 +392,8 @@ def test_non_parametric_inference_contrast_computation():
             non_parametric_inference(Y, X, [], 'intercept', mask)
         # check that passing no explicit contrast when the design
         # matrix has more than one columns raises an error
-        X = pd.DataFrame(
-            np.random.RandomState(42).uniform(size=(4, 2)),
-            columns=["r1", "r2"],
-        )
+        rng = np.random.RandomState(42)
+        X = pd.DataFrame(rng.uniform(size=(4, 2)), columns=["r1", "r2"])
         with pytest.raises(ValueError):
             non_parametric_inference(Y, X, None)
         del func_img, FUNCFILE, neg_log_pvals_img, X, Y

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -346,7 +346,10 @@ def test_second_level_contrast_computation():
             model.compute_contrast(c1, None, None, '')
         # check that passing no explicit contrast when the design
         # matrix has more than one columns raises an error
-        X = pd.DataFrame(np.random.RandomState(42).uniform(size=(4, 2)), columns=['r1', 'r2'])
+        X = pd.DataFrame(
+            np.random.RandomState(42).uniform(size=(4, 2)),
+            columns=["r1", "r2"],
+        )
         model = model.fit(Y, design_matrix=X)
         with pytest.raises(ValueError):
             model.compute_contrast(None)
@@ -391,7 +394,10 @@ def test_non_parametric_inference_contrast_computation():
             non_parametric_inference(Y, X, [], 'intercept', mask)
         # check that passing no explicit contrast when the design
         # matrix has more than one columns raises an error
-        X = pd.DataFrame(np.random.RandomState(42).uniform(size=(4, 2)), columns=['r1', 'r2'])
+        X = pd.DataFrame(
+            np.random.RandomState(42).uniform(size=(4, 2)),
+            columns=["r1", "r2"],
+        )
         with pytest.raises(ValueError):
             non_parametric_inference(Y, X, None)
         del func_img, FUNCFILE, neg_log_pvals_img, X, Y

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -96,8 +96,9 @@ def test_fmri_inputs():
     # Test processing of FMRI inputs
     with InTemporaryDirectory():
         # prepare fake data
+        rng = np.random.RandomState(42)
         p, q = 80, 10
-        X = np.random.randn(p, q)
+        X = rng.standard_normal(size=(p, q))
         shapes = ((7, 8, 9, 10),)
         mask, FUNCFILE, _ = write_fake_fmri_data_and_design(shapes)
         FUNCFILE = FUNCFILE[0]
@@ -173,8 +174,9 @@ def test_fmri_inputs_for_non_parametric_inference():
     # Test processing of FMRI inputs
     with InTemporaryDirectory():
         # prepare fake data
+        rng = np.random.RandomState(42)
         p, q = 80, 10
-        X = np.random.randn(p, q)
+        X = rng.standard_normal(size=(p, q))
         shapes = ((7, 8, 9, 10),)
         mask, FUNCFILE, _ = write_fake_fmri_data_and_design(shapes)
         FUNCFILE = FUNCFILE[0]
@@ -344,7 +346,7 @@ def test_second_level_contrast_computation():
             model.compute_contrast(c1, None, None, '')
         # check that passing no explicit contrast when the design
         # matrix has more than one columns raises an error
-        X = pd.DataFrame(np.random.rand(4, 2), columns=['r1', 'r2'])
+        X = pd.DataFrame(np.random.RandomState(42).uniform(size=(4, 2)), columns=['r1', 'r2'])
         model = model.fit(Y, design_matrix=X)
         with pytest.raises(ValueError):
             model.compute_contrast(None)
@@ -389,7 +391,7 @@ def test_non_parametric_inference_contrast_computation():
             non_parametric_inference(Y, X, [], 'intercept', mask)
         # check that passing no explicit contrast when the design
         # matrix has more than one columns raises an error
-        X = pd.DataFrame(np.random.rand(4, 2), columns=['r1', 'r2'])
+        X = pd.DataFrame(np.random.RandomState(42).uniform(size=(4, 2)), columns=['r1', 'r2'])
         with pytest.raises(ValueError):
             non_parametric_inference(Y, X, None)
         del func_img, FUNCFILE, neg_log_pvals_img, X, Y

--- a/nilearn/glm/tests/test_thresholding.py
+++ b/nilearn/glm/tests/test_thresholding.py
@@ -12,11 +12,12 @@ from nilearn.glm import (cluster_level_inference, fdr_threshold,
 
 
 def test_fdr():
+    rng = np.random.RandomState(42)
     n = 100
     x = np.linspace(.5 / n, 1. - .5 / n, n)
     x[:10] = .0005
     x = norm.isf(x)
-    np.random.shuffle(x)
+    rng.shuffle(x)
     assert_almost_equal(fdr_threshold(x, .1), norm.isf(.0005))
     assert fdr_threshold(x, .001) == np.infty
     with pytest.raises(ValueError):

--- a/nilearn/glm/tests/test_utils.py
+++ b/nilearn/glm/tests/test_utils.py
@@ -19,8 +19,9 @@ from nilearn._utils.glm import (_check_and_load_tables,
 
 
 def test_full_rank():
+    rng = np.random.RandomState(42)
     n, p = 10, 5
-    X = np.random.randn(n, p)
+    X = rng.standard_normal(size=(n, p))
     X_, _ = full_rank(X)
     assert_array_almost_equal(X, X_)
     X[:, -1] = X[:, :-1].sum(1)
@@ -30,7 +31,7 @@ def test_full_rank():
 
 
 def test_z_score():
-    p = np.random.rand(10)
+    p = np.random.RandomState(42).uniform(size=10)
     assert_array_almost_equal(norm.sf(z_score(p)), p)
     # check the numerical precision
     for p in [1.e-250, 1 - 1.e-16]:
@@ -39,23 +40,25 @@ def test_z_score():
 
 
 def test_mahalanobis():
+    rng = np.random.RandomState(42)
     n = 50
-    x = np.random.rand(n) / n
-    A = np.random.rand(n, n) / n
+    x = rng.uniform(size=n) / n
+    A = rng.uniform(size=(n, n)) / n
     A = np.dot(A.transpose(), A) + np.eye(n)
     mah = np.dot(x, np.dot(spl.inv(A), x))
     assert_almost_equal(mah, multiple_mahalanobis(x, A), decimal=1)
 
 
 def test_mahalanobis2():
+    rng = np.random.RandomState(42)
     n = 50
-    x = np.random.randn(n, 3)
+    x = rng.standard_normal(size=(n, 3))
     Aa = np.zeros([n, n, 3])
     for i in range(3):
-        A = np.random.randn(120, n)
+        A = rng.standard_normal(size=(120, n))
         A = np.dot(A.T, A)
         Aa[:, :, i] = A
-    i = np.random.randint(3)
+    i = rng.randint(3)
     mah = np.dot(x[:, i], np.dot(spl.inv(Aa[:, :, i]), x[:, i]))
     f_mah = (multiple_mahalanobis(x, Aa))[i]
     assert np.allclose(mah, f_mah)
@@ -73,8 +76,9 @@ def test_mahalanobis_errors():
 
 
 def test_multiple_fast_inv():
+    rng = np.random.RandomState(42)
     shape = (10, 20, 20)
-    X = np.random.randn(shape[0], shape[1], shape[2])
+    X = rng.standard_normal(size=shape)
     X_inv_ref = np.zeros(shape)
     for i in range(shape[0]):
         X[i] = np.dot(X[i], X[i].T)

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -275,8 +275,8 @@ def test_crop_threshold_tolerance():
 def test_mean_img():
     rng = np.random.RandomState(42)
     data1 = np.zeros((5, 6, 7))
-    data2 = rng.rand(5, 6, 7)
-    data3 = rng.rand(5, 6, 7, 3)
+    data2 = rng.uniform(size=(5, 6, 7))
+    data3 = rng.uniform(size=(5, 6, 7, 3))
     affine = np.diag((4, 3, 2, 1))
     img1 = nibabel.Nifti1Image(data1, affine=affine)
     img2 = nibabel.Nifti1Image(data2, affine=affine)
@@ -319,7 +319,7 @@ def test_mean_img():
 def test_mean_img_resample():
     # Test resampling in mean_img with a permutation of the axes
     rng = np.random.RandomState(42)
-    data = rng.rand(5, 6, 7, 40)
+    data = rng.uniform(size=(5, 6, 7, 40))
     affine = np.diag((4, 3, 2, 1))
     img = nibabel.Nifti1Image(data, affine=affine)
     mean_img = nibabel.Nifti1Image(data.mean(axis=-1), affine=affine)
@@ -337,8 +337,10 @@ def test_mean_img_resample():
 
 
 def test_swap_img_hemispheres():
+    rng = np.random.RandomState(42)
+
     # make sure input image data is not overwritten inside function
-    data = np.random.randn(4, 5, 7)
+    data = rng.standard_normal(size=(4, 5, 7))
     data_img = nibabel.Nifti1Image(data, np.eye(4))
     image.swap_img_hemispheres(data_img)
     np.testing.assert_array_equal(get_data(data_img), data)
@@ -405,9 +407,8 @@ def test_pd_index_img():
 
     fourth_dim_size = img_4d.shape[3]
 
-    rng = np.random.RandomState(0)
-
-    arr = rng.rand(fourth_dim_size) > 0.5
+    rng = np.random.RandomState(42)
+    arr = rng.uniform(size=fourth_dim_size) > 0.5
     df = pd.DataFrame({"arr": arr})
 
     np_index_img = image.index_img(img_4d, arr)
@@ -494,8 +495,9 @@ def test_new_img_like_non_iterable_header():
     Tests that when an niimg's header is not iterable
     & it is set to be copied, an error is not raised.
     """
-    fake_fmri_data = np.random.rand(10, 10, 10, 10)
-    fake_affine = np.random.rand(4, 4)
+    rng = np.random.RandomState(42)
+    fake_fmri_data = rng.uniform(size=(10, 10, 10, 10))
+    fake_affine = rng.uniform(size=(4, 4))
     fake_spatial_image = nibabel.spatialimages.SpatialImage(fake_fmri_data,
                                                             fake_affine)
     assert new_img_like(fake_spatial_image,
@@ -607,10 +609,8 @@ def test_math_img():
 
 
 def test_clean_img():
-
-    rng = np.random.RandomState(0)
-
-    data = rng.randn(10, 10, 10, 100) + .5
+    rng = np.random.RandomState(42)
+    data = rng.standard_normal(size=(10, 10, 10, 100)) + .5
     data_flat = data.T.reshape(100, -1)
     data_img = nibabel.Nifti1Image(data, np.eye(4))
 

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -43,8 +43,9 @@ def rotation(theta, phi):
 def test_identity_resample():
     """ Test resampling with an identity affine.
     """
+    rng = np.random.RandomState(42)
     shape = (3, 2, 5, 2)
-    data = np.random.randint(0, 10, shape)
+    data = rng.randint(0, 10, shape)
     affine = np.eye(4)
     affine[:3, -1] = 0.5 * np.array(shape[:3])
     rot_img = resample_img(Nifti1Image(data, affine),
@@ -80,9 +81,9 @@ def test_identity_resample():
 def test_downsample():
     """ Test resampling with a 1/2 down-sampling affine.
     """
-    rand_gen = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
     shape = (6, 3, 6, 2)
-    data = rand_gen.random_sample(shape)
+    data = rng.random_sample(shape)
     affine = np.eye(4)
     rot_img = resample_img(Nifti1Image(data, affine),
                            target_affine=2 * affine, interpolation='nearest')
@@ -123,10 +124,10 @@ def test_downsample():
 def test_resampling_fill_value():
     """ Test resampling with a non-zero fill value
     """
-    prng = np.random.RandomState(10)
+    rng = np.random.RandomState(42)
 
-    data_3d = prng.rand(1, 4, 4)
-    data_4d = prng.rand(1, 4, 4, 3)
+    data_3d = rng.uniform(size=(1, 4, 4))
+    data_4d = rng.uniform(size=(1, 4, 4, 3))
 
     angle = np.pi/4
     rot = rotation(0, angle)
@@ -159,10 +160,10 @@ def test_resampling_fill_value():
 def test_resampling_with_affine():
     """ Test resampling with a given rotation part of the affine.
     """
-    prng = np.random.RandomState(10)
+    rng = np.random.RandomState(42)
 
-    data_3d = prng.randint(4, size=(1, 4, 4))
-    data_4d = prng.randint(4, size=(1, 4, 4, 3))
+    data_4d = rng.randint(4, size=(1, 4, 4, 3))
+    data_3d = rng.randint(4, size=(1, 4, 4))
 
     for data in [data_3d, data_4d]:
         for angle in (0, np.pi, np.pi / 2., np.pi / 4., np.pi / 3.):
@@ -187,10 +188,10 @@ def test_resampling_with_affine():
 
 
 def test_resampling_continuous_with_affine():
-    prng = np.random.RandomState(10)
+    rng = np.random.RandomState(42)
 
-    data_3d = prng.randint(1, 4, size=(1, 10, 10))
-    data_4d = prng.randint(1, 4, size=(1, 10, 10, 3))
+    data_3d = rng.randint(1, 4, size=(1, 10, 10))
+    data_4d = rng.randint(1, 4, size=(1, 10, 10, 3))
 
     for data in [data_3d, data_4d]:
         for angle in (0, np.pi / 2., np.pi, 3 * np.pi / 2.):
@@ -217,10 +218,11 @@ def test_resampling_continuous_with_affine():
 
 
 def test_resampling_error_checks():
+    rng = np.random.RandomState(42)
     shape = (3, 2, 5, 2)
     target_shape = (5, 3, 2)
     affine = np.eye(4)
-    data = np.random.randint(0, 10, shape)
+    data = rng.randint(0, 10, shape)
     img = Nifti1Image(data, affine)
 
     # Correct parameters: no exception
@@ -517,9 +519,9 @@ def test_resampling_nan():
 
 def test_resample_to_img():
     # Testing resample to img function
-    rand_gen = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
     shape = (6, 3, 6, 3)
-    data = rand_gen.random_sample(shape)
+    data = rng.random_sample(shape)
 
     source_affine = np.eye(4)
     source_img = Nifti1Image(data, source_affine)
@@ -549,12 +551,12 @@ def test_crop():
 
 def test_resample_identify_affine_int_translation():
     # Testing resample to img function
-    rand_gen = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
 
     source_shape = (6, 4, 6)
     source_affine = np.eye(4)
     source_affine[:, 3] = np.append(np.random.randint(0, 4, 3), 1)
-    source_data = rand_gen.random_sample(source_shape)
+    source_data = rng.random_sample(source_shape)
     source_img = Nifti1Image(source_data, source_affine)
 
     target_shape = (11, 10, 9)
@@ -617,12 +619,12 @@ def test_reorder_img():
     # shape, whereas reordering does.
     shape = (5, 5, 5, 2, 2)
     rng = np.random.RandomState(42)
-    data = rng.rand(*shape)
+    data = rng.uniform(size=shape)
     affine = np.eye(4)
     affine[:3, -1] = 0.5 * np.array(shape[:3])
     ref_img = Nifti1Image(data, affine)
     # Test with purely positive matrices and compare to a rotation
-    for theta, phi in np.random.randint(4, size=(5, 2)):
+    for theta, phi in rng.randint(4, size=(5, 2)):
         rot = rotation(theta * np.pi / 2, phi * np.pi / 2)
         rot[np.abs(rot) < 0.001] = 0
         rot[rot > 0.9] = 1
@@ -664,7 +666,7 @@ def test_reorder_img():
         reorder_img(ref_img, resample=interpolation)
 
     # Test flipping an axis
-    data = rng.rand(*shape)
+    data = rng.uniform(size=shape)
     for i in (0, 1, 2):
         # Make a diagonal affine with a negative axis, and check that
         # can be reordered, also vary the shape
@@ -727,10 +729,11 @@ def test_reorder_img_mirror():
 
 
 def test_coord_transform_trivial():
+    rng = np.random.RandomState(42)
     sform = np.eye(4)
-    x = np.random.random((10,))
-    y = np.random.random((10,))
-    z = np.random.random((10,))
+    x = rng.random_sample((10,))
+    y = rng.random_sample((10,))
+    z = rng.random_sample((10,))
 
     x_, y_, z_ = coord_transform(x, y, z, sform)
     np.testing.assert_array_equal(x, x_)

--- a/nilearn/input_data/tests/test_base_masker.py
+++ b/nilearn/input_data/tests/test_base_masker.py
@@ -15,7 +15,7 @@ def test_cropping_code_paths():
     # with a smaller mask. The results must be identical
     rng = np.random.RandomState(42)
     data = np.zeros([20, 30, 40, 5])
-    data[10:15, 5:20, 10:30, :] = 1. + rng.rand(5, 15, 20, 5)
+    data[10:15, 5:20, 10:30, :] = 1. + rng.uniform(size=(5, 15, 20, 5))
 
     affine = np.eye(4)
 

--- a/nilearn/input_data/tests/test_multi_nifti_masker.py
+++ b/nilearn/input_data/tests/test_multi_nifti_masker.py
@@ -162,9 +162,11 @@ def test_shelving():
 
 
 def test_compute_multi_gray_matter_mask():
+    rng = np.random.RandomState(42)
+
     # Check mask is correctly is correctly calculated
-    imgs = [Nifti1Image(np.random.rand(9, 9, 5), np.eye(4)),
-            Nifti1Image(np.random.rand(9, 9, 5), np.eye(4))]
+    imgs = [Nifti1Image(rng.uniform(size=(9, 9, 5)), np.eye(4)),
+            Nifti1Image(rng.uniform(size=(9, 9, 5)), np.eye(4))]
 
     masker = MultiNiftiMasker(mask_strategy='template')
     masker.fit(imgs)
@@ -196,11 +198,12 @@ def test_dtype():
 
 
 def test_standardization():
+    rng = np.random.RandomState(42)
     data_shape = (9, 9, 5)
     n_samples = 500
 
-    signals = np.random.randn(2, np.prod(data_shape), n_samples)
-    means = np.random.randn(2, np.prod(data_shape), 1) * 50 + 1000
+    signals = rng.standard_normal(size=(2, np.prod(data_shape), n_samples))
+    means = rng.standard_normal(size=(2, np.prod(data_shape), 1)) * 50 + 1000
     signals += means
 
     img1 = Nifti1Image(signals[0].reshape(data_shape + (n_samples,)),

--- a/nilearn/input_data/tests/test_nifti_labels_masker.py
+++ b/nilearn/input_data/tests/test_nifti_labels_masker.py
@@ -19,7 +19,7 @@ from nilearn.image import get_data, new_img_like
 
 def generate_random_img(shape, length=1, affine=np.eye(4),
                         rand_gen=np.random.RandomState(0)):
-    data = rand_gen.randn(*(shape + (length,)))
+    data = rand_gen.standard_normal(size=(shape + (length,)))
     return nibabel.Nifti1Image(data, affine), nibabel.Nifti1Image(
         as_ndarray(data[..., 0] > 0.2, dtype=np.int8), affine)
 
@@ -317,11 +317,12 @@ def test_nifti_labels_masker_resampling():
 
 
 def test_standardization():
+    rng = np.random.RandomState(42)
     data_shape = (9, 9, 5)
     n_samples = 500
 
-    signals = np.random.randn(np.prod(data_shape), n_samples)
-    means = np.random.randn(np.prod(data_shape), 1) * 50 + 1000
+    signals = rng.standard_normal(size=(np.prod(data_shape), n_samples))
+    means = rng.standard_normal(size=(np.prod(data_shape), 1)) * 50 + 1000
     signals += means
     img = nibabel.Nifti1Image(
             signals.reshape(data_shape + (n_samples,)), np.eye(4)

--- a/nilearn/input_data/tests/test_nifti_maps_masker.py
+++ b/nilearn/input_data/tests/test_nifti_maps_masker.py
@@ -18,7 +18,7 @@ from nilearn.image import get_data
 
 def generate_random_img(shape, length=1, affine=np.eye(4),
                         rand_gen=np.random.RandomState(0)):
-    data = rand_gen.randn(*(shape + (length,)))
+    data = rand_gen.standard_normal(size=(shape + (length,)))
     return nibabel.Nifti1Image(data, affine), nibabel.Nifti1Image(
         as_ndarray(data[..., 0] > 0.2, dtype=np.int8), affine)
 
@@ -304,11 +304,12 @@ def test_nifti_maps_masker_overlap():
 
 
 def test_standardization():
+    rng = np.random.RandomState(42)
     data_shape = (9, 9, 5)
     n_samples = 500
 
-    signals = np.random.randn(np.prod(data_shape), n_samples)
-    means = np.random.randn(np.prod(data_shape), 1) * 50 + 1000
+    signals = rng.standard_normal(size=(np.prod(data_shape), n_samples))
+    means = rng.standard_normal(size=(np.prod(data_shape), 1)) * 50 + 1000
     signals += means
     img = nibabel.Nifti1Image(signals.reshape(data_shape + (n_samples,)),
                               np.eye(4))

--- a/nilearn/input_data/tests/test_nifti_masker.py
+++ b/nilearn/input_data/tests/test_nifti_masker.py
@@ -182,7 +182,10 @@ def test_4d_single_scan():
     # Test that, in list of 4d images with last dimension=1, they are
     # considered as 3d
 
-    data_5d = [np.random.random((10, 10, 10, 1)) for i in range(5)]
+    data_5d = [
+        np.random.RandomState(42).random_sample((10, 10, 10, 1))
+        for i in range(5)
+    ]
     data_4d = [d[..., 0] for d in data_5d]
     data_5d = [nibabel.Nifti1Image(d, np.eye(4)) for d in data_5d]
     data_4d = [nibabel.Nifti1Image(d, np.eye(4)) for d in data_4d]
@@ -203,7 +206,10 @@ def test_5d():
     # Test that, in list of 4d images with last dimension=1, they are
     # considered as 3d
 
-    data_5d = [np.random.random((10, 10, 10, 3)) for i in range(5)]
+    data_5d = [
+        np.random.RandomState(42).random_sample((10, 10, 10, 3))
+        for i in range(5)
+    ]
     data_5d = [nibabel.Nifti1Image(d, np.eye(4)) for d in data_5d]
 
     masker = NiftiMasker(mask_img=mask_img)
@@ -317,7 +323,7 @@ def test_compute_epi_mask():
 def test_compute_brain_mask():
     # Check masker for template masking strategy
 
-    img = np.random.rand(9, 9, 5)
+    img = np.random.RandomState(42).uniform(size=(9, 9, 5))
     img = Nifti1Image(img, np.eye(4))
 
     masker = NiftiMasker(mask_strategy='template')
@@ -394,11 +400,12 @@ def test_dtype():
 
 
 def test_standardization():
+    rng = np.random.RandomState(42)
     data_shape = (9, 9, 5)
     n_samples = 500
 
-    signals = np.random.randn(np.prod(data_shape), n_samples)
-    means = np.random.randn(np.prod(data_shape), 1) * 50 + 1000
+    signals = rng.standard_normal(size=(np.prod(data_shape), n_samples))
+    means = rng.standard_normal(size=(np.prod(data_shape), 1)) * 50 + 1000
     signals += means
     img = Nifti1Image(signals.reshape(data_shape + (n_samples,)), np.eye(4))
 

--- a/nilearn/input_data/tests/test_nifti_masker.py
+++ b/nilearn/input_data/tests/test_nifti_masker.py
@@ -182,10 +182,8 @@ def test_4d_single_scan():
     # Test that, in list of 4d images with last dimension=1, they are
     # considered as 3d
 
-    data_5d = [
-        np.random.RandomState(42).random_sample((10, 10, 10, 1))
-        for i in range(5)
-    ]
+    rng = np.random.RandomState(42)
+    data_5d = [rng.random_sample((10, 10, 10, 1)) for i in range(5)]
     data_4d = [d[..., 0] for d in data_5d]
     data_5d = [nibabel.Nifti1Image(d, np.eye(4)) for d in data_5d]
     data_4d = [nibabel.Nifti1Image(d, np.eye(4)) for d in data_4d]
@@ -206,10 +204,8 @@ def test_5d():
     # Test that, in list of 4d images with last dimension=1, they are
     # considered as 3d
 
-    data_5d = [
-        np.random.RandomState(42).random_sample((10, 10, 10, 3))
-        for i in range(5)
-    ]
+    rng = np.random.RandomState(42)
+    data_5d = [rng.random_sample((10, 10, 10, 3)) for i in range(5)]
     data_5d = [nibabel.Nifti1Image(d, np.eye(4)) for d in data_5d]
 
     masker = NiftiMasker(mask_img=mask_img)

--- a/nilearn/input_data/tests/test_nifti_spheres_masker.py
+++ b/nilearn/input_data/tests/test_nifti_spheres_masker.py
@@ -9,7 +9,7 @@ from nilearn.image import get_data, new_img_like
 
 
 def test_seed_extraction():
-    data = np.random.random((3, 3, 3, 5))
+    data = np.random.RandomState(42).random_sample((3, 3, 3, 5))
     img = nibabel.Nifti1Image(data, np.eye(4))
     masker = NiftiSpheresMasker([(1, 1, 1)])
     # Test the fit
@@ -20,7 +20,7 @@ def test_seed_extraction():
 
 
 def test_sphere_extraction():
-    data = np.random.random((3, 3, 3, 5))
+    data = np.random.RandomState(42).random_sample((3, 3, 3, 5))
     img = nibabel.Nifti1Image(data, np.eye(4))
     masker = NiftiSpheresMasker([(1, 1, 1)], radius=1)
     # Test the fit
@@ -45,7 +45,7 @@ def test_sphere_extraction():
 
 
 def test_anisotropic_sphere_extraction():
-    data = np.random.random((3, 3, 3, 5))
+    data = np.random.RandomState(42).random_sample((3, 3, 3, 5))
     affine = np.eye(4)
     affine[0, 0] = 2
     affine[2, 2] = 2
@@ -82,7 +82,7 @@ def test_nifti_spheres_masker_overlap():
     affine = np.eye(4)
     shape = (5, 5, 5)
 
-    data = np.random.random(shape + (5,))
+    data = np.random.RandomState(42).random_sample(shape + (5,))
     fmri_img = nibabel.Nifti1Image(data, affine)
 
     seeds = [(0, 0, 0), (2, 2, 2)]
@@ -107,7 +107,7 @@ def test_small_radius():
     affine = np.eye(4)
     shape = (3, 3, 3)
 
-    data = np.random.random(shape)
+    data = np.random.RandomState(42).random_sample(shape)
     mask = np.zeros(shape)
     mask[1, 1, 1] = 1
     mask[2, 2, 2] = 1
@@ -138,7 +138,7 @@ def test_is_nifti_spheres_masker_give_nans():
     data_with_nans = np.zeros((10, 10, 10), dtype=np.float32)
     data_with_nans[:, :, :] = np.nan
 
-    data_without_nans = np.random.random((9, 9, 9))
+    data_without_nans = np.random.RandomState(42).random_sample((9, 9, 9))
     indices = np.nonzero(data_without_nans)
 
     # Leaving nans outside of some data
@@ -158,7 +158,7 @@ def test_is_nifti_spheres_masker_give_nans():
 
 
 def test_standardization():
-    data = np.random.random((3, 3, 3, 5))
+    data = np.random.RandomState(42).random_sample((3, 3, 3, 5))
     img = nibabel.Nifti1Image(data, np.eye(4))
 
     # test zscore
@@ -182,7 +182,7 @@ def test_standardization():
 
 def test_nifti_spheres_masker_inverse_transform():
     # Applying the sphere_extraction example from above backwards
-    data = np.random.random((3, 3, 3, 5))
+    data = np.random.RandomState(42).random_sample((3, 3, 3, 5))
     img = nibabel.Nifti1Image(data, np.eye(4))
     masker = NiftiSpheresMasker([(1, 1, 1)], radius=1)
     # Test the fit
@@ -220,18 +220,20 @@ def test_nifti_spheres_masker_inverse_transform():
 
 
 def test_nifti_spheres_masker_inverse_overlap():
+    rng = np.random.RandomState(42)
+
     # Test overlapping data in inverse_transform
     affine = np.eye(4)
     shape = (5, 5, 5)
 
-    data = np.random.random(shape + (5,))
+    data = rng.random_sample(shape + (5,))
     fmri_img = nibabel.Nifti1Image(data, affine)
 
     # Apply mask image - to allow inversion
     mask_img = new_img_like(fmri_img, np.ones(shape))
     seeds = [(0, 0, 0), (2, 2, 2)]
     # Inverse data
-    inv_data = np.random.random(len(seeds))
+    inv_data = rng.random_sample(len(seeds))
 
     overlapping_masker = NiftiSpheresMasker(seeds, radius=1,
                                             allow_overlap=True,
@@ -264,7 +266,7 @@ def test_small_radius_inverse():
     affine = np.eye(4)
     shape = (3, 3, 3)
 
-    data = np.random.random(shape)
+    data = np.random.RandomState(42).random_sample(shape)
     mask = np.zeros(shape)
     mask[1, 1, 1] = 1
     mask[2, 2, 2] = 1

--- a/nilearn/plotting/tests/test_find_cuts.py
+++ b/nilearn/plotting/tests/test_find_cuts.py
@@ -52,7 +52,7 @@ def test_find_cut_coords():
     # pseudo-4D images as input (i.e., X, Y, Z, 1)
     # previously raised "ValueError: too many values to unpack"
     rng = np.random.RandomState(42)
-    data_3d = rng.randn(10, 10, 10)
+    data_3d = rng.standard_normal(size=(10, 10, 10))
     data_4d = data_3d[..., np.newaxis]
     affine = np.eye(4)
     img_3d = nibabel.Nifti1Image(data_3d, affine)

--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -106,7 +106,7 @@ def test_save_sprite():
     """
 
     # Generate a simulated volume with a square inside
-    data = np.random.RandomState(0).uniform(size=140).reshape(7, 5, 4)
+    data = np.random.RandomState(42).uniform(size=140).reshape(7, 5, 4)
     mask = np.zeros((7, 5, 4), dtype=int)
     mask[1:-1, 1:-1, 1:-1] = 1
     # Save the sprite using BytesIO

--- a/nilearn/plotting/tests/test_html_surface.py
+++ b/nilearn/plotting/tests/test_html_surface.py
@@ -122,7 +122,7 @@ def test_view_surf():
     assert "SOME_TITLE" in html.html
     html = html_surface.view_surf(fsaverage['pial_right'])
     check_html(html)
-    atlas = np.random.RandomState(0).randint(0, 10, size=len(mesh[0]))
+    atlas = np.random.RandomState(42).randint(0, 10, size=len(mesh[0]))
     html = html_surface.view_surf(
         fsaverage['pial_left'], atlas, symmetric_cmap=False)
     check_html(html)

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -53,7 +53,9 @@ def testdata_4d():
     """
     rng = np.random.RandomState(42)
     img_4d = nibabel.Nifti1Image(rng.uniform(size=(7, 7, 3, 10)), mni_affine)
-    img_4d_long = nibabel.Nifti1Image(rng.uniform(size=(7, 7, 3, 1777)), mni_affine)
+    img_4d_long = nibabel.Nifti1Image(
+        rng.uniform(size=(7, 7, 3, 1777)), mni_affine
+    )
     img_mask = nibabel.Nifti1Image(np.ones((7, 7, 3), int), mni_affine)
     data = {
         'img_4d': img_4d,
@@ -400,7 +402,9 @@ def test_plot_stat_map_colorbar_variations(testdata_3d):
     data_positive = get_data(img_positive)
     rng = np.random.RandomState(42)
     data_negative = -data_positive
-    data_heterogeneous = data_positive * rng.standard_normal(size=data_positive.shape)
+    data_heterogeneous = data_positive * rng.standard_normal(
+        size=data_positive.shape
+    )
     img_negative = nibabel.Nifti1Image(data_negative, mni_affine)
     img_heterogeneous = nibabel.Nifti1Image(data_heterogeneous, mni_affine)
 

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -38,7 +38,7 @@ def testdata_3d():
     """
     data_positive = np.zeros((7, 7, 3))
     rng = np.random.RandomState(42)
-    data_rng = rng.rand(7, 7, 3)
+    data_rng = rng.uniform(size=(7, 7, 3))
     data_positive[1:-1, 2:-1, 1:] = data_rng[1:-1, 2:-1, 1:]
     img_3d = nibabel.Nifti1Image(data_positive, mni_affine)
     data = {
@@ -52,8 +52,8 @@ def testdata_4d():
     """Random 4D images for testing figures for multivolume data.
     """
     rng = np.random.RandomState(42)
-    img_4d = nibabel.Nifti1Image(rng.rand(7, 7, 3, 10), mni_affine)
-    img_4d_long = nibabel.Nifti1Image(rng.rand(7, 7, 3, 1777), mni_affine)
+    img_4d = nibabel.Nifti1Image(rng.uniform(size=(7, 7, 3, 10)), mni_affine)
+    img_4d_long = nibabel.Nifti1Image(rng.uniform(size=(7, 7, 3, 1777)), mni_affine)
     img_mask = nibabel.Nifti1Image(np.ones((7, 7, 3), int), mni_affine)
     data = {
         'img_4d': img_4d,
@@ -233,7 +233,7 @@ def test_plot_stat_map(testdata_3d):
     plot_stat_map(new_img, threshold=1000, colorbar=True)
 
     rng = np.random.RandomState(42)
-    data = rng.randn(91, 109, 91)
+    data = rng.standard_normal(size=(91, 109, 91))
     new_img = nibabel.Nifti1Image(data, aff)
     plot_stat_map(new_img, threshold=1000, colorbar=True)
 
@@ -244,7 +244,8 @@ def test_plot_stat_map(testdata_3d):
 def test_plot_stat_map_threshold_for_affine_with_rotation(testdata_3d):
     # threshold was not being applied when affine has a rotation
     # see https://github.com/nilearn/nilearn/issues/599 for more details
-    data = np.random.randn(10, 10, 10)
+    rng = np.random.RandomState(42)
+    data = rng.standard_normal(size=(10, 10, 10))
     # matrix with rotation
     affine = np.array([[-3., 1., 0., 1.],
                        [-1., -3., 0., -2.],
@@ -399,7 +400,7 @@ def test_plot_stat_map_colorbar_variations(testdata_3d):
     data_positive = get_data(img_positive)
     rng = np.random.RandomState(42)
     data_negative = -data_positive
-    data_heterogeneous = data_positive * rng.randn(*data_positive.shape)
+    data_heterogeneous = data_positive * rng.standard_normal(size=data_positive.shape)
     img_negative = nibabel.Nifti1Image(data_negative, mni_affine)
     img_heterogeneous = nibabel.Nifti1Image(data_heterogeneous, mni_affine)
 
@@ -464,8 +465,8 @@ def test_plot_img_with_resampling(testdata_3d):
 
 def test_plot_noncurrent_axes():
     """Regression test for Issue #450"""
-
-    maps_img = nibabel.Nifti1Image(np.random.random((10, 10, 10)), np.eye(4))
+    rng = np.random.RandomState(42)
+    maps_img = nibabel.Nifti1Image(rng.random_sample((10, 10, 10)), np.eye(4))
     fh1 = plt.figure()
     fh2 = plt.figure()
     ax1 = fh1.add_subplot(1, 1, 1)
@@ -658,7 +659,7 @@ def test_singleton_ax_dim():
 def test_plot_prob_atlas():
     affine = np.eye(4)
     shape = (6, 8, 10, 5)
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
     data_rng = rng.normal(size=shape)
     img = nibabel.Nifti1Image(data_rng, affine)
     # Testing the 4D plot prob atlas with contours
@@ -1332,7 +1333,7 @@ def test_plot_markers_exceptions():
         plot_markers([1, 2, 3], node_coords, **kwargs)
 
     # node_values incorrect shape
-    adjacency_matrix = np.random.random((4, 4))
+    adjacency_matrix = np.random.RandomState(42).random_sample((4, 4))
     with pytest.raises(ValueError, match="Dimension mismatch"):
         plot_markers(adjacency_matrix, node_coords, **kwargs)
 

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -15,8 +15,8 @@ from nilearn.surface.testing_utils import generate_surf
 
 def test_plot_surf():
     mesh = generate_surf()
-    rng = np.random.RandomState(0)
-    bg = rng.randn(mesh[0].shape[0], )
+    rng = np.random.RandomState(42)
+    bg = rng.standard_normal(size=mesh[0].shape[0])
 
     # Plot mesh only
     plot_surf(mesh)
@@ -40,7 +40,7 @@ def test_plot_surf():
 
 def test_plot_surf_error():
     mesh = generate_surf()
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
 
     # Wrong inputs for view or hemi
     with pytest.raises(ValueError, match='view must be one of'):
@@ -52,25 +52,25 @@ def test_plot_surf_error():
     with pytest.raises(
             ValueError,
             match='bg_map does not have the same number of vertices'):
-        plot_surf(mesh, bg_map=rng.randn(mesh[0].shape[0] - 1, ))
+        plot_surf(mesh, bg_map=rng.standard_normal(size=mesh[0].shape[0] - 1))
 
     # Wrong size of surface data
     with pytest.raises(
             ValueError,
             match='surf_map does not have the same number of vertices'):
-        plot_surf(mesh, surf_map=rng.randn(mesh[0].shape[0] + 1, ))
+        plot_surf(mesh, surf_map=rng.standard_normal(size=mesh[0].shape[0] + 1))
 
     with pytest.raises(
             ValueError,
             match='surf_map can only have one dimension'):
-        plot_surf(mesh, surf_map=rng.randn(mesh[0].shape[0], 2))
+        plot_surf(mesh, surf_map=rng.standard_normal(size=(mesh[0].shape[0], 2)))
 
 
 def test_plot_surf_stat_map():
     mesh = generate_surf()
-    rng = np.random.RandomState(0)
-    bg = rng.randn(mesh[0].shape[0], )
-    data = 10 * rng.randn(mesh[0].shape[0], )
+    rng = np.random.RandomState(42)
+    bg = rng.standard_normal(size=mesh[0].shape[0])
+    data = 10 * rng.standard_normal(size=mesh[0].shape[0])
 
     # Plot mesh with stat map
     plot_surf_stat_map(mesh, stat_map=data)
@@ -132,8 +132,8 @@ def test_plot_surf_stat_map():
 
 def test_plot_surf_stat_map_error():
     mesh = generate_surf()
-    rng = np.random.RandomState(0)
-    data = 10 * rng.randn(mesh[0].shape[0], )
+    rng = np.random.RandomState(42)
+    data = 10 * rng.standard_normal(size=mesh[0].shape[0])
 
     # Try to input vmin
     with pytest.raises(
@@ -155,11 +155,11 @@ def test_plot_surf_stat_map_error():
 
 def test_plot_surf_roi():
     mesh = generate_surf()
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
     roi_idx = rng.randint(0, mesh[0].shape[0], size=10)
     roi_map = np.zeros(mesh[0].shape[0])
     roi_map[roi_idx] = 1
-    parcellation = rng.rand(mesh[0].shape[0])
+    parcellation = rng.uniform(size=mesh[0].shape[0])
 
     # plot roi
     plot_surf_roi(mesh, roi_map=roi_map)
@@ -195,7 +195,7 @@ def test_plot_surf_roi():
 
 def test_plot_surf_roi_error():
     mesh = generate_surf()
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
     roi_idx = rng.randint(0, mesh[0].shape[0], size=5)
     with pytest.raises(
             ValueError,
@@ -207,7 +207,7 @@ def _generate_img():
     mni_affine = MNI152TEMPLATE.get_affine()
     data_positive = np.zeros((7, 7, 3))
     rng = np.random.RandomState(42)
-    data_rng = rng.rand(7, 7, 3)
+    data_rng = rng.uniform(size=(7, 7, 3))
     data_positive[1:-1, 2:-1, 1:] = data_rng[1:-1, 2:-1, 1:]
     nii = nibabel.Nifti1Image(data_positive, mni_affine)
     return nii
@@ -366,8 +366,8 @@ def test_plot_surf_contours():
 def test_plot_surf_contours_error():
     mesh = generate_surf()
     # we need an invalid parcellation for testing
-    rng = np.random.RandomState(0)
-    invalid_parcellation = rng.rand(mesh[0].shape[0])
+    rng = np.random.RandomState(42)
+    invalid_parcellation = rng.uniform(size=(mesh[0].shape[0]))
     parcellation = np.zeros((mesh[0].shape[0],))
     parcellation[mesh[1][3]] = 1
     parcellation[mesh[1][5]] = 2

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -56,14 +56,18 @@ def test_plot_surf_error():
 
     # Wrong size of surface data
     with pytest.raises(
-            ValueError,
-            match='surf_map does not have the same number of vertices'):
-        plot_surf(mesh, surf_map=rng.standard_normal(size=mesh[0].shape[0] + 1))
+        ValueError, match="surf_map does not have the same number of vertices"
+    ):
+        plot_surf(
+            mesh, surf_map=rng.standard_normal(size=mesh[0].shape[0] + 1)
+        )
 
     with pytest.raises(
-            ValueError,
-            match='surf_map can only have one dimension'):
-        plot_surf(mesh, surf_map=rng.standard_normal(size=(mesh[0].shape[0], 2)))
+        ValueError, match="surf_map can only have one dimension"
+    ):
+        plot_surf(
+            mesh, surf_map=rng.standard_normal(size=(mesh[0].shape[0], 2))
+        )
 
 
 def test_plot_surf_stat_map():

--- a/nilearn/regions/tests/test_parcellations.py
+++ b/nilearn/regions/tests/test_parcellations.py
@@ -164,7 +164,7 @@ def test_parcellations_transform_multi_nifti_images():
 
 
 def test_check_parameters_transform():
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
     data = np.ones((10, 11, 12, 10))
     data[6, 7, 8] = 2
     data[9, 10, 11] = 3
@@ -172,7 +172,7 @@ def test_check_parameters_transform():
     # single image
     fmri_img = nibabel.Nifti1Image(data, affine=np.eye(4))
     # single confound
-    confounds = rng.randn(*(10, 3))
+    confounds = rng.standard_normal(size=(10, 3))
     # Tests to check whether imgs, confounds returned are
     # list or not. Pre-check in parameters to work for list
     # of multi images and multi confounds
@@ -198,7 +198,7 @@ def test_check_parameters_transform():
 
 
 def test_parcellations_transform_with_multi_confounds_multi_images():
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
     data = np.ones((10, 11, 12, 10))
     data[6, 7, 8] = 2
     data[9, 10, 11] = 3
@@ -206,7 +206,7 @@ def test_parcellations_transform_with_multi_confounds_multi_images():
     fmri_img = nibabel.Nifti1Image(data, affine=np.eye(4))
     fmri_imgs = [fmri_img, fmri_img, fmri_img]
 
-    confounds = rng.randn(*(10, 3))
+    confounds = rng.standard_normal(size=(10, 3))
     confounds_list = (confounds, confounds, confounds)
 
     for method in ['kmeans', 'ward', 'complete', 'average', 'rena']:
@@ -221,7 +221,7 @@ def test_parcellations_transform_with_multi_confounds_multi_images():
 
 
 def test_fit_transform():
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
     data = np.ones((10, 11, 12, 10))
     data[6, 7, 8] = 2
     data[9, 10, 11] = 3
@@ -229,7 +229,7 @@ def test_fit_transform():
     fmri_img = nibabel.Nifti1Image(data, affine=np.eye(4))
     fmri_imgs = [fmri_img, fmri_img, fmri_img]
 
-    confounds = rng.randn(*(10, 3))
+    confounds = rng.standard_normal(size=(10, 3))
     confounds_list = [confounds, confounds, confounds]
 
     for method in ['kmeans', 'ward', 'complete', 'average', 'rena']:

--- a/nilearn/regions/tests/test_region_extractor.py
+++ b/nilearn/regions/tests/test_region_extractor.py
@@ -17,7 +17,7 @@ from nilearn.image import get_data
 
 def _make_random_data(shape):
     affine = np.eye(4)
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
     data_rng = rng.normal(size=shape)
     img = nibabel.Nifti1Image(data_rng, affine)
     data = get_data(img)
@@ -52,6 +52,8 @@ def test_threshold_maps_ratio():
     # smoke test for function _threshold_maps_ratio with randomly
     # generated maps
 
+    rng = np.random.RandomState(42)
+
     maps, _ = generate_maps((6, 8, 10), n_regions=3)
 
     # test that there is no side effect
@@ -66,7 +68,7 @@ def test_threshold_maps_ratio():
 
     # check that the size should be same for 3D image
     # before and after thresholding
-    img = np.zeros((30, 30, 30)) + 0.1 * np.random.randn(30, 30, 30)
+    img = np.zeros((30, 30, 30)) + 0.1 * rng.standard_normal(size=(30, 30, 30))
     img = nibabel.Nifti1Image(img, affine=np.eye(4))
     thr_maps_3d = _threshold_maps_ratio(img, threshold=0.5)
     assert img.shape == thr_maps_3d.shape
@@ -85,11 +87,13 @@ def test_invalids_extract_types_in_connected_regions():
 
 
 def test_connected_regions():
+    rng = np.random.RandomState(42)
+
     # 4D maps
     n_regions = 4
     maps, mask_img = generate_maps((30, 30, 30), n_regions=n_regions)
     # 3D maps
-    map_img = np.zeros((30, 30, 30)) + 0.1 * np.random.randn(30, 30, 30)
+    map_img = np.zeros((30, 30, 30)) + 0.1 * rng.standard_normal(size=(30, 30, 30))
     map_img = nibabel.Nifti1Image(map_img, affine=np.eye(4))
 
     # smoke test for function connected_regions and also to check

--- a/nilearn/regions/tests/test_region_extractor.py
+++ b/nilearn/regions/tests/test_region_extractor.py
@@ -93,7 +93,9 @@ def test_connected_regions():
     n_regions = 4
     maps, mask_img = generate_maps((30, 30, 30), n_regions=n_regions)
     # 3D maps
-    map_img = np.zeros((30, 30, 30)) + 0.1 * rng.standard_normal(size=(30, 30, 30))
+    map_img = np.zeros((30, 30, 30)) + 0.1 * rng.standard_normal(
+        size=(30, 30, 30)
+    )
     map_img = nibabel.Nifti1Image(map_img, affine=np.eye(4))
 
     # smoke test for function connected_regions and also to check

--- a/nilearn/regions/tests/test_signal_extraction.py
+++ b/nilearn/regions/tests/test_signal_extraction.py
@@ -217,7 +217,7 @@ def test_signal_extraction_with_maps():
     n_instants = 13
 
     # Generate signals
-    rand_gen = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
 
     maps_img, mask_img = generate_maps(shape, n_regions, border=1)
     maps_data = get_data(maps_img)
@@ -227,7 +227,7 @@ def test_signal_extraction_with_maps():
 
     signals = np.zeros((n_instants, maps_data.shape[-1]))
     for n in range(maps_data.shape[-1]):
-        signals[:, n] = rand_gen.randn(n_instants)
+        signals[:, n] = rng.standard_normal(size=n_instants)
         data[maps_data[..., n] > 0, :] = signals[:, n]
     img = nibabel.Nifti1Image(data, np.eye(4))
 
@@ -416,7 +416,7 @@ def test__trim_maps():
                          (np.float, np.float32, np.float64, np.int, np.uint),
                          )
 def test_img_to_signals_labels_non_float_type(target_dtype):
-    fake_fmri_data = np.random.RandomState(0).rand(10, 10, 10, 10) > 0.5
+    fake_fmri_data = np.random.RandomState(42).uniform(size=(10, 10, 10, 10)) > 0.5
     fake_affine = np.eye(4, 4).astype(np.float64)
     fake_fmri_img_orig = nibabel.Nifti1Image(
                                         fake_fmri_data.astype(np.float64),

--- a/nilearn/regions/tests/test_signal_extraction.py
+++ b/nilearn/regions/tests/test_signal_extraction.py
@@ -416,7 +416,9 @@ def test__trim_maps():
                          (np.float, np.float32, np.float64, np.int, np.uint),
                          )
 def test_img_to_signals_labels_non_float_type(target_dtype):
-    fake_fmri_data = np.random.RandomState(42).uniform(size=(10, 10, 10, 10)) > 0.5
+    fake_fmri_data = (
+        np.random.RandomState(42).uniform(size=(10, 10, 10, 10)) > 0.5
+    )
     fake_affine = np.eye(4, 4).astype(np.float64)
     fake_fmri_img_orig = nibabel.Nifti1Image(
                                         fake_fmri_data.astype(np.float64),

--- a/nilearn/tests/test_niimg.py
+++ b/nilearn/tests/test_niimg.py
@@ -60,7 +60,11 @@ def test_img_data_dtype():
     dtype_matches = []
     with InTemporaryDirectory():
         for logical_dtype in nifti1_dtypes:
-            dataobj = np.random.RandomState(42).uniform(0, 255, (2, 2, 2)).astype(logical_dtype)
+            dataobj = (
+                np.random.RandomState(42)
+                .uniform(0, 255, (2, 2, 2))
+                .astype(logical_dtype)
+            )
             for on_disk_dtype in nifti1_dtypes:
                 img = Nifti1Image(dataobj, np.eye(4))
                 img.set_data_dtype(on_disk_dtype)

--- a/nilearn/tests/test_niimg.py
+++ b/nilearn/tests/test_niimg.py
@@ -59,12 +59,9 @@ def test_img_data_dtype():
         np.float32, np.float64)
     dtype_matches = []
     with InTemporaryDirectory():
+        rng = np.random.RandomState(42)
         for logical_dtype in nifti1_dtypes:
-            dataobj = (
-                np.random.RandomState(42)
-                .uniform(0, 255, (2, 2, 2))
-                .astype(logical_dtype)
-            )
+            dataobj = rng.uniform(0, 255, (2, 2, 2)).astype(logical_dtype)
             for on_disk_dtype in nifti1_dtypes:
                 img = Nifti1Image(dataobj, np.eye(4))
                 img.set_data_dtype(on_disk_dtype)

--- a/nilearn/tests/test_niimg.py
+++ b/nilearn/tests/test_niimg.py
@@ -60,8 +60,7 @@ def test_img_data_dtype():
     dtype_matches = []
     with InTemporaryDirectory():
         for logical_dtype in nifti1_dtypes:
-            dataobj = np.random.uniform(0, 255,
-                                        size=(2, 2, 2)).astype(logical_dtype)
+            dataobj = np.random.RandomState(42).uniform(0, 255, (2, 2, 2)).astype(logical_dtype)
             for on_disk_dtype in nifti1_dtypes:
                 img = Nifti1Image(dataobj, np.eye(4))
                 img.set_data_dtype(on_disk_dtype)

--- a/nilearn/tests/test_niimg_conversions.py
+++ b/nilearn/tests/test_niimg_conversions.py
@@ -489,13 +489,13 @@ def test_concat_niimg_dtype():
 
 def nifti_generator(buffer):
     for i in range(10):
-        buffer.append(Nifti1Image(np.random.random((10, 10, 10)), np.eye(4)))
+        buffer.append(Nifti1Image(np.random.RandomState(42).random_sample((10, 10, 10)), np.eye(4)))
         yield buffer[-1]
 
 
 def test_iterator_generator():
     # Create a list of random images
-    l = [Nifti1Image(np.random.random((10, 10, 10)), np.eye(4))
+    l = [Nifti1Image(np.random.RandomState(42).random_sample((10, 10, 10)), np.eye(4))
          for i in range(10)]
     cc = _utils.concat_niimgs(l)
     assert cc.shape[-1] == 10

--- a/nilearn/tests/test_niimg_conversions.py
+++ b/nilearn/tests/test_niimg_conversions.py
@@ -488,21 +488,18 @@ def test_concat_niimg_dtype():
 
 
 def nifti_generator(buffer):
+    rng = np.random.RandomState(42)
     for i in range(10):
-        buffer.append(
-            Nifti1Image(
-                np.random.RandomState(42).random_sample((10, 10, 10)),
-                np.eye(4),
-            )
-        )
+        buffer.append(Nifti1Image(rng.random_sample((10, 10, 10)), np.eye(4)))
         yield buffer[-1]
 
 
 def test_iterator_generator():
     # Create a list of random images
+    rng = np.random.RandomState(42)
     list_images = [
         Nifti1Image(
-            np.random.RandomState(42).random_sample((10, 10, 10)), np.eye(4)
+            rng.random_sample((10, 10, 10)), np.eye(4)
         )
         for i in range(10)
     ]

--- a/nilearn/tests/test_niimg_conversions.py
+++ b/nilearn/tests/test_niimg_conversions.py
@@ -489,23 +489,32 @@ def test_concat_niimg_dtype():
 
 def nifti_generator(buffer):
     for i in range(10):
-        buffer.append(Nifti1Image(np.random.RandomState(42).random_sample((10, 10, 10)), np.eye(4)))
+        buffer.append(
+            Nifti1Image(
+                np.random.RandomState(42).random_sample((10, 10, 10)),
+                np.eye(4),
+            )
+        )
         yield buffer[-1]
 
 
 def test_iterator_generator():
     # Create a list of random images
-    l = [Nifti1Image(np.random.RandomState(42).random_sample((10, 10, 10)), np.eye(4))
-         for i in range(10)]
-    cc = _utils.concat_niimgs(l)
+    list_images = [
+        Nifti1Image(
+            np.random.RandomState(42).random_sample((10, 10, 10)), np.eye(4)
+        )
+        for i in range(10)
+    ]
+    cc = _utils.concat_niimgs(list_images)
     assert cc.shape[-1] == 10
-    assert_array_almost_equal(get_data(cc)[..., 0], get_data(l[0]))
+    assert_array_almost_equal(get_data(cc)[..., 0], get_data(list_images[0]))
 
     # Same with iteration
-    i = image.iter_img(l)
+    i = image.iter_img(list_images)
     cc = _utils.concat_niimgs(i)
     assert cc.shape[-1] == 10
-    assert_array_almost_equal(get_data(cc)[..., 0], get_data(l[0]))
+    assert_array_almost_equal(get_data(cc)[..., 0], get_data(list_images[0]))
 
     # Now, a generator
     b = []

--- a/nilearn/tests/test_segmentation.py
+++ b/nilearn/tests/test_segmentation.py
@@ -11,7 +11,9 @@ from nilearn._utils.segmentation import _random_walker
 
 
 def test_modes_in_random_walker():
-    img = np.zeros((30, 30, 30)) + 0.1 * np.random.RandomState(42).standard_normal(size=(30, 30, 30))
+    img = np.zeros((30, 30, 30)) + 0.1 * np.random.RandomState(
+        42
+    ).standard_normal(size=(30, 30, 30))
     img[9:21, 9:21, 9:21] = 1
     img[10:20, 10:20, 10:20] = 0
     labels = np.zeros_like(img)
@@ -64,7 +66,9 @@ def test_reorder_labels():
     # by reordering them to make no gaps/differences between integers. We expect
     # labels to be of same shape even if they are reordered.
     # Issue #938, comment #14.
-    data = np.zeros((5, 5)) + 0.1 * np.random.RandomState(42).standard_normal(size=(5, 5))
+    data = np.zeros((5, 5)) + 0.1 * np.random.RandomState(42).standard_normal(
+        size=(5, 5)
+    )
     data[1:5, 1:5] = 1
 
     labels = np.zeros_like(data)

--- a/nilearn/tests/test_segmentation.py
+++ b/nilearn/tests/test_segmentation.py
@@ -11,7 +11,7 @@ from nilearn._utils.segmentation import _random_walker
 
 
 def test_modes_in_random_walker():
-    img = np.zeros((30, 30, 30)) + 0.1 * np.random.randn(30, 30, 30)
+    img = np.zeros((30, 30, 30)) + 0.1 * np.random.RandomState(42).standard_normal(size=(30, 30, 30))
     img[9:21, 9:21, 9:21] = 1
     img[10:20, 10:20, 10:20] = 0
     labels = np.zeros_like(img)
@@ -44,14 +44,14 @@ def test_bad_inputs():
         _random_walker(img, labels)
 
     # Too many dimensions
-    np.random.seed(42)
-    img = np.random.normal(size=(3, 3, 3, 3, 3))
+    rng = np.random.RandomState(42)
+    img = rng.normal(size=(3, 3, 3, 3, 3))
     labels = np.arange(3 ** 5).reshape(img.shape)
     with pytest.raises(ValueError):
         _random_walker(img, labels)
 
     # Spacing incorrect length
-    img = np.random.normal(size=(10, 10))
+    img = rng.normal(size=(10, 10))
     labels = np.zeros((10, 10))
     labels[2, 4] = 2
     labels[6, 8] = 5
@@ -64,7 +64,7 @@ def test_reorder_labels():
     # by reordering them to make no gaps/differences between integers. We expect
     # labels to be of same shape even if they are reordered.
     # Issue #938, comment #14.
-    data = np.zeros((5, 5)) + 0.1 * np.random.randn(5, 5)
+    data = np.zeros((5, 5)) + 0.1 * np.random.RandomState(42).standard_normal(size=(5, 5))
     data[1:5, 1:5] = 1
 
     labels = np.zeros_like(data)

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -53,16 +53,16 @@ def generate_signals(n_features=17, n_confounds=5, length=41,
     confounds : numpy.ndarray, shape (length, n_confounds)
         random signals used as confounds.
     """
-    rand_gen = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
 
     # Generate random confounds
     confounds_shape = (length, n_confounds)
     confounds = np.ndarray(confounds_shape, order=order)
-    confounds[...] = rand_gen.randn(*confounds_shape)
+    confounds[...] = rng.standard_normal(size=confounds_shape)
     confounds[...] = scipy.signal.detrend(confounds, axis=0)
 
     # Compute noise based on confounds, with random factors
-    factors = rand_gen.randn(n_confounds, n_features)
+    factors = rng.standard_normal(size=(n_confounds, n_features))
     noises_shape = (length, n_features)
     noises = np.ndarray(noises_shape, order=order)
     noises[...] = np.dot(confounds, factors)
@@ -72,10 +72,10 @@ def generate_signals(n_features=17, n_confounds=5, length=41,
     signals_shape = noises_shape
     signals = np.ndarray(signals_shape, order=order)
     if same_variance:
-        signals[...] = rand_gen.randn(*signals_shape)
+        signals[...] = rng.standard_normal(size=signals_shape)
     else:
-        signals[...] = (4. * abs(rand_gen.randn(signals_shape[1])) + 0.5
-                        ) * rand_gen.randn(*signals_shape)
+        signals[...] = (4. * abs(rng.standard_normal(size=signals_shape[1])) + 0.5
+                        ) * rng.standard_normal(size=signals_shape)
 
     signals[...] = scipy.signal.detrend(signals, axis=0)
     return signals, noises, confounds
@@ -94,10 +94,10 @@ def generate_trends(n_features=17, length=41):
     trends : numpy.ndarray, shape (length, n_features)
         output signals, one per column.
     """
-    rand_gen = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
     trends = scipy.signal.detrend(np.linspace(0, 1.0, length), type="constant")
     trends = np.repeat(np.atleast_2d(trends).T, n_features, axis=1)
-    factors = rand_gen.randn(n_features)
+    factors = rng.standard_normal(size=n_features)
     return trends * factors
 
 
@@ -111,7 +111,7 @@ def generate_signals_plus_trends(n_features=17, n_samples=41):
 
 
 def test_butterworth():
-    rand_gen = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
     n_features = 20000
     n_samples = 100
 
@@ -121,7 +121,7 @@ def test_butterworth():
 
     # Compare output for different options.
     # single timeseries
-    data = rand_gen.randn(n_samples)
+    data = rng.standard_normal(size=n_samples)
     data_original = data.copy()
     '''
     May be only on py3.5:
@@ -148,7 +148,7 @@ def test_butterworth():
     np.testing.assert_(id(out_single) != id(data))
 
     # multiple timeseries
-    data = rand_gen.randn(n_samples, n_features)
+    data = rng.standard_normal(size=(n_samples, n_features))
     data[:, 0] = data_original  # set first timeseries to previous data
     data_original = data.copy()
 
@@ -177,12 +177,12 @@ def test_butterworth():
 
 
 def test_standardize():
-    rand_gen = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
     n_features = 10
     n_samples = 17
 
     # Create random signals with offsets
-    a = rand_gen.random_sample((n_samples, n_features))
+    a = rng.random_sample((n_samples, n_features))
     a += np.linspace(0, 2., n_features)
 
     # transpose array to fit _standardize input.
@@ -311,14 +311,14 @@ def test_clean_detrending():
 
 def test_clean_t_r():
     """Different TRs must produce different results after filtering"""
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
     n_samples = 34
     # n_features  Must be higher than 500
     n_features = 501
     x_orig = generate_signals_plus_trends(n_features=n_features,
                                           n_samples=n_samples)
-    random_tr_list1 = np.round(rng.rand(3) * 10, decimals=2)
-    random_tr_list2 = np.round(rng.rand(3) * 10, decimals=2)
+    random_tr_list1 = np.round(rng.uniform(size=3) * 10, decimals=2)
+    random_tr_list2 = np.round(rng.uniform(size=3) * 10, decimals=2)
     for tr1, tr2 in zip(random_tr_list1, random_tr_list2):
         low_pass_freq_list = tr1 * np.array([1.0 / 100, 1.0 / 110])
         high_pass_freq_list = tr1 * np.array([1.0 / 210, 1.0 / 190])
@@ -509,7 +509,6 @@ def test_clean_finite_no_inplace_mod():
     Test for verifying that the passed in signal array is not modified.
     For PR #2125 . This test is failing on master, passing in this PR.
     """
-    rng = np.random.RandomState(0)
     n_samples = 2
     # n_features  Must be higher than 500
     n_features = 501
@@ -617,14 +616,14 @@ def test_clean_psc():
 
 
 def test_clean_zscore():
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(42)
     n_samples = 500
     n_features = 5
 
     signals, _, _ = generate_signals(n_features=n_features,
                                      length=n_samples)
 
-    signals += rng.randn(1, n_features)
+    signals += rng.standard_normal(size=(1, n_features))
     cleaned_signals = clean(signals, standardize='zscore')
     np.testing.assert_almost_equal(cleaned_signals.mean(0), 0)
     np.testing.assert_almost_equal(cleaned_signals.std(0), 1)

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -74,8 +74,9 @@ def generate_signals(n_features=17, n_confounds=5, length=41,
     if same_variance:
         signals[...] = rng.standard_normal(size=signals_shape)
     else:
-        signals[...] = (4. * abs(rng.standard_normal(size=signals_shape[1])) + 0.5
-                        ) * rng.standard_normal(size=signals_shape)
+        signals[...] = (
+            4.0 * abs(rng.standard_normal(size=signals_shape[1])) + 0.5
+        ) * rng.standard_normal(size=signals_shape)
 
     signals[...] = scipy.signal.detrend(signals, axis=0)
     return signals, noises, confounds


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #2534 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Ensure that tests are properly seeded
- Use `RandomState` consistently (as many places as possible except where `sklearn.utils.check_random_state` is used)
- Use as many [Generator](https://numpy.org/doc/stable/reference/random/generator.html) methods with the same name as those of [RandomState](https://numpy.org/doc/stable/reference/random/legacy.html#numpy.random.RandomState) so that in the future if we switch to Generator we can do so easily using a contextual search. The methods replaced are -
    - rand (supported by RandomState only) -> uniform (supported by both Generator and RandomState)
    - randn (supported by RandomState only) -> standard_normal (supported by both Generator and RandomState)
