### PR TITLE
drop Python 3.5 in release 0.8.0

### DIFF
--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -50,7 +50,7 @@ os.environ.setdefault("KMP_INIT_AT_FORK", "FALSE")
 
 def _py35_deprecation_warning():
     py35_warning = ('Python 3.5 support is deprecated and will be removed in '
-                    'a future release. Consider switching to Python 3.6 or 3.7'
+                    'the 0.8.0 release. Consider switching to Python 3.6 or 3.7'
                     )
     warnings.filterwarnings('once', message=py35_warning)
     warnings.warn(message=py35_warning,


### PR DESCRIPTION
Warn Python 3.5 users that we will drop support in release 0.8.0.