### PR TITLE
Fix label names in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Something not working as described? Missing/incorrect documentation? This is the place.
 title: ''
-labels: 'bug'
+labels: 'Bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Got an idea for a new feature, or changing an existing one? This is the place.
 title: ''
-labels: 'feature'
+labels: 'Enhancement'
 assignees: ''
 
 ---


### PR DESCRIPTION
Fix labelling in current issue templates as part of the todolist of #2629 :

- label `bug` was misspelled
- label `feature` doesn't exist