### PR TITLE
MAINT: Avoid NumPy deprecations

### DIFF
--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -132,7 +132,7 @@ def run_glm(Y, X, noise_model='ar1', bins=100, n_jobs=1, verbose=0):
             / (ols_result.residuals ** 2).sum(axis=0)
         )
         del ols_result
-        ar1 = (ar1 * bins).astype(np.int) * 1. / bins
+        ar1 = (ar1 * bins).astype(np.int64) * 1. / bins
         # Fit the AR model acccording to current AR(1) estimates
         results = {}
         labels = ar1

--- a/nilearn/glm/first_level/hemodynamic_models.py
+++ b/nilearn/glm/first_level/hemodynamic_models.py
@@ -59,8 +59,8 @@ def _gamma_difference_hrf(tr, oversampling=50, time_length=32., onset=0.,
 
     """
     dt = tr / oversampling
-    time_stamps = np.linspace(0, time_length,
-                              np.rint(float(time_length) / dt).astype(np.int))
+    time_stamps = np.linspace(
+        0, time_length, np.rint(float(time_length) / dt).astype(np.int64))
     time_stamps -= onset
     hrf = (
         gamma.pdf(time_stamps, delay / dispersion, dt / dispersion)
@@ -291,7 +291,7 @@ def _sample_condition(exp_condition, frame_times, oversampling=50,
 
     hr_frame_times = np.linspace(frame_times.min() + min_onset,
                                  frame_times.max() * (1 + 1. / (n - 1)),
-                                 np.rint(n_hr).astype(np.int))
+                                 np.rint(n_hr).astype(np.int64))
 
     # Get the condition information
     onsets, durations, values = tuple(map(np.asanyarray, exp_condition))
@@ -302,7 +302,7 @@ def _sample_condition(exp_condition, frame_times, oversampling=50,
 
     # Set up the regressor timecourse
     tmax = len(hr_frame_times)
-    regressor = np.zeros_like(hr_frame_times).astype(np.float)
+    regressor = np.zeros_like(hr_frame_times).astype(np.float64)
     t_onset = np.minimum(np.searchsorted(hr_frame_times, onsets), tmax - 1)
     for t, v in zip(t_onset, values):
         regressor[t] += v

--- a/nilearn/glm/regression.py
+++ b/nilearn/glm/regression.py
@@ -97,7 +97,7 @@ class OLSModel(object):
                                           np.transpose(self.calc_beta))
         self.df_total = self.whitened_design.shape[0]
 
-        eps = np.abs(self.design).sum() * np.finfo(np.float).eps
+        eps = np.abs(self.design).sum() * np.finfo(np.float64).eps
         self.df_model = matrix_rank(self.design, eps)
         self.df_residuals = self.df_total - self.df_model
 


### PR DESCRIPTION
Avoid at least some warnings of the form:
```
  /home/larsoner/python/nilearn/nilearn/glm/regression.py:100: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```