### PR TITLE
Override the decoder score method

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,6 +26,12 @@ Enhancements
 - :class:`nilearn.decoding.Decoder` and :class:`nilearn.decoding.DecoderRegressor`
   is now implemented with random predictions to estimate a chance level.
 
+- All classes inheriting from :class:`nilearn.decoding._BaseDecoder` now override
+  the `score` method to use whatever scoring strategy was defined through the
+  `scoring` attribute instead of the sklearn default. 
+  If the `scoring` attribute of the decoder is set to None, the scoring strategy
+  will default to accuracy for classifiers and to r2 score for regressors.
+
 - :func:`nilearn.plotting.plot_surf` and deriving functions like :func:`nilearn.plotting.plot_surf_roi`
   now accept an optional argument `cbar_tick_format` to specify how numbers should be displayed on the
   colorbar of surface plots. The default format is scientific notation except for :func:`nilearn.plotting.plot_surf_roi`

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,9 +26,10 @@ Enhancements
 - :class:`nilearn.decoding.Decoder` and :class:`nilearn.decoding.DecoderRegressor`
   is now implemented with random predictions to estimate a chance level.
 
-- All classes inheriting from :class:`nilearn.decoding._BaseDecoder` now override
-  the `score` method to use whatever scoring strategy was defined through the
-  `scoring` attribute instead of the sklearn default. 
+- :class:`nilearn.decoding.Decoder`, :class:`nilearn.decoding.DecoderRegressor`,
+  :class:`nilearn.decoding.FREMRegressor`, and :class:`nilearn.decoding.FREMClassifier`
+  now override the `score` method to use whatever scoring strategy was defined through
+  the `scoring` attribute instead of the sklearn default. 
   If the `scoring` attribute of the decoder is set to None, the scoring strategy
   will default to accuracy for classifiers and to r2 score for regressors.
 

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -39,7 +39,8 @@ from sklearn.metrics import (accuracy_score,
                              recall_score,
                              r2_score,
                              mean_absolute_error,
-                             mean_squared_error)
+                             mean_squared_error,
+                             make_scorer)
 
 from nilearn._utils import CacheMixin
 from nilearn._utils.cache_mixin import _check_memory
@@ -80,6 +81,7 @@ SCORING_METRICS = {"accuracy": accuracy_score,
                    "neg_mean_absolute_error": mean_absolute_error,
                    "neg_mean_squared_error": mean_squared_error,
                    }
+SCORING_METRICS = {k: make_scorer(v) for k,v in SCORING_METRICS.items()}
 
 def _check_param_grid(estimator, X, y, param_grid=None):
     """Check param_grid and return sensible default if param_grid is None.
@@ -640,8 +642,7 @@ class _BaseDecoder(LinearRegression, CacheMixin):
             raise ValueError("Unable to compute score. "
                              "No scoring metric was provided "
                              "to Decoder object.")
-        y_pred = self.predict(X)
-        return self._scoring_metric(y, y_pred, *args)
+        return self._scoring_metric(self, X, y, *args)
 
     def decision_function(self, X):
         """Predict class labels for samples in X.

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -251,9 +251,8 @@ def test_decoder_binary_classification():
     model = Decoder(estimator='dummy_classifier',
                     scoring=None)
     assert model.scoring is None
-    assert model.scorer is None
     model.fit(X, y)
-    assert model.scorer == get_scorer("accuracy")
+    assert model.scorer_ == get_scorer("accuracy")
     assert model.score(X, y) == 0.5
 
     # check different screening_percentile value

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -372,6 +372,14 @@ def test_decoder_regression():
     assert r2_score(y, y_pred) <= 0.
     assert model.score(X, y) == r2_score(y, y_pred)
 
+    # Check that default scoring metric for regression is r2
+    model = DecoderRegressor(estimator='dummy_regressor',
+                             mask=mask,
+                             scoring=None)
+    model.fit(X, y)
+    y_pred = model.predict(X)
+    assert model.score(X, y) == r2_score(y, y_pred)
+
     # decoder object use other strategy for dummy regressor
     param = dict(strategy='median')
     dummy_regressor.set_params(**param)

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -22,7 +22,7 @@ from nilearn.input_data import NiftiMasker
 from sklearn.datasets import load_iris, make_classification, make_regression
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression, RidgeClassifierCV, RidgeCV
-from sklearn.metrics import accuracy_score, r2_score, roc_auc_score, make_scorer
+from sklearn.metrics import accuracy_score, r2_score, roc_auc_score, get_scorer
 from sklearn.model_selection import KFold, LeaveOneGroupOut
 from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVR, LinearSVC
