### PR TITLE
Call load_surf_data in plot_stat_map before _get_colorbar_and_data_ra…

### DIFF
--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -574,13 +574,15 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
     nilearn.plotting.plot_surf: For brain surface visualization.
     """
 
+    loaded_stat_map = load_surf_data(stat_map)
+
     # Call _get_colorbar_and_data_ranges to derive symmetric vmin, vmax
     # And colorbar limits depending on symmetric_cbar settings
     cbar_vmin, cbar_vmax, vmin, vmax = _get_colorbar_and_data_ranges(
-        stat_map, vmax, symmetric_cbar, kwargs)
+        loaded_stat_map, vmax, symmetric_cbar, kwargs)
 
     display = plot_surf(
-        surf_mesh, surf_map=stat_map, bg_map=bg_map, hemi=hemi, view=view,
+        surf_mesh, surf_map=loaded_stat_map, bg_map=bg_map, hemi=hemi, view=view,
         avg_method='mean', threshold=threshold, cmap=cmap, colorbar=colorbar,
         alpha=alpha, bg_on_data=bg_on_data, darkness=darkness, vmax=vmax,
         vmin=vmin, title=title, output_file=output_file, axes=axes,


### PR DESCRIPTION
…nges

<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #2603 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->

Note: I didn't check whether `stat_map` is a string or a Numpy array in `plot_surf_stat_map` in order to call or not `load_surf_data`. This is done already in `load_surf_data`, which returns the array itself in the second option.