### PR TITLE
[FIX] get_clusters_table: ensure input is 3D and accept filenames

### DIFF
--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -16,6 +16,7 @@ from nilearn.image import get_data
 from nilearn.image.resampling import coord_transform
 from nilearn._utils import check_niimg_3d
 
+
 def _local_max(data, affine, min_distance):
     """Find all local maxima of the array, separated by at least min_distance.
     Adapted from https://stackoverflow.com/a/22631583/2589328

--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -14,7 +14,7 @@ from scipy import ndimage
 
 from nilearn.image import get_data
 from nilearn.image.resampling import coord_transform
-
+from nilearn._utils import check_niimg_3d
 
 def _local_max(data, affine, min_distance):
     """Find all local maxima of the array, separated by at least min_distance.
@@ -159,6 +159,8 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
     """
     cols = ['Cluster ID', 'X', 'Y', 'Z', 'Peak Stat', 'Cluster Size (mm3)']
 
+    # check that stat_img is niimg-like object and 3D
+    stat_img = check_niimg_3d(stat_img)
     # If cluster threshold is used, there is chance that stat_map will be
     # modified, therefore copy is needed
     if cluster_threshold is None:

--- a/nilearn/reporting/tests/test_reporting.py
+++ b/nilearn/reporting/tests/test_reporting.py
@@ -69,7 +69,7 @@ def test_local_max():
     assert np.all(np.isnan(vals))
 
 
-def test_get_clusters_table():
+def test_get_clusters_table(tmp_path):
     shape = (9, 10, 11)
     data = np.zeros(shape)
     data[2:4, 5:7, 6:8] = 5.
@@ -87,6 +87,14 @@ def test_get_clusters_table():
     cluster_table = get_clusters_table(stat_img, 4, 9)
     assert len(cluster_table) == 0
 
+    # test with filename
+    fname = str(tmp_path / "stat_img.nii.gz")
+    stat_img.to_filename(fname)
+    cluster_table = get_clusters_table(fname, 4, 0)
+    assert len(cluster_table) == 1
+
+    # test with extra dimension
+    array[..., np.newaxis]
 
 def test_get_clusters_table_not_modifying_stat_image():
     shape = (9, 10, 11)

--- a/nilearn/reporting/tests/test_reporting.py
+++ b/nilearn/reporting/tests/test_reporting.py
@@ -94,7 +94,11 @@ def test_get_clusters_table(tmp_path):
     assert len(cluster_table) == 1
 
     # test with extra dimension
-    array[..., np.newaxis]
+    data_extra_dim = data[..., np.newaxis]
+    stat_img_extra_dim = nib.Nifti1Image(data_extra_dim, np.eye(4))
+    cluster_table = get_clusters_table(stat_img_extra_dim, 4, 0)
+    assert len(cluster_table) == 1
+
 
 def test_get_clusters_table_not_modifying_stat_image():
     shape = (9, 10, 11)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #2700 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- use check_niimg_3d to load filenames and ensure input is 3D
- test filename functionality and extra dimensions
