### PR TITLE
Add cbar_tick_format arg to plot_surf

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,6 +26,11 @@ Enhancements
 - :class:`nilearn.decoding.Decoder` and :class:`nilearn.decoding.DecoderRegressor`
   is now implemented with random predictions to estimate a chance level.
 
+- :func:`nilearn.plotting.plot_surf` and deriving functions like :func:`nilearn.plotting.plot_surf_roi`
+  now accept an optional argument `cbar_tick_format` to specify how numbers should be displayed on the
+  colorbar of surface plots. The default format is scientific notation except for :func:`nilearn.plotting.plot_surf_roi`
+  for which it is set as integers.
+
 .. _v0.7.0:
 
 0.7.0

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -138,6 +138,7 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
     nilearn.plotting.plot_surf_stat_map : for plotting statistical maps on
         brain surfaces.
     """
+    _default_figsize = [6, 4]
 
     # load mesh and derive axes limits
     mesh = load_surf_mesh(surf_mesh)
@@ -195,15 +196,20 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
         if isinstance(cmap, str):
             cmap = plt.cm.get_cmap(cmap)
 
+    figsize = _default_figsize
+    # Leave space for colorbar
+    if colorbar:
+        figsize[0] += .7
     # initiate figure and 3d axes
     if axes is None:
         if figure is None:
-            figure = plt.figure()
+            figure = plt.figure(figsize=figsize)
         axes = Axes3D(figure, rect=[0, 0, 1, 1],
                       xlim=limits, ylim=limits)
     else:
         if figure is None:
             figure = axes.get_figure()
+            figure.set_size_inches(*figsize)
         axes.set_xlim(*limits)
         axes.set_ylim(*limits)
     axes.view_init(elev=elev, azim=azim)
@@ -264,7 +270,7 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
         if vmax is None:
             vmax = np.nanmax(surf_map_faces)
 
-        # treshold if inidcated
+        # treshold if indicated
         if threshold is None:
             kept_indices = np.arange(surf_map_faces.shape[0])
         else:

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -284,10 +284,16 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
             our_cmap = get_cmap(cmap)
             norm = Normalize(vmin=vmin, vmax=vmax)
 
+            # Default number of ticks is 5...
             nb_ticks = 5
-            ticks = np.linspace(vmin, vmax, nb_ticks)
+            # ...unless we are dealing with integers with a small range
+            # in this case, we reduce the number of ticks
+            if cbar_tick_format == "%i" and vmax - vmin < nb_ticks:
+                ticks = np.arange(vmin, vmax + 1)
+                nb_ticks = len(ticks)
+            else:
+                ticks = np.linspace(vmin, vmax, nb_ticks)
             bounds = np.linspace(vmin, vmax, our_cmap.N)
-
             if threshold is not None:
                 cmaplist = [our_cmap(i) for i in range(our_cmap.N)]
                 # set colors to grey for absolute values < threshold

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -98,14 +98,15 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
         .5 indicates the background values are reduced by half before being
         applied.
 
-    vmin, vmax: lower / upper bound to plot surf_data values
+    vmin, vmax: float, float, lower / upper bound to plot surf_data values
         If None, the values will be set to min/max of the data
 
-    cbar_vmin, cbar_vmax: lower / upper bounds for the colorbar, optional.
+    cbar_vmin, cbar_vmax: float, float, lower / upper bounds for the colorbar, optional.
         If None, the values will be set from the data.
         Default values are None.
 
-    cbar_tick_format: str, optional, default is '%.2g' for scientific notation.
+    cbar_tick_format: str, optional,
+        Default is '%.2g' for scientific notation.
         Controls how to format the tick labels of the colorbar.
         Ex: use "%i" to display as integers.
 
@@ -832,8 +833,8 @@ def plot_img_on_surf(stat_map, surf_mesh='fsaverage5', mask_img=None,
 def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
                   hemi='left', view='lateral', threshold=1e-14,
                   alpha='auto', vmin=None, vmax=None, cmap='gist_ncar',
-                  bg_on_data=False, darkness=1, title=None,
-                  output_file=None, axes=None, figure=None, **kwargs):
+                  cbar_tick_format="%i", bg_on_data=False, darkness=1, 
+                  title=None, output_file=None, axes=None, figure=None, **kwargs):
     """ Plotting ROI on a surface mesh with optional background
 
     .. versionadded:: 0.3
@@ -875,6 +876,11 @@ def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
     cmap : matplotlib colormap str or colormap object, default 'gist_ncar'
         To use for plotting of the rois. Either a string which is a name
         of a matplotlib colormap, or a matplotlib colormap object.
+
+    cbar_tick_format: str, optional,
+        Default is '%i' for integers.
+        Controls how to format the tick labels of the colorbar.
+        Ex: use "%.2g" to display using scientific notation.
 
     alpha : float, default is 'auto'
         Alpha level of the mesh (not the stat_map). If default,
