### PR TITLE
[MRG] Support multiple doc versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,6 +308,46 @@ jobs:
           fi
       - save_data_cache
 
+    deploy:
+        docker:
+            - image: circleci/python:3.7
+        steps:
+            - attach_workspace:
+                at: /tmp/build
+            - run:
+                name: Fetch docs
+                command: |
+                    set -e
+                    mkdir -p ~/.ssh
+                    echo -e "Host *\nStrictHostKeyChecking no" > ~/.ssh/config
+                    chmod og= ~/.ssh/config
+                    if [ ! -d ~/nilearn.github.io ]; then
+                        git clone git@github.com:nilearn/nilearn.github.io.git ~/nilearn.github.io --depth=1
+                    fi
+            - run:
+                name: Deploy dev docs
+                command: |
+                    set -e;
+                    if [ "${CIRCLE_BRANCH}" == "master" ]; then
+                        git config --global user.email "circle@nilearn.com";
+                        git config --global user.name "CircleCI";
+                        cd ~/nilearn.github.io;
+                        git checkout master
+                        git remote -v
+                        git fetch origin
+                        git reset --hard origin/master
+                        git clean -xdf
+                        echo "Deploying dev docs for ${CIRCLE_BRANCH}.";
+                        rm -Rf dev;
+                        cp -a /tmp/build/html dev;
+                        git add -A;
+                        git commit -m "CircleCI update of dev docs ($(CIRCLE_BUILD_NUM)).";
+                        git push origin master;
+                    else
+                        echo "No deployment (build: ${CIRCLE_BRANCH}).";
+                    fi
+
+
 workflows:
   version: 2
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,7 +308,6 @@ jobs:
           fi
       - save_data_cache
 
-jobs:
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,44 +308,44 @@ jobs:
           fi
       - save_data_cache
 
-    deploy:
-        docker:
-            - image: circleci/python:3.7
-        steps:
-            - attach_workspace:
-                at: /tmp/build
-            - run:
-                name: Fetch docs
-                command: |
-                    set -e
-                    mkdir -p ~/.ssh
-                    echo -e "Host *\nStrictHostKeyChecking no" > ~/.ssh/config
-                    chmod og= ~/.ssh/config
-                    if [ ! -d ~/nilearn.github.io ]; then
-                        git clone git@github.com:nilearn/nilearn.github.io.git ~/nilearn.github.io --depth=1
-                    fi
-            - run:
-                name: Deploy dev docs
-                command: |
-                    set -e;
-                    if [ "${CIRCLE_BRANCH}" == "master" ]; then
-                        git config --global user.email "circle@nilearn.com";
-                        git config --global user.name "CircleCI";
-                        cd ~/nilearn.github.io;
-                        git checkout master
-                        git remote -v
-                        git fetch origin
-                        git reset --hard origin/master
-                        git clean -xdf
-                        echo "Deploying dev docs for ${CIRCLE_BRANCH}.";
-                        rm -Rf dev;
-                        cp -a /tmp/build/html dev;
-                        git add -A;
-                        git commit -m "CircleCI update of dev docs ($(CIRCLE_BUILD_NUM)).";
-                        git push origin master;
-                    else
-                        echo "No deployment (build: ${CIRCLE_BRANCH}).";
-                    fi
+  deploy:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - attach_workspace:
+        at: /tmp/build
+      - run:
+        name: Fetch docs
+        command: |
+          set -e
+          mkdir -p ~/.ssh
+          echo -e "Host *\nStrictHostKeyChecking no" > ~/.ssh/config
+          chmod og= ~/.ssh/config
+          if [ ! -d ~/nilearn.github.io ]; then
+            git clone git@github.com:nilearn/nilearn.github.io.git ~/nilearn.github.io --depth=1
+          fi
+      - run:
+        name: Deploy dev docs
+        command: |
+          set -e;
+          if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            git config --global user.email "circle@nilearn.com";
+            git config --global user.name "CircleCI";
+            cd ~/nilearn.github.io;
+            git checkout master
+            git remote -v
+            git fetch origin
+            git reset --hard origin/master
+            git clean -xdf
+            echo "Deploying dev docs for ${CIRCLE_BRANCH}.";
+            rm -Rf dev;
+            cp -a /tmp/build/html dev;
+            git add -A;
+            git commit -m "CircleCI update of dev docs ($(CIRCLE_BUILD_NUM)).";
+            git push origin master;
+          else
+            echo "No deployment (build: ${CIRCLE_BRANCH}).";
+          fi
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,39 +315,39 @@ jobs:
       - image: circleci/python:3.7
     steps:
       - attach_workspace:
-        at: /tmp/build
+          at: /tmp/build
       - run:
-        name: Fetch docs
-        command: |
-          set -e
-          mkdir -p ~/.ssh
-          echo -e "Host *\nStrictHostKeyChecking no" > ~/.ssh/config
-          chmod og= ~/.ssh/config
-          if [ ! -d ~/nilearn.github.io ]; then
-            git clone git@github.com:nilearn/nilearn.github.io.git ~/nilearn.github.io --depth=1
-          fi
+          name: Fetch docs
+          command: |
+            set -e
+            mkdir -p ~/.ssh
+            echo -e "Host *\nStrictHostKeyChecking no" > ~/.ssh/config
+            chmod og= ~/.ssh/config
+            if [ ! -d ~/nilearn.github.io ]; then
+              git clone git@github.com:nilearn/nilearn.github.io.git ~/nilearn.github.io --depth=1
+            fi
       - run:
-        name: Deploy dev docs
-        command: |
-          set -e;
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
-            git config --global user.email "circle@nilearn.com";
-            git config --global user.name "CircleCI";
-            cd ~/nilearn.github.io;
-            git checkout master
-            git remote -v
-            git fetch origin
-            git reset --hard origin/master
-            git clean -xdf
-            echo "Deploying dev docs for ${CIRCLE_BRANCH}.";
-            rm -Rf dev;
-            cp -a /tmp/build/html dev;
-            git add -A;
-            git commit -m "CircleCI update of dev docs ($(CIRCLE_BUILD_NUM)).";
-            git push origin master;
-          else
-            echo "No deployment (build: ${CIRCLE_BRANCH}).";
-          fi
+          name: Deploy dev docs
+          command: |
+            set -e;
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              git config --global user.email "circle@nilearn.com";
+              git config --global user.name "CircleCI";
+              cd ~/nilearn.github.io;
+              git checkout master
+              git remote -v
+              git fetch origin
+              git reset --hard origin/master
+              git clean -xdf
+              echo "Deploying dev docs for ${CIRCLE_BRANCH}.";
+              rm -Rf dev;
+              cp -a /tmp/build/html dev;
+              git add -A;
+              git commit -m "CircleCI update of dev docs ($(CIRCLE_BUILD_NUM)).";
+              git push origin master;
+            else
+              echo "No deployment (build: ${CIRCLE_BRANCH}).";
+            fi
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,6 +308,8 @@ jobs:
           fi
       - save_data_cache
 
+jobs:
+
   deploy:
     docker:
       - image: circleci/python:3.7
@@ -354,6 +356,14 @@ workflows:
   default:
     jobs:
       - build_docs
