### PR TITLE
[MRG] Glm duplicate events

### DIFF
--- a/nilearn/glm/first_level/experimental_paradigm.py
+++ b/nilearn/glm/first_level/experimental_paradigm.py
@@ -101,11 +101,11 @@ def check_events(events):
     #   - trial type
     #   - onset
     column_defining_event_identity = ['trial_type',
-                                      'onset']
+                                      'onset',
+                                      'duration',]
 
     # Duplicate handling strategy
-    strategy = {'duration': np.max,   # Keep the max duration of duplicate events
-                'modulation': np.sum, # Sum the modulation values of duplicate events
+    strategy = {'modulation': np.sum, # Sum the modulation values of duplicate events
                 }
 
     cleaned_events = events_copy.groupby(

--- a/nilearn/glm/first_level/experimental_paradigm.py
+++ b/nilearn/glm/first_level/experimental_paradigm.py
@@ -16,6 +16,8 @@ Author: Bertrand Thirion, 2015
 import warnings
 
 import numpy as np
+import pandas as pd
+from pandas.api.types import is_numeric_dtype
 
 VALID_FIELDS = set(["onset",
                     "duration",
@@ -51,27 +53,73 @@ def check_events(events):
         defaults to ones(n_events) when no duration is provided.
 
     """
-    if 'onset' not in events.keys():
-        raise ValueError('The provided events data has no onset column.')
-    if 'duration' not in events.keys():
-        raise ValueError('The provided events data has no duration column.')
+    # Check that events is a Pandas DataFrame
+    if not isinstance(events, pd.DataFrame):
+        raise TypeError("Events should be a Pandas DataFrame. "
+                        "A {} was provided instead.".format(
+                            type(events)))
+    # Column checks
+    for col_name in ['onset', 'duration']:
+        if col_name not in events.columns:
+            raise ValueError("The provided events data "
+                             "has no {} column.".format(
+                                 col_name))
 
-    onset = np.array(events['onset'])
-    duration = np.array(events['duration']).astype(np.float)
-    n_events = len(onset)
-    modulation = np.ones(n_events)
-    if 'trial_type' not in events.keys():
+    # Make a copy of the dataframe
+    events_copy = events.copy()
+
+    # Handle missing trial types
+    if 'trial_type' not in events_copy.columns:
         warnings.warn("'trial_type' column not found "
                       "in the given events data.")
-        trial_type = np.repeat('dummy', n_events)
+        events_copy['trial_type'] = 'dummy'
+
+    # Handle modulation
+    if 'modulation' in events_copy.columns:
+        warnings.warn("'modulation' column found in "
+                      "the given events data.")
     else:
-        trial_type = np.array(events['trial_type'])
-    if 'modulation' in events.keys():
-        warnings.warn("'modulation' column found in the given events data.")
-        modulation = np.array(events['modulation']).astype(np.float)
-    for event,_ in events.items():
-        if event not in VALID_FIELDS:
-            warnings.warn("Unexpected key `{}` in events "
-                          "will be ignored.".format(
-                              event))
+        events_copy['modulation'] = 1
+
+    # Warn for each unexpected column that will
+    # not be used afterwards
+    unexpected_columns = set(events_copy.columns).difference(VALID_FIELDS)
+    for unexpected_column in unexpected_columns:
+        warnings.warn("Unexpected column {} in events data.".format(
+            unexpected_column))
+
+    # Make sure we have a numeric type for duration
+    if not is_numeric_dtype(events_copy['duration']):
+        try:
+            events_copy = events_copy.astype({'duration': float})
+        except:
+            raise ValueError("Could not cast duration to float "
+                             " in events data.")
+
+    # Handle duplicate events
+    # Two events are duplicates if they have the same:
+    #   - trial type
+    #   - onset
+    column_defining_event_identity = ['trial_type',
+                                      'onset']
+
+    # Duplicate handling strategy
+    strategy = {'duration': np.max,   # Keep the max duration of duplicate events
+                'modulation': np.sum, # Sum the modulation values of duplicate events
+                }
+
+    cleaned_events = events_copy.groupby(
+                        column_defining_event_identity,
+                        sort=False).agg(strategy).reset_index()
+
+    # If there are duplicates, give a warning
+    if len(cleaned_events) != len(events_copy):
+        warnings.warn("Duplicated events were detected. "
+                      "You might want to verify your inputs.")
+
+    trial_type = cleaned_events['trial_type'].values
+    onset = cleaned_events['onset'].values
+    duration = cleaned_events['duration'].values
+    modulation = cleaned_events['modulation'].values
     return trial_type, onset, duration, modulation
+

--- a/nilearn/glm/first_level/experimental_paradigm.py
+++ b/nilearn/glm/first_level/experimental_paradigm.py
@@ -85,7 +85,7 @@ def check_events(events):
     # not be used afterwards
     unexpected_columns = set(events_copy.columns).difference(VALID_FIELDS)
     for unexpected_column in unexpected_columns:
-        warnings.warn("Unexpected column {} in events data.".format(
+        warnings.warn("Unexpected column `{}` in events data.".format(
             unexpected_column))
 
     # Make sure we have a numeric type for duration

--- a/nilearn/glm/first_level/experimental_paradigm.py
+++ b/nilearn/glm/first_level/experimental_paradigm.py
@@ -85,8 +85,9 @@ def check_events(events):
     # not be used afterwards
     unexpected_columns = set(events_copy.columns).difference(VALID_FIELDS)
     for unexpected_column in unexpected_columns:
-        warnings.warn("Unexpected column `{}` in events data.".format(
-            unexpected_column))
+        warnings.warn(("Unexpected column `{}` in events "
+                       "data will be ignored.").format(
+                            unexpected_column))
 
     # Make sure we have a numeric type for duration
     if not is_numeric_dtype(events_copy['duration']):
@@ -94,27 +95,28 @@ def check_events(events):
             events_copy = events_copy.astype({'duration': float})
         except:
             raise ValueError("Could not cast duration to float "
-                             " in events data.")
+                             "in events data.")
 
     # Handle duplicate events
     # Two events are duplicates if they have the same:
     #   - trial type
     #   - onset
-    column_defining_event_identity = ['trial_type',
+    COLUMN_DEFINING_EVENT_IDENTITY = ['trial_type',
                                       'onset',
                                       'duration',]
 
     # Duplicate handling strategy
-    strategy = {'modulation': np.sum, # Sum the modulation values of duplicate events
+    STRATEGY = {'modulation': np.sum, # Sum the modulation values of duplicate events
                 }
 
     cleaned_events = events_copy.groupby(
-                        column_defining_event_identity,
-                        sort=False).agg(strategy).reset_index()
+                        COLUMN_DEFINING_EVENT_IDENTITY,
+                        sort=False).agg(STRATEGY).reset_index()
 
     # If there are duplicates, give a warning
     if len(cleaned_events) != len(events_copy):
         warnings.warn("Duplicated events were detected. "
+                      "Amplitudes of these events will be summed. "
                       "You might want to verify your inputs.")
 
     trial_type = cleaned_events['trial_type'].values

--- a/nilearn/glm/tests/test_paradigm.py
+++ b/nilearn/glm/tests/test_paradigm.py
@@ -22,9 +22,10 @@ def basic_paradigm():
                            'duration': durations})
     return events
 
+
 def duplicate_events_paradigm():
-    conditions = ['c0', 'c0', 'c0', 'c1', 'c1', 'c0']
-    onsets = [10, 30, 70, 10, 30, 70]
+    conditions = ['c0', 'c0', 'c0', 'c0','c1', 'c1']
+    onsets = [10, 30, 70, 70, 10, 30]
     durations = [1., 1., 1., 1., 1., 1]
     events = pd.DataFrame({'trial_type': conditions,
                            'onset': onsets,
@@ -155,6 +156,7 @@ def test_duplicate_events():
     assert_array_equal(duration, [1. , 1. , 1., 1. , 1. ])
     # Modulation was updated
     assert_array_equal(modulation, [1, 1, 2, 1, 1])
+
 
 def test_read_events():
     """ test that a events for an experimental paradigm are correctly read.

--- a/nilearn/glm/tests/test_paradigm.py
+++ b/nilearn/glm/tests/test_paradigm.py
@@ -84,6 +84,10 @@ def test_check_events():
     """
     events = basic_paradigm()
     # Errors checkins
+    # Wrong type
+    with pytest.raises(TypeError,
+                       match="Events should be a Pandas DataFrame."):
+        check_events([])
     # Missing onset
     missing_onset = events.drop(columns=['onset'])
     with pytest.raises(ValueError,

--- a/nilearn/glm/tests/test_paradigm.py
+++ b/nilearn/glm/tests/test_paradigm.py
@@ -25,7 +25,7 @@ def basic_paradigm():
 def duplicate_events_paradigm():
     conditions = ['c0', 'c0', 'c0', 'c1', 'c1', 'c0']
     onsets = [10, 30, 70, 10, 30, 70]
-    durations = [1., 1., 1., 1., 1., 1.2]
+    durations = [1., 1., 1., 1., 1., 1]
     events = pd.DataFrame({'trial_type': conditions,
                            'onset': onsets,
                            'duration': durations})
@@ -152,8 +152,7 @@ def test_duplicate_events():
         ttype, onset, duration, modulation = check_events(events)
     assert_array_equal(ttype, ['c0', 'c0', 'c0', 'c1', 'c1'])
     assert_array_equal(onset, [10, 30, 70, 10, 30])
-    # Max duration was kept
-    assert_array_equal(duration, [1. , 1. , 1.2, 1. , 1. ])
+    assert_array_equal(duration, [1. , 1. , 1., 1. , 1. ])
     # Modulation was updated
     assert_array_equal(modulation, [1, 1, 2, 1, 1])
 

--- a/nilearn/glm/tests/test_paradigm.py
+++ b/nilearn/glm/tests/test_paradigm.py
@@ -17,7 +17,16 @@ def basic_paradigm():
     conditions = ['c0', 'c0', 'c0', 'c1', 'c1', 'c1', 'c2', 'c2', 'c2']
     onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
     durations = 1 * np.ones(9)
-    events = pd.DataFrame({'name': conditions,
+    events = pd.DataFrame({'trial_type': conditions,
+                           'onset': onsets,
+                           'duration': durations})
+    return events
+
+def duplicate_events_paradigm():
+    conditions = ['c0', 'c0', 'c0', 'c1', 'c1', 'c0']
+    onsets = [10, 30, 70, 10, 30, 70]
+    durations = [1., 1., 1., 1., 1., 1.2]
+    events = pd.DataFrame({'trial_type': conditions,
                            'onset': onsets,
                            'duration': durations})
     return events
@@ -29,7 +38,7 @@ def modulated_block_paradigm():
     onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
     durations = 5 + 5 * rng.uniform(size=len(onsets))
     values = rng.uniform(size=len(onsets))
-    events = pd.DataFrame({'name': conditions,
+    events = pd.DataFrame({'trial_type': conditions,
                            'onset': onsets,
                            'duration': durations,
                            'modulation': values})
@@ -42,7 +51,7 @@ def modulated_event_paradigm():
     onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
     durations = 1 * np.ones(9)
     values = rng.uniform(size=len(onsets))
-    events = pd.DataFrame({'name': conditions,
+    events = pd.DataFrame({'trial_type': conditions,
                            'onset': onsets,
                            'durations': durations,
                            'amplitude': values})
@@ -53,7 +62,7 @@ def block_paradigm():
     conditions = ['c0', 'c0', 'c0', 'c1', 'c1', 'c1', 'c2', 'c2', 'c2']
     onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
     durations = 5 * np.ones(9)
-    events = pd.DataFrame({'name': conditions,
+    events = pd.DataFrame({'trial_type': conditions,
                            'onset': onsets,
                            'duration': durations})
     return events
@@ -79,36 +88,74 @@ def test_check_events():
     with pytest.raises(ValueError,
                        match='The provided events data has no onset column.'):
         check_events(missing_onset)
+
     # Missing duration
     missing_duration = events.drop(columns=['duration'])
     with pytest.raises(ValueError,
                        match='The provided events data has no duration column.'):
         check_events(missing_duration)
+
+    # Duration wrong type
+    wrong_duration = events.copy()
+    wrong_duration['duration'] = 'foo'
+    with pytest.raises(ValueError,
+                       match="Could not cast duration to float"):
+        check_events(wrong_duration)
+
     # Warnings checkins
     # Missing trial type
+    missing_ttype = events.drop(columns=['trial_type'])
     with pytest.warns(UserWarning,
                       match="'trial_type' column not found"):
-        ttype, onset, duration, modulation = check_events(events)
+        ttype, onset, duration, modulation = check_events(missing_ttype)
+
     # Check that missing trial type yields a 'dummy' array
-    assert_array_equal(ttype, np.repeat('dummy', len(events)))
+    assert len(np.unique(ttype)) == 1
+    assert ttype[0] == 'dummy'
+
+    ttype, onset, duration, modulation = check_events(events)
+
+    # Check that given trial type is right
+    assert_array_equal(ttype,
+                       ['c0', 'c0', 'c0', 'c1', 'c1', 'c1', 'c2', 'c2', 'c2'])
+
     # Check that missing modulation yields an array one ones
     assert_array_equal(modulation, np.ones(len(events)))
+
     # Modulation is provided
     events['modulation'] = np.ones(len(events))
     with pytest.warns(UserWarning,
                       match="'modulation' column found in the given events data."):
         check_events(events)
+
     # An unexpected field is provided
     events = events.drop(columns=['modulation'])
     events['foo'] = np.zeros(len(events))
     with pytest.warns(UserWarning,
-                      match="Unexpected key `foo` in events will be ignored."):
+                      match="Unexpected column `foo` in events data."):
         ttype2, onset2, duration2, modulation2 = check_events(events)
     assert_array_equal(ttype, ttype2)
     assert_array_equal(onset, onset2)
     assert_array_equal(duration, duration2)
     assert_array_equal(modulation, modulation2)
 
+
+def test_duplicate_events():
+    """Test the function check_events when the paradigm contains
+    duplicate events.
+
+    """
+    events = duplicate_events_paradigm()
+    # Check that a warning is given to the user
+    with pytest.warns(UserWarning,
+                      match="Duplicated events were detected."):
+        ttype, onset, duration, modulation = check_events(events)
+    assert_array_equal(ttype, ['c0', 'c0', 'c0', 'c1', 'c1'])
+    assert_array_equal(onset, [10, 30, 70, 10, 30])
+    # Max duration was kept
+    assert_array_equal(duration, [1. , 1. , 1.2, 1. , 1. ])
+    # Modulation was updated
+    assert_array_equal(modulation, [1, 1, 2, 1, 1])
 
 def test_read_events():
     """ test that a events for an experimental paradigm are correctly read.


### PR DESCRIPTION
This PR addresses #2668 by:

- proposing a way to handle duplicate events, that is events with the same trial type and onset. These events are handled in the following way: their modulation is summed, the maximum duration is kept (assuming their are different), and a warning is given to the user that something might be wrong in the input data.
- updating the `check_events` function to rely more on pandas functionalities since a `DataFrame` is assumed as input
- update and add tests

Notes
- This is still WIP
- I'm not sure this is the best way to handle this weird case. I'm open to suggestions if someone has other ideas 