### PR TITLE
[MRG] Mosaic mode of displaying brain images

### DIFF
--- a/doc/plotting/index.rst
+++ b/doc/plotting/index.rst
@@ -191,9 +191,9 @@ Different display modes
      :target: ../auto_examples/01_plotting/plot_demo_more_plotting.html
      :scale: 50
 
-.. |plot_mosaic| image:: ../auto_examples/01_plotting/images/sphx_glr_plot_demo_more_plotting_010.png
+.. |plot_mosaic| image:: ../auto_examples/01_plotting/images/sphx_glr_plot_demo_more_plotting_011.png
      :target: ../auto_examples/01_plotting/plot_demo_more_plotting.html
-     :scale: 30
+     :scale: 50
 
 .. |plot_lzr| image:: ../auto_examples/01_plotting/images/sphx_glr_plot_demo_glass_brain_extensive_006.png
      :target: ../auto_examples/01_plotting/plot_demo_glass_brain_extensive.html

--- a/doc/plotting/index.rst
+++ b/doc/plotting/index.rst
@@ -191,6 +191,10 @@ Different display modes
      :target: ../auto_examples/01_plotting/plot_demo_more_plotting.html
      :scale: 50
 
+.. |plot_mosaic| image:: ../auto_examples/01_plotting/images/sphx_glr_plot_demo_more_plotting_010.png
+     :target: ../auto_examples/01_plotting/plot_demo_more_plotting.html
+     :scale: 50
+
 .. |plot_lzr| image:: ../auto_examples/01_plotting/images/sphx_glr_plot_demo_glass_brain_extensive_006.png
      :target: ../auto_examples/01_plotting/plot_demo_glass_brain_extensive.html
      :scale: 50
@@ -245,6 +249,11 @@ Different display modes
                    |hack|
                    Tiled slicer: 3 cuts along the x, y, z directions,
                    arranged in a 2x2 grid
+
+|plot_mosaic|      `display_mode='tiled', cut_coords=[36, -27, 60]`
+                   |hack|
+                   Mosaic slicer: multiple cuts along the x, y, z directions,
+                   with cuts automatically positioned by default
 
 |plot_lzr|         `Glass brain display_mode='lzr'`
                    |hack|

--- a/doc/plotting/index.rst
+++ b/doc/plotting/index.rst
@@ -191,9 +191,9 @@ Different display modes
      :target: ../auto_examples/01_plotting/plot_demo_more_plotting.html
      :scale: 50
 
-.. |plot_mosaic| image:: ../auto_examples/01_plotting/images/sphx_glr_plot_demo_more_plotting_011.png
+.. |plot_mosaic| image:: ../auto_examples/01_plotting/images/sphx_glr_plot_demo_more_plotting_010.png
      :target: ../auto_examples/01_plotting/plot_demo_more_plotting.html
-     :scale: 50
+     :scale: 30
 
 .. |plot_lzr| image:: ../auto_examples/01_plotting/images/sphx_glr_plot_demo_glass_brain_extensive_006.png
      :target: ../auto_examples/01_plotting/plot_demo_glass_brain_extensive.html

--- a/doc/plotting/index.rst
+++ b/doc/plotting/index.rst
@@ -193,7 +193,7 @@ Different display modes
 
 .. |plot_mosaic| image:: ../auto_examples/01_plotting/images/sphx_glr_plot_demo_more_plotting_010.png
      :target: ../auto_examples/01_plotting/plot_demo_more_plotting.html
-     :scale: 50
+     :scale: 30
 
 .. |plot_lzr| image:: ../auto_examples/01_plotting/images/sphx_glr_plot_demo_glass_brain_extensive_006.png
      :target: ../auto_examples/01_plotting/plot_demo_glass_brain_extensive.html
@@ -250,7 +250,7 @@ Different display modes
                    Tiled slicer: 3 cuts along the x, y, z directions,
                    arranged in a 2x2 grid
 
-|plot_mosaic|      `display_mode='tiled', cut_coords=[36, -27, 60]`
+|plot_mosaic|      `display_mode='mosaic'`
                    |hack|
                    Mosaic slicer: multiple cuts along the x, y, z directions,
                    with cuts automatically positioned by default

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -52,6 +52,11 @@ Enhancements
   perform a fixed resampling during download or keep original images. This can be handy to reduce disk usage.
   By default, the downloaded images are not resampled.
 
