### PR TITLE
[FIX] Update confounds filename following `fmriprep`

### DIFF
--- a/nilearn/_utils/data_gen.py
+++ b/nilearn/_utils/data_gen.py
@@ -483,7 +483,9 @@ def basic_confounds(length):
 def create_fake_bids_dataset(base_dir='', n_sub=10, n_ses=2,
                              tasks=['localizer', 'main'],
                              n_runs=[1, 3], with_derivatives=True,
-                             with_confounds=True, no_session=False):
+                             with_confounds=True,
+                             confounds_tag="desc-confounds_timeseries",
+                             no_session=False):
     """Creates a fake bids dataset directory with dummy files.
     Returns fake dataset directory name.
 
@@ -513,6 +515,12 @@ def create_fake_bids_dataset(base_dir='', n_sub=10, n_ses=2,
 
     with_confounds: bool, optional
         Default: True
+
+    confounds_tag: string (filename suffix), optional
+        If generating confounds, what path should they have? Defaults to
+        `desc-confounds_timeseries` as in `fmriprep` >= 20.2 but can be other
+        values (e.g. "desc-confounds_regressors" as in `fmriprep` < 20.2)
+        Default: "desc-confounds_timeseries"
 
     no_session: bool, optional
         Specifying no_sessions will only produce runs and files without the
@@ -612,7 +620,7 @@ def create_fake_bids_dataset(base_dir='', n_sub=10, n_ses=2,
                         if with_confounds:
                             confounds_path = os.path.join(
                                 func_path,
-                                file_id + '_desc-confounds_regressors.tsv',
+                                file_id + '_' + confounds_tag + '.tsv',
                             )
                             basic_confounds(100).to_csv(confounds_path,
                                                         sep='\t', index=None)

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -962,7 +962,7 @@ def first_level_from_bids(dataset_path, task_label, space_label=None,
         # Get confounds. If not found it will be assumed there are none.
         # If there are confounds, they are assumed to be present for all runs.
         confounds = get_bids_files(derivatives_path, modality_folder='func',
-                                   file_tag='desc-confounds_regressors',
+                                   file_tag='desc-confounds*',
                                    file_type='tsv', sub_label=sub_label,
                                    filters=filters)
 

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -475,7 +475,7 @@ def test_first_level_from_bids():
         # test issues with confound files. There should be only one confound
         # file per img. An one per image or None. Case when one is missing
         confound_files = get_bids_files(os.path.join(bids_path, 'derivatives'),
-                                        file_tag='desc-confounds_regressors')
+                                        file_tag='desc-confounds_timeseries')
         os.remove(confound_files[-1])
         with pytest.raises(ValueError):
             first_level_from_bids(

--- a/nilearn/glm/tests/test_utils.py
+++ b/nilearn/glm/tests/test_utils.py
@@ -168,7 +168,20 @@ def test_get_bids_files():
         # Get Top level folder files. Only 1 in this case, the README file.
         selection = get_bids_files(bids_path, sub_folder=False)
         assert len(selection) == 1
+        # 80 counfonds (4 runs per ses & sub), testing `fmriprep` >= 20.2 path
+        selection = get_bids_files(os.path.join(bids_path, 'derivatives'),
+                file_tag='desc-confounds_timeseries')
+        assert len(selection) == 80
 
+    with InTemporaryDirectory():
+        bids_path = create_fake_bids_dataset(n_sub=10, n_ses=2,
+                                             tasks=['localizer', 'main'],
+                                             n_runs=[1, 3],
+                                             confounds_tag="desc-confounds_regressors")
+        # 80 counfonds (4 runs per ses & sub), testing `fmriprep` >= 20.2 path
+        selection = get_bids_files(os.path.join(bids_path, 'derivatives'),
+                file_tag='desc-confounds_regressors')
+        assert len(selection) == 80
 
 def test_parse_bids_filename():
     fields = ['sub', 'ses', 'task', 'lolo']


### PR DESCRIPTION
In https://github.com/nipreps/fmriprep/commit/73e4ccde5080f2d66ba720bba03a13d270f8f65f, `fmriprep` changed the path of the output confound file from `~_desc-confounds_regressors.tsv` to `~_desc-confounds_timeseries.tsv`. This change occurred before the release of the LTS version 20.2 which is now recommended. I didn't find a reference to this change in either the changelogs or BIDS specification but this caused a bug in my pipeline.

This commit updates the function `first_level_from_bids` in `first_level.py` so that the `get_bids_files` call that seeks confound files matches both possible path. A possible alternative would be to match only the new version but this would break backward compatibility with `fmriprep` versions before 20.2

There are no associated issue yet, but I was about to open one and instead went directly for this pull request.