### PR TITLE
NF: Multiple scores in searchlight analysis

### DIFF
--- a/examples/02_decoding/plot_haxby_searchlight.py
+++ b/examples/02_decoding/plot_haxby_searchlight.py
@@ -106,7 +106,8 @@ from nilearn import image
 mean_fmri = image.mean_img(fmri_img)
 
 from nilearn.plotting import plot_stat_map, plot_img, show
-searchlight_img = new_img_like(mean_fmri, searchlight.scores_)
+scores = np.mean(searchlight.scores_, axis=-1)
+searchlight_img = new_img_like(mean_fmri, scores)
 
 # Because scores are not a zero-center test statistics, we cannot use
 # plot_stat_map

--- a/examples/02_decoding/plot_haxby_searchlight_surface.py
+++ b/examples/02_decoding/plot_haxby_searchlight_surface.py
@@ -13,6 +13,7 @@ searchlight decoding. NeuroImage 56, 582–592.
 # Load Haxby dataset
 # -------------------
 import pandas as pd
+import numpy as np
 from nilearn import datasets
 
 # We fetch 2nd subject from haxby datasets (which is default)
@@ -75,6 +76,7 @@ cv = KFold(n_splits=3, shuffle=False)
 
 # Cross-validated search light
 scores = search_light(X, y, estimator, adjacency, cv=cv, n_jobs=1)
+scores = np.mean(scores['test_score'], axis=-1)
 
 #########################################################################
 # Visualization

--- a/nilearn/decoding/tests/test_searchlight.py
+++ b/nilearn/decoding/tests/test_searchlight.py
@@ -37,8 +37,9 @@ def test_searchlight():
                                  radius=0.5, n_jobs=n_jobs,
                                  scoring='accuracy', cv=cv, verbose=1)
     sl.fit(data_img, cond)
-    assert np.where(sl.scores_ == 1)[0].size == 1
-    assert sl.scores_[2, 2, 2] == 1.
+    scores = np.mean(sl.scores_, axis=-1)
+    assert np.where(scores == 1)[0].size == 1
+    assert scores[2, 2, 2] == 1.
 
     # The voxel selected in process_mask_img is too far from the signal
     process_mask = np.zeros((5, 5, 5), np.bool)
@@ -49,27 +50,30 @@ def test_searchlight():
                                  radius=0.5, n_jobs=n_jobs,
                                  scoring='accuracy', cv=cv)
     sl.fit(data_img, cond)
-    assert np.where(sl.scores_ == 1)[0].size == 0
+    scores = np.mean(sl.scores_, axis=-1)
+    assert np.where(scores == 1)[0].size == 0
 
     # Medium radius : little ball selected
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img, radius=1,
                                  n_jobs=n_jobs, scoring='accuracy', cv=cv)
     sl.fit(data_img, cond)
-    assert np.where(sl.scores_ == 1)[0].size == 7
-    assert sl.scores_[2, 2, 2] == 1.
-    assert sl.scores_[1, 2, 2] == 1.
-    assert sl.scores_[2, 1, 2] == 1.
-    assert sl.scores_[2, 2, 1] == 1.
-    assert sl.scores_[3, 2, 2] == 1.
-    assert sl.scores_[2, 3, 2] == 1.
-    assert sl.scores_[2, 2, 3] == 1.
+    scores = np.mean(sl.scores_, axis=-1)
+    assert np.where(scores == 1)[0].size == 7
+    assert scores[2, 2, 2] == 1.
+    assert scores[1, 2, 2] == 1.
+    assert scores[2, 1, 2] == 1.
+    assert scores[2, 2, 1] == 1.
+    assert scores[3, 2, 2] == 1.
+    assert scores[2, 3, 2] == 1.
+    assert scores[2, 2, 3] == 1.
 
     # Big radius : big ball selected
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img, radius=2,
                                  n_jobs=n_jobs, scoring='accuracy', cv=cv)
     sl.fit(data_img, cond)
