### PR TITLE
BUG: Fix for latest matplotlib

### DIFF
--- a/nilearn/_utils/data_gen.py
+++ b/nilearn/_utils/data_gen.py
@@ -128,7 +128,7 @@ def generate_maps(shape, n_regions, overlap=0, border=1,
 
 
 def generate_labeled_regions(shape, n_regions, rand_gen=None, labels=None,
-                             affine=np.eye(4), dtype=np.int):
+                             affine=np.eye(4), dtype=int):
     """Generate a 3D volume with labeled regions.
 
     Parameters
@@ -166,7 +166,7 @@ def generate_labeled_regions(shape, n_regions, rand_gen=None, labels=None,
     for n, row in zip(labels, regions):
         row[row > 0] = n
     data = np.zeros(shape, dtype=dtype)
-    data[np.ones(shape, dtype=np.bool)] = regions.sum(axis=0).T
+    data[np.ones(shape, dtype=bool)] = regions.sum(axis=0).T
     return nibabel.Nifti1Image(data, affine)
 
 
@@ -266,9 +266,9 @@ def generate_fake_fmri(shape=(10, 11, 12), length=17, kind="noise",
                 nibabel.Nifti1Image(mask, affine))
 
     block_size = 3 if block_size is None else block_size
-    flat_fmri = fmri[mask.astype(np.bool)]
+    flat_fmri = fmri[mask.astype(bool)]
     flat_fmri /= np.abs(flat_fmri).max()
-    target = np.zeros(length, dtype=np.int)
+    target = np.zeros(length, dtype=int)
     rest_max_size = (length - (n_blocks * block_size)) // n_blocks
     if rest_max_size < 0:
         raise ValueError(
@@ -298,7 +298,7 @@ def generate_fake_fmri(shape=(10, 11, 12), length=17, kind="noise",
     target = target if block_type == 'classification' \
         else target.astype(np.float)
     fmri = np.zeros(fmri.shape)
-    fmri[mask.astype(np.bool)] = flat_fmri
+    fmri[mask.astype(bool)] = flat_fmri
     return (nibabel.Nifti1Image(fmri, affine),
             nibabel.Nifti1Image(mask, affine), target)
 

--- a/nilearn/_utils/numpy_conversions.py
+++ b/nilearn/_utils/numpy_conversions.py
@@ -11,14 +11,15 @@ import numpy as np
 def _asarray(arr, dtype=None, order=None):
     # np.asarray does not take "K" and "A" orders in version 1.3.0
     if order in ("K", "A", None):
-        if (arr.itemsize == 1 and dtype == np.bool) \
-                or (arr.dtype == np.bool and np.dtype(dtype).itemsize == 1):
+        if (arr.itemsize == 1 and dtype in (bool, np.bool_)) \
+                or (arr.dtype in (bool, np.bool_) and
+                    np.dtype(dtype).itemsize == 1):
             ret = arr.view(dtype=dtype)
         else:
             ret = np.asarray(arr, dtype=dtype)
     else:
-        if (((arr.itemsize == 1 and dtype == np.bool) or
-            (arr.dtype == np.bool and np.dtype(dtype).itemsize == 1))
+        if (((arr.itemsize == 1 and dtype in (bool, np.bool)) or
+            (arr.dtype in (bool, np.bool_) and np.dtype(dtype).itemsize == 1))
             and (order == "F" and arr.flags["F_CONTIGUOUS"]
                  or order == "C" and arr.flags["C_CONTIGUOUS"])):
             ret = arr.view(dtype=dtype)

--- a/nilearn/conftest.py
+++ b/nilearn/conftest.py
@@ -15,6 +15,22 @@ except ImportError:
     collect_ignore = ['plotting',
                       'reporting',
                       ]
+    matplotlib = None
+
+
+def pytest_configure(config):
+    """Use Agg so that no figures pop up."""
+    if matplotlib is not None:
+        matplotlib.use('Agg', force=True)
+
+
+@pytest.fixture(autouse=True)
+def close_all():
+    """Close all matplotlib figures."""
+    yield
+    if matplotlib is not None:
+        import matplotlib.pyplot as plt
+        plt.close('all')  # takes < 1 us so just always do it
 
 
 def pytest_collection_modifyitems(items):

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -231,8 +231,7 @@ def _crop_colorbar(cbar, cbar_vmin, cbar_vmax):
     # _outline was removed in
     # https://github.com/matplotlib/matplotlib/commit/03a542e875eba091a027046d5ec652daa8be6863
     # so we use the code from there
-    if LooseVersion(matplotlib.__version__) >= LooseVersion("3.2.0") and \
-            hasattr(cbar, '_outline'):
+    if LooseVersion(matplotlib.__version__) >= LooseVersion("3.2.0"):
         cbar.ax.set_ylim(cbar_vmin, cbar_vmax)
         X, _ = cbar._mesh()
         X = np.array([X[0], X[-1]])

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -691,7 +691,7 @@ def _plot_roi_contours(display, roi_img, cmap, alpha, linewidths):
         if label == 0:
             continue
         data = (roi_data == label)
-        data = data.astype(np.int)
+        data = data.astype(int)
         img = new_img_like(roi_img, data, affine=roi_img.affine)
         display.add_contours(img, levels=[0.5], colors=[color_list[idx - 1]],
                              alpha=alpha, linewidths=linewidths,

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -228,12 +228,22 @@ def _crop_colorbar(cbar, cbar_vmin, cbar_vmax):
 
     # matplotlib >= 3.2.0 no longer normalizes axes between 0 and 1
     # See https://matplotlib.org/3.2.1/api/prev_api_changes/api_changes_3.2.0.html
-    if LooseVersion(matplotlib.__version__) >= LooseVersion("3.2.0"):
+    # _outline was removed in
+    # https://github.com/matplotlib/matplotlib/commit/03a542e875eba091a027046d5ec652daa8be6863
+    # so we use the code from there
+    if LooseVersion(matplotlib.__version__) >= LooseVersion("3.2.0") and \
+            hasattr(cbar, '_outline'):
         cbar.ax.set_ylim(cbar_vmin, cbar_vmax)
         X, _ = cbar._mesh()
-        new_X = np.array([X[0], X[-1]])
-        new_Y = np.array([[cbar_vmin, cbar_vmin], [cbar_vmax, cbar_vmax]])
-        xy = cbar._outline(new_X, new_Y)
+        X = np.array([X[0], X[-1]])
+        Y = np.array([[cbar_vmin, cbar_vmin], [cbar_vmax, cbar_vmax]])
+        N = X.shape[0]
+        ii = [0, 1, N - 2, N - 1, 2 * N - 1, 2 * N - 2, N + 1, N, 0]
+        x = X.T.reshape(-1)[ii]
+        y = Y.T.reshape(-1)[ii]
+        xy = (np.column_stack([y, x])
+              if cbar.orientation == 'horizontal' else
+              np.column_stack([x, y]))
         cbar.outline.set_xy(xy)
     else:
         cbar.ax.set_ylim(cbar.norm(cbar_vmin), cbar.norm(cbar_vmax))
@@ -1458,7 +1468,7 @@ optional
     -----
     The plotted image should in MNI space for this function to work properly.
 
-    This function is deprecated and will be removed in the 0.9.0 release. Use 
+    This function is deprecated and will be removed in the 0.9.0 release. Use
     plot_markers instead.
     """
     dep_msg = ("This function is deprecated and will be "
@@ -1553,21 +1563,21 @@ optional
     return display
 
 
-def plot_markers(node_values, node_coords, node_size='auto', 
-                 node_cmap=plt.cm.viridis_r, node_vmin=None, node_vmax=None, 
-                 node_threshold=None, alpha=0.7, output_file=None, 
-                 display_mode="ortho", figure=None, axes=None, title=None, 
-                 annotate=True, black_bg=False, node_kwargs=None, 
+def plot_markers(node_values, node_coords, node_size='auto',
+                 node_cmap=plt.cm.viridis_r, node_vmin=None, node_vmax=None,
+                 node_threshold=None, alpha=0.7, output_file=None,
+                 display_mode="ortho", figure=None, axes=None, title=None,
+                 annotate=True, black_bg=False, node_kwargs=None,
                  colorbar=True):
     """Plot network nodes (markers) on top of the brain glass schematics.
 
-    Nodes are color coded according to provided nodal measure. Nodal measure 
-    usually represents some notion of node importance.  
+    Nodes are color coded according to provided nodal measure. Nodal measure
+    usually represents some notion of node importance.
 
     Parameters
     ----------
     node_values : array_like of length n
-        Vector containing nodal importance measure. Each node will be colored 
+        Vector containing nodal importance measure. Each node will be colored
         acording to corresponding node value.
     node_coords : numpy array_like of shape (n, 3)
         3d coordinates of the graph nodes in world space.
@@ -1577,20 +1587,20 @@ def plot_markers(node_values, node_coords, node_size='auto',
     node_cmap : str or colormap
         Colormap used to represent the node measure.
     node_vmin : float, optional
-        Lower bound of the colormap. If `None`, the min of the node_values is 
+        Lower bound of the colormap. If `None`, the min of the node_values is
         used.
     node_vmax : float, optional
-        Upper bound of the colormap. If `None`, the min of the node_values is 
+        Upper bound of the colormap. If `None`, the min of the node_values is
         used.
     node_threshold : float
-        If provided only the nodes with a value greater than node_threshold 
+        If provided only the nodes with a value greater than node_threshold
         will be shown.
     alpha : float between 0 and 1. Default is 0.7
         Alpha transparency for markers
     output_file : string, or None, optional
         The name of an image file to export the plot to. Valid extensions
         are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed. 
+        is saved to a file, and the display is closed.
     display_mode : string, optional. Default is 'ortho'.
         Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
         'z' - axial, 'l' - sagittal left hemisphere only,
@@ -1625,34 +1635,34 @@ def plot_markers(node_values, node_coords, node_size='auto',
     node_coords = np.array(node_coords)
 
     # Validate node_values
-    if node_values.shape != (node_coords.shape[0], ): 
+    if node_values.shape != (node_coords.shape[0], ):
         msg = ("Dimension mismatch: 'node_values' should be vector of length "
                "{0}, but current shape is {1} instead of {2}").format(
                    len(node_coords),
-                   node_values.shape, 
-                   (node_coords.shape[0], ))        
-        raise ValueError(msg) 
+                   node_values.shape,
+                   (node_coords.shape[0], ))
+        raise ValueError(msg)
 
     display = plot_glass_brain(None, display_mode=display_mode,
                                figure=figure, axes=axes, title=title,
                                annotate=annotate, black_bg=black_bg)
 
     if isinstance(node_size, str) and node_size == 'auto':
-        node_size = min(1e4 / len(node_coords), 100)  
+        node_size = min(1e4 / len(node_coords), 100)
 
     # Filter out nodes with node values below threshold
     if node_threshold is not None:
         if node_threshold > np.max(node_values):
             msg = ("Provided 'node_threshold' value: {0} should not exceed "
-                   "highest node value: {1}").format(node_threshold, 
-                                                     np.max(node_values)) 
+                   "highest node value: {1}").format(node_threshold,
+                                                     np.max(node_values))
             raise ValueError(msg)
 
         retained_nodes = node_values > node_threshold
         node_values = node_values[retained_nodes]
-        node_coords = node_coords[retained_nodes]  
+        node_coords = node_coords[retained_nodes]
         if isinstance(node_size, collections.abc.Iterable):
-            node_size = [size for ok_retain, size in 
+            node_size = [size for ok_retain, size in
                          zip(retained_nodes, node_size) if ok_retain]
 
     # Calculate node colors based on value
@@ -1662,7 +1672,7 @@ def plot_markers(node_values, node_coords, node_size='auto',
         node_vmin = 0.9 * node_vmin
         node_vmax = 1.1 * node_vmax
     norm = matplotlib.colors.Normalize(vmin=node_vmin, vmax=node_vmax)
-    node_cmap = (plt.get_cmap(node_cmap) if isinstance(node_cmap, str) 
+    node_cmap = (plt.get_cmap(node_cmap) if isinstance(node_cmap, str)
                  else node_cmap)
     node_color = [node_cmap(norm(node_value)) for node_value in node_values]
 

--- a/nilearn/plotting/tests/conftest.py
+++ b/nilearn/plotting/tests/conftest.py
@@ -1,9 +1,0 @@
-import pytest
-
-
-@pytest.fixture(autouse=True)
-def close_all():
-    """Close all matplotlib figures."""
-    yield
-    import matplotlib.pyplot as plt
-    plt.close('all')

--- a/nilearn/plotting/tests/conftest.py
+++ b/nilearn/plotting/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def close_all():
+    """Close all matplotlib figures."""
+    yield
+    import matplotlib.pyplot as plt
+    plt.close('all')

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -2,7 +2,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 import os
-import tempfile
 from functools import partial
 from distutils.version import LooseVersion
 
@@ -25,7 +24,7 @@ from nilearn.plotting.img_plotting import (MNI152TEMPLATE, plot_anat, plot_img,
                                            plot_roi, plot_stat_map, plot_epi,
                                            plot_glass_brain, plot_connectome,
                                            plot_connectome_strength,
-                                           plot_markers, plot_prob_atlas, 
+                                           plot_markers, plot_prob_atlas,
                                            plot_carpet,
                                            _get_colorbar_and_data_ranges)
 from nilearn import plotting
@@ -120,7 +119,7 @@ def test_plot_roi_contours():
     plt.close()
 
 
-def test_demo_plot_roi():
+def test_demo_plot_roi(tmpdir):
     # This is only a smoke test
     demo_plot_roi()
     # Test the black background code path
@@ -130,76 +129,54 @@ def test_demo_plot_roi():
 
     # Save execution time and memory
     plt.close()
-
-    with tempfile.NamedTemporaryFile(suffix='.png') as fp:
+    filename = str(tmpdir.join('test.png'))
+    with open(filename, 'wb') as fp:
         out = demo_plot_roi(output_file=fp)
     assert out is None
 
 
-def test_plot_anat(testdata_3d):
+def test_plot_anat(testdata_3d, tmpdir):
     img = testdata_3d['img']
 
     # Test saving with empty plot
     z_slicer = plot_anat(anat_img=False, display_mode='z')
-    filename = tempfile.mktemp(suffix='.png')
-    try:
-        z_slicer.savefig(filename)
-    finally:
-        os.remove(filename)
+    filename = str(tmpdir.join('test.png'))
+    z_slicer.savefig(filename)
 
     z_slicer = plot_anat(display_mode='z')
-    filename = tempfile.mktemp(suffix='.png')
-    try:
-        z_slicer.savefig(filename)
-    finally:
-        os.remove(filename)
+    z_slicer.savefig(filename)
 
     ortho_slicer = plot_anat(img, dim='auto')
-    filename = tempfile.mktemp(suffix='.png')
-    try:
-        ortho_slicer.savefig(filename)
-    finally:
-        os.remove(filename)
+    ortho_slicer.savefig(filename)
 
     # Save execution time and memory
     plt.close()
 
 
-def test_plot_functions(testdata_3d, testdata_4d):
+def test_plot_functions(testdata_3d, testdata_4d, tmpdir):
     img_3d = testdata_3d['img']
     img_4d = testdata_4d['img_4d']
     img_4d_mask = testdata_4d['img_mask']
 
     # smoke-test for 3D plotting functions with default arguments
+    filename = str(tmpdir.join('temp.png'))
     for plot_func in [plot_anat, plot_img, plot_stat_map, plot_epi,
                       plot_glass_brain]:
-        filename = tempfile.mktemp(suffix='.png')
-        try:
-            plot_func(img_3d, output_file=filename)
-        finally:
-            os.remove(filename)
+        plot_func(img_3d, output_file=filename)
 
     # smoke-test for 4D plotting functions with default arguments
     for plot_func in [plot_carpet]:
-        filename = tempfile.mktemp(suffix='.png')
-        try:
-            plot_func(img_4d, mask_img=img_4d_mask, output_file=filename)
-        finally:
-            os.remove(filename)
+        plot_func(img_4d, mask_img=img_4d_mask, output_file=filename)
 
     # test for bad input arguments (cf. #510)
     ax = plt.subplot(111, rasterized=True)
-    filename = tempfile.mktemp(suffix='.png')
-    try:
-        plot_stat_map(img_3d, symmetric_cbar=True,
-                      output_file=filename,
-                      axes=ax, vmax=np.nan)
-    finally:
-        os.remove(filename)
+    plot_stat_map(img_3d, symmetric_cbar=True,
+                  output_file=filename,
+                  axes=ax, vmax=np.nan)
     plt.close()
 
 
-def test_plot_glass_brain(testdata_3d):
+def test_plot_glass_brain(testdata_3d, tmpdir):
     img = testdata_3d['img']
 
     # test plot_glass_brain with colorbar
@@ -212,7 +189,7 @@ def test_plot_glass_brain(testdata_3d):
     # Save execution time and memory
     plt.close()
     # smoke-test for hemispheric glass brain
-    filename = tempfile.mktemp(suffix='.png')
+    filename = str(tmpdir.join('test.png'))
     plot_glass_brain(img, output_file=filename, display_mode='lzry')
     plt.close()
 
@@ -354,25 +331,18 @@ def test_plot_carpet(testdata_4d):
     plt.close(display)
 
 
-def test_save_plot(testdata_3d):
+def test_save_plot(testdata_3d, tmpdir):
     img = testdata_3d['img']
 
     kwargs_list = [{}, {'display_mode': 'x', 'cut_coords': 3}]
 
+    filename = str(tmpdir.join('test.png'))
     for kwargs in kwargs_list:
-        filename = tempfile.mktemp(suffix='.png')
-        try:
-            display = plot_stat_map(img, output_file=filename, **kwargs)
-        finally:
-            os.remove(filename)
+        display = plot_stat_map(img, output_file=filename, **kwargs)
         assert display is None
 
         display = plot_stat_map(img, **kwargs)
-        filename = tempfile.mktemp(suffix='.png')
-        try:
-            display.savefig(filename)
-        finally:
-            os.remove(filename)
+        display.savefig(filename)
 
         # Save execution time and memory
         plt.close()
@@ -492,7 +462,7 @@ def test_plot_noncurrent_axes():
     plt.close()
 
 
-def test_plot_connectome():
+def test_plot_connectome(tmpdir):
     node_color = ['green', 'blue', 'k', 'cyan']
     # symmetric up to 1e-3 relative tolerance
     adjacency_matrix = np.array([[1., -2., 0.3, 0.],
@@ -516,14 +486,11 @@ def test_plot_connectome():
                     [tuple(each) for each in node_coords],
                     **kwargs)
     # saving to file
-    filename = tempfile.mktemp(suffix='.png')
-    try:
-        display = plot_connectome(*args, output_file=filename, **kwargs)
-        assert display is None
-        assert (os.path.isfile(filename) and
-                    os.path.getsize(filename) > 0)
-    finally:
-        os.remove(filename)
+    filename = str(tmpdir.join('temp.png'))
+    display = plot_connectome(*args, output_file=filename, **kwargs)
+    assert display is None
+    assert os.path.isfile(filename)
+    assert os.path.getsize(filename) > 0
     plt.close()
 
     # with node_kwargs, edge_kwargs and edge_cmap arguments
@@ -1138,7 +1105,7 @@ def test_plot_glass_brain_with_completely_masked_img():
     plt.close()
 
 
-def test_connectome_strength():
+def test_connectome_strength(tmpdir):
     # symmetric up to 1e-3 relative tolerance
     adjacency_matrix = np.array([[1., -2., 0.3, 0.],
                                  [-2.002, 1, 0., 0.],
@@ -1160,16 +1127,13 @@ def test_connectome_strength():
                              **kwargs)
 
     # saving to file
-    filename = tempfile.mktemp(suffix='.png')
-    try:
-        display = plot_connectome_strength(
-            *args, output_file=filename, **kwargs
-        )
-        assert display is None
-        assert (os.path.isfile(filename) and  # noqa: W504
-                    os.path.getsize(filename) > 0)
-    finally:
-        os.remove(filename)
+    filename = str(tmpdir.join('test.png'))
+    display = plot_connectome_strength(
+        *args, output_file=filename, **kwargs
+    )
+    assert display is None
+    assert os.path.isfile(filename)
+    assert os.path.getsize(filename) > 0
     plt.close()
 
     # passing node args
@@ -1255,7 +1219,7 @@ def test_plot_connectome_strength_exceptions():
                                  **kwargs)
 
 
-def test_plot_markers():
+def test_plot_markers(tmpdir):
     # Minimal usage
     node_values = [1, 2, 3, 4]
     node_coords = np.array([[39 ,   6, -32],
@@ -1286,15 +1250,12 @@ def test_plot_markers():
     plt.close()
 
     # Saving to file
-    filename = tempfile.mktemp(suffix='.png')
-    try:
-        display = plot_markers(*args, output_file=filename, **kwargs)
-        assert display is None
-        assert (os.path.isfile(filename) and  # noqa: W504
-                    os.path.getsize(filename) > 0)
-    finally:
-        os.remove(filename)
-        plt.close()
+    filename = str(tmpdir.join('test.png'))
+    display = plot_markers(*args, output_file=filename, **kwargs)
+    assert display is None
+    assert (os.path.isfile(filename) and  # noqa: W504
+                os.path.getsize(filename) > 0)
+    plt.close()
 
     # Different options for node_size
     plot_markers(*args, node_size=10, **kwargs)


### PR DESCRIPTION
On latest matplotlib I get (this is from MNE but we vendor your fix):
```
  File "/home/larsoner/python/mne-python/mne/fixes.py", line 1104, in _crop_colorbar
    xy = cbar._outline(new_X, new_Y)
AttributeError: 'ColorbarBase' object has no attribute '_outline'
```
See inline comments for description.

Not sure if there is a better fix or not...