+- The functions :func:`nilearn.plotting.plot_epi`, :func:`nilearn.plotting.plot_roi`,
+  :func:`nilearn.plotting.plot_stat_map`, :func:`nilearn.plotting.plot_prob_atlas`
+  is now implemented with new display mode Mosaic. That implies plotting 3D maps
+  in multiple columns and rows in a single axes.
+
 .. _v0.7.0:
 
 0.7.0

--- a/examples/01_plotting/plot_demo_more_plotting.py
+++ b/examples/01_plotting/plot_demo_more_plotting.py
@@ -134,6 +134,14 @@ plotting.plot_stat_map(stat_img, display_mode='tiled',
                        cut_coords=[36, -27, 60],
                        title="display_mode='tiled'")
 
+########################################
+# Visualizing three views along multiple rows and columns
+# -------------------------------------------------------------------------
+# display_mode='mosaic' for sagittal, coronal and axial view
+
+plotting.plot_stat_map(stat_img, display_mode='mosaic',
+                       title="display_mode='mosaic'")
+
 ###############################################################################
 # Demonstrating various display features
 # ---------------------------------------

--- a/examples/01_plotting/plot_demo_more_plotting.py
+++ b/examples/01_plotting/plot_demo_more_plotting.py
@@ -137,11 +137,31 @@ plotting.plot_stat_map(stat_img, display_mode='tiled',
 ########################################
 # Visualizing three views along multiple rows and columns
 # -------------------------------------------------------------------------
-# display_mode='mosaic' for sagittal, coronal and axial view
+# display_mode='mosaic' for sagittal, coronal and axial view with
+# default option i.e. cut_coords=None
 
 plotting.plot_stat_map(stat_img, display_mode='mosaic',
-                       title="display_mode='mosaic'")
+                       title="display_mode='mosaic' default cut_coords")
 
+########################################
+# Now, changing the number of slices along columns
+# -------------------------------------------------------------------------
+# display_mode='mosaic' for sagittal, coronal and axial view with
+# number of slices specified as integer i.e. cut_coords=3
+
+plotting.plot_stat_map(stat_img, display_mode='mosaic',
+                       cut_coords=3,
+                       title="display_mode='mosaic' with cut_coords=3")
+
+########################################
+# Now, another way of limiting the number of slices along rows and columns
+# -------------------------------------------------------------------------
+# display_mode='mosaic' for sagittal, coronal and axial view with
+# number of slices specified as tuple of length 3
+
+plotting.plot_stat_map(stat_img, display_mode='mosaic',
+                       cut_coords=(5, 4, 10),
+                       title="display_mode='mosaic' with cut_coords as tuple")
 ###############################################################################
 # Demonstrating various display features
 # ---------------------------------------

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -1835,7 +1835,7 @@ class MosaicSlicer(BaseSlicer):
 
         Parameters
         ----------
-        img : 3D Nifti1Image
+        img : 3D Nifti1Image, optional
             The brain image.
 
         threshold : float, optional
@@ -1844,7 +1844,9 @@ class MosaicSlicer(BaseSlicer):
             the absolute value of the map.
 
         cut_coords : list/tuple of 3 floats, integer, optional
-            xyz world coordinates of cuts.
+            xyz world coordinates of cuts. If cut_coords
+            are not provided, 7 coordinates of cuts are automatically
+            calculated.
 
         Returns
         -------

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -1814,7 +1814,17 @@ class YZSlicer(OrthoSlicer):
 
 
 class MosaicSlicer(BaseSlicer):
-    """
+    """ A class to create 3 axes for plotting cuts of 3D maps,
+    in multiple rows and columns.
+
+    Attributes
+    ----------
+    axes : dictionary of axes
+        The 3 axes used to plot multiple views.
+
+    frame_axes : axes
+        The axes framing the whole set of views.
+
     """
     _cut_displayed = 'yxz'
     _axes_class = CutAxes

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -1907,6 +1907,9 @@ class MosaicSlicer(BaseSlicer):
             additional arguments to pass to self._axes_class
 
         """
+        if not isinstance(self.cut_coords, dict):
+            self.cut_coords = self.find_cut_coords(cut_coords=self.cut_coords)
+
         if len(self.cut_coords) != len(self._cut_displayed):
             raise ValueError('The number cut_coords passed does not'
                              ' match the mosaic mode')

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -7,7 +7,6 @@ the data with different layout of cuts.
 
 import collections.abc
 import numbers
