### PR TITLE
[MRG] FIX score method with decomposition estimators

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -50,6 +50,8 @@ NEW
   to enable annotation of a slice coordinate position with the float.
 - New example in `examples/02_decoding/plot_haxby_searchlight_surface.py`
   to demo how to do cortical surface-based searchlight decoding with Nilearn.
+- The decomposition estimators will now accept argument `per_component`
+  with `score` method to explain the variance for each component.
 
 
 Fixes
@@ -63,6 +65,8 @@ Fixes
   correct orientation; before left and right were inverted.
 - :func:`nilearn.mass_univariate.permuted_ols` no longer returns transposed
   t-statistic arrays when no permutations are performed.
+- Fix decomposition estimators returning explained variance score as 0.
+  based on all components i.e., when per_component=False.
 
 
 Changes

--- a/examples/03_connectivity/plot_compare_decomposition.py
+++ b/examples/03_connectivity/plot_compare_decomposition.py
@@ -129,6 +129,23 @@ for i, cur_img in enumerate(iter_img(dictlearning_components_img)):
     plot_stat_map(cur_img, display_mode="z", title="Comp %d" % i,
                   cut_coords=1, colorbar=False)
 
+###############################################################################
+# Estimate explained variance per component and plot using matplotlib
+#
+# The fitted object `dictlearning` can be used to calculate the score per component
+scores = dict_learning.score(func_filenames, per_component=False)
+
+# Plot the scores
+import numpy as np
+from matplotlib import pyplot as plt
+
+plt.figure(figsize=(6, 4))
+plt.plot(scores, label='Explained variance score per component')
+plt.axis('tight')
+plt.xlabel('Component #')
+plt.xticks(np.arange(20))
+plt.legend(loc='best', frameon=False)
+
 
 show()
 ################################################################################

--- a/examples/03_connectivity/plot_compare_decomposition.py
+++ b/examples/03_connectivity/plot_compare_decomposition.py
@@ -132,20 +132,22 @@ for i, cur_img in enumerate(iter_img(dictlearning_components_img)):
 ###############################################################################
 # Estimate explained variance per component and plot using matplotlib
 #
-# The fitted object `dictlearning` can be used to calculate the score per component
+# The fitted object `dict_learning` can be used to calculate the score per component
 scores = dict_learning.score(func_filenames, per_component=True)
 
 # Plot the scores
 import numpy as np
 from matplotlib import pyplot as plt
+from matplotlib.ticker import FormatStrFormatter
 
-plt.figure(figsize=(6, 4))
-plt.plot(scores, label='Explained variance score per component')
-plt.axis('tight')
-plt.xlabel('Component #')
-plt.xticks(np.arange(20))
-plt.legend(loc='best', frameon=False)
-
+plt.figure(figsize=(4, 4))
+positions = np.arange(len(scores))
+plt.barh(positions, scores)
+plt.ylabel('Component #', size=12)
+plt.xlabel('Explained variance', size=12)
+plt.yticks(np.arange(20))
+plt.gca().xaxis.set_major_formatter(FormatStrFormatter('%.3f'))
+plt.tight_layout()
 
 show()
 ################################################################################

--- a/examples/03_connectivity/plot_compare_decomposition.py
+++ b/examples/03_connectivity/plot_compare_decomposition.py
@@ -133,7 +133,7 @@ for i, cur_img in enumerate(iter_img(dictlearning_components_img)):
 # Estimate explained variance per component and plot using matplotlib
 #
 # The fitted object `dictlearning` can be used to calculate the score per component
-scores = dict_learning.score(func_filenames, per_component=False)
+scores = dict_learning.score(func_filenames, per_component=True)
 
 # Plot the scores
 import numpy as np
@@ -155,4 +155,3 @@ show()
 #     created using Dictionary Learning, see :ref:`example Regions 
 #     extraction using Dictionary Learning and functional connectomes
 #     <sphx_glr_auto_examples_03_connectivity_plot_extract_regions_dictlearning_maps.py>`.
-

--- a/nilearn/decomposition/base.py
+++ b/nilearn/decomposition/base.py
@@ -564,5 +564,5 @@ def explained_variance(X, components, per_component=True):
         lr = LinearRegression(fit_intercept=True)
         lr.fit(components.T, X.T)
         res = X - lr.coef_.dot(components)
-        res_var = np.var(res)
-        return np.maximum(0., 1. - res_var / full_var)
+        res_var = _sum_of_squares(res).sum()
+        return np.maximum(0., 1. - res_var / _sum_of_squares(X).sum())