@@ -193,7 +193,7 @@ def test_decoder_binary_classification():
     assert accuracy_score(y, y_pred) == 0.5
 
     # Set scoring of decoder with a callable
-    accuracy_scorer = make_scorer(accuracy_score)
+    accuracy_scorer = get_scorer('accuracy')
     model = Decoder(estimator='dummy_classifier',
                     mask=mask,
                     scoring=accuracy_scorer)
@@ -240,20 +240,19 @@ def test_decoder_binary_classification():
     pytest.raises(NotImplementedError, model.fit, X, y)
 
     # Raises an error with unknown scoring metrics
-    with pytest.raises(ValueError, match="Unknown scoring metric"):
+    with pytest.raises(ValueError,
+                       match="'foo' is not a valid scoring value"):
         model = Decoder(estimator=dummy_classifier,
                         mask=mask,
                         scoring="foo")
 
-    # Raises an error when computing score without
-    # a defined scoring strategy
+    # Default scoring
     model = Decoder(estimator='dummy_classifier',
                     scoring=None)
     assert model.scoring is None
-    assert model._scoring_metric is None
+    assert model._scorer == get_scorer("accuracy")
     model.fit(X, y)
-    with pytest.raises(ValueError, match="Unable to compute score"):
-        model.score(X, y)
+    assert model.score(X, y) == 0.5
 
     # check different screening_percentile value
     for screening_percentile in [100, 20, None]:

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -240,18 +240,20 @@ def test_decoder_binary_classification():
     pytest.raises(NotImplementedError, model.fit, X, y)
 
     # Raises an error with unknown scoring metrics
+    model = Decoder(estimator=dummy_classifier,
+                    mask=mask,
+                    scoring="foo")
     with pytest.raises(ValueError,
                        match="'foo' is not a valid scoring value"):
-        model = Decoder(estimator=dummy_classifier,
-                        mask=mask,
-                        scoring="foo")
+        model.fit(X, y)
 
     # Default scoring
     model = Decoder(estimator='dummy_classifier',
                     scoring=None)
     assert model.scoring is None
-    assert model._scorer == get_scorer("accuracy")
+    assert model.scorer is None
     model.fit(X, y)
+    assert model.scorer == get_scorer("accuracy")
     assert model.score(X, y) == 0.5
 
     # check different screening_percentile value

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -22,7 +22,7 @@ from nilearn.input_data import NiftiMasker
 from sklearn.datasets import load_iris, make_classification, make_regression
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression, RidgeClassifierCV, RidgeCV
-from sklearn.metrics import accuracy_score, r2_score, roc_auc_score
+from sklearn.metrics import accuracy_score, r2_score, roc_auc_score, make_scorer
 from sklearn.model_selection import KFold, LeaveOneGroupOut
 from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVR, LinearSVC
@@ -191,6 +191,16 @@ def test_decoder_binary_classification():
     assert model.scoring == "roc_auc"
     assert model.score(X, y) == 0.5
     assert accuracy_score(y, y_pred) == 0.5
+
+    # Set scoring of decoder with a callable
+    accuracy_scorer = make_scorer(accuracy_score)
+    model = Decoder(estimator='dummy_classifier',
+                    mask=mask,
+                    scoring=accuracy_scorer)
+    model.fit(X, y)
+    y_pred = model.predict(X)
+    assert model.scoring == accuracy_scorer
+    assert model.score(X, y) == accuracy_score(y, y_pred)
 
     # An error should be raise when trying to compute
     # the score whithout having called fit first.


### PR DESCRIPTION
Fixes #2667 

This PR proposes to override the `score` method of the base decoder class such as to compute scores using the scoring strategy provided by the user when instantiating the decoder rather than a default method. 

The scoring strategy of the decoder is defined by

- `decoder.scoring` : Callable, or str, or `None`. Either the scoring method itself or its name as defined in the docstring. If set to `None`, `decoder.score(X, y)` will raise an error.
- `decoding._scoring_metric` : Callable. The scoring method.