### PR TITLE
[MRG] High variance confounds in maskers

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -41,6 +41,13 @@ Enhancements
   colorbar of surface plots. The default format is scientific notation except for :func:`nilearn.plotting.plot_surf_roi`
   for which it is set as integers.
 
+- :class:`nilearn.input_data.NiftiMasker`, :class:`nilearn.input_data.NiftiLabelsMasker`, 
+  :class:`nilearn.input_data.MultiNiftiMasker`, :class:`nilearn.input_data.NiftiMapsMasker`,
+  and :class:`nilearn.input_data.NiftiSpheresMasker` can now compute high variance confounds
+  on the images provided to `transform` and regress them out automatically. This behaviour is 
+  controlled through the `high_variance_confounds` boolean parameter of these maskers which
+  default to False.
+
 .. _v0.7.0:
 
 0.7.0

--- a/examples/03_connectivity/plot_multi_subject_connectome.py
+++ b/examples/03_connectivity/plot_multi_subject_connectome.py
@@ -57,8 +57,9 @@ mem = Memory('nilearn_cache')
 
 masker = input_data.NiftiMapsMasker(
     msdl_atlas_dataset.maps, resampling_target="maps", detrend=True,
-    low_pass=None, high_pass=0.01, t_r=2, standardize=True,
-    memory='nilearn_cache', memory_level=1, verbose=2)
+    high_variance_confounds=True, low_pass=None, high_pass=0.01,
+    t_r=2, standardize=True, memory='nilearn_cache', memory_level=1,
+    verbose=2)
 masker.fit()
 
 subject_time_series = []
@@ -68,12 +69,8 @@ for func_filename, confound_filename in zip(func_filenames,
                                             confound_filenames):
     print("Processing file %s" % func_filename)
 
-    # Computing some confounds
-    hv_confounds = mem.cache(image.high_variance_confounds)(
-        func_filename)
-
     region_ts = masker.transform(func_filename,
-                                 confounds=[hv_confounds, confound_filename])
+                                 confounds=confound_filename)
     subject_time_series.append(region_ts)
 
 

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -18,6 +18,7 @@ from .. import signal
 from .. import _utils
 from .._utils.cache_mixin import CacheMixin, cache
 from .._utils.class_inspect import enclosing_scope_name