--- a/nilearn/decomposition/base.py
+++ b/nilearn/decomposition/base.py
@@ -23,7 +23,7 @@ from .._utils.niimg import _safe_get_data
 from .._utils.niimg_conversions import _resolve_globbing
 from ..input_data import NiftiMapsMasker
 from ..input_data.masker_validation import check_embedded_nifti_masker
-from ..signal import _sum_of_squares
+from ..signal import _row_sum_of_squares
 
 
 def fast_svd(X, n_components, random_state=None):
@@ -564,5 +564,5 @@ def explained_variance(X, components, per_component=True):
         lr = LinearRegression(fit_intercept=True)
         lr.fit(components.T, X.T)
         res = X - lr.coef_.dot(components)
-        res_var = _sum_of_squares(res).sum()
-        return np.maximum(0., 1. - res_var / _sum_of_squares(X).sum())
+        res_var = _row_sum_of_squares(res).sum()
+        return np.maximum(0., 1. - res_var / _row_sum_of_squares(X).sum())

--- a/nilearn/decomposition/base.py
+++ b/nilearn/decomposition/base.py
@@ -522,7 +522,8 @@ class BaseDecomposition(BaseEstimator, CacheMixin, TransformerMixin):
         """
         self._check_components_()
         data = mask_and_reduce(self.masker_, imgs, confounds,
-                               reduction_ratio=1.)
+                               reduction_ratio=1.,
+                               random_state=self.random_state)
         return self._raw_score(data, per_component=per_component)
 
 
@@ -556,6 +557,8 @@ def explained_variance(X, components, per_component=True):
             res = X - np.outer(projected_data[i],
                                components[i])
             res_var[i] = np.var(res)
+            # Free some memory
+            del res
         return np.maximum(0., 1. - res_var / full_var)
     else:
         lr = LinearRegression(fit_intercept=True)

--- a/nilearn/decomposition/base.py
+++ b/nilearn/decomposition/base.py
@@ -563,6 +563,6 @@ def explained_variance(X, components, per_component=True):
     else:
         lr = LinearRegression(fit_intercept=True)
         lr.fit(components.T, X.T)
-        res_var = X - lr.coef_.dot(components)
-        res_var = _sum_of_squares(res_var).sum()
-        return np.maximum(0., 1. - res_var / _sum_of_squares(X).sum())
+        res = X - lr.coef_.dot(components)
+        res_var = np.var(res)
+        return np.maximum(0., 1. - res_var / full_var)

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -234,3 +234,22 @@ def test_with_globbing_patterns_with_multi_subjects():
         # n_components = 3
         check_shape = data[0].shape[:3] + (3,)
         assert components_img.shape, check_shape
+
+
+def test_canica_score():
+    # Multi subjects
+    imgs, mask_img, _, _ = _make_canica_test_data(n_subjects=3)
+    n_components = 10
+    canica = CanICA(n_components=10, mask=mask_img, random_state=0)
+    canica.fit(imgs)
+
+    # One score for all components
+    scores = canica.score(imgs, per_component=False)
+    assert scores <= 1
+    assert 0 <= scores
+
+    # Per component score
+    scores = canica.score(imgs, per_component=True)
+    assert scores.shape, (n_components,)
+    assert np.all(scores <= 1)
+    assert np.all(0 <= scores)

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -149,3 +149,30 @@ def test_with_globbing_patterns_with_multi_subjects():
         # n_components = 3
         check_shape = data[0].shape[:3] + (3,)
         assert components_img.shape, check_shape
+
+
+def test_dictlearning_score():
+    # Multi subjects
+    imgs, mask_img, _, _ = _make_canica_test_data(n_subjects=3)
+    n_components = 10
+    dictlearn = DictLearning(n_components=10, mask=mask_img, random_state=0)
+
+    # Test error before object fit
+    with pytest.raises(
+            ValueError,
+            match="Object has no components_ attribute. "
+                  "This is probably because fit has not been called"):
+        dictlearn.score(imgs, per_component=False)
+
+    dictlearn.fit(imgs)
+
+    # One score for all components
+    scores = dictlearn.score(imgs, per_component=False)
+    assert scores <= 1
+    assert 0 <= scores
+
+    # Per component score
+    scores = dictlearn.score(imgs, per_component=True)
+    assert scores.shape, (n_components,)
+    assert np.all(scores <= 1)
+    assert np.all(0 <= scores)

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -124,9 +124,8 @@ def _sum_of_squares(signals, n_batches=20):
     """Compute sum of squares for each signal.
     This function is equivalent to
 