+
+      - deploy:
+          requires:
+            - build_docs
+          filters:
+            branches:
+              only:
+                - main
 
   nightly:
     triggers:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -83,7 +83,7 @@ html_dev:	sym_links
 	# These two lines make the build a bit more lengthy, and the
 	# the embedding of images more robust
 	rm -rf $(BUILDDIR)/html/_images
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	BUILD_DEV_HTML=1 $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	touch $(BUILDDIR)/html/.nojekyll
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
@@ -103,7 +103,7 @@ html-modified-examples-only: 	sym_links
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 html_dev-noplot:
-	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	BUILD_DEV_HTML=1 $(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	touch $(BUILDDIR)/html/.nojekyll
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -91,7 +91,6 @@ html_dev:	sym_links
 html_dev-strict:	sym_links
 	# Build html documentation using a strict mode: Warnings are
 	# considered as errors.
-	BUILD_DEV_HTML=1
 	make check
 	touch $(BUILDDIR)/html/.nojekyll
 	@echo
@@ -187,7 +186,7 @@ pdf: latex
 check:
 	rm -rf _build/doctrees
 	rm -rf $(BUILDDIR)/html/_images
-	$(SPHINXBUILD) -W -T -n -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	BUILD_DEV_HTML=1 $(SPHINXBUILD) -W -T -n -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 
 install:
 	rm -rf _build/doctrees _build/nilearn.github.io

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -55,7 +55,31 @@ force_html: force html
 force:
 	find . -name \*.rst -exec touch {} \;
 
-html:	sym_links
+html: html_dev
+
+html-strict: html_dev-strict
+
+html-noplot: html_dev-noplot
+
+html_stable:
+	rm -rf $(BUILDDIR)/html_stable/_images
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html_stable
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html_stable"
+
+html_stable-strict:   sym_links
+	make check
+	touch $(BUILDDIR)/html_stable/.nojekyll
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html_stable"
+
+html_stable-noplot:
+	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html_stable
+	touch $(BUILDDIR)/html_stable/.nojekyll
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html_stable."
+
+html_dev:	sym_links
 	# These two lines make the build a bit more lengthy, and the
 	# the embedding of images more robust
 	rm -rf $(BUILDDIR)/html/_images
@@ -64,7 +88,7 @@ html:	sym_links
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-html-strict:	sym_links
+html_dev-strict:	sym_links
 	# Build html documentation using a strict mode: Warnings are
 	# considered as errors.
 	make check
@@ -78,7 +102,7 @@ html-modified-examples-only: 	sym_links
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-html-noplot:
+html_dev-noplot:
 	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	touch $(BUILDDIR)/html/.nojekyll
 	@echo
@@ -174,11 +198,15 @@ install:
 	# history prior to the last commit
 	git clone --no-checkout --depth 1 git@github.com:nilearn/nilearn.github.io.git _build/nilearn.github.io
 	touch _build/nilearn.github.io/.nojekyll
-	make html
+	# Build dev doc
+	make html_dev
+	# Build stable doc
+	make html_stable
 	cd _build/ && \
-	cp -r html/* nilearn.github.io && \
-	cd nilearn.github.io && \
-	git add * && \
-	git add .nojekyll && \
+	cp -r html/* nilearn.github.io/dev && \
+	cp -r html_stable/* nilearn.github.io/stable && \
+	git add nilearn.github.io/dev/* && \
+	git add nilearn.github.io/stable/* && \
+	git add nilearn.github.io/.nojekyll && \
 	git commit -a -m 'Make install' && \
 	git push

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -97,7 +97,7 @@ html_dev-strict:	sym_links
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 html-modified-examples-only: 	sym_links
-	$(SPHINXBUILD) -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -D sphinx_gallery_conf.run_stale_examples=True -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	BUILD_DEV_HTML=1 $(SPHINXBUILD) -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -D sphinx_gallery_conf.run_stale_examples=True -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	touch $(BUILDDIR)/html/.nojekyll
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -91,6 +91,7 @@ html_dev:	sym_links
 html_dev-strict:	sym_links
 	# Build html documentation using a strict mode: Warnings are
 	# considered as errors.
+	BUILD_DEV_HTML=1
 	make check
 	touch $(BUILDDIR)/html/.nojekyll
 	@echo

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -202,11 +202,14 @@ install:
 	make html_dev
 	# Build stable doc
 	make html_stable
-	cd _build/ && \
-	cp -r html/* nilearn.github.io/dev && \
-	cp -r html_stable/* nilearn.github.io/stable && \
-	git add nilearn.github.io/dev/* && \
-	git add nilearn.github.io/stable/* && \
-	git add nilearn.github.io/.nojekyll && \
-	git commit -a -m 'Make install' && \
+	cd _build/nilearn.github.io/ && \
+    mkdir dev/ && \
+	cp -r ../html/* dev/ && \
+	mkdir stable/ && \
+	cp -r ../html_stable/* stable/ && \
+	git add dev/* && \
+	git add stable/* && \
+	git add .nojekyll && \
+	git commit -a -m "Make install"
 	git push
+

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -229,6 +229,11 @@ html_show_sourcelink = False
 # base URL from which the finished HTML is served.
 #html_use_opensearch = ''
 
+# variables to pass to HTML templating engine
+build_dev_html = bool(int(os.environ.get('BUILD_DEV_HTML', False)))
+
+html_context = {'build_dev_html': build_dev_html}
+
 # If nonempty, this is the file name suffix for HTML files (e.g. ".xhtml").
 #html_file_suffix = ''
 

--- a/doc/themes/nilearn/layout.html
+++ b/doc/themes/nilearn/layout.html
@@ -85,6 +85,26 @@ $(function() {
         updateTopMenuPosition(banner_height, width)
     })
 });
+
+/* When the user clicks on the button,
+toggle between hiding and showing the dropdown content */
+function toggle_button() {
+  document.getElementById("VersionDropdown").classList.toggle("show");
+}
+
+// Close the dropdown menu if the user clicks outside of it
+window.onclick = function(event) {
+  if (!event.target.matches('.dropbtn')) {
+    var dropdowns = document.getElementsByClassName("dropdown-content");
+    var i;
+    for (i = 0; i < dropdowns.length; i++) {
+      var openDropdown = dropdowns[i];
+      if (openDropdown.classList.contains('show')) {
+        openDropdown.classList.remove('show');
+      }
+    }
+  }
+} 
 </script>
 
 {%- if (pagename == 'index') %}
@@ -242,6 +262,15 @@ $(function () {
     <h1>Nilearn:</h1>
     <h2>Statistics for NeuroImaging in Python</h2>
   </div>
+
+    <div class="dropdown">
+        <button onclick="toggle_button()" class="dropbtn">Select documentation version</button>
+        <div id="VersionDropdown" class="dropdown-content">
+            <a href="https://nilearn.github.io/dev/index.html">Development version</a>
+            <a href="https://nilearn.github.io/stable/index.html">Stable version</a>
+        </div>
+    </div>
+
   <div class="search_form">
     <div class="gcse-search" id="cse" style="width: 100%;"></div>
     <script>

--- a/doc/themes/nilearn/layout.html
+++ b/doc/themes/nilearn/layout.html
@@ -25,6 +25,12 @@
 <div class=related-wrapper>
     {{relbar()}}
 </div>
+{% if build_dev_html %}
+<div class="alert-danger">
+This is documentation for the <em>unstable development version</em> of Nilearn,
+the current stable version is available <a href="https://nilearn.github.io/stable/index.html">here</a>.
+</div>
+{% endif %}
 {% endblock %}
 
 {% block rootrellink %}

--- a/doc/themes/nilearn/static/nature.css_t
+++ b/doc/themes/nilearn/static/nature.css_t
@@ -65,6 +65,11 @@ div.content {
 }
 
 
+.alert-danger {
+    background-color: #e74c3c;
+    border-color: #e74c3c;
+    color: #ffffff;
+}
 
 div.topic {
     background-color: #eee;
@@ -688,7 +693,7 @@ div.sphinxsidebar ul ul li {
 
 div.sphinxsidebarwrapper {
     width: 227px;
-    padding-top: .5em;
+    padding-top: 1em;
 }
 
 div.sphinxsidebarwrapper ul li p {

--- a/doc/themes/nilearn/static/nature.css_t
+++ b/doc/themes/nilearn/static/nature.css_t
@@ -69,6 +69,7 @@ div.content {
     background-color: #e74c3c;
     border-color: #e74c3c;
     color: #ffffff;
+    padding: 0.2em;
 }
 
 div.topic {
@@ -693,7 +694,7 @@ div.sphinxsidebar ul ul li {
 
 div.sphinxsidebarwrapper {
     width: 227px;
-    padding-top: 1em;
+    padding-top: 1.5em;
 }
 
 div.sphinxsidebarwrapper ul li p {

--- a/doc/themes/nilearn/static/nature.css_t
+++ b/doc/themes/nilearn/static/nature.css_t
@@ -64,6 +64,52 @@ div.content {
     padding-bottom: 10px;
 }
 
+/* Dropdown Button */
+.dropbtn {
+  background-color: #3498DB;
+  color: white;
+  padding: 10px;
+  heigth: max-content;
+  font-size: 16px;
+  border: none;
+  cursor: pointer;
+}
+
+/* Dropdown button on hover & focus */
+.dropbtn:hover, .dropbtn:focus {
+  background-color: #2980B9;
+}
+
+/* The container <div> - needed to position the dropdown content */
+.dropdown {
+  width: max-content;
+  height: 50px;
+  position: relative;
+  display: grid;
+}
+
+/* Dropdown Content (Hidden by Default) */
+.dropdown-content {
+  display: none;
+  background-color: #f1f1f1;
+  min-width: 160px;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  z-index: 1;
+}
+
+/* Links inside the dropdown */
+.dropdown-content a {
+  color: black;
+  padding: 2px 2px;
+  text-decoration: none;
+  display: block;
+}
+
+/* Change color of dropdown links on hover */
+.dropdown-content a:hover {background-color: #ddd}
+
+/* Show the dropdown menu (use JS to add this class to the .dropdown-content container when the user clicks on the dropdown button) */
+.show {display:grid;}
 
 .alert-danger {
     background-color: #e74c3c;
@@ -535,6 +581,7 @@ div.bodywrapper h1 {
 
 div.sphinxsidebar {
     margin: 0;
+    margin-top: 50px;
     padding: 0 15px 15px 0;
     min-width: 226px;
     width: 17%;


### PR DESCRIPTION
Addresses #2594 

This is still WIP but since I'm not 100% sure of what I'm doing, I thought I'd share to see if people have recommendations/concerns on the implementation so far...

**Objective Steps**

- [x] Build doc for `stable` and `dev` versions
- [x] Automate the build and deploy for `dev` doc through CircleCI
- [x] Add red danger banner on `dev` doc with a link to `stable` doc

**To be addressed in future PRs**

- Add redirect in index to the `stable` version at the root of Github pages 
- Maintain older doc versions
- Provide user-friendly way of changing the doc version (dropdown menu or something alike...)
