### PR TITLE
[MRG] Allow asymmetric matrices in plot_connectome

### DIFF
--- a/examples/03_connectivity/plot_atlas_comparison.py
+++ b/examples/03_connectivity/plot_atlas_comparison.py
@@ -105,30 +105,13 @@ def lag_correlation(time_series, lag):
                                                          serie[:-lag, j])[0, 1]
     return np.mean(lag_cor, axis=0)
 
-# We can check that this function mimics the underlying work done by
-# ConnectivityMeasure when the covariance estimator is empirical
-# rather than Ledoit-Wolf (default estimator)
-from sklearn.covariance import EmpiricalCovariance
-from numpy.testing import assert_array_almost_equal
-
-empirical_connectome_measure = ConnectivityMeasure(
-                                    cov_estimator=EmpiricalCovariance(),
-                                    kind='correlation')
-empirical_correlation_matrices = empirical_connectome_measure.fit_transform(
-                                    time_series)
-mean_empirical_correlation_matrix = empirical_connectome_measure.mean_
-lag0_correlation = lag_correlation(time_series, 0)
-assert_array_almost_equal(mean_empirical_correlation_matrix,
-                          lag0_correlation)
-
-# Compute lag-1 correlations and plot connectomes for lag-0 and lag-1
-lag1_correlation = lag_correlation(time_series, 1)
-
-plotting.plot_connectome(lag0_correlation, coordinates, edge_threshold="90%",
-                         title='Lag-0 correlation')
-
-plotting.plot_connectome(lag1_correlation, coordinates, edge_threshold="90%",
-                         title='Lag-1 correlation')
+# Compute lag-0 and lag-1 correlations and plot associated connectomes
+for lag in [0, 1]:
+    lag_correlation_matrix = lag_correlation(time_series, lag)
+    plotting.plot_connectome(lag_correlation_matrix, coordinates,
+                             edge_threshold="90%",
+                             title='Lag-{} correlation'.format(
+                                 lag))
 
 ##########################################################################
 # Load probabilistic atlases - extracting coordinates on brain maps

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -549,13 +549,22 @@ class GlassBrainAxes(BaseAxes):
             xdata, ydata = start_end_point_2d.T
             # If directed is True, add an arrow
             if directed:
