### PR TITLE
[MRG] Update surface functions

### DIFF
--- a/doc/modules/reference.rst
+++ b/doc/modules/reference.rst
@@ -536,17 +536,6 @@ the :ref:`user guide <user_guide>` for more information and usage examples.
 
 .. No relevant user manual section yet.
 
-**Classes**:
-
-.. currentmodule:: nilearn.surface
-
-.. autosummary::
-   :toctree: generated/
-   :template: class.rst
-
-   Surface
-   Mesh
-
 **Functions**:
 
 .. currentmodule:: nilearn.surface

--- a/doc/modules/reference.rst
+++ b/doc/modules/reference.rst
@@ -536,6 +536,17 @@ the :ref:`user guide <user_guide>` for more information and usage examples.
 
 .. No relevant user manual section yet.
 
+**Classes**:
+
+.. currentmodule:: nilearn.surface
+
+.. autosummary::
+   :toctree: generated/
+   :template: class.rst
+
+   Surface
+   Mesh
+
 **Functions**:
 
 .. currentmodule:: nilearn.surface
@@ -546,4 +557,7 @@ the :ref:`user guide <user_guide>` for more information and usage examples.
 
    load_surf_data
    load_surf_mesh
+   load_surface
    vol_to_surf
+   check_surface
+   check_mesh_and_data

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -14,6 +14,9 @@ NEW
   MNI152 template.
 - :func:`nilearn.datasets.load_mni152_wm_mask` loads mask from the white-matter
   MNI152 template.
+- Meshes and Surfaces are now represented by dedicated objects.
+- :func:`nilearn.surface.load_surface` was added to instanciate a surface object from a mesh
+  and texture data.
 
 Fixes
 -----
@@ -52,6 +55,8 @@ Enhancements
   parameters or common lists of options for example. The standard parts are defined
   in a single location (`nilearn._utils.docs.py`) which makes them easier to
   maintain and update. (See `#2875 <https://github.com/nilearn/nilearn/pull/2875>`_).
+- :func:`nilearn.plotting.plot_surf` and deriving functions like :func:`nilearn.plotting.plot_surf_roi` now take a unique Surface object instead of separate mesh and data. Previous usage with separate mesh and data is now deprecated and will be removed in release 0.9.
+- :func:`nilearn.surface.vol_to_surf` return value will change from a texture array to a Surface object in release 0.9. Using this function currently gives a deprecation message.
 
 Changes
 -------
@@ -109,9 +114,6 @@ NEW
   the provided label image and provide summary statistics on each region (name, volume...).
   If a functional image was provided to fit, the middle image is plotted with the regions
   overlaid as contours. Finally, if a mask is provided, its contours are shown in green.
-- Meshes and Surfaces are now represented by dedicated objects.
-- :func:`nilearn.surface.load_surface` was added to instanciate a surface object from a mesh
-  and texture data.
 
 Fixes
 -----
@@ -169,8 +171,6 @@ Enhancements
 - Fetcher :func:`nilearn.datasets.fetch_surf_fsaverage` now provides
   attributes `{area, curv, sphere, thick}_{left, right}` for all fsaverage
   resolutions.
-- :func:`nilearn.plotting.plot_surf` and deriving functions like :func:`nilearn.plotting.plot_surf_roi` now take a unique Surface object instead of separate mesh and data. Previous usage with separate mesh and data is now deprecated and will be removed in release 0.9.
-- :func:`nilearn.surface.vol_to_surf` return value will change from a texture array to a Surface object in release 0.9. Using this function currently gives a deprecation message.
 
 Changes
 -------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -109,6 +109,9 @@ NEW
   the provided label image and provide summary statistics on each region (name, volume...).
   If a functional image was provided to fit, the middle image is plotted with the regions
   overlaid as contours. Finally, if a mask is provided, its contours are shown in green.
+- Meshes and Surfaces are now represented by dedicated objects.
+- :func:`nilearn.surface.load_surface` was added to instanciate a surface object from a mesh
+  and texture data.
 
 Fixes
 -----
@@ -233,11 +236,6 @@ NEW
   stability of p-value estimation. It computes 1 - p-value using the Cumulative
   Distribution Function in the same way as `nilearn.glm.Contrast.p_value`
   computes the p-value using the Survival Function.
-
-- Meshes and Surfaces are now represented by dedicated objects.
-
-- :func:`nilearn.surface.load_surface` was added to instanciate a surface object from a mesh
-  and texture data.
 
 Fixes
 -----

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -166,6 +166,8 @@ Enhancements
 - Fetcher :func:`nilearn.datasets.fetch_surf_fsaverage` now provides
   attributes `{area, curv, sphere, thick}_{left, right}` for all fsaverage
   resolutions.
+- :func:`nilearn.plotting.plot_surf` and deriving functions like :func:`nilearn.plotting.plot_surf_roi` now take a unique Surface object instead of separate mesh and data. Previous usage with separate mesh and data is now deprecated and will be removed in release 0.9.
+- :func:`nilearn.surface.vol_to_surf` return value will change from a texture array to a Surface object in release 0.9. Using this function currently gives a deprecation message.
 
 Changes
 -------
@@ -231,6 +233,11 @@ NEW
   stability of p-value estimation. It computes 1 - p-value using the Cumulative
   Distribution Function in the same way as `nilearn.glm.Contrast.p_value`
   computes the p-value using the Survival Function.
+
+- Meshes and Surfaces are now represented by dedicated objects.
+
+- :func:`nilearn.surface.load_surface` was added to instanciate a surface object from a mesh
+  and texture data.
 
 Fixes
 -----

--- a/examples/01_plotting/plot_3d_map_to_surface_projection.py
+++ b/examples/01_plotting/plot_3d_map_to_surface_projection.py
@@ -29,9 +29,11 @@ fsaverage = datasets.fetch_surf_fsaverage()
 # Sample the 3D data around each node of the mesh
 # -----------------------------------------------
 
-from nilearn import surface
+from nilearn.surface import vol_to_surf, Surface
 
-texture = surface.vol_to_surf(stat_img, fsaverage.pial_right)
+texture = vol_to_surf(stat_img, fsaverage.pial_right)
+# Define a Surface object with mesh and texture
+surf = Surface(fsaverage.infl_right, texture)
 
 ##############################################################################
 # Plot the result
@@ -39,9 +41,8 @@ texture = surface.vol_to_surf(stat_img, fsaverage.pial_right)
 
 from nilearn import plotting
 
-plotting.plot_surf_stat_map(fsaverage.infl_right, texture, hemi='right',
-                            title='Surface right hemisphere', colorbar=True,
-                            threshold=1., bg_map=fsaverage.sulc_right)
+plotting.plot_surf_stat_map(surf, hemi='right', title='Surface right hemisphere',
+                            colorbar=True, threshold=1., bg_map=fsaverage.sulc_right)
 
 ##############################################################################
 # Plot 3D image for comparison
@@ -61,6 +62,7 @@ import numpy as np
 
 destrieux_atlas = datasets.fetch_atlas_surf_destrieux()
 parcellation = destrieux_atlas['map_right']
+surf_parcellation = Surface(fsaverage.infl_right, parcellation)
 
 # these are the regions we want to outline
 regions_dict = {b'G_postcentral': 'Postcentral gyrus',
@@ -76,14 +78,11 @@ labels = list(regions_dict.values())
 # Display outlines of the regions of interest on top of a statistical map
 # -----------------------------------------------------------------------
 
-figure = plotting.plot_surf_stat_map(fsaverage.infl_right, texture, hemi='right',
-                                     title='Surface right hemisphere',
-                                     colorbar=True, threshold=1.,
-                                     bg_map=fsaverage.sulc_right)
+figure = plotting.plot_surf_stat_map(surf, hemi='right', title='Surface right hemisphere',
+                                     colorbar=True, threshold=1., bg_map=fsaverage.sulc_right)
 
-plotting.plot_surf_contours(fsaverage.infl_right, parcellation, labels=labels,
-                            levels=regions_indices, figure=figure, legend=True,
-                            colors=['g', 'k'])
+plotting.plot_surf_contours(surf_parcellation, labels=labels, levels=regions_indices,
+                            figure=figure, legend=True, colors=['g', 'k'])
 plotting.show()
 
 ##############################################################################
@@ -96,10 +95,10 @@ plotting.show()
 # computation time, but finer visualizations.
 
 big_fsaverage = datasets.fetch_surf_fsaverage('fsaverage')
-big_texture = surface.vol_to_surf(stat_img, big_fsaverage.pial_right)
+big_texture = vol_to_surf(stat_img, big_fsaverage.pial_right)
+big_surf = Surface(big_fsaverage.infl_right, big_texture)
 
-plotting.plot_surf_stat_map(big_fsaverage.infl_right,
-                            big_texture, hemi='right', colorbar=True,
+plotting.plot_surf_stat_map(big_surf, hemi='right', colorbar=True,
                             title='Surface right hemisphere: fine mesh',
                             threshold=1., bg_map=big_fsaverage.sulc_right)
 

--- a/examples/01_plotting/plot_3d_map_to_surface_projection.py
+++ b/examples/01_plotting/plot_3d_map_to_surface_projection.py
@@ -41,12 +41,17 @@ surf = load_surface((fsaverage.infl_right, texture))
 
 from nilearn import plotting
 
+# Define a background surface
+# using sulcal depth
+background = load_surface((fsaverage.infl_right,
+                           fsaverage.sulc_right))
+
 plotting.plot_surf_stat_map(surf,
                             hemi='right',
                             title='Surface right hemisphere',
                             colorbar=True,
                             threshold=1.,
-                            bg_map=fsaverage.sulc_right)
+                            bg_surf=background)
 
 ##############################################################################
 # Plot 3D image for comparison
@@ -94,7 +99,7 @@ figure = plotting.plot_surf_stat_map(surf,
                                      title='Surface right hemisphere',
                                      colorbar=True,
                                      threshold=1.,
-                                     bg_map=fsaverage.sulc_right)
+                                     bg_surf=background)
 
 plotting.plot_surf_contours(surf_parcellation,
                             labels=labels,
@@ -117,13 +122,15 @@ big_fsaverage = datasets.fetch_surf_fsaverage('fsaverage')
 big_texture = vol_to_surf(stat_img, big_fsaverage.pial_right)
 big_surf = load_surface((big_fsaverage.infl_right,
                          big_texture))
+big_background = load_surface((big_fsaverage.infl_right,
+                               big_fsaverage.sulc_right))
 
 plotting.plot_surf_stat_map(big_surf,
                             hemi='right',
                             colorbar=True,
                             title='Surface right hemisphere: fine mesh',
                             threshold=1.,
-                            bg_map=big_fsaverage.sulc_right)
+                            bg_surf=big_background)
 
 
 ##############################################################################
@@ -154,7 +161,7 @@ plotting.show()
 view = plotting.view_surf(fsaverage.infl_right,
                           texture,
                           threshold='90%',
-                          bg_map=fsaverage.sulc_right)
+                          bg_surf=background)
 
 # In a Jupyter notebook, if ``view`` is the output of a cell, it will
 # be displayed below the cell

--- a/examples/01_plotting/plot_3d_map_to_surface_projection.py
+++ b/examples/01_plotting/plot_3d_map_to_surface_projection.py
@@ -29,11 +29,11 @@ fsaverage = datasets.fetch_surf_fsaverage()
 # Sample the 3D data around each node of the mesh
 # -----------------------------------------------
 
-from nilearn.surface import vol_to_surf, Surface
+from nilearn.surface import vol_to_surf, load_surface
 
 texture = vol_to_surf(stat_img, fsaverage.pial_right)
 # Define a Surface object with mesh and texture
-surf = Surface(fsaverage.infl_right, texture)
+surf = load_surface((fsaverage.infl_right, texture))
 
 ##############################################################################
 # Plot the result
@@ -62,7 +62,8 @@ import numpy as np
 
 destrieux_atlas = datasets.fetch_atlas_surf_destrieux()
 parcellation = destrieux_atlas['map_right']
