### PR TITLE
[MRG] Handle nans in surf plotting

### DIFF
--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -279,7 +279,13 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
 
         # treshold if indicated
         if threshold is None:
-            kept_indices = np.arange(surf_map_faces.shape[0])
+            # If no thresholding and nans, filter them out
+            if np.any(np.isnan(surf_map_faces)):
+                kept_indices = np.where(
+                                np.logical_not(
+                                    np.isnan(surf_map_faces)))[0]
+            else:
+                kept_indices = np.arange(surf_map_faces.shape[0])
         else:
             kept_indices = np.where(np.abs(surf_map_faces) >= threshold)[0]
 

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -280,12 +280,9 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
         # treshold if indicated
         if threshold is None:
             # If no thresholding and nans, filter them out
-            if np.any(np.isnan(surf_map_faces)):
-                kept_indices = np.where(
-                                np.logical_not(
-                                    np.isnan(surf_map_faces)))[0]
-            else:
-                kept_indices = np.arange(surf_map_faces.shape[0])
+            kept_indices = np.where(
+                            np.logical_not(
+                                np.isnan(surf_map_faces)))[0]
         else:
             kept_indices = np.where(np.abs(surf_map_faces) >= threshold)[0]
 

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -120,6 +120,7 @@ def test_plot_surf_stat_map():
 
     fig = plot_surf_stat_map(mesh, stat_map=data, colorbar=False)
     assert len(fig.axes) == 1
+
     # symmetric_cbar
     fig = plot_surf_stat_map(
         mesh, stat_map=data, colorbar=True, symmetric_cbar=True)
@@ -128,6 +129,7 @@ def test_plot_surf_stat_map():
     yticklabels = fig.axes[1].get_yticklabels()
     first, last = yticklabels[0].get_text(), yticklabels[-1].get_text()
     assert float(first) == - float(last)
+
     # no symmetric_cbar
     fig = plot_surf_stat_map(
         mesh, stat_map=data, colorbar=True, symmetric_cbar=False)
@@ -136,6 +138,17 @@ def test_plot_surf_stat_map():
     yticklabels = fig.axes[1].get_yticklabels()
     first, last = yticklabels[0].get_text(), yticklabels[-1].get_text()
     assert float(first) != - float(last)
+
+    # Test handling of nan values in texture data
+    # Add nan values in the texture
+    data[2] = np.nan
+    # Plot the surface stat map
+    ax = plot_surf_stat_map(mesh, stat_map=data)
+    # Check that the resulting plot facecolors contain no transparent faces
+    # (last column equals zero) even though the texture contains nan values
+    assert(mesh[1].shape[0] ==
+            ((ax._axstack.as_list()[0].collections[0]._facecolors[:, 3]) != 0).sum())
+
     # Save execution time and memory
     plt.close()
 


### PR DESCRIPTION
Fixes #2690 

Filter out nan values from the texture when no thresholding is performed. This is done automatically with thresholding, hence the inconsistent behaviour observed in #2690 

```python
import warnings;warnings.filterwarnings('ignore')
import numpy as np
from nilearn import plotting, datasets, surface

# Get a statistical map
motor_images = datasets.fetch_neurovault_motor_task()
# Get a cortical mesh
fsaverage = datasets.fetch_surf_fsaverage()
# Sample the 3D data around each node of the mesh
texture = surface.vol_to_surf(motor_images.images[0], fsaverage.pial_right)
# Put some nans in
texture[::2] = np.nan
# Plot the stat map with the mesh
plotting.plot_surf_stat_map(fsaverage.infl_right, texture, hemi='right',
                            title='Surface right hemisphere', colorbar=True,
                            bg_map=fsaverage.sulc_right)
```
![fixes](https://user-images.githubusercontent.com/2639645/107493674-2e39cc80-6b8e-11eb-89b7-fa013b2e04b4.png)

Pinging @alexisthual who found the bug 