### PR TITLE
fix for FirstLevelModel compute_contrast for multiple runs with varying matrice size or columns

### DIFF
--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -568,6 +568,11 @@ class FirstLevelModel(BaseGLM):
             raise ValueError('contrast_def must be an array or str or list of'
                              ' (array or str)')
 
+        n_runs = len(self.labels_)
+        if len(con_vals) != n_runs:
+            warn('One contrast given, assuming it for all %d runs' % n_runs)
+            con_vals = con_vals * n_runs
+        
         # Translate formulas to vectors
         for cidx, (con, design_mat) in enumerate(zip(con_vals,
                                                      self.design_matrices_)
@@ -576,11 +581,6 @@ class FirstLevelModel(BaseGLM):
             if isinstance(con, str):
                 con_vals[cidx] = expression_to_contrast_vector(
                     con, design_columns)
-
-        n_runs = len(self.labels_)
-        if len(con_vals) != n_runs:
-            warn('One contrast given, assuming it for all %d runs' % n_runs)
-            con_vals = con_vals * n_runs
 
         valid_types = ['z_score', 'stat', 'p_value', 'effect_size',
                        'effect_variance']

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -570,7 +570,7 @@ class FirstLevelModel(BaseGLM):
 
         n_runs = len(self.labels_)
         n_contrasts = len(con_vals)
-        if n_contrasts == 1:
+        if n_contrasts == 1 and n_runs > 1:
             warn('One contrast given, assuming it for all %d runs' % n_runs)
             con_vals = con_vals * n_runs
         elif n_contrasts != n_runs:

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -332,7 +332,7 @@ class FirstLevelModel(BaseGLM):
     def fit(self, run_imgs, events=None, confounds=None,
             design_matrices=None):
         """Fit the GLM
-        
+
         For each run:
         1. create design matrix X
         2. do a masker job: fMRI_data -> Y
@@ -569,10 +569,14 @@ class FirstLevelModel(BaseGLM):
                              ' (array or str)')
 
         n_runs = len(self.labels_)
-        if len(con_vals) != n_runs:
+        n_contrasts = len(con_vals)
+        if n_contrasts == 1:
             warn('One contrast given, assuming it for all %d runs' % n_runs)
             con_vals = con_vals * n_runs
-        
+        elif n_contrasts != n_runs:
+            raise ValueError('%n contrasts given, while there are %n runs' %
+                             (n_contrasts, n_runs))
+
         # Translate formulas to vectors
         for cidx, (con, design_mat) in enumerate(zip(con_vals,
                                                      self.design_matrices_)

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -7,6 +7,7 @@ import shutil
 import numpy as np
 import pandas as pd
 import pytest
+import warnings
 from nibabel import Nifti1Image, load
 from nibabel.tmpdirs import InTemporaryDirectory
 from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
@@ -251,7 +252,8 @@ def test_compute_contrast_num_contrasts():
         multi_session_model.compute_contrast([np.eye(rk)[1]]*2)
 
     multi_session_model.compute_contrast([np.eye(rk)[1]]*3)
-    multi_session_model.compute_contrast([np.eye(rk)[1]])
+    with pytest.warns(UserWarning, match='One contrast given, assuming it for all 3 runs'):
+        multi_session_model.compute_contrast([np.eye(rk)[1]])
 
 def test_run_glm():
     rng = np.random.RandomState(42)

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -232,7 +232,7 @@ def test_high_level_glm_different_design_matrices_formulas():
 
     # Compute contrast with formulas
     cols_formula = tuple(design_matrices[0].columns[:2])
-    formula = "%s-%s"%(cols_formula)
+    formula = "%s-%s" % cols_formula
     z_joint_formula = multi_session_model.compute_contrast(
         formula, output_type='effect_size')
 

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -216,6 +216,27 @@ def test_high_level_glm_different_design_matrices():
                         2 * get_data(z_joint))
 
 
+def test_high_level_glm_different_design_matrices_formulas():
+    # test that one can estimate a contrast when design matrices are different
+    shapes, rk = ((7, 8, 7, 15), (7, 8, 7, 19)), 3
+    mask, fmri_data, design_matrices = generate_fake_fmri_data_and_design(shapes, rk)
+
+    # make column names identical
+    design_matrices[1].columns = design_matrices[0].columns
+    # add a column to the second design matrix
+    design_matrices[1]['new'] = np.ones((19, 1))
+
+    # Fit a glm with two sessions and design matrices
+    multi_session_model = FirstLevelModel(mask_img=mask).fit(
+        fmri_data, design_matrices=design_matrices)
+
+    # Compute contrast with formulas
+    cols_formula = tuple(design_matrices[0].columns[:2])
+    formula = "%s-%s"%(cols_formula)
+    z_joint_formula = multi_session_model.compute_contrast(
+        formula, output_type='effect_size')
+
+
 def test_run_glm():
     rng = np.random.RandomState(42)
     n, p, q = 100, 80, 10
@@ -280,7 +301,7 @@ def test_fmri_inputs():
                 # test with confounds as numpy array
                 FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d],
                                                    confounds=conf.values)
-                
+
                 FirstLevelModel(mask_img=mask).fit([fi, fi],
                                                    design_matrices=[d, d])
                 FirstLevelModel(mask_img=None).fit((fi, fi),

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -237,6 +237,22 @@ def test_high_level_glm_different_design_matrices_formulas():
         formula, output_type='effect_size')
 
 
+def test_compute_contrast_num_contrasts():
+
+    shapes, rk = ((7, 8, 7, 15), (7, 8, 7, 19), (7, 8, 7, 13)), 3
+    mask, fmri_data, design_matrices = generate_fake_fmri_data_and_design(shapes, rk)
+
+    # Fit a glm with 3 sessions and design matrices
+    multi_session_model = FirstLevelModel(mask_img=mask).fit(
+        fmri_data, design_matrices=design_matrices)
+
+    # raise when n_contrast != n_runs | 1
+    with pytest.raises(ValueError):
+        multi_session_model.compute_contrast([np.eye(rk)[1]]*2)
+
+    multi_session_model.compute_contrast([np.eye(rk)[1]]*3)
+    multi_session_model.compute_contrast([np.eye(rk)[1]])
+
 def test_run_glm():
     rng = np.random.RandomState(42)
     n, p, q = 100, 80, 10

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -234,8 +234,9 @@ def test_high_level_glm_different_design_matrices_formulas():
     # Compute contrast with formulas
     cols_formula = tuple(design_matrices[0].columns[:2])
     formula = "%s-%s" % cols_formula
-    z_joint_formula = multi_session_model.compute_contrast(
-        formula, output_type='effect_size')
+    with pytest.warns(UserWarning, match='One contrast given, assuming it for all 2 runs'):
+        z_joint_formula = multi_session_model.compute_contrast(
+            formula, output_type='effect_size')
 
 
 def test_compute_contrast_num_contrasts():


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #2687 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

Inverts the order of 2 blocks of codes in `compute_contrast` first
https://github.com/nilearn/nilearn/blob/e372946bfc91419bc1dbbfadebfed6e6a402956d/nilearn/glm/first_level/first_level.py#L578-L583
 then https://github.com/nilearn/nilearn/blob/e372946bfc91419bc1dbbfadebfed6e6a402956d/nilearn/glm/first_level/first_level.py#L572-L578 

This fixes computation of contrast given as text formulas for:
- matrices with varying size (mostly due to cosine drifts in runs with varying length) that for now crashes unless hacked.
- matrices with varying column ordering (for whatever weird reason) for which the contrast would be computed on the wrong columns assuming order from first run matrix.