-surf_parcellation = Surface(fsaverage.infl_right, parcellation)
+surf_parcellation = load_surface((fsaverage.infl_right,
+                                  parcellation))
 
 # these are the regions we want to outline
 regions_dict = {b'G_postcentral': 'Postcentral gyrus',
@@ -96,7 +97,8 @@ plotting.show()
 
 big_fsaverage = datasets.fetch_surf_fsaverage('fsaverage')
 big_texture = vol_to_surf(stat_img, big_fsaverage.pial_right)
-big_surf = Surface(big_fsaverage.infl_right, big_texture)
+big_surf = load_surface((big_fsaverage.infl_right,
+                         big_texture))
 
 plotting.plot_surf_stat_map(big_surf, hemi='right', colorbar=True,
                             title='Surface right hemisphere: fine mesh',

--- a/examples/01_plotting/plot_3d_map_to_surface_projection.py
+++ b/examples/01_plotting/plot_3d_map_to_surface_projection.py
@@ -41,18 +41,28 @@ surf = load_surface((fsaverage.infl_right, texture))
 
 from nilearn import plotting
 
-plotting.plot_surf_stat_map(surf, hemi='right', title='Surface right hemisphere',
-                            colorbar=True, threshold=1., bg_map=fsaverage.sulc_right)
+plotting.plot_surf_stat_map(surf,
+                            hemi='right',
+                            title='Surface right hemisphere',
+                            colorbar=True,
+                            threshold=1.,
+                            bg_map=fsaverage.sulc_right)
 
 ##############################################################################
 # Plot 3D image for comparison
 # ----------------------------
 
-plotting.plot_glass_brain(stat_img, display_mode='r', plot_abs=False,
-                          title='Glass brain', threshold=2.)
+plotting.plot_glass_brain(stat_img,
+                          display_mode='r',
+                          plot_abs=False,
+                          title='Glass brain',
+                          threshold=2.)
 
-plotting.plot_stat_map(stat_img, display_mode='x', threshold=1.,
-                       cut_coords=range(0, 51, 10), title='Slices')
+plotting.plot_stat_map(stat_img,
+                       display_mode='x',
+                       threshold=1.,
+                       cut_coords=range(0, 51, 10),
+                       title='Slices')
 
 ##############################################################################
 # Use an atlas and choose regions to outline
@@ -79,11 +89,19 @@ labels = list(regions_dict.values())
 # Display outlines of the regions of interest on top of a statistical map
 # -----------------------------------------------------------------------
 
-figure = plotting.plot_surf_stat_map(surf, hemi='right', title='Surface right hemisphere',
-                                     colorbar=True, threshold=1., bg_map=fsaverage.sulc_right)
+figure = plotting.plot_surf_stat_map(surf,
+                                     hemi='right',
+                                     title='Surface right hemisphere',
+                                     colorbar=True,
+                                     threshold=1.,
+                                     bg_map=fsaverage.sulc_right)
 
-plotting.plot_surf_contours(surf_parcellation, labels=labels, levels=regions_indices,
-                            figure=figure, legend=True, colors=['g', 'k'])
+plotting.plot_surf_contours(surf_parcellation,
+                            labels=labels,
+                            levels=regions_indices,
+                            figure=figure,
+                            legend=True,
+                            colors=['g', 'k'])
 plotting.show()
 
 ##############################################################################
@@ -100,9 +118,12 @@ big_texture = vol_to_surf(stat_img, big_fsaverage.pial_right)
 big_surf = load_surface((big_fsaverage.infl_right,
                          big_texture))
 
-plotting.plot_surf_stat_map(big_surf, hemi='right', colorbar=True,
+plotting.plot_surf_stat_map(big_surf,
+                            hemi='right',
+                            colorbar=True,
                             title='Surface right hemisphere: fine mesh',
-                            threshold=1., bg_map=big_fsaverage.sulc_right)
+                            threshold=1.,
+                            bg_map=big_fsaverage.sulc_right)
 
 
 ##############################################################################
@@ -130,7 +151,9 @@ plotting.show()
 # visualizations in a web browser. See :ref:`interactive-surface-plotting` for
 # more details.
 
-view = plotting.view_surf(fsaverage.infl_right, texture, threshold='90%',
+view = plotting.view_surf(fsaverage.infl_right,
+                          texture,
+                          threshold='90%',
                           bg_map=fsaverage.sulc_right)
 
 # In a Jupyter notebook, if ``view`` is the output of a cell, it will

--- a/examples/01_plotting/plot_surf_atlas.py
+++ b/examples/01_plotting/plot_surf_atlas.py
@@ -48,10 +48,11 @@ print('Fsaverage5 sulcal depth map of left hemisphere is at: %s' %
 # -------------
 
 # Display Destrieux parcellation on fsaverage5 pial surface using nilearn
-from nilearn.surface import Surface
+from nilearn.surface import load_surface
 from nilearn import plotting
 
-surf_pial_left = Surface(fsaverage.pial_left, parcellation)
+surf_pial_left = load_surface((fsaverage.pial_left,
+                               parcellation))
 
 plotting.plot_surf_roi(surf_pial_left, hemi='left', view='lateral',
                        bg_map=fsaverage['sulc_left'], bg_on_data=True,
@@ -59,7 +60,8 @@ plotting.plot_surf_roi(surf_pial_left, hemi='left', view='lateral',
 
 ###############################################################################
 # Display Destrieux parcellation on inflated fsaverage5 surface
-surf_infl_left = Surface(fsaverage.infl_left, parcellation)
+surf_infl_left = load_surface((fsaverage.infl_left,
+                               parcellation))
 
 plotting.plot_surf_roi(surf_infl_left, hemi='left', view='lateral',
                        bg_map=fsaverage['sulc_left'], bg_on_data=True,

--- a/examples/01_plotting/plot_surf_atlas.py
+++ b/examples/01_plotting/plot_surf_atlas.py
@@ -125,7 +125,9 @@ plotting.show()
 # visualizations in a web browser. See :ref:`interactive-surface-plotting` for
 # more details.
 
-view = plotting.view_surf(surf_infl_left, cmap='gist_ncar', symmetric_cmap=False)
+view = plotting.view_surf(surf_infl_left,
+                          cmap='gist_ncar',
+                          symmetric_cmap=False)
 # In a Jupyter notebook, if ``view`` is the output of a cell, it will
 # be displayed below the cell
 

--- a/examples/01_plotting/plot_surf_atlas.py
+++ b/examples/01_plotting/plot_surf_atlas.py
@@ -54,8 +54,15 @@ from nilearn import plotting
 surf_pial_left = load_surface((fsaverage.pial_left,
                                parcellation))
 
-plotting.plot_surf_roi(surf_pial_left, hemi='left', view='lateral',
-                       bg_map=fsaverage['sulc_left'], bg_on_data=True,
+# Define a background surface
+background = load_surface((fsaverage.pial_left,
+                           fsaverage.sulc_left))
+
+plotting.plot_surf_roi(surf_pial_left,
+                       hemi='left',
+                       view='lateral',
+                       bg_surf=background,
+                       bg_on_data=True,
                        darkness=.5)
 
 ###############################################################################
@@ -63,20 +70,23 @@ plotting.plot_surf_roi(surf_pial_left, hemi='left', view='lateral',
 surf_infl_left = load_surface((fsaverage.infl_left,
                                parcellation))
 
-plotting.plot_surf_roi(surf_infl_left, hemi='left', view='lateral',
-                       bg_map=fsaverage['sulc_left'], bg_on_data=True,
+plotting.plot_surf_roi(surf_infl_left,
+                       hemi='left',
+                       view='lateral',
+                       bg_surf=background,
+                       bg_on_data=True,
                        darkness=.5)
 
 ###############################################################################
 # Display Destrieux parcellation with different views: posterior
 plotting.plot_surf_roi(surf_infl_left, hemi='left', view='posterior',
-                       bg_map=fsaverage['sulc_left'], bg_on_data=True,
+                       bg_surf=background, bg_on_data=True,
                        darkness=.5)
 
 ###############################################################################
 # Display Destrieux parcellation with different views: ventral
 plotting.plot_surf_roi(surf_infl_left, hemi='left', view='ventral',
-                       bg_map=fsaverage['sulc_left'], bg_on_data=True,
+                       bg_surf=background, bg_on_data=True,
                        darkness=.5)
 plotting.show()
 

--- a/examples/01_plotting/plot_surf_atlas.py
+++ b/examples/01_plotting/plot_surf_atlas.py
@@ -48,31 +48,32 @@ print('Fsaverage5 sulcal depth map of left hemisphere is at: %s' %
 # -------------
 
 # Display Destrieux parcellation on fsaverage5 pial surface using nilearn
+from nilearn.surface import Surface
 from nilearn import plotting
 
-plotting.plot_surf_roi(fsaverage['pial_left'], roi_map=parcellation,
-                       hemi='left', view='lateral',
+surf_pial_left = Surface(fsaverage.pial_left, parcellation)
+
+plotting.plot_surf_roi(surf_pial_left, hemi='left', view='lateral',
                        bg_map=fsaverage['sulc_left'], bg_on_data=True,
                        darkness=.5)
 
 ###############################################################################
 # Display Destrieux parcellation on inflated fsaverage5 surface
-plotting.plot_surf_roi(fsaverage['infl_left'], roi_map=parcellation,
-                       hemi='left', view='lateral',
+surf_infl_left = Surface(fsaverage.infl_left, parcellation)
+
+plotting.plot_surf_roi(surf_infl_left, hemi='left', view='lateral',
                        bg_map=fsaverage['sulc_left'], bg_on_data=True,
                        darkness=.5)
 
 ###############################################################################
 # Display Destrieux parcellation with different views: posterior
-plotting.plot_surf_roi(fsaverage['infl_left'], roi_map=parcellation,
-                       hemi='left', view='posterior',
+plotting.plot_surf_roi(surf_infl_left, hemi='left', view='posterior',
                        bg_map=fsaverage['sulc_left'], bg_on_data=True,
                        darkness=.5)
 
 ###############################################################################
 # Display Destrieux parcellation with different views: ventral
-plotting.plot_surf_roi(fsaverage['infl_left'], roi_map=parcellation,
-                       hemi='left', view='ventral',
+plotting.plot_surf_roi(surf_infl_left, hemi='left', view='ventral',
                        bg_map=fsaverage['sulc_left'], bg_on_data=True,
                        darkness=.5)
 plotting.show()
@@ -93,11 +94,11 @@ coordinates = []
 labels = destrieux_atlas['labels']
 for hemi in ['left', 'right']:
     vert = destrieux_atlas['map_%s' % hemi]
-    rr, _ = surface.load_surf_mesh(fsaverage['pial_%s' % hemi])
+    mesh = surface.load_surf_mesh(fsaverage['pial_%s' % hemi])
     for k, label in enumerate(labels):
         if "Unknown" not in str(label):  # Omit the Unknown label.
             # Compute mean location of vertices in label of index k
-            coordinates.append(np.mean(rr[vert == k], axis=0))
+            coordinates.append(np.mean(mesh.coordinates[vert == k], axis=0))
 
 coordinates = np.array(coordinates)  # 3D coordinates of parcels
 
@@ -122,8 +123,7 @@ plotting.show()
 # visualizations in a web browser. See :ref:`interactive-surface-plotting` for
 # more details.
 
-view = plotting.view_surf(fsaverage.infl_left, parcellation,
-                          cmap='gist_ncar', symmetric_cmap=False)
+view = plotting.view_surf(surf_infl_left, cmap='gist_ncar', symmetric_cmap=False)
 # In a Jupyter notebook, if ``view`` is the output of a cell, it will
 # be displayed below the cell
 

--- a/examples/01_plotting/plot_surf_stat_map.py
+++ b/examples/01_plotting/plot_surf_stat_map.py
@@ -120,10 +120,17 @@ pcc_map[pcc_labels] = 1
 pcc_surf = load_surface((fsaverage.pial_left,
                          pcc_map))
 
+# Define a background surface
+background = load_surface((fsaverage.pial_left,
+                           fsaverage.sulc_left))
+
 from nilearn import plotting
 
-plotting.plot_surf_roi(pcc_surf, hemi='left', view='medial',
-                       bg_map=fsaverage['sulc_left'], bg_on_data=True,
+plotting.plot_surf_roi(pcc_surf,
+                       hemi='left',
+                       view='medial',
+                       bg_surf=background,
+                       bg_on_data=True,
                        title='PCC Seed')
 
 ###############################################################################
@@ -132,14 +139,14 @@ surf = load_surface((fsaverage.pial_left,
                      stat_map))
 
 plotting.plot_surf_stat_map(surf, hemi='left', view='medial', colorbar=True,
-                            bg_map=fsaverage['sulc_left'], bg_on_data=True,
+                            bg_surf=background, bg_on_data=True,
                             darkness=.3, title='Correlation map')
 
 ###############################################################################
 # Many different options are available for plotting, for example thresholding,
 # or using custom colormaps
 plotting.plot_surf_stat_map(surf, hemi='left', view='medial', colorbar=True,
-                            bg_map=fsaverage['sulc_left'], bg_on_data=True,
+                            bg_map=background, bg_on_data=True,
                             cmap='Spectral', threshold=.5,
                             title='Threshold and colormap')
 
@@ -156,7 +163,7 @@ plotting.plot_surf_stat_map(surf, hemi='left', view='lateral', colorbar=True,
 ###############################################################################
 # The plots can be saved to file, in which case the display is closed after
 # creating the figure
-plotting.plot_surf_stat_map(surf, hemi='left', bg_map=fsaverage['sulc_left'],
+plotting.plot_surf_stat_map(surf, hemi='left', bg_surf=background,
                             bg_on_data=True, threshold=.5, colorbar=True,
                             output_file='plot_surf_stat_map.png')
 

--- a/examples/01_plotting/plot_surf_stat_map.py
+++ b/examples/01_plotting/plot_surf_stat_map.py
@@ -83,7 +83,7 @@ print('Fsaverage5 sulcal depth map of left hemisphere is at: %s' %
 # --------------------------------
 
 # Load resting state time series from nilearn
-from nilearn.surface import load_surf_data, Surface
+from nilearn.surface import load_surf_data, load_surface
 
 timeseries = load_surf_data(nki_dataset['func_left'][0])
 
@@ -117,7 +117,8 @@ stat_map[np.where(np.mean(timeseries, axis=1) == 0)] = 0
 # Transform ROI indices in ROI map
 pcc_map = np.zeros(parcellation.shape[0], dtype=int)
 pcc_map[pcc_labels] = 1
-pcc_surf = Surface(fsaverage.pial_left, pcc_map)
+pcc_surf = load_surface((fsaverage.pial_left,
+                         pcc_map))
 
 from nilearn import plotting
 
@@ -127,7 +128,8 @@ plotting.plot_surf_roi(pcc_surf, hemi='left', view='medial',
 
 ###############################################################################
 # Display unthresholded stat map with a slightly dimmed background
-surf = Surface(fsaverage.pial_left, stat_map)
+surf = load_surface((fsaverage.pial_left,
+                     stat_map))
 
 plotting.plot_surf_stat_map(surf, hemi='left', view='medial', colorbar=True,
                             bg_map=fsaverage['sulc_left'], bg_on_data=True,

--- a/examples/01_plotting/plot_surf_stat_map.py
+++ b/examples/01_plotting/plot_surf_stat_map.py
@@ -83,9 +83,9 @@ print('Fsaverage5 sulcal depth map of left hemisphere is at: %s' %
 # --------------------------------
 
 # Load resting state time series from nilearn
-from nilearn import surface
+from nilearn.surface import load_surf_data, Surface
 
-timeseries = surface.load_surf_data(nki_dataset['func_left'][0])
+timeseries = load_surf_data(nki_dataset['func_left'][0])
 
 # Extract seed region via label
 pcc_region = b'G_cingul-Post-dorsal'
@@ -117,26 +117,26 @@ stat_map[np.where(np.mean(timeseries, axis=1) == 0)] = 0
 # Transform ROI indices in ROI map
 pcc_map = np.zeros(parcellation.shape[0], dtype=int)
 pcc_map[pcc_labels] = 1
+pcc_surf = Surface(fsaverage.pial_left, pcc_map)
 
 from nilearn import plotting
 
-plotting.plot_surf_roi(fsaverage['pial_left'], roi_map=pcc_map,
-                       hemi='left', view='medial',
+plotting.plot_surf_roi(pcc_surf, hemi='left', view='medial',
                        bg_map=fsaverage['sulc_left'], bg_on_data=True,
                        title='PCC Seed')
 
 ###############################################################################
 # Display unthresholded stat map with a slightly dimmed background
-plotting.plot_surf_stat_map(fsaverage['pial_left'], stat_map=stat_map,
-                            hemi='left', view='medial', colorbar=True,
+surf = Surface(fsaverage.pial_left, stat_map)
+
+plotting.plot_surf_stat_map(surf, hemi='left', view='medial', colorbar=True,
                             bg_map=fsaverage['sulc_left'], bg_on_data=True,
                             darkness=.3, title='Correlation map')
 
 ###############################################################################
 # Many different options are available for plotting, for example thresholding,
 # or using custom colormaps
-plotting.plot_surf_stat_map(fsaverage['pial_left'], stat_map=stat_map,
-                            hemi='left', view='medial', colorbar=True,
+plotting.plot_surf_stat_map(surf, hemi='left', view='medial', colorbar=True,
                             bg_map=fsaverage['sulc_left'], bg_on_data=True,
                             cmap='Spectral', threshold=.5,
                             title='Threshold and colormap')
@@ -147,16 +147,14 @@ plotting.plot_surf_stat_map(fsaverage['pial_left'], stat_map=stat_map,
 # half transparent surface.
 # Note that you can also control the transparency with a background map using
 # the alpha parameter.
-plotting.plot_surf_stat_map(fsaverage['pial_left'], stat_map=stat_map,
-                            hemi='left', view='lateral', colorbar=True,
+plotting.plot_surf_stat_map(surf, hemi='left', view='lateral', colorbar=True,
                             cmap='Spectral', threshold=.5,
                             title='Plotting without background')
 
 ###############################################################################
 # The plots can be saved to file, in which case the display is closed after
 # creating the figure
-plotting.plot_surf_stat_map(fsaverage['infl_left'], stat_map=stat_map,
-                            hemi='left', bg_map=fsaverage['sulc_left'],
+plotting.plot_surf_stat_map(surf, hemi='left', bg_map=fsaverage['sulc_left'],
                             bg_on_data=True, threshold=.5, colorbar=True,
                             output_file='plot_surf_stat_map.png')
 

--- a/examples/01_plotting/plot_surface_projection_strategies.py
+++ b/examples/01_plotting/plot_surface_projection_strategies.py
@@ -27,7 +27,7 @@ import matplotlib
 from matplotlib import pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 
-from nilearn.surface import surface
+from nilearn.surface import surface, Mesh
 from nilearn.plotting import show
 
 
@@ -43,8 +43,10 @@ angles = u.flatten() * 2 * np.pi / N_T
 x, y = np.cos(angles), np.sin(angles)
 z = v.flatten() * 2 / N_Z
 
-mesh = [np.asarray([x, y, z]).T, triangulation.triangles]
-inner_mesh = [[.7, .7, 1.] * mesh[0], triangulation.triangles]
+mesh = Mesh(np.asarray([x, y, z]).T,
+            triangulation.triangles)
+inner_mesh = Mesh([.7, .7, 1.] * mesh[0],
+                  triangulation.triangles)
 
 
 #########################################################################

--- a/examples/02_decoding/plot_haxby_searchlight_surface.py
+++ b/examples/02_decoding/plot_haxby_searchlight_surface.py
@@ -82,10 +82,11 @@ scores = search_light(X, y, estimator, adjacency, cv=cv, n_jobs=1)
 # Visualization
 # -------------
 from nilearn import plotting
-from nilearn.surface import Surface
+from nilearn.surface import load_surface
 
 chance = .5
-surf = Surface(infl_mesh, scores - chance)
+surf = load_surface((infl_mesh,
+                     scores - chance))
 
 plotting.plot_surf_stat_map(surf, view='medial', colorbar=True,
                             threshold=0.1, bg_map=fsaverage['sulc_' + hemi],

--- a/examples/02_decoding/plot_haxby_searchlight_surface.py
+++ b/examples/02_decoding/plot_haxby_searchlight_surface.py
@@ -88,7 +88,11 @@ chance = .5
 surf = load_surface((infl_mesh,
                      scores - chance))
 
+# Define a background surface
+background = load_surface((infl_mesh,
+                           fsaverage['sulc_' + hemi]))
+
 plotting.plot_surf_stat_map(surf, view='medial', colorbar=True,
-                            threshold=0.1, bg_map=fsaverage['sulc_' + hemi],
+                            threshold=0.1, bg_surf=background,
                             title='Accuracy map, left hemisphere')
 plotting.show()

--- a/examples/02_decoding/plot_haxby_searchlight_surface.py
+++ b/examples/02_decoding/plot_haxby_searchlight_surface.py
@@ -36,7 +36,7 @@ y, session = y[condition_mask], session[condition_mask]
 # Surface bold response
 # ----------------------
 from nilearn.datasets import fetch_surf_fsaverage
-from nilearn.surface import Mesh, vol_to_surf, load_surf_mesh
+from nilearn.surface import vol_to_surf, load_surf_mesh
 from sklearn import neighbors
 
 # Fetch a coarse surface of the left hemisphere only for speed
@@ -56,8 +56,8 @@ infl_mesh = load_surf_mesh(fsaverage['infl_' + hemi])
 radius = 3.
 nn = neighbors.NearestNeighbors(radius=radius)
 adjacency = nn.fit(
-                infl_mesh.coordinates).radius_neighbors_graph(
-                                infl_mesh.coordinates).tolil()
+    infl_mesh.coordinates).radius_neighbors_graph(
+        infl_mesh.coordinates).tolil()
 
 #########################################################################
 # Searchlight computation

--- a/examples/04_glm_first_level/plot_localizer_surface_analysis.py
+++ b/examples/04_glm_first_level/plot_localizer_surface_analysis.py
@@ -67,6 +67,8 @@ fsaverage = nilearn.datasets.fetch_surf_fsaverage()
 from nilearn.surface import vol_to_surf, load_surface
 texture = vol_to_surf(fmri_img, fsaverage.pial_right)
 surf = load_surface((fsaverage.pial_right, texture))
+background = load_surface((fsaverage.pial_right,
+                           fsaverage.sulc_right))
 
 ###############################################################################
 # Perform first level analysis
@@ -178,9 +180,12 @@ for index, (contrast_id, contrast_val) in enumerate(contrasts.items()):
     # we plot it on the surface, on the inflated fsaverage mesh,
     # together with a suitable background to give an impression
     # of the cortex folding.
-    plotting.plot_surf_stat_map(score_surface, hemi='right',
-                                title=contrast_id, colorbar=True,
-                                threshold=3., bg_map=fsaverage.sulc_right)
+    plotting.plot_surf_stat_map(score_surface,
+                                hemi='right',
+                                title=contrast_id,
+                                colorbar=True,
+                                threshold=3.,
+                                bg_surf=background)
 
 ###############################################################################
 # Analysing the left hemisphere
@@ -194,6 +199,8 @@ for index, (contrast_id, contrast_val) in enumerate(contrasts.items()):
 texture = vol_to_surf(fmri_img, fsaverage.pial_left)
 surf = load_surface((fsaverage.pial_left,
                      texture))
+background = load_surface((fsaverage.pial_left,
+                           fsaverage.sulc_left))
 
 ###############################################################################
 # Then we estimate the General Linear Model.
@@ -210,8 +217,11 @@ for index, (contrast_id, contrast_val) in enumerate(contrasts.items()):
     score_surf = load_surface((fsaverage.infl_left,
                                contrast.z_score()))
     # plot the result
-    plotting.plot_surf_stat_map(score_surf, hemi='left',
-                                title=contrast_id, colorbar=True,
-                                threshold=3., bg_map=fsaverage.sulc_left)
+    plotting.plot_surf_stat_map(score_surf,
+                                hemi='left',
+                                title=contrast_id,
+                                colorbar=True,
+                                threshold=3.,
+                                bg_surf=background)
 
 plotting.show()

--- a/examples/04_glm_first_level/plot_localizer_surface_analysis.py
+++ b/examples/04_glm_first_level/plot_localizer_surface_analysis.py
@@ -64,9 +64,9 @@ fsaverage = nilearn.datasets.fetch_surf_fsaverage()
 ###############################################################################
 # The projection function simply takes the fMRI data and the mesh.
 # Note that those correspond spatially, are they are both in MNI space.
-from nilearn.surface import vol_to_surf, Surface
+from nilearn.surface import vol_to_surf, load_surface
 texture = vol_to_surf(fmri_img, fsaverage.pial_right)
-surf = Surface(fsaverage.pial_right, texture)
+surf = load_surface((fsaverage.pial_right, texture))
 
 ###############################################################################
 # Perform first level analysis
@@ -173,8 +173,8 @@ for index, (contrast_id, contrast_val) in enumerate(contrasts.items()):
     contrast = compute_contrast(labels, estimates, contrast_val,
                                 contrast_type='t')
     # we present the Z-transform of the t map
-    z_score = contrast.z_score()
-    score_surface = Surface(fsaverage.infl_right, z_score)
+    score_surface = load_surface((fsaverage.infl_right,
+                                  contrast.z_score()))
     # we plot it on the surface, on the inflated fsaverage mesh,
     # together with a suitable background to give an impression
     # of the cortex folding.
@@ -192,7 +192,8 @@ for index, (contrast_id, contrast_val) in enumerate(contrasts.items()):
 ###############################################################################
 # We project the fMRI data to the mesh.
 texture = vol_to_surf(fmri_img, fsaverage.pial_left)
-surf = Surface(fsaverage.pial_left, texture)
+surf = load_surface((fsaverage.pial_left,
+                     texture))
 
 ###############################################################################
 # Then we estimate the General Linear Model.
@@ -206,8 +207,8 @@ for index, (contrast_id, contrast_val) in enumerate(contrasts.items()):
     # compute contrasts
     contrast = compute_contrast(labels, estimates, contrast_val,
                                 contrast_type='t')
-    z_score = contrast.z_score()
-    score_surf = Surface(fsaverage.infl_left, z_score)
+    score_surf = load_surface((fsaverage.infl_left,
+                               contrast.z_score()))
     # plot the result
     plotting.plot_surf_stat_map(score_surf, hemi='left',
                                 title=contrast_id, colorbar=True,

--- a/examples/07_advanced/plot_surface_bids_analysis.py
+++ b/examples/07_advanced/plot_surface_bids_analysis.py
@@ -74,7 +74,7 @@ fsaverage = fetch_surf_fsaverage(mesh='fsaverage5')
 # The projection function simply takes the fMRI data and the mesh.
 # Note that those correspond spatially, as they are both in MNI space.
 import numpy as np
-from nilearn.surface import vol_to_surf, Surface
+from nilearn.surface import vol_to_surf, load_surface
 from nilearn.glm.first_level import make_first_level_design_matrix
 from nilearn.glm.first_level import run_glm
 from nilearn.glm.contrasts import compute_contrast
@@ -86,7 +86,8 @@ z_scores_left = []
 for (fmri_img, confound, events) in zip(
         models_run_imgs, models_confounds, models_events):
     texture = vol_to_surf(fmri_img[0], fsaverage.pial_right)
-    surf_right = Surface(fsaverage.pial_right, texture)
+    surf_right = load_surface((fsaverage.pial_right,
+                               texture))
     n_scans = surf_right.data.shape[1]
     frame_times = t_r * (np.arange(n_scans) + .5)
 
@@ -116,7 +117,8 @@ for (fmri_img, confound, events) in zip(
 
     # Do the left hemipshere exactly in the same way.
     texture = vol_to_surf(fmri_img, fsaverage.pial_left)
-    surf_left = Surface(fsaverage.pial_left, texture)
+    surf_left = load_surface((fsaverage.pial_left,
+                              texture))
     labels, estimates = run_glm(surf_left.data.T, design_matrix.values)
     contrast = compute_contrast(labels, estimates, contrast_values,
                                 contrast_type='t')
@@ -140,8 +142,10 @@ t_right, pval_right = ttest_1samp(np.array(z_scores_right), 0)
 
 ############################################################################
 # What we have so far are p-values: we convert them to z-values for plotting.
-surf_z_val_left = Surface(fsaverage.infl_left, norm.isf(pval_left))
-surf_z_val_right = Surface(fsaverage.infl_right, norm.isf(pval_right))
+surf_z_val_left = load_surface((fsaverage.infl_left,
+                                norm.isf(pval_left)))
+surf_z_val_right = load_surface((fsaverage.infl_right,
+                                 norm.isf(pval_right)))
 
 ############################################################################
 # Plot the resulting maps, at first on the left hemipshere.

--- a/examples/07_advanced/plot_surface_bids_analysis.py
+++ b/examples/07_advanced/plot_surface_bids_analysis.py
@@ -150,13 +150,28 @@ surf_z_val_right = load_surface((fsaverage.infl_right,
 ############################################################################
 # Plot the resulting maps, at first on the left hemipshere.
 from nilearn import plotting
-plotting.plot_surf_stat_map(surf_z_val_left, hemi='left',
-    title="language-string, left hemisphere", colorbar=True,
-    threshold=3., bg_map=fsaverage.sulc_left)
+
+# Define a background surface
+background_left = load_surface((fsaverage.infl_left,
+                                fsaverage.sulc_left))
+
+plotting.plot_surf_stat_map(surf_z_val_left,
+                            hemi='left',
+                            title="language-string, left hemisphere",
+                            colorbar=True,
+                            threshold=3.,
+                            bg_surf=background_left)
+
 ############################################################################
 # Next, on the right hemisphere.
-plotting.plot_surf_stat_map(surf_z_val_left, hemi='right',
-    title="language-string, right hemisphere", colorbar=True,
-    threshold=3., bg_map=fsaverage.sulc_right)
+background_right = load_surface((fsaverage.infl_left,
+                                fsaverage.sulc_left))
+
+plotting.plot_surf_stat_map(surf_z_val_right,
+                            hemi='right',
+                            title="language-string, right hemisphere",
+                            colorbar=True,
+                            threshold=3.,
+                            bg_surf=background_right)
 
 plotting.show()

--- a/nilearn/_utils/__init__.py
+++ b/nilearn/_utils/__init__.py
@@ -10,10 +10,12 @@ from .numpy_conversions import as_ndarray
 from .cache_mixin import CacheMixin
 
 from .logger import _compose_err_msg
-from nilearn._utils.helpers import rename_parameters, remove_parameters
+from nilearn._utils.helpers import (rename_parameters,
+                                    remove_parameters,
+                                    deprecated)
 
 __all__ = ['check_niimg', 'check_niimg_3d', 'concat_niimgs', 'check_niimg_4d',
-           '_repr_niimgs', 'copy_img', 'load_niimg',
+           '_repr_niimgs', 'copy_img', 'load_niimg', 'deprecated',
            'as_ndarray', 'CacheMixin', '_compose_err_msg', 'rename_parameters',
            'remove_parameters', 'fill_doc',
            ]

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -3,15 +3,16 @@ import warnings
 
 
 def deprecated(message):
-  def deprecated_decorator(func):
-      def deprecated_func(*args, **kwargs):
-          warnings.warn("{} deprecation : {}".format(
-                                    func.__name__, message),
-                        category=DeprecationWarning,
-                        stacklevel=2)
-          return func(*args, **kwargs)
-      return deprecated_func
-  return deprecated_decorator
+    def deprecated_decorator(func):
+        @functools.wraps(func)
+        def deprecated_func(*args, **kwargs):
+            warnings.warn("{} deprecation : {}".format(
+                            func.__name__, message),
+                            category=DeprecationWarning,
+                            stacklevel=2)
+            return func(*args, **kwargs)
+        return deprecated_func
+    return deprecated_decorator
 
 
 def rename_parameters(replacement_params,

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -6,10 +6,12 @@ def deprecated(message):
     def deprecated_decorator(func):
         @functools.wraps(func)
         def deprecated_func(*args, **kwargs):
-            warnings.warn("{} deprecation : {}".format(
-                            func.__name__, message),
-                            category=DeprecationWarning,
-                            stacklevel=2)
+            warnings.warn(
+                "{} deprecation : {}".format(func.__name__,
+                                             message),
+                category=DeprecationWarning,
+                stacklevel=2
+            )
             return func(*args, **kwargs)
         return deprecated_func
     return deprecated_decorator

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -2,6 +2,18 @@ import functools
 import warnings
 
 
+def deprecated(message):
+  def deprecated_decorator(func):
+      def deprecated_func(*args, **kwargs):
+          warnings.warn("{} deprecation : {}".format(
+                                    func.__name__, message),
+                        category=DeprecationWarning,
+                        stacklevel=2)
+          return func(*args, **kwargs)
+      return deprecated_func
+  return deprecated_decorator
+
+
 def rename_parameters(replacement_params,
                       end_version='future',
                       lib_name='Nilearn',

--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -241,7 +241,7 @@ deprecate_separate_mesh_data_view_surf = partial(
     _deprecate_separate_mesh_data, argument="surf_map")
 
 
-@rename_parameters({'bg_map': 'bg_surf'}, '0.9.0')
+@rename_parameters({'bg_map': 'bg_surf'}, '0.10.0')
 @deprecate_separate_mesh_data_view_surf
 def view_surf(surf_mesh, surf_map=None, *, bg_surf=None, threshold=None,
               cmap=cm.cold_hot, black_bg=False, vmax=None, vmin=None,
@@ -253,9 +253,9 @@ def view_surf(surf_mesh, surf_map=None, *, bg_surf=None, threshold=None,
     ----------
     surf_mesh : str or list of two numpy.ndarray or Mesh or Surface
 
-            .. deprecated:: 0.7.2
-                `surf_mesh` is deprecated in 0.7.2 and will be renamed
-                'surface' in 0.9.0.
+            .. deprecated:: 0.8.1
+                `surf_mesh` is deprecated in 0.8.1 and will be renamed
+                'surface' in 0.10.0.
 
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
@@ -293,8 +293,8 @@ def view_surf(surf_mesh, surf_map=None, *, bg_surf=None, threshold=None,
         .thickness, .area, .curv, .sulc, .annot, .label) or
         a Numpy array
 
-            .. deprecated:: 0.7.2
-                `surf_map` is deprecated in 0.7.2 and will be removed in 0.9.0.
+            .. deprecated:: 0.8.1
+                `surf_map` is deprecated in 0.8.1 and will be removed in 0.10.0.
                 Please use a Surface object to define the map. This will not be
                 used if a Surface is provided as first argument.
 
@@ -303,9 +303,9 @@ def view_surf(surf_mesh, surf_map=None, *, bg_surf=None, threshold=None,
         `surface.data` in greyscale. `bg_surf.data` is most likely a
         sulcal depth map for realistic shading.
 
-        .. versionchanged:: 0.7.2
-            `bg_surf` was introduced in 0.7.2 and replaces `bg_map`.
-            `bg_map` will not be supported after release 0.9.0.
+        .. versionchanged:: 0.8.1
+            `bg_surf` was introduced in 0.8.1 and replaces `bg_map`.
+            `bg_map` will not be supported after release 0.10.0.
 
     threshold : str, number or None, optional
         If None, no thresholding.

--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -235,6 +235,7 @@ def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
 deprecate_separate_mesh_data_view_surf = partial(
     _deprecate_separate_mesh_data, argument="surf_map")
 
+
 @deprecate_separate_mesh_data_view_surf
 def view_surf(surf_mesh, surf_map=None, *, bg_map=None, threshold=None,
               cmap=cm.cold_hot, black_bg=False, vmax=None, vmin=None,

--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -294,9 +294,10 @@ def view_surf(surf_mesh, surf_map=None, *, bg_surf=None, threshold=None,
         a Numpy array
 
             .. deprecated:: 0.8.1
-                `surf_map` is deprecated in 0.8.1 and will be removed in 0.10.0.
-                Please use a Surface object to define the map. This will not be
-                used if a Surface is provided as first argument.
+                `surf_map` is deprecated in 0.8.1 and will be
+                removed in 0.10.0. Please use a Surface object
+                to define the map. This will not be used if a
+                Surface is provided as first argument.
 
     bg_surf : Surface, optional
         Background surface to be plotted on `surface.mesh` underneath

--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -32,7 +32,8 @@ def _get_vertexcolor(surf_map, cmap, norm,
         bg_map = np.ones(len(surf_map)) * .5
         bg_vmin, bg_vmax = 0, 1
     else:
-        if hasattr(bg_surf, 'data'):
+        if(hasattr(bg_surf, 'mesh')
+           and hasattr(bg_surf, 'data')):
             bg_map = bg_surf.data
         else:
             bg_map = surface.load_surf_data(bg_surf)
@@ -45,8 +46,8 @@ def _get_vertexcolor(surf_map, cmap, norm,
 
 
 def _one_mesh_info(surf_map, surf_mesh, threshold=None, cmap=cm.cold_hot,
-                  black_bg=False, bg_surf=None, symmetric_cmap=True,
-                  vmax=None, vmin=None):
+                   black_bg=False, bg_surf=None, symmetric_cmap=True,
+                   vmax=None, vmin=None):
     """Prepare info for plotting one surface map on a single mesh.
 
     This computes the dictionary that gets inserted in the web page,
@@ -374,7 +375,8 @@ def view_surf(surf_mesh, surf_map=None, *, bg_surf=None, threshold=None,
         surf_mesh, surf_map = surface.check_mesh_and_data(
             surf_mesh, surf_map)
     if bg_surf is not None:
-        if not hasattr(bg_surf, 'mesh'):
+        if(not hasattr(bg_surf, 'mesh')
+           or not hasattr(bg_surf, 'data')):
             _, bg_surf = surface.check_mesh_and_data(surf_mesh, bg_surf)
     info = _one_mesh_info(
         surf_map=surf_map, surf_mesh=surf_mesh, threshold=threshold,

--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -4,11 +4,13 @@ import collections.abc
 import numpy as np
 import matplotlib as mpl
 from matplotlib import cm as mpl_cm
+from functools import partial
 
 from nilearn._utils.niimg_conversions import check_niimg_3d
 from nilearn._utils import fill_doc
 from nilearn import surface
 from nilearn import datasets
+from nilearn.plotting.surf_plotting import _deprecate_separate_mesh_data
 from nilearn.plotting.html_document import HTMLDocument
 from nilearn.plotting import cm
 from nilearn.plotting.js_plotting_utils import (
@@ -230,7 +232,11 @@ def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
     return _fill_html_template(info, embed_js=True)
 
 
-def view_surf(surf_mesh, surf_map=None, bg_map=None, threshold=None,
+deprecate_separate_mesh_data_view_surf = partial(
+    _deprecate_separate_mesh_data, argument="surf_map")
+
+@deprecate_separate_mesh_data_view_surf
+def view_surf(surf_mesh, surf_map=None, *, bg_map=None, threshold=None,
               cmap=cm.cold_hot, black_bg=False, vmax=None, vmin=None,
               symmetric_cmap=True, colorbar=True, colorbar_height=.5,
               colorbar_fontsize=25, title=None, title_fontsize=25):
@@ -238,15 +244,42 @@ def view_surf(surf_mesh, surf_map=None, bg_map=None, threshold=None,
 
     Parameters
     ----------
-    surf_mesh : str or list of two numpy.ndarray
-        Surface mesh geometry, can be a file (valid formats are
-        .gii or Freesurfer specific files such as .orig, .pial,
-        .sphere, .white, .inflated) or
-        a list of two Numpy arrays, the first containing the x-y-z coordinates
-        of the mesh vertices, the second containing the indices
-        (into coords) of the mesh faces.
+    surf_mesh : str or list of two numpy.ndarray or Mesh or Surface
+        Deprecated, will be renamed 'surface' in 0.9.
+        If a Surface-like object is provided instead of a Mesh, `surface.data`
+        will overwrite the `surf_map` argument.
+        It can be:
+        - a Surface-like object with a mesh and data attributes
+
+        A surface can be:
+            - a nilearn.surface.Surface
+            - a sequence (mesh, data) where:
+
+            A mesh can be:
+                - a nilearn.surface.Mesh
+                - a path to .gii or .gii.gz etc.
+                - a sequence of two numpy arrays,
+                  the first containing vertex coordinates
+                  and the second containing triangles.
+
+            Data can be:
+                - a path to .gii or .gii.gz etc.
+                - a numpy array with shape (n_vertices,)
+                  or (n_time_point, n_vertices)
+
+        - a surface mesh geometry (deprecated)
+
+        A Mesh can be:
+            - a file (valid formats are .gii or Freesurfer specific
+              files such as .orig, .pial, .sphere, .white, .inflated)
+            - a list of two Numpy arrays, the first containing the
+              x-y-z coordinates of the mesh vertices, the second
+              containing the indices (into coords) of the mesh faces.
 
     surf_map : str or numpy.ndarray, optional
+        Deprecated, will be removed in 0.9. Please use a Surface object to
+        define the map. This argument will be removed if a Surface object is
+        provided as first argument.
         Data to be displayed on the surface mesh. Can be a file (valid formats
         are .gii, .mgz, .nii, .nii.gz, or Freesurfer specific files such as
         .thickness, .area, .curv, .sulc, .annot, .label) or

--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -246,7 +246,11 @@ def view_surf(surf_mesh, surf_map=None, *, bg_map=None, threshold=None,
     Parameters
     ----------
     surf_mesh : str or list of two numpy.ndarray or Mesh or Surface
-        Deprecated, will be renamed 'surface' in 0.9.
+
+            .. deprecated:: 0.7.2
+                `surf_mesh` is deprecated in 0.7.2 and will be renamed
+                'surface' in 0.9.0.
+
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
         It can be:
@@ -278,13 +282,15 @@ def view_surf(surf_mesh, surf_map=None, *, bg_map=None, threshold=None,
               containing the indices (into coords) of the mesh faces.
 
     surf_map : str or numpy.ndarray, optional
-        Deprecated, will be removed in 0.9. Please use a Surface object to
-        define the map. This argument will be removed if a Surface object is
-        provided as first argument.
         Data to be displayed on the surface mesh. Can be a file (valid formats
         are .gii, .mgz, .nii, .nii.gz, or Freesurfer specific files such as
         .thickness, .area, .curv, .sulc, .annot, .label) or
         a Numpy array
+
+            .. deprecated:: 0.7.2
+                `surf_map` is deprecated in 0.7.2 and will be removed in 0.9.0.
+                Please use a Surface object to define the map. This will not be
+                used if a Surface is provided as first argument.
 
     bg_map : Surface data, optional
         Background image to be plotted on the mesh underneath the

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -18,7 +18,8 @@ from nilearn.plotting.img_plotting import (_get_colorbar_and_data_ranges,
 from nilearn.surface import (load_surf_data,
                              load_surf_mesh,
                              load_surface,
-                             vol_to_surf)
+                             vol_to_surf,
+                             Surface)
 from nilearn.surface.surface import _check_mesh
 from nilearn._utils import check_niimg_3d
 import warnings
@@ -812,10 +813,12 @@ def plot_surf_stat_map(surf_mesh, stat_map, *, bg_map=None,
     cbar_vmin, cbar_vmax, vmin, vmax = _get_colorbar_and_data_ranges(
         loaded_stat_map, vmax, symmetric_cbar, kwargs)
 
+    surf = Surface(surf_mesh, loaded_stat_map)
+
     display = plot_surf(
-        surf_mesh, surf_map=loaded_stat_map, bg_map=bg_map, hemi=hemi, view=view,
-        avg_method='mean', threshold=threshold, cmap=cmap, colorbar=colorbar,
-        alpha=alpha, bg_on_data=bg_on_data, darkness=darkness, vmax=vmax,
+        surf, bg_map=bg_map, hemi=hemi, view=view, avg_method='mean',
+        threshold=threshold, cmap=cmap, colorbar=colorbar, alpha=alpha,
+        bg_on_data=bg_on_data, darkness=darkness, vmax=vmax,
         vmin=vmin, title=title, output_file=output_file, axes=axes,
         figure=figure, cbar_vmin=cbar_vmin, cbar_vmax=cbar_vmax, **kwargs)
 
@@ -1212,7 +1215,9 @@ def plot_surf_roi(surf_mesh, roi_map, *, bg_map=None,
                          'roi_map = np.zeros(n_vertices)\n'
                          'roi_map[roi_idx] = 1')
 
-    display = plot_surf(mesh, surf_map=roi, bg_map=bg_map,
+    surf = Surface(mesh, roi)
+
+    display = plot_surf(surf, bg_map=bg_map,
                         hemi=hemi, view=view, avg_method='median',
                         threshold=threshold, cmap=cmap,
                         cbar_tick_format=cbar_tick_format, alpha=alpha,

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -94,24 +94,29 @@ def plot_surf(surf_mesh, surf_map=None, *, bg_map=None,
                 A surface can be:
                     - a nilearn.surface.Surface
                     - a sequence (mesh, data) where:
+
                         - mesh can be:
                             - a nilearn.surface.Mesh
                             - a path to .gii or .gii.gz etc.
                             - a sequence of two numpy arrays,
                             the first containing vertex coordinates
                             and the second containing triangles.
+
                         - data can be:
                             - a path to .gii or .gii.gz etc.
                             - a numpy array with shape (n_vertices,)
                             or (n_time_points, n_vertices)
+
             - a surface mesh geometry (deprecated)
                 A Mesh can be:
+
                     - a file (valid formats are .gii or Freesurfer specific
                     files such as .orig, .pial, .sphere, .white, .inflated)
                     - a list of two Numpy arrays, the first containing the
                     x-y-z coordinates of the mesh vertices, the second
                     containing the indices (into coords) of the mesh faces
                     - a Mesh object with "coordinates" and "faces" attributes.
+
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
 
@@ -507,16 +512,19 @@ def plot_surf_contours(surf_mesh, roi_map, *, axes=None, figure=None, levels=Non
                 A surface can be:
                     - a nilearn.surface.Surface
                     - a sequence (mesh, data) where:
+
                         - mesh can be:
                             - a nilearn.surface.Mesh
                             - a path to .gii or .gii.gz etc.
                             - a sequence of two numpy arrays,
                             the first containing vertex coordinates
                             and the second containing triangles.
+
                         - data can be:
                             - a path to .gii or .gii.gz etc.
                             - a numpy array with shape (n_vertices,)
                             or (n_time_points, n_vertices)
+
             - a surface mesh geometry (deprecated)
                 A Mesh can be:
                     - a file (valid formats are .gii or Freesurfer specific
@@ -525,6 +533,7 @@ def plot_surf_contours(surf_mesh, roi_map, *, axes=None, figure=None, levels=Non
                     x-y-z coordinates of the mesh vertices, the second
                     containing the indices (into coords) of the mesh faces
                     - a Mesh object with "coordinates" and "faces" attributes.
+
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
 
@@ -673,16 +682,19 @@ def plot_surf_stat_map(surf_mesh, stat_map, *, bg_map=None,
                 A surface can be:
                     - a nilearn.surface.Surface
                     - a sequence (mesh, data) where:
+
                         - mesh can be:
                             - a nilearn.surface.Mesh
                             - a path to .gii or .gii.gz etc.
                             - a sequence of two numpy arrays,
                             the first containing vertex coordinates
                             and the second containing triangles.
+
                         - data can be:
                             - a path to .gii or .gii.gz etc.
                             - a numpy array with shape (n_vertices,)
                             or (n_time_points, n_vertices)
+
             - a surface mesh geometry (deprecated)
                 A Mesh can be:
                     - a file (valid formats are .gii or Freesurfer specific
@@ -691,6 +703,7 @@ def plot_surf_stat_map(surf_mesh, stat_map, *, bg_map=None,
                     x-y-z coordinates of the mesh vertices, the second
                     containing the indices (into coords) of the mesh faces
                     - a Mesh object with "coordinates" and "faces" attributes.
+
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
 
@@ -1064,16 +1077,19 @@ def plot_surf_roi(surf_mesh, roi_map, *, bg_map=None,
                 A surface can be:
                     - a nilearn.surface.Surface
                     - a sequence (mesh, data) where:
+
                         - mesh can be:
                             - a nilearn.surface.Mesh
                             - a path to .gii or .gii.gz etc.
                             - a sequence of two numpy arrays,
                             the first containing vertex coordinates
                             and the second containing triangles.
+
                         - data can be:
                             - a path to .gii or .gii.gz etc.
                             - a numpy array with shape (n_vertices,)
                             or (n_time_points, n_vertices)
+
             - a surface mesh geometry (deprecated)
                 A Mesh can be:
                     - a file (valid formats are .gii or Freesurfer specific
@@ -1082,6 +1098,7 @@ def plot_surf_roi(surf_mesh, roi_map, *, bg_map=None,
                     x-y-z coordinates of the mesh vertices, the second
                     containing the indices (into coords) of the mesh faces
                     - a Mesh object with "coordinates" and "faces" attributes.
+
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
 

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -93,28 +93,33 @@ def plot_surf(surf_mesh, surf_map=None, *, bg_map=None,
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
         It can be:
-            - a Surface-like object with a mesh and data attributes
-            A surface can be:
-                - a nilearn.surface.Surface
-                - a sequence (mesh, data) where:
-                    - mesh can be:
-                        - a nilearn.surface.Mesh
-                        - a path to .gii or .gii.gz etc.
-                        - a sequence of two numpy arrays,
-                        the first containing vertex coordinates
-                        and the second containing triangles.
-                    - data can be:
-                        - a path to .gii or .gii.gz etc.
-                        - a numpy array with shape (n_vertices,)
-                        or (n_time_points, n_vertices)
-            - a surface mesh geometry (deprecated)
-            A Mesh can be:
-                - a file (valid formats are .gii or Freesurfer specific
-                files such as .orig, .pial, .sphere, .white, .inflated)
-                - a list of two Numpy arrays, the first containing the
-                x-y-z coordinates of the mesh vertices, the second
-                containing the indices (into coords) of the mesh faces
-                - a Mesh object with "coordinates" and "faces" attributes.
+        - a Surface-like object with a mesh and data attributes
+
+        A surface can be:
+            - a nilearn.surface.Surface
+            - a sequence (mesh, data) where:
+
+            A mesh can be:
+                - a nilearn.surface.Mesh
+                - a path to .gii or .gii.gz etc.
+                - a sequence of two numpy arrays,
+                  the first containing vertex coordinates
+                  and the second containing triangles.
+
+            Data can be:
+                - a path to .gii or .gii.gz etc.
+                - a numpy array with shape (n_vertices,)
+                  or (n_time_points, n_vertices)
+
+        - a surface mesh geometry (deprecated)
+
+        A Mesh can be:
+            - a file (valid formats are .gii or Freesurfer specific
+              files such as .orig, .pial, .sphere, .white, .inflated)
+            - a list of two Numpy arrays, the first containing the
+              x-y-z coordinates of the mesh vertices, the second
+              containing the indices (into coords) of the mesh faces
+            - a Mesh object with "coordinates" and "faces" attributes.
 
     surf_map : str or numpy.ndarray, optional
         Deprecated, will be removed in 0.9. Please use a Surface object to
@@ -507,28 +512,33 @@ def plot_surf_contours(surf_mesh, roi_map, *, axes=None, figure=None, levels=Non
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
         It can be:
-            - a Surface-like object with a mesh and data attributes
-            A surface can be:
-                - a nilearn.surface.Surface
-                - a sequence (mesh, data) where:
-                    - mesh can be:
-                        - a nilearn.surface.Mesh
-                        - a path to .gii or .gii.gz etc.
-                        - a sequence of two numpy arrays,
-                        the first containing vertex coordinates
-                        and the second containing triangles.
-                    - data can be:
-                        - a path to .gii or .gii.gz etc.
-                        - a numpy array with shape (n_vertices,)
-                        or (n_time_points, n_vertices)
-            - a surface mesh geometry (deprecated)
-            A Mesh can be:
-                - a file (valid formats are .gii or Freesurfer specific
-                files such as .orig, .pial, .sphere, .white, .inflated)
-                - a list of two Numpy arrays, the first containing the
-                x-y-z coordinates of the mesh vertices, the second
-                containing the indices (into coords) of the mesh faces
-                - a Mesh object with "coordinates" and "faces" attributes.
+        - a Surface-like object with a mesh and data attributes
+
+        A surface can be:
+            - a nilearn.surface.Surface
+            - a sequence (mesh, data) where:
+
+            A mesh can be:
+                - a nilearn.surface.Mesh
+                - a path to .gii or .gii.gz etc.
+                - a sequence of two numpy arrays,
+                  the first containing vertex coordinates
+                  and the second containing triangles.
+
+            Data can be:
+                - a path to .gii or .gii.gz etc.
+                - a numpy array with shape (n_vertices,)
+                  or (n_time_points, n_vertices)
+
+        - a surface mesh geometry (deprecated)
+
+        A Mesh can be:
+            - a file (valid formats are .gii or Freesurfer specific
+              files such as .orig, .pial, .sphere, .white, .inflated)
+            - a list of two Numpy arrays, the first containing the
+              x-y-z coordinates of the mesh vertices, the second
+              containing the indices (into coords) of the mesh faces
+            - a Mesh object with "coordinates" and "faces" attributes.
 
     roi_map : str or numpy.ndarray or list of numpy.ndarray
         Deprecated, will be removed in 0.9. Please use a Surface object to
@@ -663,7 +673,7 @@ def plot_surf_stat_map(surf_mesh, stat_map, *, bg_map=None,
                        colorbar=True, symmetric_cbar="auto", bg_on_data=False,
                        darkness=1, title=None, output_file=None, axes=None,
                        figure=None, **kwargs):
-    """Plotting a stats map on a surface mesh with optional background
+    """Plotting a stats map on a surface mesh with optional background.
 
     .. versionadded:: 0.3
 
@@ -674,28 +684,33 @@ def plot_surf_stat_map(surf_mesh, stat_map, *, bg_map=None,
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
         It can be:
-            - a Surface-like object with a mesh and data attributes
-            A surface can be:
-                - a nilearn.surface.Surface
-                - a sequence (mesh, data) where:
-                    - mesh can be:
-                        - a nilearn.surface.Mesh
-                        - a path to .gii or .gii.gz etc.
-                        - a sequence of two numpy arrays,
-                        the first containing vertex coordinates
-                        and the second containing triangles.
-                    - data can be:
-                        - a path to .gii or .gii.gz etc.
-                        - a numpy array with shape (n_vertices,)
-                        or (n_time_points, n_vertices)
-            - a surface mesh geometry (deprecated)
-            A Mesh can be:
-                - a file (valid formats are .gii or Freesurfer specific
-                files such as .orig, .pial, .sphere, .white, .inflated)
-                - a list of two Numpy arrays, the first containing the
-                x-y-z coordinates of the mesh vertices, the second
-                containing the indices (into coords) of the mesh faces
-                - a Mesh object with "coordinates" and "faces" attributes.
+        - a Surface-like object with a mesh and data attributes
+
+        A surface can be:
+            - a nilearn.surface.Surface
+            - a sequence (mesh, data) where:
+
+            A mesh can be:
+                - a nilearn.surface.Mesh
+                - a path to .gii or .gii.gz etc.
+                - a sequence of two numpy arrays,
+                  the first containing vertex coordinates
+                  and the second containing triangles.
+
+            Data can be:
+                - a path to .gii or .gii.gz etc.
+                - a numpy array with shape (n_vertices,)
+                  or (n_time_points, n_vertices)
+
+        - a surface mesh geometry (deprecated)
+
+        A Mesh can be:
+            - a file (valid formats are .gii or Freesurfer specific
+              files such as .orig, .pial, .sphere, .white, .inflated)
+            - a list of two Numpy arrays, the first containing the
+              x-y-z coordinates of the mesh vertices, the second
+              containing the indices (into coords) of the mesh faces
+            - a Mesh object with "coordinates" and "faces" attributes.
 
     stat_map : str or numpy.ndarray
         Deprecated, will be removed in 0.9. Please use a Surface object to
@@ -1066,28 +1081,33 @@ def plot_surf_roi(surf_mesh, roi_map, *, bg_map=None,
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
         It can be:
-            - a Surface-like object with a mesh and data attributes
-            A surface can be:
-                - a nilearn.surface.Surface
-                - a sequence (mesh, data) where:
-                    - mesh can be:
-                        - a nilearn.surface.Mesh
-                        - a path to .gii or .gii.gz etc.
-                        - a sequence of two numpy arrays,
-                        the first containing vertex coordinates
-                        and the second containing triangles.
-                    - data can be:
-                        - a path to .gii or .gii.gz etc.
-                        - a numpy array with shape (n_vertices,)
-                        or (n_time_points, n_vertices)
-            - a surface mesh geometry (deprecated)
-            A Mesh can be:
-                - a file (valid formats are .gii or Freesurfer specific
-                files such as .orig, .pial, .sphere, .white, .inflated)
-                - a list of two Numpy arrays, the first containing the
-                x-y-z coordinates of the mesh vertices, the second
-                containing the indices (into coords) of the mesh faces
-                - a Mesh object with "coordinates" and "faces" attributes.
+        - a Surface-like object with a mesh and data attributes
+
+        A surface can be:
+            - a nilearn.surface.Surface
+            - a sequence (mesh, data) where:
+
+            A mesh can be:
+                - a nilearn.surface.Mesh
+                - a path to .gii or .gii.gz etc.
+                - a sequence of two numpy arrays,
+                  the first containing vertex coordinates
+                  and the second containing triangles.
+
+            Data can be:
+                - a path to .gii or .gii.gz etc.
+                - a numpy array with shape (n_vertices,)
+                  or (n_time_points, n_vertices)
+
+        - a surface mesh geometry (deprecated)
+
+        A Mesh can be:
+            - a file (valid formats are .gii or Freesurfer specific
+              files such as .orig, .pial, .sphere, .white, .inflated)
+            - a list of two Numpy arrays, the first containing the
+              x-y-z coordinates of the mesh vertices, the second
+              containing the indices (into coords) of the mesh faces
+            - a Mesh object with "coordinates" and "faces" attributes.
 
     roi_map : str or numpy.ndarray or list of numpy.ndarray
         Deprecated, will be removed in 0.9. Please use a Surface object to

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -39,7 +39,7 @@ def _deprecate_separate_mesh_data(func, argument):
     texture as multiple arguments in surface related
     functions. The new usage consists in providing a
     single surface object. This new usage will become
-    mandatory in the 0.9 release of Nilearn.
+    mandatory in the 0.10 release of Nilearn.
 
     """
     @wraps(func)
@@ -52,7 +52,7 @@ def _deprecate_separate_mesh_data(func, argument):
                           "to `{}` has been deprecated. You should "
                           "now provide a nilearn Surface object instead. "
                           "The `surf_mesh` arg will be renamed `surface`, "
-                          "and `{}` will be removed in version 0.9.".format(
+                          "and `{}` will be removed in version 0.10.".format(
                               func.__name__, argument),
                           FutureWarning)
             return func(surf_mesh, *args, **kwargs)
@@ -87,7 +87,7 @@ deprecate_separate_mesh_data_plot_surf = partial(
     _deprecate_separate_mesh_data, argument="surf_map")
 
 
-@rename_parameters({'bg_map': 'bg_surf'}, '0.9.0')
+@rename_parameters({'bg_map': 'bg_surf'}, '0.10.0')
 @deprecate_separate_mesh_data_plot_surf
 def plot_surf(surf_mesh, surf_map=None, *, bg_surf=None,
               hemi='left', view='lateral', cmap=None, colorbar=False,
@@ -103,9 +103,9 @@ def plot_surf(surf_mesh, surf_map=None, *, bg_surf=None,
     ----------
     surf_mesh : str or list of two numpy.ndarray or Mesh or Surface
 
-            .. deprecated:: 0.7.2
-                `surf_mesh` is deprecated in 0.7.2 and will be renamed
-                `surface` in 0.9.0. A Surface object will have to be
+            .. deprecated:: 0.8.1
+                `surf_mesh` is deprecated in 0.8.1 and will be renamed
+                `surface` in 0.10.0. A Surface object will have to be
                 provided.
 
         If a Surface-like object is provided instead of a Mesh, `surface.data`
@@ -145,8 +145,8 @@ def plot_surf(surf_mesh, surf_map=None, *, bg_surf=None,
         .thickness, .area, .curv, .sulc, .annot, .label) or
         a Numpy array with a value for each vertex of the surf_mesh.
 
-            .. deprecated:: 0.7.2
-                `surf_map` is deprecated in 0.7.2 and will be removed in 0.9.0.
+            .. deprecated:: 0.8.1
+                `surf_map` is deprecated in 0.8.1 and will be removed in 0.10.0.
                 Please use a Surface object to define the map. Will be ignored
                 if a Surface object is provided as first argument.
 
@@ -155,9 +155,9 @@ def plot_surf(surf_mesh, surf_map=None, *, bg_surf=None,
         `surface.data` in greyscale. `bg_surf.data` is most likely a
         sulcal depth map for realistic shading.
 
-        .. versionchanged:: 0.7.2
-            `bg_surf` was introduced in 0.7.2 and replaces `bg_map`.
-            `bg_map` will not be supported after release 0.9.0.
+        .. versionchanged:: 0.8.1
+            `bg_surf` was introduced in 0.8.1 and replaces `bg_map`.
+            `bg_map` will not be supported after release 0.10.0.
 
     hemi : {'left', 'right'}, optional
         Hemisphere to display. Default='left'.
@@ -543,9 +543,9 @@ def plot_surf_contours(surf_mesh, roi_map, *, axes=None, figure=None,
     ----------
     surf_mesh : str or list of two numpy.ndarray or Mesh or Surface
 
-            .. deprecated:: 0.7.2
-                `surf_mesh` is deprecated in 0.7.2 and will be renamed
-                `surface` in 0.9.0. A Surface object will have to be
+            .. deprecated:: 0.8.1
+                `surf_mesh` is deprecated in 0.8.1 and will be renamed
+                `surface` in 0.10.0. A Surface object will have to be
                 provided.
 
         If a Surface-like object is provided instead of a Mesh, `surface.data`
@@ -587,8 +587,8 @@ def plot_surf_contours(surf_mesh, roi_map, *, axes=None, figure=None,
         The value at each vertex one inside the ROI and zero inside ROI, or an
         integer giving the label number for atlases.
 
-            .. deprecated:: 0.7.2
-                `roi_map` is deprecated in 0.7.2 and will be removed in 0.9.0.
+            .. deprecated:: 0.8.1
+                `roi_map` is deprecated in 0.8.1 and will be removed in 0.10.0.
                 Please use a Surface object to define the map. Will be ignored
                 if a Surface object is provided as first argument.
 
@@ -709,7 +709,7 @@ deprecate_separate_mesh_data_plot_surf_stat_map = partial(
     _deprecate_separate_mesh_data, argument="stat_map")
 
 
-@rename_parameters({'bg_map': 'bg_surf'}, '0.9.0')
+@rename_parameters({'bg_map': 'bg_surf'}, '0.10.0')
 @deprecate_separate_mesh_data_plot_surf_stat_map
 def plot_surf_stat_map(surf_mesh, stat_map, *, bg_surf=None,
                        hemi='left', view='lateral', threshold=None,
@@ -725,9 +725,9 @@ def plot_surf_stat_map(surf_mesh, stat_map, *, bg_surf=None,
     ----------
     surf_mesh : str or list of two numpy.ndarray or Mesh or Surface
 
-            .. deprecated:: 0.7.2
+            .. deprecated:: 0.8.1
                 `surf_mesh` is deprecated and will be renamed
-                `surface` in 0.9.0. A Surface object will have to be
+                `surface` in 0.10.0. A Surface object will have to be
                 provided.
 
         If a Surface-like object is provided instead of a Mesh, `surface.data`
@@ -767,8 +767,8 @@ def plot_surf_stat_map(surf_mesh, stat_map, *, bg_surf=None,
         Freesurfer specific files such as .thickness, .curv, .sulc, .annot,
         .label) or a Numpy array with a value for each vertex of the surf_mesh.
 
-            .. deprecated:: 0.7.2
-                `stat_map` is deprecated in 0.7.2 and will be removed in 0.9.0.
+            .. deprecated:: 0.8.1
+                `stat_map` is deprecated in 0.8.1 and will be removed in 0.10.0.
                 Please use a Surface object to define the map. Will be ignored
                 if a Surface object is provided as first argument.
 
@@ -777,9 +777,9 @@ def plot_surf_stat_map(surf_mesh, stat_map, *, bg_surf=None,
         `surface.data` in greyscale. `bg_surf.data` is most likely a
         sulcal depth map for realistic shading.
 
-        .. versionchanged:: 0.7.2
-            `bg_surf` was introduced in 0.7.2 and replaces `bg_map`.
-            `bg_map` will not be supported after release 0.9.0.
+        .. versionchanged:: 0.8.1
+            `bg_surf` was introduced in 0.8.1 and replaces `bg_map`.
+            `bg_map` will not be supported after release 0.10.0.
 
     hemi : {'left', 'right'}, optional
         Hemispere to display. Default='left'.
@@ -1131,7 +1131,7 @@ deprecate_separate_mesh_data_plot_surf_roi = partial(
     _deprecate_separate_mesh_data, argument="roi_map")
 
 
-@rename_parameters({'bg_map': 'bg_surf'}, '0.9.0')
+@rename_parameters({'bg_map': 'bg_surf'}, '0.10.0')
 @deprecate_separate_mesh_data_plot_surf_roi
 def plot_surf_roi(surf_mesh, roi_map, *, bg_surf=None,
                   hemi='left', view='lateral', threshold=1e-14,
@@ -1146,9 +1146,9 @@ def plot_surf_roi(surf_mesh, roi_map, *, bg_surf=None,
     ----------
     surf_mesh : str or list of two numpy.ndarray or Mesh or Surface
 
-            .. deprecated:: 0.7.2
-                `surf_mesh` is deprecated in 0.7.2 and will be renamed
-                `surface` in 0.9.0. A Surface object will have to be
+            .. deprecated:: 0.8.1
+                `surf_mesh` is deprecated in 0.8.1 and will be renamed
+                `surface` in 0.10.0. A Surface object will have to be
                 provided.
 
         If a Surface-like object is provided instead of a Mesh, `surface.data`
@@ -1190,8 +1190,8 @@ def plot_surf_roi(surf_mesh, roi_map, *, bg_surf=None,
         The value at each vertex one inside the ROI and zero inside ROI, or an
         integer giving the label number for atlases.
 
-            .. deprecated:: 0.7.2
-                `roi_map` is deprecated in 0.7.2 and will be removed in 0.9.0.
+            .. deprecated:: 0.8.1
+                `roi_map` is deprecated in 0.8.1 and will be removed in 0.10.0.
                 Please use a Surface object to define the map. Will be ignored
                 if a Surface object is provided as first argument.
 
@@ -1203,9 +1203,9 @@ def plot_surf_roi(surf_mesh, roi_map, *, bg_surf=None,
         `surface.data` in greyscale. `bg_surf.data` is most likely a
         sulcal depth map for realistic shading.
 
-        .. versionchanged:: 0.7.2
-            `bg_surf` was introduced in 0.7.2 and replaces `bg_map`.
-            `bg_map` will not be supported after release 0.9.0.
+        .. versionchanged:: 0.8.1
+            `bg_surf` was introduced in 0.8.1 and replaces `bg_map`.
+            `bg_map` will not be supported after release 0.10.0.
 
     view : {'lateral', 'medial', 'dorsal', 'ventral', 'anterior', 'posterior'}, optional
         View of the surface that is rendered. Default='lateral'.

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -45,8 +45,8 @@ def _deprecate_separate_mesh_data(func, argument):
     def wrapper(surf_mesh, *args, **kwargs):
         # Deprecate previous usage where the first argument
         # is a mesh instead of a surface.
-        if not (hasattr(surf_mesh, "mesh") and
-                hasattr(surf_mesh, "data")):
+        if not (hasattr(surf_mesh, "mesh")
+                and hasattr(surf_mesh, "data")):
             warnings.warn("Giving a mesh and a texture separately "
                           "to `{}` has been deprecated. You should "
                           "now provide a nilearn Surface object instead. "
@@ -65,16 +65,26 @@ def _deprecate_separate_mesh_data(func, argument):
             if argument in kwargs and kwargs[argument] is not None:
                 kwargs[argument] = surf_mesh.data
             try:
-                return func(surf_mesh.mesh, surf_mesh.data, *args, **kwargs)
+                return func(surf_mesh.mesh,
+                            surf_mesh.data,
+                            *args,
+                            **kwargs)
             except TypeError:
                 if len(args) > 0:
                     args = args[1:]
-                    return func(surf_mesh.mesh, surf_mesh.data, *args, **kwargs)
-                return func(surf_mesh.mesh, *args, **kwargs)
+                    return func(surf_mesh.mesh,
+                                surf_mesh.data,
+                                *args,
+                                **kwargs)
+                return func(surf_mesh.mesh,
+                            *args,
+                            **kwargs)
     return wrapper
+
 
 deprecate_separate_mesh_data_plot_surf = partial(
     _deprecate_separate_mesh_data, argument="surf_map")
+
 
 @deprecate_separate_mesh_data_plot_surf
 def plot_surf(surf_mesh, surf_map=None, *, bg_map=None,
@@ -500,10 +510,12 @@ def _get_faces_on_edge(faces, parc_idx):
 deprecate_separate_mesh_data_plot_surf_contours = partial(
     _deprecate_separate_mesh_data, argument="roi_map")
 
+
 @deprecate_separate_mesh_data_plot_surf_contours
-def plot_surf_contours(surf_mesh, roi_map, *, axes=None, figure=None, levels=None,
-                       labels=None, colors=None, legend=False, cmap='tab20',
-                       title=None, output_file=None, **kwargs):
+def plot_surf_contours(surf_mesh, roi_map, *, axes=None, figure=None,
+                       levels=None, labels=None, colors=None,
+                       legend=False, cmap='tab20', title=None,
+                       output_file=None, **kwargs):
     """Plotting contours of ROIs on a surface, optionally over a statistical map.
 
     Parameters
@@ -664,8 +676,10 @@ def plot_surf_contours(surf_mesh, roi_map, *, axes=None, figure=None, levels=Non
     else:
         return figure
 
+
 deprecate_separate_mesh_data_plot_surf_stat_map = partial(
     _deprecate_separate_mesh_data, argument="stat_map")
+
 
 @deprecate_separate_mesh_data_plot_surf_stat_map
 def plot_surf_stat_map(surf_mesh, stat_map, *, bg_map=None,
@@ -1042,7 +1056,7 @@ def plot_img_on_surf(stat_map, surf_mesh='fsaverage5', mask_img=None,
         # ax.set_facecolor("#e0e0e0")
         # We increase this value to better position the camera of the
         # 3D projection plot. The default value makes meshes look too small.
-        ax.dist = 7 
+        ax.dist = 7
 
     if colorbar:
         sm = _colorbar_from_array(image.get_data(stat_map),
@@ -1066,6 +1080,7 @@ def plot_img_on_surf(stat_map, surf_mesh='fsaverage5', mask_img=None,
 
 deprecate_separate_mesh_data_plot_surf_roi = partial(
     _deprecate_separate_mesh_data, argument="roi_map")
+
 
 @deprecate_separate_mesh_data_plot_surf_roi
 def plot_surf_roi(surf_mesh, roi_map, *, bg_map=None,

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -32,7 +32,7 @@ VALID_VIEWS = "anterior", "posterior", "medial", "lateral", "dorsal", "ventral"
 VALID_HEMISPHERES = "left", "right"
 
 
-def _deprecate_seperate_mesh_data(func, argument):
+def _deprecate_separate_mesh_data(func, argument):
     """Decorator to deprecate usage of mesh and
     texture as multiple arguments in surface related
     functions. The new usage consists in providing a
@@ -72,10 +72,10 @@ def _deprecate_seperate_mesh_data(func, argument):
                 return func(surf_mesh.mesh, *args, **kwargs)
     return wrapper
 
-deprecate_seperate_mesh_data_plot_surf = partial(
-    _deprecate_seperate_mesh_data, argument="surf_map")
+deprecate_separate_mesh_data_plot_surf = partial(
+    _deprecate_separate_mesh_data, argument="surf_map")
 
-@deprecate_seperate_mesh_data_plot_surf
+@deprecate_separate_mesh_data_plot_surf
 def plot_surf(surf_mesh, surf_map=None, *, bg_map=None,
               hemi='left', view='lateral', cmap=None, colorbar=False,
               avg_method='mean', threshold=None, alpha='auto',
@@ -89,32 +89,32 @@ def plot_surf(surf_mesh, surf_map=None, *, bg_map=None,
     Parameters
     ----------
     surf_mesh : str or list of two numpy.ndarray or Mesh or Surface
-        Deprecated, will be renamed `surface` in 0.9. Either:
-            - a Surface-like object with a mesh and data attributes
-                A surface can be:
-                    - a nilearn.surface.Surface
-                    - a sequence (mesh, data) where:
-                        - mesh can be:
-                            - a nilearn.surface.Mesh
-                            - a path to .gii or .gii.gz etc.
-                            - a sequence of two numpy arrays,
-                            the first containing vertex coordinates
-                            and the second containing triangles.
-                        - data can be:
-                            - a path to .gii or .gii.gz etc.
-                            - a numpy array with shape (n_vertices,)
-                            or (n_time_points, n_vertices)
-            - a surface mesh geometry (deprecated)
-                A Mesh can be:
-                    - a file (valid formats are .gii or Freesurfer specific
-                    files such as .orig, .pial, .sphere, .white, .inflated)
-                    - a list of two Numpy arrays, the first containing the
-                    x-y-z coordinates of the mesh vertices, the second
-                    containing the indices (into coords) of the mesh faces
-                    - a Mesh object with "coordinates" and "faces" attributes.
-
+        Deprecated, will be renamed `surface` in 0.9.
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
+        It can be:
+            - a Surface-like object with a mesh and data attributes
+            A surface can be:
+                - a nilearn.surface.Surface
+                - a sequence (mesh, data) where:
+                    - mesh can be:
+                        - a nilearn.surface.Mesh
+                        - a path to .gii or .gii.gz etc.
+                        - a sequence of two numpy arrays,
+                        the first containing vertex coordinates
+                        and the second containing triangles.
+                    - data can be:
+                        - a path to .gii or .gii.gz etc.
+                        - a numpy array with shape (n_vertices,)
+                        or (n_time_points, n_vertices)
+            - a surface mesh geometry (deprecated)
+            A Mesh can be:
+                - a file (valid formats are .gii or Freesurfer specific
+                files such as .orig, .pial, .sphere, .white, .inflated)
+                - a list of two Numpy arrays, the first containing the
+                x-y-z coordinates of the mesh vertices, the second
+                containing the indices (into coords) of the mesh faces
+                - a Mesh object with "coordinates" and "faces" attributes.
 
     surf_map : str or numpy.ndarray, optional
         Deprecated, will be removed in 0.9. Please use a Surface object to
@@ -491,10 +491,10 @@ def _get_faces_on_edge(faces, parc_idx):
     return np.logical_and(faces_outside_edge > 0, verts_per_face < 3)
 
 
-deprecate_seperate_mesh_data_plot_surf_contours = partial(
-    _deprecate_seperate_mesh_data, argument="roi_map")
+deprecate_separate_mesh_data_plot_surf_contours = partial(
+    _deprecate_separate_mesh_data, argument="roi_map")
 
-@deprecate_seperate_mesh_data_plot_surf_contours
+@deprecate_separate_mesh_data_plot_surf_contours
 def plot_surf_contours(surf_mesh, roi_map, *, axes=None, figure=None, levels=None,
                        labels=None, colors=None, legend=False, cmap='tab20',
                        title=None, output_file=None, **kwargs):
@@ -503,32 +503,32 @@ def plot_surf_contours(surf_mesh, roi_map, *, axes=None, figure=None, levels=Non
     Parameters
     ----------
     surf_mesh : str or list of two numpy.ndarray or Mesh or Surface
-        Deprecated, will be renamed `surface` in 0.9. Either:
-            - a Surface-like object with a mesh and data attributes
-                A surface can be:
-                    - a nilearn.surface.Surface
-                    - a sequence (mesh, data) where:
-                        - mesh can be:
-                            - a nilearn.surface.Mesh
-                            - a path to .gii or .gii.gz etc.
-                            - a sequence of two numpy arrays,
-                            the first containing vertex coordinates
-                            and the second containing triangles.
-                        - data can be:
-                            - a path to .gii or .gii.gz etc.
-                            - a numpy array with shape (n_vertices,)
-                            or (n_time_points, n_vertices)
-            - a surface mesh geometry (deprecated)
-                A Mesh can be:
-                    - a file (valid formats are .gii or Freesurfer specific
-                    files such as .orig, .pial, .sphere, .white, .inflated)
-                    - a list of two Numpy arrays, the first containing the
-                    x-y-z coordinates of the mesh vertices, the second
-                    containing the indices (into coords) of the mesh faces
-                    - a Mesh object with "coordinates" and "faces" attributes.
-
+        Deprecated, will be renamed `surface` in 0.9.
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
+        It can be:
+            - a Surface-like object with a mesh and data attributes
+            A surface can be:
+                - a nilearn.surface.Surface
+                - a sequence (mesh, data) where:
+                    - mesh can be:
+                        - a nilearn.surface.Mesh
+                        - a path to .gii or .gii.gz etc.
+                        - a sequence of two numpy arrays,
+                        the first containing vertex coordinates
+                        and the second containing triangles.
+                    - data can be:
+                        - a path to .gii or .gii.gz etc.
+                        - a numpy array with shape (n_vertices,)
+                        or (n_time_points, n_vertices)
+            - a surface mesh geometry (deprecated)
+            A Mesh can be:
+                - a file (valid formats are .gii or Freesurfer specific
+                files such as .orig, .pial, .sphere, .white, .inflated)
+                - a list of two Numpy arrays, the first containing the
+                x-y-z coordinates of the mesh vertices, the second
+                containing the indices (into coords) of the mesh faces
+                - a Mesh object with "coordinates" and "faces" attributes.
 
     roi_map : str or numpy.ndarray or list of numpy.ndarray
         Deprecated, will be removed in 0.9. Please use a Surface object to
@@ -653,10 +653,10 @@ def plot_surf_contours(surf_mesh, roi_map, *, axes=None, figure=None, levels=Non
     else:
         return figure
 
-deprecate_seperate_mesh_data_plot_surf_stat_map = partial(
-    _deprecate_seperate_mesh_data, argument="stat_map")
+deprecate_separate_mesh_data_plot_surf_stat_map = partial(
+    _deprecate_separate_mesh_data, argument="stat_map")
 
-@deprecate_seperate_mesh_data_plot_surf_stat_map
+@deprecate_separate_mesh_data_plot_surf_stat_map
 def plot_surf_stat_map(surf_mesh, stat_map, *, bg_map=None,
                        hemi='left', view='lateral', threshold=None,
                        alpha='auto', vmax=None, cmap='cold_hot',
@@ -670,32 +670,32 @@ def plot_surf_stat_map(surf_mesh, stat_map, *, bg_map=None,
     Parameters
     ----------
     surf_mesh : str or list of two numpy.ndarray or Mesh or Surface
-        Deprecated, will be renamed `surface` in 0.9. Either:
-            - a Surface-like object with a mesh and data attributes
-                A surface can be:
-                    - a nilearn.surface.Surface
-                    - a sequence (mesh, data) where:
-                        - mesh can be:
-                            - a nilearn.surface.Mesh
-                            - a path to .gii or .gii.gz etc.
-                            - a sequence of two numpy arrays,
-                            the first containing vertex coordinates
-                            and the second containing triangles.
-                        - data can be:
-                            - a path to .gii or .gii.gz etc.
-                            - a numpy array with shape (n_vertices,)
-                            or (n_time_points, n_vertices)
-            - a surface mesh geometry (deprecated)
-                A Mesh can be:
-                    - a file (valid formats are .gii or Freesurfer specific
-                    files such as .orig, .pial, .sphere, .white, .inflated)
-                    - a list of two Numpy arrays, the first containing the
-                    x-y-z coordinates of the mesh vertices, the second
-                    containing the indices (into coords) of the mesh faces
-                    - a Mesh object with "coordinates" and "faces" attributes.
-
+        Deprecated, will be renamed `surface` in 0.9.
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
+        It can be:
+            - a Surface-like object with a mesh and data attributes
+            A surface can be:
+                - a nilearn.surface.Surface
+                - a sequence (mesh, data) where:
+                    - mesh can be:
+                        - a nilearn.surface.Mesh
+                        - a path to .gii or .gii.gz etc.
+                        - a sequence of two numpy arrays,
+                        the first containing vertex coordinates
+                        and the second containing triangles.
+                    - data can be:
+                        - a path to .gii or .gii.gz etc.
+                        - a numpy array with shape (n_vertices,)
+                        or (n_time_points, n_vertices)
+            - a surface mesh geometry (deprecated)
+            A Mesh can be:
+                - a file (valid formats are .gii or Freesurfer specific
+                files such as .orig, .pial, .sphere, .white, .inflated)
+                - a list of two Numpy arrays, the first containing the
+                x-y-z coordinates of the mesh vertices, the second
+                containing the indices (into coords) of the mesh faces
+                - a Mesh object with "coordinates" and "faces" attributes.
 
     stat_map : str or numpy.ndarray
         Deprecated, will be removed in 0.9. Please use a Surface object to
@@ -1046,10 +1046,10 @@ def plot_img_on_surf(stat_map, surf_mesh='fsaverage5', mask_img=None,
         return fig, axes
 
 
-deprecate_seperate_mesh_data_plot_surf_roi = partial(
-    _deprecate_seperate_mesh_data, argument="roi_map")
+deprecate_separate_mesh_data_plot_surf_roi = partial(
+    _deprecate_separate_mesh_data, argument="roi_map")
 
-@deprecate_seperate_mesh_data_plot_surf_roi
+@deprecate_separate_mesh_data_plot_surf_roi
 def plot_surf_roi(surf_mesh, roi_map, *, bg_map=None,
                   hemi='left', view='lateral', threshold=1e-14,
                   alpha='auto', vmin=None, vmax=None, cmap='gist_ncar',
@@ -1062,32 +1062,32 @@ def plot_surf_roi(surf_mesh, roi_map, *, bg_map=None,
     Parameters
     ----------
     surf_mesh : str or list of two numpy.ndarray or Mesh or Surface
-        Deprecated, will be renamed `surface` in 0.9. Either:
-            - a Surface-like object with a mesh and data attributes
-                A surface can be:
-                    - a nilearn.surface.Surface
-                    - a sequence (mesh, data) where:
-                        - mesh can be:
-                            - a nilearn.surface.Mesh
-                            - a path to .gii or .gii.gz etc.
-                            - a sequence of two numpy arrays,
-                            the first containing vertex coordinates
-                            and the second containing triangles.
-                        - data can be:
-                            - a path to .gii or .gii.gz etc.
-                            - a numpy array with shape (n_vertices,)
-                            or (n_time_points, n_vertices)
-            - a surface mesh geometry (deprecated)
-                A Mesh can be:
-                    - a file (valid formats are .gii or Freesurfer specific
-                    files such as .orig, .pial, .sphere, .white, .inflated)
-                    - a list of two Numpy arrays, the first containing the
-                    x-y-z coordinates of the mesh vertices, the second
-                    containing the indices (into coords) of the mesh faces
-                    - a Mesh object with "coordinates" and "faces" attributes.
-
+        Deprecated, will be renamed `surface` in 0.9.
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
+        It can be:
+            - a Surface-like object with a mesh and data attributes
+            A surface can be:
+                - a nilearn.surface.Surface
+                - a sequence (mesh, data) where:
+                    - mesh can be:
+                        - a nilearn.surface.Mesh
+                        - a path to .gii or .gii.gz etc.
+                        - a sequence of two numpy arrays,
+                        the first containing vertex coordinates
+                        and the second containing triangles.
+                    - data can be:
+                        - a path to .gii or .gii.gz etc.
+                        - a numpy array with shape (n_vertices,)
+                        or (n_time_points, n_vertices)
+            - a surface mesh geometry (deprecated)
+            A Mesh can be:
+                - a file (valid formats are .gii or Freesurfer specific
+                files such as .orig, .pial, .sphere, .white, .inflated)
+                - a list of two Numpy arrays, the first containing the
+                x-y-z coordinates of the mesh vertices, the second
+                containing the indices (into coords) of the mesh faces
+                - a Mesh object with "coordinates" and "faces" attributes.
 
     roi_map : str or numpy.ndarray or list of numpy.ndarray
         Deprecated, will be removed in 0.9. Please use a Surface object to

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -94,22 +94,18 @@ def plot_surf(surf_mesh, surf_map=None, *, bg_map=None,
                 A surface can be:
                     - a nilearn.surface.Surface
                     - a sequence (mesh, data) where:
-
                         - mesh can be:
                             - a nilearn.surface.Mesh
                             - a path to .gii or .gii.gz etc.
                             - a sequence of two numpy arrays,
                             the first containing vertex coordinates
                             and the second containing triangles.
-
                         - data can be:
                             - a path to .gii or .gii.gz etc.
                             - a numpy array with shape (n_vertices,)
                             or (n_time_points, n_vertices)
-
             - a surface mesh geometry (deprecated)
                 A Mesh can be:
-
                     - a file (valid formats are .gii or Freesurfer specific
                     files such as .orig, .pial, .sphere, .white, .inflated)
                     - a list of two Numpy arrays, the first containing the
@@ -512,19 +508,16 @@ def plot_surf_contours(surf_mesh, roi_map, *, axes=None, figure=None, levels=Non
                 A surface can be:
                     - a nilearn.surface.Surface
                     - a sequence (mesh, data) where:
-
                         - mesh can be:
                             - a nilearn.surface.Mesh
                             - a path to .gii or .gii.gz etc.
                             - a sequence of two numpy arrays,
                             the first containing vertex coordinates
                             and the second containing triangles.
-
                         - data can be:
                             - a path to .gii or .gii.gz etc.
                             - a numpy array with shape (n_vertices,)
                             or (n_time_points, n_vertices)
-
             - a surface mesh geometry (deprecated)
                 A Mesh can be:
                     - a file (valid formats are .gii or Freesurfer specific
@@ -682,19 +675,16 @@ def plot_surf_stat_map(surf_mesh, stat_map, *, bg_map=None,
                 A surface can be:
                     - a nilearn.surface.Surface
                     - a sequence (mesh, data) where:
-
                         - mesh can be:
                             - a nilearn.surface.Mesh
                             - a path to .gii or .gii.gz etc.
                             - a sequence of two numpy arrays,
                             the first containing vertex coordinates
                             and the second containing triangles.
-
                         - data can be:
                             - a path to .gii or .gii.gz etc.
                             - a numpy array with shape (n_vertices,)
                             or (n_time_points, n_vertices)
-
             - a surface mesh geometry (deprecated)
                 A Mesh can be:
                     - a file (valid formats are .gii or Freesurfer specific
@@ -1077,19 +1067,16 @@ def plot_surf_roi(surf_mesh, roi_map, *, bg_map=None,
                 A surface can be:
                     - a nilearn.surface.Surface
                     - a sequence (mesh, data) where:
-
                         - mesh can be:
                             - a nilearn.surface.Mesh
                             - a path to .gii or .gii.gz etc.
                             - a sequence of two numpy arrays,
                             the first containing vertex coordinates
                             and the second containing triangles.
-
                         - data can be:
                             - a path to .gii or .gii.gz etc.
                             - a numpy array with shape (n_vertices,)
                             or (n_time_points, n_vertices)
-
             - a surface mesh geometry (deprecated)
                 A Mesh can be:
                     - a file (valid formats are .gii or Freesurfer specific

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -146,9 +146,10 @@ def plot_surf(surf_mesh, surf_map=None, *, bg_surf=None,
         a Numpy array with a value for each vertex of the surf_mesh.
 
             .. deprecated:: 0.8.1
-                `surf_map` is deprecated in 0.8.1 and will be removed in 0.10.0.
-                Please use a Surface object to define the map. Will be ignored
-                if a Surface object is provided as first argument.
+                `surf_map` is deprecated in 0.8.1 and will be
+                removed in 0.10.0. Please use a Surface object
+                to define the map. Will be ignored if a Surface
+                object is provided as first argument.
 
     bg_surf : Surface, optional
         Background surface to be plotted on `surface.mesh` underneath
@@ -768,9 +769,10 @@ def plot_surf_stat_map(surf_mesh, stat_map, *, bg_surf=None,
         .label) or a Numpy array with a value for each vertex of the surf_mesh.
 
             .. deprecated:: 0.8.1
-                `stat_map` is deprecated in 0.8.1 and will be removed in 0.10.0.
-                Please use a Surface object to define the map. Will be ignored
-                if a Surface object is provided as first argument.
+                `stat_map` is deprecated in 0.8.1 and will be removed
+                in 0.10.0. Please use a Surface object to define the
+                map. Will be ignored if a Surface object is provided
+                as first argument.
 
     bg_surf : Surface, optional
         Background surface to be plotted on `surface.mesh` underneath

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -100,7 +100,12 @@ def plot_surf(surf_mesh, surf_map=None, *, bg_map=None,
     Parameters
     ----------
     surf_mesh : str or list of two numpy.ndarray or Mesh or Surface
-        Deprecated, will be renamed `surface` in 0.9.
+
+            .. deprecated:: 0.7.2
+                `surf_mesh` is deprecated in 0.7.2 and will be renamed
+                `surface` in 0.9.0. A Surface object will have to be
+                provided.
+
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
         It can be:
@@ -133,13 +138,15 @@ def plot_surf(surf_mesh, surf_map=None, *, bg_map=None,
             - a Mesh object with "coordinates" and "faces" attributes.
 
     surf_map : str or numpy.ndarray, optional
-        Deprecated, will be removed in 0.9. Please use a Surface object to
-        define the map. This argument will be ignored if a Surface object is
-        provided as first argument.
         Data to be displayed on the surface mesh. Can be a file (valid formats
         are .gii, .mgz, .nii, .nii.gz, or Freesurfer specific files such as
         .thickness, .area, .curv, .sulc, .annot, .label) or
         a Numpy array with a value for each vertex of the surf_mesh.
+
+            .. deprecated:: 0.7.2
+                `surf_map` is deprecated in 0.7.2 and will be removed in 0.9.0.
+                Please use a Surface object to define the map. Will be ignored
+                if a Surface object is provided as first argument.
 
     bg_map : Surface data object (to be defined), optional
         Background image to be plotted on the mesh underneath the
@@ -521,7 +528,12 @@ def plot_surf_contours(surf_mesh, roi_map, *, axes=None, figure=None,
     Parameters
     ----------
     surf_mesh : str or list of two numpy.ndarray or Mesh or Surface
-        Deprecated, will be renamed `surface` in 0.9.
+
+            .. deprecated:: 0.7.2
+                `surf_mesh` is deprecated in 0.7.2 and will be renamed
+                `surface` in 0.9.0. A Surface object will have to be
+                provided.
+
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
         It can be:
@@ -554,15 +566,17 @@ def plot_surf_contours(surf_mesh, roi_map, *, axes=None, figure=None,
             - a Mesh object with "coordinates" and "faces" attributes.
 
     roi_map : str or numpy.ndarray or list of numpy.ndarray
-        Deprecated, will be removed in 0.9. Please use a Surface object to
-        define the map. This argument will be ignored if a Surface object is
-        provided as first argument.
         ROI map to be displayed on the surface mesh, can be a file
         (valid formats are .gii, .mgz, .nii, .nii.gz, or Freesurfer specific
         files such as .annot or .label), or
         a Numpy array with a value for each vertex of the surf_mesh.
         The value at each vertex one inside the ROI and zero inside ROI, or an
         integer giving the label number for atlases.
+
+            .. deprecated:: 0.7.2
+                `roi_map` is deprecated in 0.7.2 and will be removed in 0.9.0.
+                Please use a Surface object to define the map. Will be ignored
+                if a Surface object is provided as first argument.
 
     axes : instance of matplotlib axes, None, optional
         The axes instance to plot to. The projection must be '3d' (e.g.,
@@ -695,7 +709,12 @@ def plot_surf_stat_map(surf_mesh, stat_map, *, bg_map=None,
     Parameters
     ----------
     surf_mesh : str or list of two numpy.ndarray or Mesh or Surface
-        Deprecated, will be renamed `surface` in 0.9.
+
+            .. deprecated:: 0.7.2
+                `surf_mesh` is deprecated and will be renamed
+                `surface` in 0.9.0. A Surface object will have to be
+                provided.
+
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
         It can be:
@@ -728,14 +747,15 @@ def plot_surf_stat_map(surf_mesh, stat_map, *, bg_map=None,
             - a Mesh object with "coordinates" and "faces" attributes.
 
     stat_map : str or numpy.ndarray
-        Deprecated, will be removed in 0.9. Please use a Surface object to
-        define the map. This argument will be ignored if a Surface object is
-        provided as first argument.
         Statistical map to be displayed on the surface mesh, can
         be a file (valid formats are .gii, .mgz, .nii, .nii.gz, or
-        Freesurfer specific files such as .thickness, .area, .curv,
-        .sulc, .annot, .label) or
-        a Numpy array with a value for each vertex of the surf_mesh.
+        Freesurfer specific files such as .thickness, .curv, .sulc, .annot,
+        .label) or a Numpy array with a value for each vertex of the surf_mesh.
+
+            .. deprecated:: 0.7.2
+                `stat_map` is deprecated in 0.7.2 and will be removed in 0.9.0.
+                Please use a Surface object to define the map. Will be ignored
+                if a Surface object is provided as first argument.
 
     bg_map : Surface data object (to be defined), optional
         Background image to be plotted on the mesh underneath the
@@ -1095,7 +1115,12 @@ def plot_surf_roi(surf_mesh, roi_map, *, bg_map=None,
     Parameters
     ----------
     surf_mesh : str or list of two numpy.ndarray or Mesh or Surface
-        Deprecated, will be renamed `surface` in 0.9.
+
+            .. deprecated:: 0.7.2
+                `surf_mesh` is deprecated in 0.7.2 and will be renamed
+                `surface` in 0.9.0. A Surface object will have to be
+                provided.
+
         If a Surface-like object is provided instead of a Mesh, `surface.data`
         will overwrite the `surf_map` argument.
         It can be:
@@ -1128,15 +1153,17 @@ def plot_surf_roi(surf_mesh, roi_map, *, bg_map=None,
             - a Mesh object with "coordinates" and "faces" attributes.
 
     roi_map : str or numpy.ndarray or list of numpy.ndarray
-        Deprecated, will be removed in 0.9. Please use a Surface object to
-        define the map. This argument will be ignored if a Surface object is
-        provided as first argument.
         ROI map to be displayed on the surface mesh, can be a file
         (valid formats are .gii, .mgz, .nii, .nii.gz, or Freesurfer specific
         files such as .annot or .label), or
         a Numpy array with a value for each vertex of the surf_mesh.
         The value at each vertex one inside the ROI and zero inside ROI, or an
         integer giving the label number for atlases.
+
+            .. deprecated:: 0.7.2
+                `roi_map` is deprecated in 0.7.2 and will be removed in 0.9.0.
+                Please use a Surface object to define the map. Will be ignored
+                if a Surface object is provided as first argument.
 
     hemi : {'left', 'right'}, optional
         Hemisphere to display. Default='left'.

--- a/nilearn/plotting/tests/test_html_surface.py
+++ b/nilearn/plotting/tests/test_html_surface.py
@@ -53,8 +53,8 @@ def test_one_mesh_info():
     background = surface.load_surface((mesh,
                                        surf_map))
     info1 = html_surface._one_mesh_info(
-         surf_map, mesh, '90%', black_bg=True,
-         bg_surf=surf_map)
+        surf_map, mesh, '90%', black_bg=True,
+        bg_surf=surf_map)
     info = html_surface._one_mesh_info(
         surf_map, mesh, '90%', black_bg=True,
         bg_surf=background)

--- a/nilearn/plotting/tests/test_html_surface.py
+++ b/nilearn/plotting/tests/test_html_surface.py
@@ -113,11 +113,12 @@ def test_view_surf():
     mesh = surface.load_surf_mesh(fsaverage['pial_right'])
     surf_map = mesh[0][:, 0]
     html = html_surface.view_surf(fsaverage['pial_right'], surf_map,
-                                  fsaverage['sulc_right'], '90%')
+                                  bg_map=fsaverage['sulc_right'],
+                                  threshold='90%')
     check_html(html, title="Surface plot")
     html = html_surface.view_surf(fsaverage['pial_right'], surf_map,
-                                  fsaverage['sulc_right'], .3,
-                                  title="SOME_TITLE")
+                                  bg_map=fsaverage['sulc_right'],
+                                  threshold=.3, title="SOME_TITLE")
     check_html(html, title="SOME_TITLE")
     assert "SOME_TITLE" in html.html
     html = html_surface.view_surf(fsaverage['pial_right'])

--- a/nilearn/plotting/tests/test_html_surface.py
+++ b/nilearn/plotting/tests/test_html_surface.py
@@ -111,25 +111,25 @@ def test_fill_html_template():
 def test_view_surf():
     fsaverage = fetch_surf_fsaverage()
     mesh = surface.load_surf_mesh(fsaverage['pial_right'])
-    surf_map = mesh[0][:, 0]
-    html = html_surface.view_surf(fsaverage['pial_right'], surf_map,
-                                  bg_map=fsaverage['sulc_right'],
+    surf = surface.load_surface((mesh, mesh[0][:, 0]))
+    html = html_surface.view_surf(surf, bg_map=fsaverage['sulc_right'],
                                   threshold='90%')
     check_html(html, title="Surface plot")
-    html = html_surface.view_surf(fsaverage['pial_right'], surf_map,
-                                  bg_map=fsaverage['sulc_right'],
+    html = html_surface.view_surf(surf, bg_map=fsaverage['sulc_right'],
                                   threshold=.3, title="SOME_TITLE")
     check_html(html, title="SOME_TITLE")
     assert "SOME_TITLE" in html.html
     html = html_surface.view_surf(fsaverage['pial_right'])
     check_html(html)
     atlas = np.random.RandomState(42).randint(0, 10, size=len(mesh[0]))
-    html = html_surface.view_surf(
-        fsaverage['pial_left'], atlas, symmetric_cmap=False)
+    with pytest.warns(FutureWarning,
+                      match="Giving a mesh and a texture separately"):
+        html = html_surface.view_surf(
+            fsaverage['pial_left'], atlas, symmetric_cmap=False)
     check_html(html)
-    html = html_surface.view_surf(fsaverage['pial_right'],
-                                  fsaverage['sulc_right'],
-                                  threshold=None, cmap='Greys')
+    surf = surface.load_surface((fsaverage['pial_right'],
+                                 fsaverage['sulc_right']))
+    html = html_surface.view_surf(surf, threshold=None, cmap='Greys')
     check_html(html)
     with pytest.raises(ValueError):
         html_surface.view_surf(mesh, mesh[0][::2, 0])

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -108,14 +108,17 @@ def test_plot_surf_error():
         ValueError, match="surf_map does not have the same number of vertices"
     ):
         plot_surf(
-            mesh, surf_map=rng.standard_normal(size=mesh[0].shape[0] + 1), surface=None
+            mesh,
+            surf_map=rng.standard_normal(size=mesh[0].shape[0] + 1),
+            surface=None
         )
 
     with pytest.raises(
         ValueError, match="surf_map can only have one dimension"
     ):
         plot_surf(
-            mesh, surf_map=rng.standard_normal(size=(mesh[0].shape[0], 2))
+            mesh,
+            surf_map=rng.standard_normal(size=(mesh[0].shape[0], 2))
         )
 
     with pytest.raises(

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -22,6 +22,7 @@ def test_plot_surf():
     bg = rng.standard_normal(size=mesh[0].shape[0])
     data = 10 * rng.standard_normal(size=mesh[0].shape[0])
     surf = load_surface([mesh, data])
+    background = load_surface((mesh, bg))
 
     # Plot mesh only
     # Check that a FutureWarning is given
@@ -31,22 +32,28 @@ def test_plot_surf():
         plot_surf(mesh)
 
     # Plot surface
-    plot_surf(surf, bg_map=bg)
+    with pytest.warns(FutureWarning,
+                      match="The parameter"):
+        plot_surf(surf, bg_map=bg)
+
+    plot_surf(surf, bg_surf=background)
 
     # Plot mesh with background
-    plot_surf(mesh, bg_map=bg)
-    plot_surf(mesh, bg_map=bg, darkness=0.5)
-    plot_surf(mesh, bg_map=bg, alpha=0.5)
+    plot_surf(mesh, bg_surf=background)
+    plot_surf(mesh, bg_surf=background, darkness=0.5)
+    plot_surf(mesh, bg_surf=background, alpha=0.5)
 
     # Plot different views
-    plot_surf(mesh, bg_map=bg, hemi='right')
-    plot_surf(mesh, bg_map=bg, view='medial')
-    plot_surf(mesh, bg_map=bg, hemi='right', view='medial')
+    plot_surf(mesh, bg_surf=background, hemi='right')
+    plot_surf(mesh, bg_surf=background, view='medial')
+    plot_surf(mesh, bg_surf=background,
+              hemi='right', view='medial')
 
     # Plot with colorbar
-    plot_surf(mesh, bg_map=bg, colorbar=True)
-    plot_surf(mesh, bg_map=bg, colorbar=True, cbar_vmin=0,
-              cbar_vmax=150, cbar_tick_format="%i")
+    plot_surf(mesh, bg_surf=background, colorbar=True)
+    plot_surf(mesh, bg_surf=background, colorbar=True,
+              cbar_vmin=0, cbar_vmax=150,
+              cbar_tick_format="%i")
 
     # Plot with avg_method
     ## Test all built-in methods and check
@@ -98,10 +105,11 @@ def test_plot_surf_error():
         plot_surf(mesh, hemi='lft')
 
     # Wrong size of background image
-    with pytest.raises(
-            ValueError,
-            match='bg_map does not have the same number of vertices'):
-        plot_surf(mesh, bg_map=rng.standard_normal(size=mesh[0].shape[0] - 1))
+    with pytest.raises(ValueError,
+                       match=('background texture does not have '
+                              'the same number of vertices')):
+        plot_surf(mesh,
+                  bg_surf=rng.standard_normal(size=mesh[0].shape[0] - 1))
 
     # Wrong size of surface data
     with pytest.raises(
@@ -165,6 +173,7 @@ def test_plot_surf_stat_map():
     bg = rng.standard_normal(size=mesh[0].shape[0])
     data = 10 * rng.standard_normal(size=mesh[0].shape[0])
     surf = load_surface([mesh, data])
+    background = load_surface((mesh, bg))
 
     # Plot mesh with stat map
     # Check that a FutureWarning is given
@@ -187,22 +196,32 @@ def test_plot_surf_stat_map():
                              "will be overwritten by the surface data.")):
         plot_surf_stat_map(surf, stat_map=data)
     # Plot mesh with background and stat map
-    plot_surf_stat_map(mesh, stat_map=data, bg_map=bg)
-    plot_surf_stat_map(surf, bg_map=bg, bg_on_data=True, darkness=0.5)
-    plot_surf_stat_map(mesh, stat_map=data, bg_map=bg, colorbar=True,
+    with pytest.warns(FutureWarning,
+                      match="The parameter"):
+        plot_surf_stat_map(surf, bg_map=bg)
+
+    plot_surf_stat_map(mesh, stat_map=data,
+                       bg_surf=background)
+    plot_surf_stat_map(surf, bg_surf=background,
+                       bg_on_data=True, darkness=0.5)
+    plot_surf_stat_map(mesh, stat_map=data,
+                       bg_surf=background, colorbar=True,
                        bg_on_data=True, darkness=0.5)
 
     # Apply threshold
-    plot_surf_stat_map(mesh, stat_map=data, bg_map=bg,
+    plot_surf_stat_map(mesh, stat_map=data, bg_surf=background,
                        bg_on_data=True, darkness=0.5,
                        threshold=0.3)
-    plot_surf_stat_map(mesh, stat_map=data, bg_map=bg, colorbar=True,
+    plot_surf_stat_map(mesh, stat_map=data,
+                       bg_surf=background, colorbar=True,
                        bg_on_data=True, darkness=0.5,
                        threshold=0.3)
 
     # Change colorbar tick format
-    plot_surf_stat_map(mesh, stat_map=data, bg_map=bg, colorbar=True,
-                       bg_on_data=True, darkness=0.5, cbar_tick_format="%.2g")
+    plot_surf_stat_map(mesh, stat_map=data,
+                       bg_surf=background, colorbar=True,
+                       bg_on_data=True, darkness=0.5,
+                       cbar_tick_format="%.2g")
 
     # Change vmax
     plot_surf_stat_map(mesh, stat_map=data, vmax=5)

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -471,7 +471,7 @@ def _interpolation_sampling(images, mesh, affine, kind='auto', radius=3,
 
 @deprecated(("The return value is deprecated and will change to "
              "a Surface object with provided mesh and computed "
-             "texture as arguments in release 0.9."))
+             "texture as arguments in release 0.10.0"))
 def vol_to_surf(img, surf_mesh,
                 radius=3., interpolation='linear', kind='auto',
                 n_samples=None, mask_img=None, inner_mesh=None, depth=None):
@@ -574,10 +574,10 @@ def vol_to_surf(img, surf_mesh,
         If 4D image is provided, a 2d array is returned, where each row
         corresponds to a mesh node.
 
-            .. deprecated:: 0.7.2
+            .. deprecated:: 0.8.1
                 The return value is deprecated and will change
                 from a numpy array to a Surface object with provided
-                mesh and computed texture as arguments in release 0.9.0.
+                mesh and computed texture as arguments in release 0.10.0.
 
     Notes
     -----
@@ -630,7 +630,7 @@ def vol_to_surf(img, surf_mesh,
     are subject to change.
 
     The return value is deprecated and will change to a Surface object
-    with provided mesh and computed texture as arguments in release 0.9.
+    with provided mesh and computed texture as arguments in release 0.10.0.
 
     """
     sampling_schemes = {'linear': _interpolation_sampling,

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -573,8 +573,11 @@ def vol_to_surf(img, surf_mesh,
         for each mesh node.
         If 4D image is provided, a 2d array is returned, where each row
         corresponds to a mesh node.
-        The return value is deprecated and will change to a Surface object
-        with provided mesh and computed texture as arguments in release 0.9.
+
+            .. deprecated:: 0.7.2
+                The return value is deprecated and will change
+                from a numpy array to a Surface object with provided
+                mesh and computed texture as arguments in release 0.9.0.
 
     Notes
     -----

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -27,6 +27,7 @@ from nilearn import datasets
 from nilearn.image import load_img
 from nilearn.image import resampling
 from nilearn._utils.path_finding import _resolve_globbing
+from nilearn._utils import deprecated
 from nilearn import _utils
 from nilearn.image import get_data
 
@@ -468,6 +469,9 @@ def _interpolation_sampling(images, mesh, affine, kind='auto', radius=3,
     return texture
 
 
+@deprecated(("The return value is deprecated and will change to "
+             "a Surface object with provided mesh and computed "
+             "texture as arguments in release 0.9."))
 def vol_to_surf(img, surf_mesh,
                 radius=3., interpolation='linear', kind='auto',
                 n_samples=None, mask_img=None, inner_mesh=None, depth=None):
@@ -569,6 +573,8 @@ def vol_to_surf(img, surf_mesh,
         for each mesh node.
         If 4D image is provided, a 2d array is returned, where each row
         corresponds to a mesh node.
+        The return value is deprecated and will change to a Surface object
+        with provided mesh and computed texture as arguments in release 0.9.
 
     Notes
     -----
@@ -619,6 +625,9 @@ def vol_to_surf(img, surf_mesh,
     --------
     This function is experimental and details such as the interpolation method
     are subject to change.
+
+    The return value is deprecated and will change to a Surface object
+    with provided mesh and computed texture as arguments in release 0.9.
 
     """
     sampling_schemes = {'linear': _interpolation_sampling,

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -918,18 +918,20 @@ def load_surface(surface):
     surface : Surface-like (see description)
         The surface to be loaded.
         A surface can be:
-            - a nilearn.surface.Surface
-            - a sequence (mesh, data) where:
-                - mesh can be:
-                    - a nilearn.surface.Mesh
-                    - a path to .gii or .gii.gz etc.
-                    - a sequence of two numpy arrays,
-                    the first containing vertex coordinates
-                    and the second containing triangles.
-                - data can be:
-                    - a path to .gii or .gii.gz etc.
-                    - a numpy array with shape (n_vertices,)
-                    or (n_time_points, n_vertices)
+        - a nilearn.surface.Surface
+        - a sequence (mesh, data) where:
+
+        Mesh can be:
+            - a nilearn.surface.Mesh
+            - a path to .gii or .gii.gz etc.
+            - a sequence of two numpy arrays,
+              the first containing vertex coordinates
+              and the second containing triangles.
+
+        Data can be:
+            - a path to .gii or .gii.gz etc.
+            - a numpy array with shape (n_vertices,)
+              or (n_time_points, n_vertices)
 
     Returns
     --------
@@ -1038,20 +1040,20 @@ def check_surface(surface):
     surface : Surface-like (see description)
         The surface to be loaded.
         A surface can be:
-            - a nilearn.surface.Surface
-            - a sequence (mesh, data) where:
+        - a nilearn.surface.Surface
+        - a sequence (mesh, data) where:
 
-            A mesh can be:
-                - a nilearn.surface.Mesh
-                - a path to .gii or .gii.gz etc.
-                - a sequence of two numpy arrays,
-                  the first containing vertex coordinates
-                  and the second containing triangles.
+        A mesh can be:
+            - a nilearn.surface.Mesh
+            - a path to .gii or .gii.gz etc.
+            - a sequence of two numpy arrays,
+              the first containing vertex coordinates
+              and the second containing triangles.
 
-            Data can be:
-                - a path to .gii or .gii.gz etc.
-                - a numpy array with shape (n_vertices,)
-                  or (n_time_points, n_vertices)
+        Data can be:
+            - a path to .gii or .gii.gz etc.
+            - a numpy array with shape (n_vertices,)
+              or (n_time_points, n_vertices)
 
     Returns
     -------

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -1040,16 +1040,18 @@ def check_surface(surface):
         A surface can be:
             - a nilearn.surface.Surface
             - a sequence (mesh, data) where:
-                - mesh can be:
-                    - a nilearn.surface.Mesh
-                    - a path to .gii or .gii.gz etc.
-                    - a sequence of two numpy arrays,
-                    the first containing vertex coordinates
-                    and the second containing triangles.
-                - data can be:
-                    - a path to .gii or .gii.gz etc.
-                    - a numpy array with shape (n_vertices,)
-                    or (n_time_points, n_vertices)
+
+            A mesh can be:
+                - a nilearn.surface.Mesh
+                - a path to .gii or .gii.gz etc.
+                - a sequence of two numpy arrays,
+                  the first containing vertex coordinates
+                  and the second containing triangles.
+
+            Data can be:
+                - a path to .gii or .gii.gz etc.
+                - a numpy array with shape (n_vertices,)
+                  or (n_time_points, n_vertices)
 
     Returns
     -------


### PR DESCRIPTION
This PR attempts to update the surface plotting functions to comply with the new `Surface` object introduced in #2672, in order to obtain a more consistent API. See also #2681.

Assuming we have defined a surface like this:

```python
surf = Surface([mesh, map])
```

Usage:

- `plot_surf(surf_mesh, surf_map=None,...)` ==> `plot_surf(surf,...)` (map is optional)
- `plot_surf_contours(surf_mesh, roi_map,...)` ==> `plot_surf_contours(surf,...)` (map is required)
- `plot_surf_stat_map(surf_mesh, stat_map,...)` ==> `plot_surf_stat_map(surf,...)` (map is required)
- `plot_surf_roi(surf_mesh, roi_map,...)` ==> `plot_surf_roi(surf,...)` (map is required)
- `plot_img_on_surf(stat_map, surf_mesh='fsaverage5',...)` (map and mesh are reversed and special values can be passed to `surf_mesh`). Untouched so far, will probably be handled in a different way.

Passing a mesh and a map as before is still possible but gives a `FutureWarning` saying that this usage is deprecated and will be removed in release 0.9.

Passing a surface object gives a `UserWarning` saying that `surf.data` will be used as the surface map instead of what was potentially provided through `surf_map`, `roi_map`, or `stat_map`.

*Note: Although this is WIP, reviews/suggestions/ideas are welcome since there might be better ways to do this!*