### PR TITLE
FIX: Avoid colormap readd

### DIFF
--- a/nilearn/plotting/cm.py
+++ b/nilearn/plotting/cm.py
@@ -211,7 +211,10 @@ _cmap_d['videen_style'] = _colors.LinearSegmentedColormap.from_list(
 locals().update(_cmap_d)
 # Register cmaps in matplotlib too
 for k, v in _cmap_d.items():
-    _cm.register_cmap(name=k, cmap=v)
+    try:  # "bwr" is in latest matplotlib
+        _cm.register_cmap(name=k, cmap=v)
+    except ValueError:
+        pass
 
 
 ################################################################################


### PR DESCRIPTION
On latest matplotlib I get:
```
  File "../examples/inverse/plot_mixed_source_space_inverse.py", line 16, in <module>
    from nilearn import plotting
  File "/home/larsoner/python/nilearn/nilearn/plotting/__init__.py", line 42, in <module>
    from . import cm
  File "/home/larsoner/python/nilearn/nilearn/plotting/cm.py", line 214, in <module>
    _cm.register_cmap(name=k, cmap=v)
  File "/home/larsoner/python/matplotlib/lib/matplotlib/cm.py", line 150, in register_cmap
    raise ValueError(msg)
ValueError: Trying to re-register the builtin cmap 'bwr'.
```
This uses a try/except pattern to avoid this.

On alternative would be to do:
```
if k not in _cm._cmap_registry
```
but this uses the private `_cmap_registry` which is probably not a great idea. I do not know of a public interface to get all registered cmaps.