@@ -939,7 +945,8 @@ def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
 
     display = plot_surf(mesh, surf_map=roi, bg_map=bg_map,
                         hemi=hemi, view=view, avg_method='median',
-                        threshold=threshold, cmap=cmap, alpha=alpha,
+                        threshold=threshold, cmap=cmap, 
+                        cbar_tick_format=cbar_tick_format, alpha=alpha,
                         bg_on_data=bg_on_data, darkness=darkness,
                         vmin=vmin, vmax=vmax, title=title,
                         output_file=output_file, axes=axes,

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -30,7 +30,7 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
               hemi='left', view='lateral', cmap=None, colorbar=False,
               avg_method='mean', threshold=None, alpha='auto',
               bg_on_data=False, darkness=1, vmin=None, vmax=None,
-              cbar_vmin=None, cbar_vmax=None,
+              cbar_vmin=None, cbar_vmax=None, cbar_tick_format='%.2g',
               title=None, output_file=None, axes=None, figure=None, **kwargs):
     """ Plotting of surfaces with optional background and data
 
@@ -99,7 +99,15 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
         applied.
 
     vmin, vmax: lower / upper bound to plot surf_data values
-        If None , the values will be set to min/max of the data
+        If None, the values will be set to min/max of the data
+
+    cbar_vmin, cbar_vmax: lower / upper bounds for the colorbar, optional.
+        If None, the values will be set from the data.
+        Default values are None.
+
+    cbar_tick_format: str, optional, default is '%.2g' for scientific notation.
+        Controls how to format the tick labels of the colorbar.
+        Ex: use "%i" to display as integers.
 
     title : str, optional
         Figure title.
@@ -297,7 +305,7 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
             cbar = figure.colorbar(
                 proxy_mappable, cax=cax, ticks=ticks,
                 boundaries=bounds, spacing='proportional',
-                format='%.2g', orientation='vertical')
+                format=cbar_tick_format, orientation='vertical')
             _crop_colorbar(cbar, cbar_vmin, cbar_vmax)
 
         p3dcollec.set_facecolors(face_colors)

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -33,6 +33,8 @@ def test_plot_surf():
 
     # Plot with colorbar
     plot_surf(mesh, bg_map=bg, colorbar=True)
+    plot_surf(mesh, bg_map=bg, colorbar=True, cbar_vmin=0,
+              cbar_vmax=150, cbar_tick_format="%i")
 
     # Save execution time and memory
     plt.close()
@@ -95,6 +97,10 @@ def test_plot_surf_stat_map():
     plot_surf_stat_map(mesh, stat_map=data, bg_map=bg, colorbar=True,
                        bg_on_data=True, darkness=0.5,
                        threshold=0.3)
+
+    # Change colorbar tick format
+    plot_surf_stat_map(mesh, stat_map=data, bg_map=bg, colorbar=True,
+                       bg_on_data=True, darkness=0.5, cbar_tick_format="%.2g")
 
     # Change vmax
     plot_surf_stat_map(mesh, stat_map=data, vmax=5)
@@ -175,12 +181,21 @@ def test_plot_surf_roi():
     cbar = img.axes[-1]
     cbar_vmin = float(cbar.get_yticklabels()[0].get_text())
     cbar_vmax = float(cbar.get_yticklabels()[-1].get_text())
+    assert cbar_vmin == 1.0
+    assert cbar_vmax == 8.0
+    img2 = plot_surf_roi(mesh, roi_map=roi_map, vmin=1.2,
+                         vmax=8.9, colorbar=True, cbar_tick_format="%.2g")
+    img2.canvas.draw()
+    cbar = img2.axes[-1]
+    cbar_vmin = float(cbar.get_yticklabels()[0].get_text())
+    cbar_vmax = float(cbar.get_yticklabels()[-1].get_text())
     assert cbar_vmin == 1.2
     assert cbar_vmax == 8.9
 
     # plot parcellation
     plot_surf_roi(mesh, roi_map=parcellation)
     plot_surf_roi(mesh, roi_map=parcellation, colorbar=True)
+    plot_surf_roi(mesh, roi_map=parcellation, colorbar=True, cbar_tick_fomat="%f")
 
     # plot to axes
     plot_surf_roi(mesh, roi_map=roi_map, ax=None, figure=plt.gcf())


### PR DESCRIPTION
Fixes #2220 

Add a `cbar_tick_format` argument to the function `plot_surf` such that users can configure how colorbar tick labels are displayed. The default is in scientific notation.

**Example**

Plot colorbar tick labels as integers:

```python
import matplotlib.pyplot as plt
from matplotlib import ticker
from nilearn import plotting, datasets

destrieux_atlas = datasets.fetch_atlas_surf_destrieux()
parcellation = destrieux_atlas['map_left']
surface = datasets.fetch_surf_fsaverage()

plotting.plot_surf_roi(surface["pial_left"], roi_map = parcellation,
        hemi = 'left', view = 'lateral', bg_map = surface["sulc_left"],
        bg_on_data = True, darkness = 0.6,
        cmap = 'jet', colorbar = True, 
        vmin=1, vmax=210, cbar_tick_format="%i")
plt.show()
```
