### PR TITLE
Change _facecolors3d to _facecolor3d in surf_plotting

### DIFF
--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -449,7 +449,13 @@ def plot_surf_contours(surf_mesh, roi_map, axes=None, figure=None, levels=None,
     for level, color, label in zip(levels, colors, labels):
         roi_indices = np.where(roi == level)[0]
         faces_outside = _get_faces_on_edge(faces, roi_indices)
-        axes.collections[0]._facecolors3d[faces_outside] = color
+        # Fix: Matplotlib version 3.3.2 to 3.3.3
+        # Attribute _facecolors3d changed to _facecolor3d in
+        # matplotlib version 3.3.3
+        try:
+            axes.collections[0]._facecolors3d[faces_outside] = color
+        except AttributeError:
+            axes.collections[0]._facecolor3d[faces_outside] = color
         if label and legend:
             patch_list.append(Patch(color=color, label=label))
     # plot legend only if indicated and labels provided


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Matplotlib version bump from 3.3.2 to 3.3.3 introduced the attribute `_facecolors3d` of `'Poly3DCollection` to become `_facecolor3d` which caused PR #2589 to fail 