-                arrow = FancyArrow(xdata[0], ydata[0],
-                                   xdata[1] - xdata[0],
-                                   ydata[1] - ydata[0],
-                                   length_includes_head=True,
-                                   width=linewidth,
-                                   head_width=3*linewidth,
-                                   **this_kwargs)
+                dx = xdata[1] - xdata[0]
+                dy = ydata[1] - ydata[0]
+                # Hack to avoid empty arrows to crash with
+                # matplotlib versions older than 3.1
+                # This can be removed once support for
+                # matplotlib pre 3.1 has been dropped.
+                if dx == 0 and dy == 0:
+                    arrow = FancyArrow(xdata[0], ydata[0],
+                                       dx, dy)
+                else:
+                    arrow = FancyArrow(xdata[0], ydata[0],
+                                       dx, dy,
+                                       length_includes_head=True,
+                                       width=linewidth,
+                                       head_width=3*linewidth,
+                                       **this_kwargs)
                 self.ax.add_patch(arrow)
             # Otherwise a line
             else:

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -12,6 +12,7 @@ from distutils.version import LooseVersion
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+import warnings
 from matplotlib import cm as mpl_cm
 from matplotlib import (colors,
                         lines,
@@ -19,6 +20,7 @@ from matplotlib import (colors,
                         )
 from matplotlib.colorbar import ColorbarBase
 from matplotlib.font_manager import FontProperties
+from matplotlib.patches import FancyArrow
 from mpl_toolkits.axes_grid1.anchored_artists import AnchoredSizeBar
 from scipy import sparse, stats
 
@@ -456,7 +458,7 @@ class GlassBrainAxes(BaseAxes):
                         c=marker_color, **kwargs)
 
     def _add_lines(self, line_coords, line_values, cmap,
-                   vmin=None, vmax=None, **kwargs):
+                   vmin=None, vmax=None, directed=False, **kwargs):
         """Plot lines
 
         Parameters
@@ -476,6 +478,10 @@ class GlassBrainAxes(BaseAxes):
             supplied the maximum absolute value within the given threshold
             will be used as minimum (multiplied by -1) and maximum
             coloring levels.
+
+        directed : boolean, optional
+            Add arrows instead of lines if set to True. Use this when plotting
+            directed graphs for example. Default=False.
 
         kwargs : dict
             Additional arguments to pass to matplotlib Line2D.
@@ -541,8 +547,20 @@ class GlassBrainAxes(BaseAxes):
             # user can override the default logic
             this_kwargs.update(kwargs)
             xdata, ydata = start_end_point_2d.T
-            line = lines.Line2D(xdata, ydata, **this_kwargs)
-            self.ax.add_line(line)
+            # If directed is True, add an arrow
+            if directed:
+                arrow = FancyArrow(xdata[0], ydata[0],
+                                   xdata[1] - xdata[0],
+                                   ydata[1] - ydata[0],
+                                   length_includes_head=True,
+                                   width=linewidth,
+                                   head_width=3*linewidth,
+                                   **this_kwargs)
+                self.ax.add_patch(arrow)
+            # Otherwise a line
+            else:
+                line = lines.Line2D(xdata, ydata, **this_kwargs)
+                self.ax.add_line(line)
 
 
 ###############################################################################
@@ -1845,8 +1863,10 @@ class OrthoProjector(OrthoSlicer):
         Parameters
         ----------
         adjacency_matrix : numpy array of shape (n, n)
-            Represents the edges strengths of the graph. Assumed to be
-            a symmetric matrix.
+            Represents the edges strengths of the graph.
+            The matrix can be symmetric which will result in
+            an undirected graph, or not symmetric which will
+            result in a directed graph.
 
         node_coords : numpy array_like of shape (n, 3)
             3d coordinates of the graph nodes in world space.
@@ -1940,34 +1960,48 @@ class OrthoProjector(OrthoSlicer):
                 "'adjacency_matrix' shape is {0}, 'node_coords' shape is {1}"
                 .format(adjacency_matrix_shape, node_coords_shape))
 
+        # If the adjacency matrix is not symmetric, give a warning
+        symmetric = True
         if not np.allclose(adjacency_matrix, adjacency_matrix.T, rtol=1e-3):
-            raise ValueError("'adjacency_matrix' should be symmetric")
+            symmetric = False
+            warnings.warn(("'adjacency_matrix' is not symmetric. "
+                           "A directed graph will be plotted."))
 
         # For a masked array, masked values are replaced with zeros
         if hasattr(adjacency_matrix, 'mask'):
             if not (adjacency_matrix.mask == adjacency_matrix.mask.T).all():
-                raise ValueError(
-                    "'adjacency_matrix' was masked with a non symmetric mask")
+                symmetric = False
+                warnings.warn(("'adjacency_matrix' was masked with "
+                               "a non symmetric mask. A directed "
+                               "graph will be plotted."))
             adjacency_matrix = adjacency_matrix.filled(0)
 
         if edge_threshold is not None:
-            # Keep a percentile of edges with the highest absolute
-            # values, so only need to look at the covariance
-            # coefficients below the diagonal
-            lower_diagonal_indices = np.tril_indices_from(adjacency_matrix,
-                                                          k=-1)
-            lower_diagonal_values = adjacency_matrix[
-                lower_diagonal_indices]
-            edge_threshold = _utils.param_validation.check_threshold(
-                edge_threshold, np.abs(lower_diagonal_values),
-                stats.scoreatpercentile, 'edge_threshold')
+            if symmetric:
+                # Keep a percentile of edges with the highest absolute
+                # values, so only need to look at the covariance
+                # coefficients below the diagonal
+                lower_diagonal_indices = np.tril_indices_from(adjacency_matrix,
+                                                              k=-1)
+                lower_diagonal_values = adjacency_matrix[
+                    lower_diagonal_indices]
+                edge_threshold = _utils.param_validation.check_threshold(
+                    edge_threshold, np.abs(lower_diagonal_values),
+                    stats.scoreatpercentile, 'edge_threshold')
+            else:
+                edge_threshold = _utils.param_validation.check_threshold(
+                    edge_threshold, np.abs(adjacency_matrix.ravel()),
+                    stats.scoreatpercentile, 'edge_threshold')
 
             adjacency_matrix = adjacency_matrix.copy()
             threshold_mask = np.abs(adjacency_matrix) < edge_threshold
             adjacency_matrix[threshold_mask] = 0
 
-        lower_triangular_adjacency_matrix = np.tril(adjacency_matrix, k=-1)
-        non_zero_indices = lower_triangular_adjacency_matrix.nonzero()
+        if symmetric:
+            lower_triangular_adjacency_matrix = np.tril(adjacency_matrix, k=-1)
+            non_zero_indices = lower_triangular_adjacency_matrix.nonzero()
+        else:
+            non_zero_indices = adjacency_matrix.nonzero()
 
         line_coords = [node_coords[list(index)]
                        for index in zip(*non_zero_indices)]
@@ -1977,7 +2011,7 @@ class OrthoProjector(OrthoSlicer):
             ax._add_markers(node_coords, node_color, node_size, **node_kwargs)
             if line_coords:
                 ax._add_lines(line_coords, adjacency_matrix_values, edge_cmap,
-                              vmin=edge_vmin, vmax=edge_vmax,
+                              vmin=edge_vmin, vmax=edge_vmax, directed=(not symmetric),
                               **edge_kwargs)
             # To obtain the brain left view, we simply invert the x axis
             if ax.direction == 'l' and not (ax.ax.get_xlim()[0] > ax.ax.get_xlim()[1]):

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -1471,8 +1471,9 @@ def plot_connectome(adjacency_matrix, node_coords,
     Parameters
     ----------
     adjacency_matrix : numpy array of shape (n, n)
-        Represents the link strengths of the graph. Assumed to be
-        a symmetric matrix.
+        Represents the link strengths of the graph. The matrix can be
+        symmetric which will result in an undirected graph, or not
+        symmetric which will result in a directed graph.
 
     node_coords : numpy array_like of shape (n, 3)
         3d coordinates of the graph nodes in world space.

--- a/nilearn/plotting/tests/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting.py
@@ -577,7 +577,9 @@ def test_plot_connectome_exceptions():
     # adjacency_matrix is not symmetric
     non_symmetric_adjacency_matrix = np.array([[1., 2],
                                                [0.4, 1.]])
-    with pytest.raises(ValueError, match='should be symmetric'):
+    with pytest.warns(UserWarning,
+                      match=("'adjacency_matrix' is not symmetric. "
+                             "A directed graph will be plotted.")):
         plot_connectome(non_symmetric_adjacency_matrix, node_coords, **kwargs)
 
     adjacency_matrix = np.array([[1., 2.],
@@ -586,7 +588,10 @@ def test_plot_connectome_exceptions():
     masked_adjacency_matrix = np.ma.masked_array(
         adjacency_matrix, [[False, True], [False, False]])
 
-    with pytest.raises(ValueError, match='non symmetric mask'):
+    with pytest.warns(UserWarning,
+                      match=("'adjacency_matrix' was masked with "
+                             "a non symmetric mask. A directed "
+                             "graph will be plotted.")):
         plot_connectome(masked_adjacency_matrix, node_coords, **kwargs)
 
     # edges threshold is neither a number nor a string


### PR DESCRIPTION
Addresses #1513 

**Description**

This PR proposes to allow asymmetric matrices to be plotted as a directed graph through the `plot_connectome` function. Previous behaviour was to raise an error.

**Example**

```python
import numpy as np
from nilearn import datasets, plotting
from nilearn.input_data import NiftiLabelsMasker
from nilearn.connectome import ConnectivityMeasure

yeo = datasets.fetch_atlas_yeo_2011()
data = datasets.fetch_development_fmri(n_subjects=10)
connectome_measure = ConnectivityMeasure(kind='correlation')
masker = NiftiLabelsMasker(labels_img=yeo['thick_17'], standardize=True,
                           memory='nilearn_cache')
time_series = []
for func, confounds in zip(data.func, data.confounds):
    time_series.append(masker.fit_transform(func, confounds=confounds))
correlation_matrices = connectome_measure.fit_transform(time_series)
mean_correlation_matrix = connectome_measure.mean_
coordinates = plotting.find_parcellation_cut_coords(labels_img=yeo['thick_17'])
# Brutal way to get asymmetric matrix...
non_symmetric = np.triu(mean_correlation_matrix)
plotting.plot_connectome(mean_correlation_matrix, coordinates,
                         edge_threshold="90%", title='symmetric')
plotting.plot_connectome(non_symmetric, coordinates,
                         edge_threshold="90%", title='asymmetric')
```
![directed_connectome](https://user-images.githubusercontent.com/2639645/108253255-db49b180-7159-11eb-8b30-6235239dd1cc.png)

**Todo**

- Add tests (to be coming soon)
- Showcase the functionality in an example (I don't think we have asymmetric connectivity measures implemented in Nilearn so far, so not sure if we can build a realistic example here...)