-    assert np.where(sl.scores_ == 1)[0].size == 33
-    assert sl.scores_[2, 2, 2] == 1.
+    scores = np.mean(sl.scores_, axis=-1)
+    assert np.where(scores == 1)[0].size == 33
+    assert scores[2, 2, 2] == 1.
 
     # group cross validation
     try:
@@ -87,15 +91,17 @@ def test_searchlight():
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img, radius=1,
                                  n_jobs=n_jobs, scoring='accuracy', cv=gcv)
     sl.fit(data_img, cond, groups)
-    assert np.where(sl.scores_ == 1)[0].size == 7
-    assert sl.scores_[2, 2, 2] == 1.
+    scores = np.mean(sl.scores_, axis=-1)
+    assert np.where(scores == 1)[0].size == 7
+    assert scores[2, 2, 2] == 1.
 
     # adding superfluous group variable
     sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img, radius=1,
                                  n_jobs=n_jobs, scoring='accuracy', cv=cv)
     sl.fit(data_img, cond, groups)
-    assert np.where(sl.scores_ == 1)[0].size == 7
-    assert sl.scores_[2, 2, 2] == 1.
+    scores = np.mean(sl.scores_, axis=-1)
+    assert np.where(scores == 1)[0].size == 7
+    assert scores[2, 2, 2] == 1.
 
     # Check whether searchlight works on list of 3D images
     rand = np.random.RandomState(0)
@@ -110,3 +116,44 @@ def test_searchlight():
     sl = searchlight.SearchLight(mask_img)
     sl.fit(imgs, y)
 
+
+def test_multiscore():
+    # Create a toy dataset to run searchlight on
+
+    # Initialize with 4x4x4 scans of random values on 30 frames
+    rand = np.random.RandomState(0)
+    frames = 30
+    data = rand.rand(5, 5, 5, frames)
+    mask = np.ones((5, 5, 5), np.bool)
+    mask_img = nibabel.Nifti1Image(mask.astype(np.int), np.eye(4))
+    # Create a condition array, with balanced classes
+    cond = np.arange(frames, dtype=int) >= (frames // 2)
+
+    # Create an activation pixel.
+    data[2, 2, 2, :] = 0
+    data[2, 2, 2][cond.astype(np.bool)] = 2
+    data_img = nibabel.Nifti1Image(data, np.eye(4))
+
+    from sklearn.model_selection import StratifiedKFold
+    cv = StratifiedKFold(n_splits=4)
+    n_jobs = 1
+
+    # Test with two metrics
+    scores = ['accuracy', 'roc_auc']
+    sl = searchlight.SearchLight(mask_img, process_mask_img=mask_img,
+                                 radius=0.5, n_jobs=n_jobs,
+                                 scoring=scores, cv=cv, 
+                                 verbose=1)
+    sl.fit(data_img, cond)
+
+    for score in scores:
+        key = 'test_{}'.format(score)
+        assert key in list(sl.scores_.keys())
+    
+    score_accuracy = np.mean(sl.scores_['test_accuracy'], axis=-1)
+    assert np.where(score_accuracy == 1)[0].size == 1
+    assert score_accuracy[2, 2, 2] == 1.
+
+    score_auc = np.mean(sl.scores_['test_roc_auc'], axis=-1)
+    assert np.where(score_auc == 1)[0].size == 1
+    assert score_auc[2, 2, 2] == 1.


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Solves #1632  .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- It allows to use multiple scoring in searchlight analyses.
- Now ```searchlight.scores_``` is a 4D image (or dict of floats) with the fourth dimension representing the cv-folds.
- Examples changed accordingly (no example has been produced for the multi-score feature)
- Added and modified tests.

Please check for the different outputs of ```search_light``` and ```SearchLight.fit```,  the first outputs always a dictionary (the output of ```cross_validate```) while ```fit``` checks whether we used multiple scores or not, if yes, the output (```sl.scores_```) is a dictionary, otherwise is an array (voxels x folds), as in the previous versions, but it's up to you how you think is the best!
