### PR TITLE
Warn in nifti masker report when no image provided to fit

### DIFF
--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -249,7 +249,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
                                     'mask and its input image. ')
         self._overlay_text = ('\n To see the input Nifti image before '
                               'resampling, hover over the displayed image.')
-
+        self._warning_message = ""
         self._shelving = False
 
     def generate_report(self):
@@ -283,6 +283,10 @@ class NiftiMasker(BaseMasker, CacheMixin):
                 # compute middle image from 4D series for plotting
                 img = image.index_img(img, dim[-1] // 2)
         else:  # images were not provided to fit
+            msg = ("No image provided to fit in NiftiMasker. "
+                   "Setting image to mask for reporting.")
+            warnings.warn(msg)
+            self._warning_message = msg
             img = mask
 
         # create display of retained input mask, image

--- a/nilearn/reporting/data/html/report_body_template.html
+++ b/nilearn/reporting/data/html/report_body_template.html
@@ -179,6 +179,11 @@ div.nilearn_report .image:hover .overlay {
   opacity: 1;
 }
 
+.elem-warn {
+    color: #FF0000;
+    font-weight: bold;
+}
+
 </style>
 <div class="nilearn_report">
   <h1 class="withtooltip">
@@ -197,6 +202,7 @@ div.nilearn_report .image:hover .overlay {
       </div>
   </div>
   <div class="pure-u-1 pure-u-md-1-3 raise">
+    <p class="elem-warn">{{warning_message}}</p>
     <p class="elem-desc">{{description}}</p>
     <p></p>
     <details>

--- a/nilearn/reporting/html_report.py
+++ b/nilearn/reporting/html_report.py
@@ -46,7 +46,7 @@ def _str_params(params):
 
 
 def _update_template(title, docstring, content, overlay,
-                     parameters, description=None):
+                     parameters, description=None, warning_message=None):
     """Populate a report with content.
 
     Parameters
@@ -69,6 +69,11 @@ def _update_template(title, docstring, content, overlay,
     description : str, optional
         An optional description of the content.
 
+    warning_message : str, optional
+        An optional warning message to be displayed in red.
+        This is used for example when no image was provided
+        to the estimator when fitting.
+
     Returns
     -------
     report : HTMLReport
@@ -85,7 +90,8 @@ def _update_template(title, docstring, content, overlay,
                           overlay=overlay,
                           docstring=docstring,
                           parameters=parameters,
-                          description=description)
+                          description=description,
+                          warning_message=warning_message)
 
     head_template_name = 'report_head_template.html'
     head_template_path = resource_path.joinpath(head_template_name)
@@ -148,6 +154,7 @@ def generate_report(estimator):
     else:  # We can create a report
         overlay, image = _define_overlay(estimator)
         description = estimator._report_description
+        warning_message = estimator._warning_message
         parameters = _str_params(estimator.get_params())
         docstring = estimator.__doc__
         snippet = docstring.partition('Parameters\n    ----------\n')[0]
@@ -156,7 +163,8 @@ def generate_report(estimator):
                                   content=_embed_img(image),
                                   overlay=_embed_img(overlay),
                                   parameters=parameters,
-                                  description=description)
+                                  description=description,
+                                  warning_message=warning_message)
     return report
 
 

--- a/nilearn/reporting/tests/test_html_report.py
+++ b/nilearn/reporting/tests/test_html_report.py
@@ -37,13 +37,19 @@ def test_3d_reports():
     # check providing mask to init
     masker = input_data.NiftiMasker(mask_img=mask_img_3d)
     masker.fit(data_img_3d)
+    assert mask._warning_message == ""
     html = masker.generate_report()
     _check_html(html)
 
     # check providing mask to init and no images to .fit
     masker = input_data.NiftiMasker(mask_img=mask_img_3d)
+    assert masker._warning_message == ""
     masker.fit()
-    html = masker.generate_report()
+    warn_message = ("No image provided to fit in NiftiMasker. "
+                    "Setting image to mask for reporting.")
+    with pytest.warns(UserWarning, match=warn_message):
+        html = masker.generate_report()
+    assert masker._warning_message == warn_message
     _check_html(html)
 
 
@@ -63,12 +69,14 @@ def test_4d_reports():
     # test .fit method
     mask = input_data.NiftiMasker(mask_strategy='epi')
     mask.fit(data_img_4d)
+    assert mask._warning_message == ""
     html = mask.generate_report()
     _check_html(html)
 
     # test .fit_transform method
     masker = input_data.NiftiMasker(mask_img=mask_img, standardize=True)
     masker.fit_transform(data_img_4d)
+    assert mask._warning_message == ""
     html = masker.generate_report()
     _check_html(html)
 


### PR DESCRIPTION
This PR tackles one of the points of #2689 by :

- giving a `UserWarning` when generating a report with a `NiftiMasker` and no image provided to fit
- printing a warning message in bold red in the report

**Example**

```python
from nilearn import datasets
from nilearn.input_data import NiftiMasker

haxby_dataset = datasets.fetch_haxby()
nifti_masker = NiftiMasker(mask_img=haxby_dataset.mask_vt[0])
nifti_masker.fit()
report = nifti_masker.generate_report()
report
```

![nifti-masker-warning](https://user-images.githubusercontent.com/2639645/107755110-a9cc8280-6d22-11eb-8c37-f57cb4e97841.png)