-import itertools
 from distutils.version import LooseVersion
 
 import matplotlib

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -532,18 +532,23 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
         coordinates of each cut in the corresponding direction.
         If None is given, the cuts is calculated automaticaly.
         If display_mode is 'x', 'y' or 'z', cut_coords can be an integer,
-        in which case it specifies the number of cuts to perform
+        in which case it specifies the number of cuts to perform.
+        If display_mode is 'mosaic', and the number of cuts is the same
+        for all directions, cut_coords can be specified as an integer.
+        It can also be a length 3 tuple specifying the number of cuts for
+        every direction if these are different.
 
     output_file : string, or None, optional
         The name of an image file to export the plot to. Valid extensions
         are .png, .pdf, .svg. If output_file is not None, the plot
         is saved to a file, and the display is closed.
 
-    display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
+    display_mode : {'ortho', 'tiled', 'mosaic', 'x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
         Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
         'z' - axial, 'ortho' - three cuts are performed in orthogonal
         directions, 'tiled' - three cuts are performed
-        and arranged in a 2x2 grid. Default='ortho'.
+        and arranged in a 2x2 grid, 'mosaic' - three cuts
+        are performed along multiple rows and columns, Default='ortho'.
 
     figure : integer or matplotlib figure, optional
         Matplotlib figure used or its number. If None is given, a
@@ -640,18 +645,23 @@ def plot_epi(epi_img=None, cut_coords=None, output_file=None,
         coordinates of each cut in the corresponding direction.
         If None is given, the cuts is calculated automaticaly.
         If display_mode is 'x', 'y' or 'z', cut_coords can be an integer,
-        in which case it specifies the number of cuts to perform
+        in which case it specifies the number of cuts to perform.
+        If display_mode is 'mosaic', and the number of cuts is the same
+        for all directions, cut_coords can be specified as an integer.
+        It can also be a length 3 tuple specifying the number of cuts for
+        every direction if these are different.
 
     output_file : string, or None, optional
         The name of an image file to export the plot to. Valid extensions
         are .png, .pdf, .svg. If output_file is not None, the plot
         is saved to a file, and the display is closed.
 
-    display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
+    display_mode : {'ortho', 'tiled', 'mosaic', 'x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
         Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
         'z' - axial, 'ortho' - three cuts are performed in orthogonal
         directions, 'tiled' - three cuts are performed
-        and arranged in a 2x2 grid. Default='ortho'.
+        and arranged in a 2x2 grid. 'mosaic' - three cuts are
+        performed along multiple rows and columns. Default='ortho'.
 
     figure : integer or matplotlib figure, optional
         Matplotlib figure used or its number. If None is given, a
@@ -787,17 +797,22 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         For display_mode == 'x', 'y', or 'z', then these are the
         coordinates of each cut in the corresponding direction.
         If None is given, the cuts is calculated automaticaly.
+        If display_mode is 'mosaic', and the number of cuts is the same
+        for all directions, cut_coords can be specified as an integer.
+        It can also be a length 3 tuple specifying the number of cuts for
+        every direction if these are different.
 
     output_file : string, or None, optional
         The name of an image file to export the plot to. Valid extensions
         are .png, .pdf, .svg. If output_file is not None, the plot
         is saved to a file, and the display is closed.
 
-    display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
+    display_mode : {'ortho', 'mosaic', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
         Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
         'z' - axial, 'ortho' - three cuts are performed in orthogonal
         directions, 'tiled' - three cuts are performed
-        and arranged in a 2x2 grid. Default='ortho'.
+        and arranged in a 2x2 grid, 'mosaic' - three cuts
+        are performed along multiple rows and columns, Default='ortho'.
 
     figure : integer or matplotlib figure, optional
         Matplotlib figure used or its number. If None is given, a
@@ -983,19 +998,23 @@ def plot_prob_atlas(maps_img, bg_img=MNI152TEMPLATE, view_type='auto',
         coordinates of each cut in the corresponding direction.
         If None is given, the cuts is calculated automaticaly.
         If display_mode is 'x', 'y' or 'z', cut_coords can be an integer,
-        in which case it specifies the number of cuts to perform
+        in which case it specifies the number of cuts to perform.
+        If display_mode is 'mosaic', and the number of cuts is the same
+        for all directions, cut_coords can be specified as an integer.
+        It can also be a length 3 tuple specifying the number of cuts for
+        every direction if these are different.
 
     output_file : string, or None, optional
         The name of an image file to export the plot to. Valid extensions
         are .png, .pdf, .svg. If output_file is not None, the plot
         is saved to a file, and the display is closed.
 
-    display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
+    display_mode : {'ortho', 'tiled', 'mosaic', 'x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
         Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
         'z' - axial, 'ortho' - three cuts are performed in orthogonal
         directions, 'tiled' - three cuts are performed
-        and arranged in a 2x2 grid.
-        Default='ortho'.
+        and arranged in a 2x2 grid, 'mosaic' - three cuts are performed along
+        multiple rows and columns, Default='ortho'.
 
     figure : integer or matplotlib figure, optional
         Matplotlib figure used or its number. If None is given, a
@@ -1179,19 +1198,23 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         coordinates of each cut in the corresponding direction.
         If None is given, the cuts is calculated automaticaly.
         If display_mode is 'x', 'y' or 'z', cut_coords can be an integer,
-        in which case it specifies the number of cuts to perform
+        in which case it specifies the number of cuts to perform.
+        If display_mode is 'mosaic', and the number of cuts is the same
+        for all directions, cut_coords can be specified as an integer.
+        It can also be a length 3 tuple specifying the number of cuts for
+        every direction if these are different.
 
     output_file : string, or None, optional
         The name of an image file to export the plot to. Valid extensions
         are .png, .pdf, .svg. If output_file is not None, the plot
         is saved to a file, and the display is closed.
 
-    display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
+    display_mode : {'ortho', 'tiled', 'mosaic', 'x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
         Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
         'z' - axial, 'ortho' - three cuts are performed in orthogonal
         directions, 'tiled' - three cuts are performed
-        and arranged in a 2x2 grid.
-        Default='ortho'.
+        and arranged in a 2x2 grid, 'mosaic' - three cuts
+        are performed along multiple rows and columns, Default='ortho'.
 
     colorbar : boolean, optional
         If True, display a colorbar on the right of the plots. Default=True.

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -23,6 +23,7 @@ def test_demo_ortho_slicer():
     oslicer = OrthoSlicer(cut_coords=(0, 0, 0))
     img = load_mni152_template()
     oslicer.add_overlay(img, cmap=plt.cm.gray)
+    oslicer.title("display mode is ortho")
     oslicer.close()
 
 

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -4,6 +4,7 @@ import tempfile
 
 import matplotlib.pyplot as plt
 import nibabel
+import pytest
 import numpy as np
 
 from nilearn.plotting.displays import OrthoSlicer, XSlicer, OrthoProjector
@@ -57,7 +58,7 @@ def test_tiled_slicer():
 def test_mosaic_slicer():
     img = load_mni152_template()
     # default cut_coords=None
-    slicer = MosaicSlicer.init_with_figure(img=img, colorbar=True)
+    slicer = MosaicSlicer.init_with_figure(img=img)
     slicer.add_overlay(img, cmap=plt.cm.gray, colorbar=True)
     # Forcing a layout here, to test the locator code
     with tempfile.TemporaryFile() as fp:
@@ -71,7 +72,31 @@ def test_mosaic_slicer():
     slicer.add_overlay(img, cmap=plt.cm.gray, colorbar=True)
     # test title
     slicer.title('Showing mosaic mode')
+
+    # test when img is None or False while initializing figure
+    slicer = MosaicSlicer.init_with_figure(img=None, cut_coords=None)
+    slicer.add_overlay(img, cmap=plt.cm.gray, colorbar=True)
+    # same test but cut_coords as integer and tuple
+    slicer = MosaicSlicer.init_with_figure(img=None, cut_coords=5)
+    slicer.add_overlay(img, cmap=plt.cm.gray, colorbar=True)
+    slicer = MosaicSlicer.init_with_figure(img=None, cut_coords=(1, 1, 1))
+    slicer.add_overlay(img, cmap=plt.cm.gray, colorbar=True)
+
+    # assert raises ValueError
+    pytest.raises(ValueError, MosaicSlicer.init_with_figure,
+                  img=None, cut_coords=(5, 4))
+
     slicer.close()
+
+
+#def test_demo_mosaic_slicer():
+#    tslicer = MosaicSlicer(cut_coords=(1, 1, 1))
+#    img = load_mni152_template()
+#    tslicer.add_overlay(img, cmap=plt.cm.gray)
+    # cut_coords as integer
+#    tslicer = MosaicSlicer(cut_coords=5)
+#    tslicer.add_overlay(img, cmap=plt.cm.gray)
+#    tslicer.close()
 
 
 def test_demo_ortho_projector():

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -89,14 +89,22 @@ def test_mosaic_slicer():
     slicer.close()
 
 
-#def test_demo_mosaic_slicer():
-#    tslicer = MosaicSlicer(cut_coords=(1, 1, 1))
-#    img = load_mni152_template()
-#    tslicer.add_overlay(img, cmap=plt.cm.gray)
+def test_demo_mosaic_slicer():
+    # cut_coords as tuple of length 3
+    mslicer = MosaicSlicer(cut_coords=(1, 1, 1))
+    img = load_mni152_template()
+    mslicer.add_overlay(img, cmap=plt.cm.gray)
     # cut_coords as integer
-#    tslicer = MosaicSlicer(cut_coords=5)
-#    tslicer.add_overlay(img, cmap=plt.cm.gray)
-#    tslicer.close()
+    mslicer = MosaicSlicer(cut_coords=5)
+    mslicer.add_overlay(img, cmap=plt.cm.gray)
+    # cut_coords as dictionary
+    mslicer = MosaicSlicer(cut_coords={'x': [10, 20],
+                                       'y': [30, 40],
+                                       'z': [15, 16]})
+    mslicer.add_overlay(img, cmap=plt.cm.gray)
+    # assert raises a ValueError
+    pytest.raises(ValueError, MosaicSlicer, cut_coords=(2, 3))
+    mslicer.close()
 
 
 def test_demo_ortho_projector():

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from nilearn.plotting.displays import OrthoSlicer, XSlicer, OrthoProjector
 from nilearn.plotting.displays import TiledSlicer
+from nilearn.plotting.displays import MosaicSlicer
 from nilearn.plotting.displays import LZRYProjector
 from nilearn.plotting.displays import LYRZProjector
 from nilearn.datasets import load_mni152_template
@@ -50,6 +51,26 @@ def test_tiled_slicer():
     # Forcing a layout here, to test the locator code
     with tempfile.TemporaryFile() as fp:
         slicer.savefig(fp)
+    slicer.close()
+
+
+def test_mosaic_slicer():
+    img = load_mni152_template()
+    # default cut_coords=None
+    slicer = MosaicSlicer.init_with_figure(img=img, colorbar=True)
+    slicer.add_overlay(img, cmap=plt.cm.gray, colorbar=True)
+    # Forcing a layout here, to test the locator code
+    with tempfile.TemporaryFile() as fp:
+        slicer.savefig(fp)
+
+    # cut_coords as an integer
+    slicer = MosaicSlicer.init_with_figure(img=img, cut_coords=4)
+    slicer.add_overlay(img, cmap=plt.cm.gray, colorbar=True)
+    # cut_coords as a tuple
+    slicer = MosaicSlicer.init_with_figure(img=img, cut_coords=(4, 5, 2))
+    slicer.add_overlay(img, cmap=plt.cm.gray, colorbar=True)
+    # test title
+    slicer.title('Showing mosaic mode')
     slicer.close()
 
 

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -68,9 +68,15 @@ def test_mosaic_slicer():
     # cut_coords as an integer
     slicer = MosaicSlicer.init_with_figure(img=img, cut_coords=4)
     slicer.add_overlay(img, cmap=plt.cm.gray, colorbar=True)
+    for d in ['x', 'y', 'z']:
+        assert d in slicer.cut_coords
+        assert len(slicer.cut_coords[d]) == 4
     # cut_coords as a tuple
     slicer = MosaicSlicer.init_with_figure(img=img, cut_coords=(4, 5, 2))
     slicer.add_overlay(img, cmap=plt.cm.gray, colorbar=True)
+    assert len(slicer.cut_coords['x']) == 4
+    assert len(slicer.cut_coords['y']) == 5
+    assert len(slicer.cut_coords['z']) == 2
     # test title
     slicer.title('Showing mosaic mode')
 
@@ -103,6 +109,7 @@ def test_demo_mosaic_slicer():
                                        'y': [30, 40],
                                        'z': [15, 16]})
     mslicer.add_overlay(img, cmap=plt.cm.gray)
+    assert mslicer.cut_coords == {'x': [10, 20], 'y': [30, 40], 'z': [15, 16]}
     # assert raises a ValueError
     pytest.raises(ValueError, MosaicSlicer, cut_coords=(2, 3))
     mslicer.close()

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -1003,6 +1003,18 @@ def test_invalid_in_display_mode_tiled_cut_coords_all_plots(testdata_3d):
             plot_func(img, display_mode='tiled', cut_coords=(2, 2))
 
 
+def test_invalid_in_display_mode_mosaic_cut_coords_all_plots(testdata_3d):
+    img = testdata_3d['img']
+
+    for plot_func in [plot_img, plot_anat, plot_roi, plot_epi,
+                      plot_stat_map, plot_prob_atlas]:
+        with pytest.raises(ValueError,
+                           match="The number cut_coords passed does not "
+                                 "match the display_mode"
+                           ):
+            plot_func(img, display_mode='mosaic', cut_coords=(2, 2))
+
+
 def test_outlier_cut_coords():
     """ Test to plot a subset of a large set of cuts found for a small area."""
     bg_img = load_mni152_template()

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -180,9 +180,11 @@ def test_plot_functions_mosaic_mode(testdata_3d):
     img_3d = testdata_3d['img']
 
     # smoke-test for 3D plotting functions with display_mode='mosaic'
-    for plot_func in [plot_anat, plot_img, plot_stat_map, plot_epi,
-                      plot_roi]:
-        plot_func(img_3d, display_mode='mosaic')
+    for cut_coords in [None, 5, (5, 4, 3)]:
+        for plot_func in [plot_anat, plot_img, plot_stat_map, plot_epi,
+                          plot_roi]:
+            plot_func(img_3d, display_mode='mosaic',
+                      title='mosaic mode', cut_coords=cut_coords)
 
     plt.close()
 

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -176,6 +176,17 @@ def test_plot_functions(testdata_3d, testdata_4d, tmpdir):
     plt.close()
 
 
+def test_plot_functions_mosaic_mode(testdata_3d):
+    img_3d = testdata_3d['img']
+
+    # smoke-test for 3D plotting functions with display_mode='mosaic'
+    for plot_func in [plot_anat, plot_img, plot_stat_map, plot_epi,
+                      plot_roi]:
+        plot_func(img_3d, display_mode='mosaic')
+
+    plt.close()
+
+
 def test_plot_glass_brain(testdata_3d, tmpdir):
     img = testdata_3d['img']
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #212 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- display_mode='mosaic' should plot images of multiple rows and columns
- By default, ```cut_coords``` are automatically found for 7 slices to plot against three direction xyz.

A simple code that works:
```python
from nilearn import datasets

# localizer dataset to have contrast maps
motor_images = datasets.fetch_neurovault_motor_task()
stat_img = motor_images.images[0]

from nilearn import plotting

plotting.plot_stat_map(stat_img, display_mode='mosaic')
plotting.show()
```
![plot_stat_map](https://user-images.githubusercontent.com/11410385/106998816-63f14680-6785-11eb-939b-48d1e67870bc.png)

```python
from nilearn.datasets import MNI152_FILE_PATH
from nilearn import plotting

plotting.plot_img(MNI152_FILE_PATH, display_mode='mosaic')
plotting.show()
```
![plot_img](https://user-images.githubusercontent.com/11410385/106999051-cd715500-6785-11eb-8604-f950be86b0cd.png)

However, there are problems.

- Code breaks if ```cut_coords``` are provided manually by the user. As current code forms a list of 7 values/coordinates per dicretion in a dictionary. e.g., cut_coords={'x': [0], 'y': [0], 'z': [0]}. Shall I raise an error with valuable error message? or change the documentation to accept list of coordinates in a dictionary for mosaic mode?

- Code breaks if same coordinates are found against three directions. E.g., -46.875 -24.375  -5.625. Since I am inspired from the logic implemented in the class ```BaseStackedSlicer```. In a dictionary, each coordinate is a key per axes value that is passed to ```add_overlay```. I don't have any ideas here.
```python
from nilearn import datasets
haxby_dataset = datasets.fetch_haxby()
from nilearn.image.image import mean_img

# Compute the mean EPI: we do the mean along the axis 3, which is time
func_filename = haxby_dataset.func[0]
mean_haxby = mean_img(func_filename)

from nilearn.plotting import find_cut_slices
for direction in ['x', 'y', 'z']:
    print(find_cut_slices(mean_haxby, direction=direction, n_cuts=7))
```
These are the issues so far I came across. Any suggestions on how to overcome these are welcome.

Rest:
-  tests
-  demo
-  documentation