### PR TITLE
BUILD: make sphinx-gallery more robust

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -44,14 +44,7 @@ clean:
 sym_links:
 	# Make sym-links to share the cache across various example
 	# directories
-	-cd ../examples/ && mkdir -p nilearn_cache
-	-cd ../examples/01_plotting/ && ln -sf ../nilearn_cache
-	-cd ../examples/02_decoding/ && ln -sf ../nilearn_cache
-	-cd ../examples/03_connectivity/ && ln -sf ../nilearn_cache
-	-cd ../examples/04_glm_first_level/ && ln -sf ../nilearn_cache
-	-cd ../examples/05_glm_second_level/ && ln -sf ../nilearn_cache
-	-cd ../examples/06_manipulating_images/ && ln -sf ../nilearn_cache
-	-cd ../examples/07_advanced/ && ln -sf ../nilearn_cache
+	-find ../examples -type d -exec ln -sf ../examples/nilearn_cache "{}/nilearn_cache" \;
 
 force_html: force html
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -44,7 +44,8 @@ clean:
 sym_links:
 	# Make sym-links to share the cache across various example
 	# directories
-	-find ../examples -type d -exec ln -sf ../examples/nilearn_cache "{}/nilearn_cache" \;
+	-find ../examples/ -type d -mindepth 1 -maxdepth 1 -not -path "../examples/nilearn_cache" -exec ln -sf ../nilearn_cache "{}/nilearn_cache" \;
+	-mkdir -p ../examples/nilearn_cache/joblib
 
 force_html: force html
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -44,6 +44,9 @@ clean:
 sym_links:
 	# Make sym-links to share the cache across various example
 	# directories
+	# The following find command selects all the depth-one
+	# subdirectories of ../examples/ and creates a sym-link to
+	# ../examples/nilearn_cache/
 	-find ../examples/ -type d -mindepth 1 -maxdepth 1 -not -path "../examples/nilearn_cache" -exec ln -sf ../nilearn_cache "{}/nilearn_cache" \;
 	-mkdir -p ../examples/nilearn_cache/joblib
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,14 +45,13 @@ sys.path.insert(0, os.path.abspath('..'))
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc',
+extensions = [
+              'sphinx_gallery.gen_gallery',
+              'sphinx.ext.autodoc',
               'sphinx.ext.autosummary',
-              ('sphinx.ext.imgmath'  # only available for sphinx >= 1.4
-                  if sphinx.version_info[:2] >= (1, 4)
-                  else 'sphinx.ext.pngmath'),
+              'sphinx.ext.imgmath',
               'sphinx.ext.intersphinx',
               'numpydoc',
-              'sphinx_gallery.gen_gallery',
               ]
 
 autosummary_generate = True


### PR DESCRIPTION
On my computer, these changes are needed so that sphinx-gallery does not error saying that the matplotlib backend is tkagg