### PR TITLE
Fix find xyz cut coords function

### DIFF
--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -114,7 +114,9 @@ def find_xyz_cut_coords(img, mask_img=None, activation_threshold=None):
             "Could not determine cut coords: "
             "All values were masked. "
             "Returning center of mass of unmasked data instead.")
-        cut_coords = ndimage.center_of_mass(np.abs(data)) + offset
+        # Call center of mass on initial data since my_map is zero.
+        # Therefore, do not add offset to cut_coords.
+        cut_coords = ndimage.center_of_mass(np.abs(data))
         x_map, y_map, z_map = cut_coords
         return np.asarray(coord_transform(x_map, y_map, z_map,
                                           img.affine)).tolist()

--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -96,7 +96,9 @@ def find_xyz_cut_coords(img, mask_img=None, activation_threshold=None):
         # check against empty mask
         if mask.sum() == 0.:
             warnings.warn(
-                "Provided mask is empty. Returning center of mass instead.")
+                "Could not determine cut coords: "
+                "Provided mask is empty. "
+                "Returning center of mass instead.")
             cut_coords = ndimage.center_of_mass(np.abs(my_map)) + offset
             x_map, y_map, z_map = cut_coords
             return np.asarray(coord_transform(x_map, y_map, z_map,
@@ -106,10 +108,16 @@ def find_xyz_cut_coords(img, mask_img=None, activation_threshold=None):
         mask = mask[slice_x, slice_y, slice_z]
         my_map *= mask
         offset += [slice_x.start, slice_y.start, slice_z.start]
-
     # Testing min and max is faster than np.all(my_map == 0)
     if (my_map.max() == 0) and (my_map.min() == 0):
-        return .5 * np.array(data.shape)
+        warnings.warn(
+            "Could not determine cut coords: "
+            "All values were masked. "
+            "Returning center of mass of unmasked data instead.")
+        cut_coords = ndimage.center_of_mass(np.abs(data)) + offset
+        x_map, y_map, z_map = cut_coords
+        return np.asarray(coord_transform(x_map, y_map, z_map,
+                                          img.affine)).tolist()
     if activation_threshold is None:
         activation_threshold = fast_abs_percentile(my_map[my_map != 0].ravel(),
                                                    80)
@@ -122,7 +130,15 @@ def find_xyz_cut_coords(img, mask_img=None, activation_threshold=None):
     mask = np.abs(my_map) > (activation_threshold - eps)
     # mask may be zero everywhere in rare cases
     if mask.max() == 0:
-        return .5 * np.array(data.shape)
+        warnings.warn(
+            "Could not determine cut coords: "
+            "All voxels were masked by the thresholding. "
+            "Returning the center of mass instead.")
+        cut_coords = ndimage.center_of_mass(np.abs(my_map)) + offset
+        x_map, y_map, z_map = cut_coords
+        return np.asarray(coord_transform(x_map, y_map, z_map,
+                                          img.affine)).tolist()
+
     mask = largest_connected_component(mask)
     slice_x, slice_y, slice_z = ndimage.find_objects(mask)[0]
     my_map = my_map[slice_x, slice_y, slice_z]

--- a/nilearn/plotting/tests/test_find_cuts.py
+++ b/nilearn/plotting/tests/test_find_cuts.py
@@ -40,13 +40,22 @@ def test_find_cut_coords():
 
     # regression test (cf. #473)
     # test case: no data exceeds the activation threshold
+    # Cut coords should be the center of mass rather than
+    # the center of the image (10, 10, 10).
     data = np.ones((36, 43, 36))
     affine = np.eye(4)
     img = nibabel.Nifti1Image(data, affine)
     x, y, z = find_xyz_cut_coords(img, activation_threshold=1.1)
-    np.testing.assert_array_equal(
-        np.array([x, y, z]),
-        0.5 * np.array(data.shape).astype(np.float))
+    np.testing.assert_array_equal([x, y, z],
+                                  [17.5, 21., 17.5])
+
+    data = np.zeros((20, 20, 20))
+    data[4:6, 4:6, 4:6] = 1000
+    img = nibabel.Nifti1Image(data, np.eye(4))
+    mask_img = nibabel.Nifti1Image(np.ones((20, 20, 20), dtype=int), np.eye(4))
+    cut_coords = find_xyz_cut_coords(img, mask_img=mask_img)
+    np.testing.assert_array_equal(cut_coords,
+                                  [4.5, 4.5, 4.5])
 
     # regression test (cf. #922)
     # pseudo-4D images as input (i.e., X, Y, Z, 1)

--- a/nilearn/plotting/tests/test_find_cuts.py
+++ b/nilearn/plotting/tests/test_find_cuts.py
@@ -51,15 +51,16 @@ def test_find_cut_coords():
 
     data = np.zeros((20, 20, 20))
     data[4:6, 4:6, 4:6] = 1000
-    img = nibabel.Nifti1Image(data, np.eye(4))
+    img = nibabel.Nifti1Image(data, 2 * np.eye(4))
     mask_data = np.ones((20, 20, 20), dtype=int)
-    mask_img = nibabel.Nifti1Image(mask_data, np.eye(4))
+    mask_img = nibabel.Nifti1Image(mask_data, 2 * np.eye(4))
     cut_coords = find_xyz_cut_coords(img, mask_img=mask_img)
     np.testing.assert_array_equal(cut_coords,
-                                  [4.5, 4.5, 4.5])
+                                  [9., 9., 9.])
 
     # Check that a warning is given when all values are masked
     # and that the center of mass is returned
+    img = nibabel.Nifti1Image(data, np.eye(4))
     mask_data[np.argwhere(data == 1000)] = 0
     mask_img = nibabel.Nifti1Image(mask_data, np.eye(4))
     with pytest.warns(UserWarning,

--- a/nilearn/plotting/tests/test_find_cuts.py
+++ b/nilearn/plotting/tests/test_find_cuts.py
@@ -52,10 +52,36 @@ def test_find_cut_coords():
     data = np.zeros((20, 20, 20))
     data[4:6, 4:6, 4:6] = 1000
     img = nibabel.Nifti1Image(data, np.eye(4))
-    mask_img = nibabel.Nifti1Image(np.ones((20, 20, 20), dtype=int), np.eye(4))
+    mask_data = np.ones((20, 20, 20), dtype=int)
+    mask_img = nibabel.Nifti1Image(mask_data, np.eye(4))
     cut_coords = find_xyz_cut_coords(img, mask_img=mask_img)
     np.testing.assert_array_equal(cut_coords,
                                   [4.5, 4.5, 4.5])
+
+    # Check that a warning is given when all values are masked
+    # and that the center of mass is returned
+    mask_data[np.argwhere(data == 1000)] = 0
+    mask_img = nibabel.Nifti1Image(mask_data, np.eye(4))
+    with pytest.warns(UserWarning,
+                      match=("Could not determine cut coords: "
+                             "All values were masked.")):
+        cut_coords = find_xyz_cut_coords(img, mask_img=mask_img)
+    np.testing.assert_array_equal(cut_coords,
+                                  [4.5, 4.5, 4.5])
+
+    # Check that a warning is given when all values are masked
+    # due to thresholding and that the center of mass is returned
+    mask_data = np.ones((20, 20, 20), dtype=int)
+    mask_img = nibabel.Nifti1Image(mask_data, np.eye(4))
+    with pytest.warns(UserWarning,
+                      match=("Could not determine cut coords: "
+                             "All voxels were masked by the thresholding.")):
+        cut_coords = find_xyz_cut_coords(img,
+                                         mask_img=mask_img,
+                                         activation_threshold=10**3)
+    np.testing.assert_array_equal(cut_coords,
+                                  [4.5, 4.5, 4.5])
+
 
     # regression test (cf. #922)
     # pseudo-4D images as input (i.e., X, Y, Z, 1)


### PR DESCRIPTION
Fixes #1189 and #1190 

- The function `find_xyz_cut_coords` now always returns a list rather than numpy array or list
- The function `find_xyz_cut_coords` returns the center of mass when all values are masked due to thresholding rather than center of image which was not in real world coordinates.

**Example**

The following code

```python
import numpy as np
import nibabel as nib
from nilearn.plotting import plot_img
from nilearn.plotting import find_xyz_cut_coords
data = np.zeros((20, 20, 20))
data[4:6, 4:6, 4:6] = 1000
img = nib.Nifti1Image(data, np.eye(4))
mask_img = nib.Nifti1Image(np.ones((20, 20, 20), dtype=int), np.eye(4))
cut_coords = find_xyz_cut_coords(img, mask_img=mask_img)
print(cut_coords)
plot_img(img)
```

was producing this output:

![find_xyz_before](https://user-images.githubusercontent.com/2639645/104738647-15ccc280-5746-11eb-9bba-a7a6e5aa02d0.png)

and now produces:

![find_xyz_after](https://user-images.githubusercontent.com/2639645/104738671-1d8c6700-5746-11eb-9f75-0be713a38927.png)
