### PR TITLE
[MRG] Add DiFuMo atlases

### DIFF
--- a/doc/modules/reference.rst
+++ b/doc/modules/reference.rst
@@ -67,6 +67,7 @@ the :ref:`user guide <user_guide>` for more information and usage examples.
    fetch_atlas_destrieux_2009
    fetch_atlas_harvard_oxford
    fetch_atlas_msdl
+   fetch_atlas_difumo
    fetch_coords_power_2011
    fetch_coords_seitzman_2018
    fetch_atlas_smith_2009

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,6 +1,15 @@
 0.7.X
 =====
 
+NEW
+---
+
+- New atlas fetcher
+  :func:`nilearn.datasets.fetch_atlas_difumo` to download *Dictionaries of Functional Modes*,
+  or “DiFuMo”, that can serve as atlases to extract functional signals with different 
+  dimensionalities (64, 128, 256, 512, and 1024). These modes are optimized to represent well
+  raw BOLD timeseries, over a with range of experimental conditions.
+
 Fixes
 -----
 

--- a/examples/01_plotting/plot_prob_atlas.py
+++ b/examples/01_plotting/plot_prob_atlas.py
@@ -46,8 +46,8 @@ subcortex = datasets.fetch_atlas_pauli_2017()
 # Dictionaries of Functional Modes (“DiFuMo”) atlas
 dim = 64
 res = 2
-difumo = datasets.fetch_difumo(dimension=dim,
-                               resolution_mm=res)
+difumo = datasets.fetch_atlas_difumo(dimension=dim,
+                                     resolution_mm=res)
 
 # Visualization
 from nilearn import plotting

--- a/examples/01_plotting/plot_prob_atlas.py
+++ b/examples/01_plotting/plot_prob_atlas.py
@@ -43,6 +43,12 @@ allen = datasets.fetch_atlas_allen_2011()
 # Pauli subcortical atlas
 subcortex = datasets.fetch_atlas_pauli_2017()
 
+# Dictionaries of Functional Modes (“DiFuMo”) atlas
+dim = 64
+res = 2
+difumo = datasets.fetch_difumo(dimension=dim,
+                               resolution_mm=res)
+
 # Visualization
 from nilearn import plotting
 
@@ -56,6 +62,7 @@ atlas_types = {'Harvard_Oxford': harvard_oxford.maps,
                'ICBM tissues': (icbm['wm'], icbm['gm'], icbm['csf']),
                'Allen2011': allen.rsn28,
                'Pauli2017 Subcortical Atlas': subcortex.maps,
+               'DiFuMo dimension {0} resolution {1}'.format(dim, res): difumo.maps,
                }
 
 for name, atlas in sorted(atlas_types.items()):