-        var = np.copy(signals)
-        var **= 2
-        var = var.sum(axis=0)
+        signals **= 2
+        signals = signals.sum(axis=0)
 
     but uses a lot less memory.
 

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -148,9 +148,7 @@ def _sum_of_squares(signals, n_batches=20):
     # Fastest for C order
     var = np.empty(signals.shape[1])
     for batch in gen_even_slices(signals.shape[1], n_batches):
-        tvar = np.copy(signals[:, batch])
-        tvar **= 2
-        var[batch] = tvar.sum(axis=0)
+        var[batch] = np.sum(signals[:, batch] ** 2, 0)
 
     return var
 

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -120,6 +120,41 @@ def _mean_of_squares(signals, n_batches=20):
     return var
 
 
+def _sum_of_squares(signals, n_batches=20):
+    """Compute sum of squares for each signal.
+    This function is equivalent to
+
+        var = np.copy(signals)
+        var **= 2
+        var = var.sum(axis=0)
+
+    but uses a lot less memory.
+
+    Parameters
+    ----------
+    signals : numpy.ndarray, shape (n_samples, n_features)
+        signal whose sum of squares must be computed.
+
+    n_batches : int, optional
+        number of batches to use in the computation. Tweaking this value
+        can lead to variation of memory usage and computation time. The higher
+        the value, the lower the memory consumption.
+
+    """
+    # No batching for small arrays
+    if signals.shape[1] < 500:
+        n_batches = 1
+
+    # Fastest for C order
+    var = np.empty(signals.shape[1])
+    for batch in gen_even_slices(signals.shape[1], n_batches):
+        tvar = np.copy(signals[:, batch])
+        tvar **= 2
+        var[batch] = tvar.sum(axis=0)
+
+    return var
+
+
 def _detrend(signals, inplace=False, type="linear", n_batches=10):
     """Detrend columns of input array.
 

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -120,7 +120,7 @@ def _mean_of_squares(signals, n_batches=20):
     return var
 
 
-def _sum_of_squares(signals, n_batches=20):
+def _row_sum_of_squares(signals, n_batches=20):
     """Compute sum of squares for each signal.
     This function is equivalent to
 

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -274,8 +274,7 @@ def test_sum_of_squares():
                                      length=n_samples,
                                      same_variance=True)
     # Reference computation
-    var1 = np.copy(signals)
-    var1 **= 2
+    var1 = signals ** 2
     var1 = var1.sum(axis=0)
 
     var2 = nisignal._sum_of_squares(signals)

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -266,6 +266,23 @@ def test_mean_of_squares():
     np.testing.assert_almost_equal(var1, var2)
 
 
+def test_sum_of_squares():
+    """Test _sum_of_squares."""
+    n_samples = 11
+    n_features = 501  # Higher than 500 required
+    signals, _, _ = generate_signals(n_features=n_features,
+                                     length=n_samples,
+                                     same_variance=True)
+    # Reference computation
+    var1 = np.copy(signals)
+    var1 **= 2
+    var1 = var1.sum(axis=0)
+
+    var2 = nisignal._sum_of_squares(signals)
+
+    np.testing.assert_almost_equal(var1, var2)
+
+
 # This test is inspired from Scipy docstring of detrend function
 def test_clean_detrending():
     n_samples = 21

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -266,8 +266,8 @@ def test_mean_of_squares():
     np.testing.assert_almost_equal(var1, var2)
 
 
-def test_sum_of_squares():
-    """Test _sum_of_squares."""
+def test_row_sum_of_squares():
+    """Test _row_sum_of_squares."""
     n_samples = 11
     n_features = 501  # Higher than 500 required
     signals, _, _ = generate_signals(n_features=n_features,
@@ -277,7 +277,7 @@ def test_sum_of_squares():
     var1 = signals ** 2
     var1 = var1.sum(axis=0)
 
-    var2 = nisignal._sum_of_squares(signals)
+    var2 = nisignal._row_sum_of_squares(signals)
 
     np.testing.assert_almost_equal(var1, var2)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #2342 #1744 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- The explained variance `score` method now returns a value based on the number of components rather than 0. always. 
- ```per_component```, a new argument introduced in `score` method returns a value per component.