+from nilearn.image import high_variance_confounds
 
 
 def filter_and_extract(imgs, extraction_function,
@@ -180,7 +181,19 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         """
         self._check_fitted()
 
-        return self.transform_single_imgs(imgs, confounds)
+        # Compute high variance confounds if requested
+        all_confounds = []
+        if self.high_variance_confounds:
+            hv_confounds = self._cache(
+                high_variance_confounds)(imgs)
+            all_confounds.append(hv_confounds)
+        if confounds is not None:
+            if isinstance(confounds, list):
+                all_confounds += confounds
+            else:
+                all_confounds.append(confounds)
+
+        return self.transform_single_imgs(imgs, all_confounds)
 
     def fit_transform(self, X, y=None, confounds=None, **fit_params):
         """Fit to data, then transform it

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -181,6 +181,9 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         """
         self._check_fitted()
 
+        if confounds is None and not self.high_variance_confounds:
+            return self.transform_single_imgs(imgs, confounds)
+
         # Compute high variance confounds if requested
         all_confounds = []
         if self.high_variance_confounds:

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -56,9 +56,9 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         Default=True.
 
     high_variance_confounds : boolean, optional
-        Boolean indicating whether high-variance confounds should be computed
-        from provided image and regressed out.
-        Default=False.
+        If True, high variance confounds are computed on provided image with
+        :func:`nilearn.image.high_variance_confounds` and default parameters
+        and regressed out. Default=False.
 
     detrend : boolean, optional
         This parameter is passed to signal.clean. Please see the related

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -55,6 +55,11 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         their mean is put to 0 and their variance to 1 in the time dimension.
         Default=True.
 
+    high_variance_confounds : boolean, optional
+        Boolean indicating whether high-variance confounds should be computed
+        from provided image and regressed out.
+        Default=False.
+
     detrend : boolean, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details. Default=False.
@@ -136,9 +141,10 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
 
     def __init__(self, mask_img=None, smoothing_fwhm=None,
                  standardize=False, standardize_confounds=True, detrend=False,
-                 low_pass=None, high_pass=None, t_r=None, target_affine=None,
-                 target_shape=None, mask_strategy='background',
-                 mask_args=None, dtype=None, memory=Memory(location=None),
+                 high_variance_confounds=False, low_pass=None, high_pass=None,
+                 t_r=None, target_affine=None, target_shape=None,
+                 mask_strategy='background', mask_args=None,
+                 dtype=None, memory=Memory(location=None),
                  memory_level=0, n_jobs=1, verbose=0):
         # Mask is provided or computed
         self.mask_img = mask_img
@@ -146,6 +152,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         self.smoothing_fwhm = smoothing_fwhm
         self.standardize = standardize
         self.standardize_confounds = standardize_confounds
+        self.high_variance_confounds = high_variance_confounds
         self.detrend = detrend
         self.low_pass = low_pass
         self.high_pass = high_pass

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -77,9 +77,9 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         Default=True.
 
     high_variance_confounds : boolean, optional
-        Boolean indicating whether high-variance confounds should be computed
-        from provided image and regressed out.
-        Default=False.
+        If True, high variance confounds are computed on provided image with
+        :func:`nilearn.image.high_variance_confounds` and default parameters
+        and regressed out. Default=False.
 
     detrend : boolean, optional
         This parameter is passed to signal.clean. Please see the related

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -76,6 +76,11 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         their mean is put to 0 and their variance to 1 in the time dimension.
         Default=True.
 
+    high_variance_confounds : boolean, optional
+        Boolean indicating whether high-variance confounds should be computed
+        from provided image and regressed out.
+        Default=False.
+
     detrend : boolean, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details. Default=False.
@@ -133,8 +138,8 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
 
     def __init__(self, labels_img, background_label=0, mask_img=None,
                  smoothing_fwhm=None, standardize=False, standardize_confounds=True,
-                 detrend=False, low_pass=None, high_pass=None, t_r=None, dtype=None,
-                 resampling_target="data",
+                 high_variance_confounds=False, detrend=False, low_pass=None,
+                 high_pass=None, t_r=None, dtype=None, resampling_target="data",
                  memory=Memory(location=None, verbose=0), memory_level=1,
                  verbose=0, strategy="mean"):
         self.labels_img = labels_img
@@ -147,6 +152,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         # Parameters for clean()
         self.standardize = standardize
         self.standardize_confounds = standardize_confounds
+        self.high_variance_confounds = high_variance_confounds
         self.detrend = detrend
         self.low_pass = low_pass
         self.high_pass = high_pass

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -75,6 +75,11 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         their mean is put to 0 and their variance to 1 in the time dimension.
         Default=True.
 
+    high_variance_confounds : boolean, optional
+        Boolean indicating whether high-variance confounds should be computed
+        from provided image and regressed out.
+        Default=False.
+
     detrend : boolean, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details. Default=False.
@@ -133,7 +138,8 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
 
     def __init__(self, maps_img, mask_img=None,
                  allow_overlap=True, smoothing_fwhm=None, standardize=False,
-                 standardize_confounds=True, detrend=False, low_pass=None, high_pass=None, t_r=None,
+                 standardize_confounds=True, high_variance_confounds=False,
+                 detrend=False, low_pass=None, high_pass=None, t_r=None,
                  dtype=None, resampling_target="data",
                  memory=Memory(location=None, verbose=0), memory_level=0,
                  verbose=0):
@@ -149,6 +155,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         # Parameters for clean()
         self.standardize = standardize
         self.standardize_confounds = standardize_confounds
+        self.high_variance_confounds = high_variance_confounds
         self.detrend = detrend
         self.low_pass = low_pass
         self.high_pass = high_pass

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -76,9 +76,9 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         Default=True.
 
     high_variance_confounds : boolean, optional
-        Boolean indicating whether high-variance confounds should be computed
-        from provided image and regressed out.
-        Default=False.
+        If True, high variance confounds are computed on provided image with
+        :func:`nilearn.image.high_variance_confounds` and default parameters
+        and regressed out. Default=False.
 
     detrend : boolean, optional
         This parameter is passed to signal.clean. Please see the related

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -123,6 +123,11 @@ class NiftiMasker(BaseMasker, CacheMixin):
         their mean is put to 0 and their variance to 1 in the time dimension.
         Default=True.
 
+    high_variance_confounds : boolean, optional
+        Boolean indicating whether high-variance confounds should be computed
+        from provided image and regressed out.
+        Default=False.
+
     detrend : boolean, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details: :func:`nilearn.signal.clean`.
@@ -213,11 +218,10 @@ class NiftiMasker(BaseMasker, CacheMixin):
 
     def __init__(self, mask_img=None, sessions=None, smoothing_fwhm=None,
                  standardize=False, standardize_confounds=True, detrend=False,
-                 low_pass=None, high_pass=None, t_r=None,
-                 target_affine=None, target_shape=None,
-                 mask_strategy='background',
-                 mask_args=None, sample_mask=None, dtype=None,
-                 memory_level=1, memory=Memory(location=None),
+                 high_variance_confounds=False, low_pass=None, high_pass=None,
+                 t_r=None, target_affine=None, target_shape=None,
+                 mask_strategy='background', mask_args=None, sample_mask=None,
+                 dtype=None, memory_level=1, memory=Memory(location=None),
                  verbose=0, reports=True,
                  ):
         # Mask is provided or computed
@@ -227,6 +231,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
         self.smoothing_fwhm = smoothing_fwhm
         self.standardize = standardize
         self.standardize_confounds = standardize_confounds
+        self.high_variance_confounds = high_variance_confounds
         self.detrend = detrend
         self.low_pass = low_pass
         self.high_pass = high_pass

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -124,9 +124,9 @@ class NiftiMasker(BaseMasker, CacheMixin):
         Default=True.
 
     high_variance_confounds : boolean, optional
-        Boolean indicating whether high-variance confounds should be computed
-        from provided image and regressed out.
-        Default=False.
+        If True, high variance confounds are computed on provided image with
+        :func:`nilearn.image.high_variance_confounds` and default parameters
+        and regressed out. Default=False.
 
     detrend : boolean, optional
         This parameter is passed to signal.clean. Please see the related
@@ -211,11 +211,11 @@ class NiftiMasker(BaseMasker, CacheMixin):
     nilearn.masking.compute_background_mask
     nilearn.masking.compute_epi_mask
     nilearn.image.resample_img
+    nilearn.image.high_variance_confounds
     nilearn.masking.apply_mask
     nilearn.signal.clean
 
     """
-
     def __init__(self, mask_img=None, sessions=None, smoothing_fwhm=None,
                  standardize=False, standardize_confounds=True, detrend=False,
                  high_variance_confounds=False, low_pass=None, high_pass=None,

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -239,9 +239,9 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         Default=True.
 
     high_variance_confounds : boolean, optional
-        Boolean indicating whether high-variance confounds should be computed
-        from provided image and regressed out.
-        Default=False.
+        If True, high variance confounds are computed on provided image with
+        :func:`nilearn.image.high_variance_confounds` and default parameters
+        and regressed out. Default=False.
 
     detrend : boolean, optional
         This parameter is passed to signal.clean. Please see the related

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -238,6 +238,11 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         their mean is put to 0 and their variance to 1 in the time dimension.
         Default=True.
 
+    high_variance_confounds : boolean, optional
+        Boolean indicating whether high-variance confounds should be computed
+        from provided image and regressed out.
+        Default=False.
+
     detrend : boolean, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details. Default=False.
@@ -282,7 +287,8 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
 
     def __init__(self, seeds, radius=None, mask_img=None, allow_overlap=False,
                  smoothing_fwhm=None, standardize=False, standardize_confounds=True,
-                 detrend=False, low_pass=None, high_pass=None, t_r=None, dtype=None,
+                 high_variance_confounds=False, detrend=False, low_pass=None,
+                 high_pass=None, t_r=None, dtype=None,
                  memory=Memory(location=None, verbose=0), memory_level=1,
                  verbose=0):
         self.seeds = seeds
@@ -296,6 +302,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         # Parameters for clean()
         self.standardize = standardize
         self.standardize_confounds = standardize_confounds
+        self.high_variance_confounds = high_variance_confounds
         self.detrend = detrend
         self.low_pass = low_pass
         self.high_pass = high_pass


### PR DESCRIPTION
Addresses #1241 

This PR proposes to add a `high_variance_confounds` boolean parameter to the maskers in order to compute high variance confounds on provided images and regress them out on the fly.

The usual coding pattern

```python
from nilearn.image import high_variance_confounds
hv_confounds = high_variance_confounds(img)
masker = NiftiMasker(standardize=True, detrend=False,
                     mask_img=mask).fit()
tseries = masker.transform(img, confounds=[hv_confounds, conf])
```
would get simplified to:

```python 
masker = NiftiMasker(standardize=True, detrend=False,
                     high_variance_confounds=True,
                     mask_img=mask).fit()
tseries = masker.transform(img, confounds=conf)
```