### PR TITLE
[ENH] Warn about cluster centers of mass outside of cluster

### DIFF
--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -47,19 +47,49 @@ def _local_max(data, affine, min_distance):
 
 
 def _identify_subpeaks(data):
+    """Identify cluster peak and subpeaks based on minimum distance.
+
+    Parameters
+    ----------
+    data : `numpy.ndarray`
+        3D array of with masked values for cluster.
+
+    Returns
+    -------
+    ijk : `numpy.ndarray`
+        (n_foci, 3) array of local maxima indices for cluster.
+    vals : `numpy.ndarray`
+        (n_foci,) array of values from data at ijk.
+    """
     # Initial identification of subpeaks with minimal minimum distance
     data_max = ndimage.filters.maximum_filter(data, 3)
-    maxima = (data == data_max)
+    maxima = data == data_max
     data_min = ndimage.filters.minimum_filter(data, 3)
-    diff = ((data_max - data_min) > 0)
+    diff = (data_max - data_min) > 0
     maxima[diff == 0] = 0
 
     labeled, n_subpeaks = ndimage.label(maxima)
     labels_index = range(1, n_subpeaks + 1)
     ijk = np.array(ndimage.center_of_mass(data, labeled, labels_index))
     ijk = np.round(ijk).astype(int)
-    vals = np.apply_along_axis(arr=ijk, axis=1, func1d=_get_val,
-                               input_arr=data)
+    vals = np.apply_along_axis(
+        arr=ijk, axis=1, func1d=_get_val, input_arr=data
+    )
+    # Determine if all subpeaks are within the cluster
+    # They may not be if the cluster is binary and has a shape where the COM is
+    # outside the cluster, like a donut.
+    cluster_idx = np.vstack(np.where(labeled)).T.tolist()
+    subpeaks_outside_cluster = [
+        i
+        for i, peak_idx in enumerate(ijk.tolist())
+        if peak_idx not in cluster_idx
+    ]
+    vals[subpeaks_outside_cluster] = np.nan
+    if subpeaks_outside_cluster:
+        warnings.warn(
+            "Attention: At least one of the (sub)peaks falls outside of the "
+            "cluster body."
+        )
     return ijk, vals
 
 

--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -60,6 +60,12 @@ def _identify_subpeaks(data):
         (n_foci, 3) array of local maxima indices for cluster.
     vals : `numpy.ndarray`
         (n_foci,) array of values from data at ijk.
+
+    Notes
+    -----
+    When a cluster's local maxima correspond to contiguous voxels with the
+    same values (as in a binary cluster), this function determines the center
+    of mass for those voxels.
     """
     # Initial identification of subpeaks with minimal minimum distance
     data_max = ndimage.filters.maximum_filter(data, 3)

--- a/nilearn/reporting/tests/test_reporting.py
+++ b/nilearn/reporting/tests/test_reporting.py
@@ -25,9 +25,10 @@ else:
 @pytest.mark.skipif(not have_mpl,
                     reason='Matplotlib not installed; required for this test')
 def test_local_max():
+    """Basic test of nilearn.reporting._get_clusters_table._local_max()"""
     shape = (9, 10, 11)
-    data = np.zeros(shape)
     # Two maxima (one global, one local), 10 voxels apart.
+    data = np.zeros(shape)
     data[4, 5, :] = [4, 3, 2, 1, 1, 1, 1, 1, 2, 3, 4]
     data[5, 5, :] = [5, 4, 3, 2, 1, 1, 1, 2, 3, 4, 6]
     data[6, 5, :] = [4, 3, 2, 1, 1, 1, 1, 1, 2, 3, 4]
@@ -40,6 +41,32 @@ def test_local_max():
     ijk, vals = _local_max(data, affine, min_distance=11)
     assert np.array_equal(ijk, np.array([[5., 5., 10.]]))
     assert np.array_equal(vals, np.array([6]))
+
+    # Two global (equal) maxima, 10 voxels apart.
+    data = np.zeros(shape)
+    data[4, 5, :] = [4, 3, 2, 1, 1, 1, 1, 1, 2, 3, 4]
+    data[5, 5, :] = [5, 4, 3, 2, 1, 1, 1, 2, 3, 4, 5]
+    data[6, 5, :] = [4, 3, 2, 1, 1, 1, 1, 1, 2, 3, 4]
+    affine = np.eye(4)
+
+    ijk, vals = _local_max(data, affine, min_distance=9)
+    assert np.array_equal(ijk, np.array([[5., 5., 0.], [5., 5., 10.]]))
+    assert np.array_equal(vals, np.array([5, 5]))
+
+    ijk, vals = _local_max(data, affine, min_distance=11)
+    assert np.array_equal(ijk, np.array([[5., 5., 0.]]))
+    assert np.array_equal(vals, np.array([5]))
+
+    # A donut.
+    data = np.zeros(shape)
+    data[4, 5, :] = [0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0]
+    data[5, 5, :] = [0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0]
+    data[6, 5, :] = [0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0]
+    affine = np.eye(4)
+
+    ijk, vals = _local_max(data, affine, min_distance=9)
+    assert np.array_equal(ijk, np.array([[5., 5., 5.]]))
+    assert np.all(np.isnan(vals))
 
 
 def test_get_clusters_table():


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #2647.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Warn about centers of mass outside of cluster in `nilearn.reporting._get_clusters_table._identify_subpeaks()` by checking if (sub)peaks fall within the cluster.
- Expand test of `nilearn.reporting._get_clusters_table._local_max()` to check for multiple maxima with the same value and binary cluster with center of mass outside of cluster.
