### PR TITLE
Make _get_safe_data consistent

### DIFF
--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -23,7 +23,7 @@ def _get_data(img):
     return data
 
 
-def _safe_get_data(img, ensure_finite=False):
+def _safe_get_data(img, ensure_finite=False, copy_data=False):
     """ Get the data in the image without having a side effect on the
         Nifti1Image object
 
@@ -36,15 +36,17 @@ def _safe_get_data(img, ensure_finite=False):
         If True, non-finite values such as (NaNs and infs) found in the
         image will be replaced by zeros.
 
+    copy_data: bool, default is False
+        If true, the returned data is a copy of the img data.
+
     Returns
     -------
     data: numpy array
         nilearn.image.get_data return from Nifti image.
     """
-    if hasattr(img, '_data_cache') and img._data_cache is None:
-        # By loading directly dataobj, we prevent caching if the data is
-        # memmaped. Preventing this side-effect can save memory in some cases.
+    if copy_data:
         img = copy.deepcopy(img)
+
     # typically the line below can double memory usage
     # that's why we invoke a forced call to the garbage collector
     gc.collect()
@@ -154,7 +156,7 @@ def copy_img(img):
 
     if not isinstance(img, nibabel.spatialimages.SpatialImage):
         raise ValueError("Input value is not an image")
-    return new_img_like(img, _safe_get_data(img).copy(), img.affine.copy(),
+    return new_img_like(img, _safe_get_data(img, copy_data=True), img.affine.copy(),
                         copy_header=True)
 
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -816,9 +816,7 @@ def threshold_img(img, threshold, mask_img=None, copy=True):
     from .. import masking
 
     img = check_niimg(img)
-    img_data = _safe_get_data(img, ensure_finite=True)
-    if copy:
-        img_data = img_data.copy()
+    img_data = _safe_get_data(img, ensure_finite=True, copy_data=copy)
     affine = img.affine
 
     if mask_img is not None:

--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -252,6 +252,7 @@ def find_cut_slices(img, direction='z', n_cuts=7, spacing='auto'):
         # affine and rotation.
         img = reorder_img(img, resample='nearest')
         affine = img.affine
+    # note: orig_data is a copy of img._data_cache thanks to np.abs
     orig_data = np.abs(_safe_get_data(img))
     this_shape = orig_data.shape[axis]
 

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -54,7 +54,8 @@ def _threshold_maps_ratio(maps_img, threshold):
     else:
         ratio = threshold
 
-    maps_data = _safe_get_data(maps, ensure_finite=True).copy()
+    # Get a copy of the data
+    maps_data = _safe_get_data(maps, ensure_finite=True, copy_data=True)
 
     abs_maps = np.abs(maps_data)
     # thresholding
@@ -182,7 +183,7 @@ def connected_regions(maps_img, min_region_size=1350,
     all_regions_imgs = []
     index_of_each_map = []
     maps_img = check_niimg(maps_img, atleast_4d=True)
-    maps = _safe_get_data(maps_img).copy()
+    maps = _safe_get_data(maps_img, copy_data=True)
     affine = maps_img.affine
     min_region_size = min_region_size / np.abs(np.linalg.det(affine[:3, :3]))
 


### PR DESCRIPTION
The function `_safe_get_data` makes a copy of the data in some particular case, see #956 
This is a possible solution that makes the data copying behaviour explicit.

Note: If the current behaviour is preferred, I can close both this PR and #956.