### PR TITLE
Allow array for node color in plot connectome

### DIFF
--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -1776,10 +1776,9 @@ class OrthoProjector(OrthoSlicer):
             edge_kwargs = {}
         if node_kwargs is None:
             node_kwargs = {}
-        if node_color == 'auto':
+        if isinstance(node_color, str) and node_color == 'auto':
             nb_nodes = len(node_coords)
             node_color = mpl_cm.Set2(np.linspace(0, 1, nb_nodes))
-
         node_coords = np.asarray(node_coords)
 
         # decompress input matrix if sparse
@@ -1814,6 +1813,13 @@ class OrthoProjector(OrthoSlicer):
                                                   node_coords_shape)
 
             raise ValueError(message)
+
+        if isinstance(node_color, (list, np.ndarray)) and len(node_color) != 1:
+            if len(node_color) != node_coords_shape[0]:
+                raise ValueError(
+                    "Mismatch between the number of nodes ({0}) "
+                    "and and the number of node colors ({1})."
+                    .format(node_coords_shape[0], len(node_color)))
 
         if node_coords_shape[0] != adjacency_matrix_shape[0]:
             raise ValueError(

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -478,6 +478,22 @@ def test_plot_connectome(tmpdir):
     plot_connectome(*args, **kwargs)
     plt.close()
 
+    # Unique node color
+    node_color = np.array(['red'])
+    kwargs = dict(edge_threshold=0.38,
+                  title='threshold=0.38',
+                  node_size=10, node_color=node_color)
+    plot_connectome(*args, **kwargs)
+    plt.close()
+
+    node_color = 'green'
+    kwargs = dict(edge_threshold=0.38,
+                  title='threshold=0.38',
+                  node_size=10)
+    plot_connectome(*args, node_color=node_color, **kwargs)
+    plt.close()
+
+
     # used to speed-up tests for the next plots
     kwargs['display_mode'] = 'x'
 
@@ -520,7 +536,8 @@ def test_plot_connectome(tmpdir):
     plt.close()
 
     # NaN matrix support
-    node_color = ['green', 'blue', 'k']
+    # Node colors specified as a numpy array rather than a list
+    node_color = np.array(['green', 'blue', 'k'])
     # Overriding 'node_color' for 3  elements of size 3.
     kwargs['node_color'] = node_color
     nan_adjacency_matrix = np.array([[1., np.nan, 0.],
@@ -577,6 +594,19 @@ def test_plot_connectome_exceptions():
                        match='should be either a number or a string'):
         plot_connectome(adjacency_matrix, node_coords,
                         edge_threshold=object(),
+                        **kwargs)
+
+    # wrong number of node colors
+    with pytest.raises(ValueError,
+                       match='Mismatch between the number of nodes'):
+        plot_connectome(adjacency_matrix, node_coords,
+                        node_color=['red', 'blue', 'yellow'],
+                        **kwargs)
+
+    with pytest.raises(ValueError,
+                       match='Mismatch between the number of nodes'):
+        plot_connectome(adjacency_matrix, node_coords,
+                        node_color=np.array(['red', 'blue', 'yellow', 'cyan']),
                         **kwargs)
 
     # wrong shapes for node_coords or adjacency_matrix


### PR DESCRIPTION
Fixes #2303 

- `node_color` specified as a numpy array (such that the element-wise comparison does not fail), resulted in an error (see #2303). This PR checks that `node_color` is a string before checking if it is equal to `auto`.
- Catch the mismatch between number of nodes and number of colors when the number of colors is larger than 1.
- Add some tests