--- a/examples/03_connectivity/plot_atlas_comparison.py
+++ b/examples/03_connectivity/plot_atlas_comparison.py
@@ -84,7 +84,9 @@ plotting.plot_connectome(mean_correlation_matrix, coordinates,
 # Load probabilistic atlases - extracting coordinates on brain maps
 # -----------------------------------------------------------------
 
-msdl = datasets.fetch_atlas_msdl()
+dim = 64
+difumo = datasets.fetch_difumo(dimension=dim,
+                               resolution_mm=2)
 
 ##########################################################################
 # Iterate over fetched atlases to extract coordinates - probabilistic
@@ -92,7 +94,7 @@ msdl = datasets.fetch_atlas_msdl()
 from nilearn.input_data import NiftiMapsMasker
 
 # create masker to extract functional data within atlas parcels
-masker = NiftiMapsMasker(maps_img=msdl['maps'], standardize=True,
+masker = NiftiMapsMasker(maps_img=difumo.maps, standardize=True,
                          memory='nilearn_cache')
 
 # extract time series from all subjects and concatenate them
@@ -108,9 +110,10 @@ correlation_matrices = connectome_measure.fit_transform(time_series)
 mean_correlation_matrix = connectome_measure.mean_
 
 # grab center coordinates for probabilistic atlas
-coordinates = plotting.find_probabilistic_atlas_cut_coords(maps_img=msdl['maps'])
+coordinates = plotting.find_probabilistic_atlas_cut_coords(maps_img=difumo.maps)
 
-# plot connectome with 80% edge strength in the connectivity
+# plot connectome with 85% edge strength in the connectivity
 plotting.plot_connectome(mean_correlation_matrix, coordinates,
-                         edge_threshold="80%", title='MSDL (probabilistic)')
+                         edge_threshold="85%",
+                         title='DiFuMo with {0} dimensions (probabilistic)'.format(dim))
 plotting.show()

--- a/examples/03_connectivity/plot_atlas_comparison.py
+++ b/examples/03_connectivity/plot_atlas_comparison.py
@@ -85,8 +85,8 @@ plotting.plot_connectome(mean_correlation_matrix, coordinates,
 # -----------------------------------------------------------------
 
 dim = 64
-difumo = datasets.fetch_difumo(dimension=dim,
-                               resolution_mm=2)
+difumo = datasets.fetch_atlas_difumo(dimension=dim,
+                                     resolution_mm=2)
 
 ##########################################################################
 # Iterate over fetched atlases to extract coordinates - probabilistic

--- a/nilearn/datasets/__init__.py
+++ b/nilearn/datasets/__init__.py
@@ -36,7 +36,8 @@ from .atlas import (fetch_atlas_craddock_2012, fetch_atlas_destrieux_2009,
                     fetch_atlas_surf_destrieux,
                     fetch_atlas_talairach,
                     fetch_atlas_pauli_2017,
-                    fetch_atlas_schaefer_2018)
+                    fetch_atlas_schaefer_2018,
+                    fetch_difumo)
 
 from .utils import get_data_dirs
 from .neurovault import (fetch_neurovault,
@@ -59,6 +60,7 @@ __all__ = ['MNI152_FILE_PATH', 'fetch_icbm152_2009', 'load_mni152_template',
            'fetch_atlas_smith_2009',
            'fetch_atlas_allen_2011',
            'fetch_atlas_yeo_2011', 'fetch_mixed_gambles', 'fetch_atlas_aal',
+           'fetch_difumo',
            'fetch_megatrawls_netmats', 'fetch_cobre',
            'fetch_surf_nki_enhanced', 'fetch_development_fmri',
            'fetch_surf_fsaverage',

--- a/nilearn/datasets/__init__.py
+++ b/nilearn/datasets/__init__.py
@@ -37,7 +37,7 @@ from .atlas import (fetch_atlas_craddock_2012, fetch_atlas_destrieux_2009,
                     fetch_atlas_talairach,
                     fetch_atlas_pauli_2017,
                     fetch_atlas_schaefer_2018,
-                    fetch_difumo)
+                    fetch_atlas_difumo)
 
 from .utils import get_data_dirs
 from .neurovault import (fetch_neurovault,
@@ -60,7 +60,7 @@ __all__ = ['MNI152_FILE_PATH', 'fetch_icbm152_2009', 'load_mni152_template',
            'fetch_atlas_smith_2009',
            'fetch_atlas_allen_2011',
            'fetch_atlas_yeo_2011', 'fetch_mixed_gambles', 'fetch_atlas_aal',
-           'fetch_difumo',
+           'fetch_atlas_difumo',
            'fetch_megatrawls_netmats', 'fetch_cobre',
            'fetch_surf_nki_enhanced', 'fetch_development_fmri',
            'fetch_surf_fsaverage',

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -46,6 +46,12 @@ def fetch_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True, verb
         Path where data should be downloaded. By default,
         files are downloaded in home directory.
 
+    resume: bool, default is True
+        whether to resumed download of a partly-downloaded file.
+
+    verbose: int, default is 1
+        verbosity level (0 means no message).
+
     Returns
     -------
     data: sklearn.datasets.base.Bunch

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -23,6 +23,8 @@ _TALAIRACH_LEVELS = ['hemisphere', 'lobe', 'gyrus', 'tissue', 'ba']
 def fetch_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True, verbose=1):
     """Fetch DiFuMo brain atlas
 
+     Dictionaries of Functional Modes, or “DiFuMo”, can serve as atlases to extract functional signals with different dimensionalities (64, 128, 256, 512, and 1024). These modes are optimized to represent well raw BOLD timeseries, over a with range of experimental conditions.
+
     Direct download links from OSF:
 
     dic = {64: https://osf.io/wjum7/download,
@@ -58,7 +60,8 @@ def fetch_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True, verb
         Dictionary-like object, the interest attributes are :
 
         - 'maps': str, 4D path to nifti file containing regions definition.
-        - 'labels': string list containing the labels of the regions.
+        - 'labels': Numpy recarray containing the labels of the regions.
+        - 'description': str, general description of the dataset.
 
     References
     ----------

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -26,7 +26,7 @@ def fetch_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True, verb
     Direct download links from OSF:
 
     dic = {64: https://osf.io/wjum7/download,
-           128: https://osf.io/kdfg3/download,
+           128: https://osf.io/n3vba/download,
            256: https://osf.io/vza2y/download,
            512: https://osf.io/a23gw/download,
            1024: https://osf.io/jpdum/download,
@@ -68,7 +68,7 @@ def fetch_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True, verb
     NeuroImage, Elsevier, 2020, pp.117126, https://hal.inria.fr/hal-02904869
     """
     dic = {64: 'wjum7',
-           128: 'kdfg3',
+           128: 'n3vba',
            256: 'vza2y',
            512: 'a23gw',
            1024: 'jpdum',

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -20,6 +20,103 @@ from ..image import new_img_like, get_data
 _TALAIRACH_LEVELS = ['hemisphere', 'lobe', 'gyrus', 'tissue', 'ba']
 
 
+def fetch_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True, verbose=1):
+    """Fetch DiFuMo brain atlas
+
+    Direct download links from OSF:
+
+    dic = {64: https://osf.io/wjum7/download,
+           128: https://osf.io/kdfg3/download,
+           256: https://osf.io/vza2y/download,
+           512: https://osf.io/a23gw/download,
+           1024: https://osf.io/jpdum/download,
+           }
+
+    Parameters
+    ----------
+    dimension : int
+        Number of dimensions in the dictionary. Valid resolutions
+        available are {64, 128, 256, 512, 1024}.
+
+    resolution_mm : int
+        The resolution in mm of the atlas to fetch. Valid options
+        available are {2, 3}.
+
+    data_dir : string, optional
+        Path where data should be downloaded. By default,
+        files are downloaded in home directory.
+
+    Returns
+    -------
+    data: sklearn.datasets.base.Bunch
+        Dictionary-like object, the interest attributes are :
+
+        - 'maps': str, 4D path to nifti file containing regions definition.
+        - 'labels': string list containing the labels of the regions.
+
+    References
+    ----------
+    Dadi, K., Varoquaux, G., Machlouzarides-Shalit, A., Gorgolewski, KJ.,
+    Wassermann, D., Thirion, B., Mensch, A.
+    Fine-grain atlases of functional modes for fMRI analysis,
+    Paper in preparation
+    """
+    dic = {64: 'wjum7',
+           128: 'kdfg3',
+           256: 'vza2y',
+           512: 'a23gw',
+           1024: 'jpdum',
+           }
+    valid_dimensions = [64, 128, 256, 512, 1024]
+    valid_resolution_mm = [2, 3]
+    if dimension not in valid_dimensions:
+        raise ValueError("Requested dimension={} is not available. Valid "
+                         "options: {}".format(dimension, valid_dimensions))
+    if resolution_mm not in valid_resolution_mm:
+        raise ValueError("Requested resolution_mm={} is not available. Valid "
+                         "options: {}".format(resolution_mm,
+                                              valid_resolution_mm))
+    
+    url = 'https://osf.io/{}/download'.format(dic[dimension])
+    opts = {'uncompress': True}
+
+    csv_file = os.path.join('{0}', 'labels_{0}_dictionary.csv')
+    if resolution_mm != 3:
+        nifti_file = os.path.join('{0}', 'maps.nii.gz')
+    else:
+        nifti_file = os.path.join('{0}', '3mm', 'resampled_maps.nii.gz')
+
+    files = [(csv_file.format(dimension), url, opts),
+             (nifti_file.format(dimension), url, opts)]
+
+    dataset_name = 'difumo_atlases'
+
+    data_dir = _get_dataset_dir(dataset_name=dataset_name, data_dir=data_dir,
+                                verbose=verbose)
+
+    # Download the zip file, first
+    files_ = _fetch_files(data_dir, files, verbose=verbose)
+    labels = np.recfromcsv(files_[0])
+
+    # README
+    readme_files = [('README.md', 'https://osf.io/u5xhn/download',
+                    {'move': 'README.md'})]
+    if not os.path.exists(os.path.join(data_dir, 'README.md')):
+        _fetch_files(data_dir, readme_files, verbose=verbose)
+
+    # Python resampling script
+    script_files = [('resample_dictionaries.py', 'https://osf.io/ezr37/download',
+                    {'move': 'resample_dictionaries.py'})]
+    if not os.path.exists(os.path.join(data_dir, 'resample_dictionaries.py')):
+        _fetch_files(data_dir, script_files, verbose=verbose)
+
+    fdescr = _get_dataset_descr(dataset_name)
+
+    params = dict(description=fdescr, maps=files_[1], labels=labels)
+    
+    return Bunch(**params)
+
+
 def fetch_atlas_craddock_2012(data_dir=None, url=None, resume=True, verbose=1):
     """Download and return file names for the Craddock 2012 parcellation
 

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -20,7 +20,7 @@ from ..image import new_img_like, get_data
 _TALAIRACH_LEVELS = ['hemisphere', 'lobe', 'gyrus', 'tissue', 'ba']
 
 
-def fetch_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True, verbose=1):
+def fetch_atlas_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True, verbose=1):
     """Fetch DiFuMo brain atlas
 
      Dictionaries of Functional Modes, or “DiFuMo”, can serve as atlases to extract functional signals with different dimensionalities (64, 128, 256, 512, and 1024). These modes are optimized to represent well raw BOLD timeseries, over a with range of experimental conditions.

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -62,10 +62,10 @@ def fetch_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True, verb
 
     References
     ----------
-    Dadi, K., Varoquaux, G., Machlouzarides-Shalit, A., Gorgolewski, KJ.,
-    Wassermann, D., Thirion, B., Mensch, A.
-    Fine-grain atlases of functional modes for fMRI analysis,
-    Paper in preparation
+    Dadi, K., Varoquaux, G., Machlouzarides-Shalit,
+    A., Gorgolewski, KJ., Wassermann, D., Thirion, B., Mensch,
+    A. Fine-grain atlases of functional modes for fMRI analysis.
+    NeuroImage, Elsevier, 2020, pp.117126, https://hal.inria.fr/hal-02904869
     """
     dic = {64: 'wjum7',
            128: 'kdfg3',

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -23,7 +23,10 @@ _TALAIRACH_LEVELS = ['hemisphere', 'lobe', 'gyrus', 'tissue', 'ba']
 def fetch_atlas_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True, verbose=1):
     """Fetch DiFuMo brain atlas
 
-     Dictionaries of Functional Modes, or “DiFuMo”, can serve as atlases to extract functional signals with different dimensionalities (64, 128, 256, 512, and 1024). These modes are optimized to represent well raw BOLD timeseries, over a with range of experimental conditions.
+    Dictionaries of Functional Modes, or “DiFuMo”, can serve as atlases to extract
+    functional signals with different dimensionalities (64, 128, 256, 512, and 1024).
+    These modes are optimized to represent well raw BOLD timeseries,
+    over a with range of experimental conditions.
 
     Direct download links from OSF:
 

--- a/nilearn/datasets/description/difumo_atlases.rst
+++ b/nilearn/datasets/description/difumo_atlases.rst
@@ -1,0 +1,32 @@
+DiFuMo atlas
+
+
+Notes
+-----
+1. We provide Dictionaries of Functional Modes “DiFuMo” that can serve as atlases to extract functional signals, eg to serve as IDPs, with different dimensionalities (64, 128, 256, 512, and 1024). These modes are optimized to represent well raw BOLD timeseries, over a with range of experimental conditions.
+               
+    - All atlases are available in .nii.gz format and sampled to MNI space
+                     
+2. Additionally, we provide meaningful names for these modes, based on their anatomical location, to facilitate reporting of results.
+
+    - Anatomical names are available for each resolution in .csv
+
+Content
+-------
+    :'maps': Nifti images with the (probabilistic) region definitions
+    :'labels': CSV file specifying the label information
+
+
+References
+----------
+For more information about this dataset's structure:
+https://hal.inria.fr/hal-02904869
+
+Dadi, K., Varoquaux, G., Machlouzarides-Shalit, A., Gorgolewski, KJ., Wassermann, D., Thirion, B., Mensch, A. Fine-grain atlases of functional modes for fMRI analysis. NeuroImage, Elsevier, 2020, pp.117126 [Link to this paper](https://hal.inria.fr/hal-02904869)
+
+
+Mensch, A., Mairal, J., Thirion, B., Varoquaux, G., 2018. Stochastic Subsampling for Factorizing Huge Matrices. IEEE Transactions on Signal Processing 66, 113–128.
+
+Poldrack, R.A., Barch, D.M., Mitchell, J.P., et al., 2013. Toward open sharing of task-based fMRI data: the OpenfMRI project. Frontiers in neuroinformatics 7.
+
+Licence: usage is unrestricted for non-commercial research purposes.

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -395,10 +395,10 @@ def test_fetch_atlas_difumo(tmp_path, request_mocker):
         request_mocker.url_mapping[url] = dict_to_archive(archive, "zip")
 
         for res in resolutions:
-            dataset = atlas.fetch_difumo(data_dir=str(tmp_path),
-                                         dimension=dim,
-                                         resolution_mm=res,
-                                         verbose=0)
+            dataset = atlas.fetch_atlas_difumo(data_dir=str(tmp_path),
+                                               dimension=dim,
+                                               resolution_mm=res,
+                                               verbose=0)
             assert len(dataset.keys()) == 3
             assert len(dataset.labels) == dim
             assert isinstance(dataset.maps, str)
@@ -406,7 +406,7 @@ def test_fetch_atlas_difumo(tmp_path, request_mocker):
             assert dataset.description != ''
 
     with pytest.raises(ValueError):
-        atlas.fetch_difumo(data_dir=str(tmp_path), dimension=42, resolution_mm=3.14)
+        atlas.fetch_atlas_difumo(data_dir=str(tmp_path), dimension=42, resolution_mm=3.14)
 
 
 def test_fetch_atlas_aal(tmp_path, request_mocker):

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -372,7 +372,7 @@ def test_fetch_atlas_yeo_2011(tmp_path, request_mocker):
 def test_fetch_atlas_difumo(tmp_path, request_mocker):
     resolutions = [2, 3] # Valid resolution values
     dimensions = [64, 128, 256, 512, 1024] # Valid dimension values
-    dimension_urls =  ['wjum7','kdfg3','vza2y','a23gw','jpdum']
+    dimension_urls =  ['wjum7','n3vba','vza2y','a23gw','jpdum']
     url_mapping = {k:v for k,v in zip(dimensions, dimension_urls)}
     url_count = 2
 

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -406,7 +406,8 @@ def test_fetch_atlas_difumo(tmp_path, request_mocker):
             assert dataset.description != ''
 
     with pytest.raises(ValueError):
-        atlas.fetch_atlas_difumo(data_dir=str(tmp_path), dimension=42, resolution_mm=3.14)
+        atlas.fetch_atlas_difumo(data_dir=str(tmp_path), dimension=42, resolution_mm=3)
+        atlas.fetch_atlas_difumo(data_dir=str(tmp_path), dimension=128, resolution_mm=3.14)
 
 
 def test_fetch_atlas_aal(tmp_path, request_mocker):


### PR DESCRIPTION
Initialize work related to #2422 

**TODO:**

- [x] Include the fetchers written by @KamalakerDadi in [here](https://github.com/Parietal-INRIA/DiFuMo/blob/master/notebook/fetcher.py)
- [x] Add tests
- [x] Add examples

**Include fetchers**

So far, I've included the fetchers and they seem to work for all dimensions and resolutions except dimension 128:

```python
from nilearn.datasets import fetch_difumo
fetch_difumo(dimension=128, resolution_mm=2)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-1-ddc87112126d> in <module>
      1 from nilearn.datasets import fetch_difumo
----> 2 fetch_difumo(dimension=128, resolution_mm=2)

~/GitRepos/nilearn-fork/nilearn/datasets/atlas.py in fetch_difumo(dimension, resolution_mm, data_dir, resume, verbose)
     97     # Download the zip file, first
     98     files_ = _fetch_files(data_dir, files, verbose=verbose)
---> 99     labels = np.recfromcsv(files_[0])
    100 
    101     # README

~/anaconda3/envs/nilearn/lib/python3.8/site-packages/numpy/lib/npyio.py in recfromcsv(fname, **kwargs)
   2347     kwargs.setdefault("delimiter", ",")
   2348     kwargs.setdefault("dtype", None)
-> 2349     output = genfromtxt(fname, **kwargs)
   2350 
   2351     usemask = kwargs.get("usemask", False)

~/anaconda3/envs/nilearn/lib/python3.8/site-packages/numpy/lib/npyio.py in genfromtxt(fname, dtype, comments, delimiter, skip_header, skip_footer, converters, missing_values, filling_values, usecols, names, excludelist, deletechars, replace_space, autostrip, case_sensitive, defaultfmt, unpack, usemask, loose, invalid_raise, max_rows, encoding)
   2078             # Raise an exception ?
   2079             if invalid_raise:
-> 2080                 raise ValueError(errmsg)
   2081             # Issue a warning ?
   2082             else:

ValueError: Some errors were detected !
    Line #33 (got 8 columns instead of 7)
    Line #77 (got 8 columns instead of 7)
    Line #102 (got 8 columns instead of 7)
```

Which comes from the fact that the column `Difumo_names`  of file `labels_128_dictionary.csv` contains entries with commas at these 3 lines:

```
32,"Inferior frontal gyrus anterior, LH",ContA,ContA,0.663216265669077,0.21269976568239995,0.08504607031149909
76,"Precentral sulcus inferior, LH",DorsAttnB,ContA,0.6499540157338471,0.24122781732390355,0.08972095856109166
101,"Superior frontal sulcus anterior, LH",DefaultB,DefaultB,0.6423921902273227,0.1324176493370131,0.12367429757247757
```

@KamalakerDadi do you have the same issue when downloading the data?

**Add tests**

WIP...

**Add examples**

I also started working on an example inspired by this [notebook](https://github.com/Parietal-INRIA/DiFuMo/blob/master/notebook/demo.ipynb), which can be seen [here](https://gist.github.com/NicolasGensollen/632de5fac6b4ad5163eb272198bf6dd4). So far it is mostly trying the masking / demasking process for all possible dimension and resolution values. If someone has some ideas on what could be shown in the final example, that would help :+1: 