### PR TITLE
[MRG][ENH] NiftiLabelsMasker Reporting

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,6 +11,11 @@ NEW
   before signal cleaning.
 - All inherent classes of `nilearn.input_data.BaseMasker` can use
   parameter `sample_mask` for sub-sample masking.
+- :class:`nilearn.input_data.NiftiLabelsMasker` can now generate HTML reports in the same
+  way as :class:`nilearn.input_data.NiftiMasker`. The report shows the regions defined by
+  the provided label image and provide summary statistics on each region (name, volume...).
+  If a functional image was provided to fit, the middle image is plotted with the regions
+  overlaid as contours. Finally, if a mask is provided, its contours are shown in green.
 
 Fixes
 -----
@@ -103,12 +108,6 @@ NEW
   stability of p-value estimation. It computes 1 - p-value using the Cumulative
   Distribution Function in the same way as `nilearn.glm.Contrast.p_value`
   computes the p-value using the Survival Function.
-
-- :class:`nilearn.input_data.NiftiLabelsMasker` can now generate HTML reports in the same
-  way as :class:`nilearn.input_data.NiftiMasker`. The report shows the regions defined by
-  the provided label image and provide summary statistics on each region (name, volume...).
-  If a functional image was provided to fit, the middle image is plotted with the regions
-  overlaid as contours. Finally, if a mask is provided, its contours are shown in green.
 
 Fixes
 -----

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -104,6 +104,12 @@ NEW
   Distribution Function in the same way as `nilearn.glm.Contrast.p_value`
   computes the p-value using the Survival Function.
 
+- :class:`nilearn.input_data.NiftiLabelsMasker` can now generate HTML reports in the same
+  way as :class:`nilearn.input_data.NiftiMasker`. The report shows the regions defined by
+  the provided label image and provide summary statistics on each region (name, volume...).
+  If a functional image was provided to fit, the middle image is plotted with the regions
+  overlaid as contours. Finally, if a mask is provided, its contours are shown in green.
+
 Fixes
 -----
 

--- a/examples/06_manipulating_images/plot_nifti_labels_simple.py
+++ b/examples/06_manipulating_images/plot_nifti_labels_simple.py
@@ -1,13 +1,18 @@
 """
-Simple example of NiftiLabelsMasker use
-=======================================
+Extracting signals from brain regions using the NiftiLabelsMasker
+=================================================================
 
-Here is a simple example of automatic signal extraction using the nifti
-labels masker.
+This simple example shows how to extract signals from functional
+fmri data and brain regions defined through an atlas.
+More precisely, this example shows how to use the NiftiLabelsMasker
+object to perform this operation in just a few lines of code.
 """
 
 ###########################################################################
 # Retrieve the brain development functional dataset
+#
+# We start by fetching the brain development functional dataset
+# and we restrict the example to one subject only.
 
 from nilearn import datasets
 dataset = datasets.fetch_development_fmri(n_subjects=1)
@@ -18,6 +23,8 @@ print('First functional nifti image (4D) is at: %s' % func_filename)
 
 ###########################################################################
 # Load an atlas
+#
+# We then load the Harvard-Oxford atlas to define the brain regions
 atlas = datasets.fetch_atlas_harvard_oxford('cort-maxprob-thr25-2mm')
 
 # The first label correspond to the background
@@ -26,11 +33,13 @@ print('The atlas contains {} non-overlapping regions'.format(
 
 ###########################################################################
 # Instantiate the mask and visualize atlas
+#
 from nilearn.input_data import NiftiLabelsMasker
 
 # Instantiate the masker with label image and label values
 masker = NiftiLabelsMasker(atlas.maps,
-                           labels=atlas.labels)
+                           labels=atlas.labels,
+                           standardize=True)
 
 # Visualize the atlas
 # Note that we need to call fit prior to generating the mask
@@ -54,8 +63,24 @@ report = masker.generate_report()
 report
 
 ###########################################################################
-# Preprocess the data with the NiftiLablesMasker
-fmri_masked = masker.transform(func_filename)
-# fmri_masked is now a 2D matrix, (n_time_points x n_regions)
-fmri_masked.shape
+# Process the data with the NiftiLablesMasker
+#
+# In order to extract the signals, we need to call transform on the
+# functional data
+signals = masker.transform(func_filename)
+# signals is a 2D matrix, (n_time_points x n_regions)
+signals.shape
 
+###########################################################################
+# Plot the signals
+import matplotlib.pyplot as plt
+
+fig = plt.figure(figsize=(15, 5))
+ax = fig.add_subplot(111)
+for label_idx in range(3):
+    ax.plot(signals[:, label_idx],
+            linewidth=2,
+            label=atlas.labels[label_idx+1]) # 0 is background
+ax.legend(loc=2)
+ax.set_title("Signals for first 3 regions")
+plt.show()

--- a/examples/06_manipulating_images/plot_nifti_labels_simple.py
+++ b/examples/06_manipulating_images/plot_nifti_labels_simple.py
@@ -29,7 +29,7 @@ atlas = datasets.fetch_atlas_harvard_oxford('cort-maxprob-thr25-2mm')
 
 # The first label correspond to the background
 print('The atlas contains {} non-overlapping regions'.format(
-                                len(atlas.labels)-1))
+    len(atlas.labels) - 1))
 
 ###########################################################################
 # Instantiate the mask and visualize atlas
@@ -80,7 +80,7 @@ ax = fig.add_subplot(111)
 for label_idx in range(3):
     ax.plot(signals[:, label_idx],
             linewidth=2,
-            label=atlas.labels[label_idx+1]) # 0 is background
+            label=atlas.labels[label_idx + 1])  # 0 is background
 ax.legend(loc=2)
 ax.set_title("Signals for first 3 regions")
 plt.show()

--- a/examples/06_manipulating_images/plot_nifti_labels_simple.py
+++ b/examples/06_manipulating_images/plot_nifti_labels_simple.py
@@ -1,0 +1,61 @@
+"""
+Simple example of NiftiLabelsMasker use
+=======================================
+
+Here is a simple example of automatic signal extraction using the nifti
+labels masker.
+"""
+
+###########################################################################
+# Retrieve the brain development functional dataset
+
+from nilearn import datasets
+dataset = datasets.fetch_development_fmri(n_subjects=1)
+func_filename = dataset.func[0]
+
+# print basic information on the dataset
+print('First functional nifti image (4D) is at: %s' % func_filename)
+
+###########################################################################
+# Load an atlas
+atlas = datasets.fetch_atlas_harvard_oxford('cort-maxprob-thr25-2mm')
+
+# The first label correspond to the background
+print('The atlas contains {} non-overlapping regions'.format(
+                                len(atlas.labels)-1))
+
+###########################################################################
+# Instantiate the mask and visualize atlas
+from nilearn.input_data import NiftiLabelsMasker
+
+# Instantiate the masker with label image and label values
+masker = NiftiLabelsMasker(atlas.maps,
+                           labels=atlas.labels)
+
+# Visualize the atlas
+# Note that we need to call fit prior to generating the mask
+masker.fit()
+
+# At this point, no functional image has been provided to the masker.
+# We can still generate a report which can be displayed in a Jupyter
+# Notebook, opened in a browser using the .open_in_browser() method,
+# or saved to a file using the .save_as_html(output_filepath) mathod.
+report = masker.generate_report()
+report
+
+##########################################################################
+# Fitting the mask and generating a report
+masker.fit(func_filename)
+
+# We can again generate a report, but this time, the provided functional
+# image is displayed with the ROI of the atlas.
+# The report also contains a summary table giving the region sizes in mm3
+report = masker.generate_report()
+report
+
+###########################################################################
+# Preprocess the data with the NiftiLablesMasker
+fmri_masked = masker.transform(func_filename)
+# fmri_masked is now a 2D matrix, (n_time_points x n_regions)
+fmri_masked.shape
+

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -139,6 +139,10 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         Must be one of: sum, mean, median, mininum, maximum, variance,
         standard_deviation. Default='mean'.
 
+    reports : boolean, optional
+         If set to True, data is saved in order to produce a report.
+         Default=True.
+
     See also
     --------
     nilearn.input_data.NiftiMasker

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -233,6 +233,10 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             labels_image = None
 
         if labels_image is not None:
+            # Remove warning message in case where the masker was
+            # previously fitted with no func image and is re-fitted
+            if 'warning_message' in self._report_content:
+                self._report_content['warning_message'] = None
             labels_image_data = image.get_data(labels_image)
             labels_image_affine = image.load_img(labels_image).affine
             # Number of regions excluding the background

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -150,12 +150,15 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
     """
     # memory and memory_level are used by CacheMixin.
 
-    def __init__(self, labels_img, labels=None, background_label=0, mask_img=None,
-                 smoothing_fwhm=None, standardize=False, standardize_confounds=True,
-                 high_variance_confounds=False, detrend=False, low_pass=None,
-                 high_pass=None, t_r=None, dtype=None, resampling_target="data",
-                 memory=Memory(location=None, verbose=0), memory_level=1,
-                 verbose=0, strategy="mean", reports=True):
+    def __init__(self, labels_img, labels=None, background_label=0,
+                 mask_img=None, smoothing_fwhm=None,
+                 standardize=False, standardize_confounds=True,
+                 high_variance_confounds=False, detrend=False,
+                 low_pass=None, high_pass=None, t_r=None, dtype=None,
+                 resampling_target="data",
+                 memory=Memory(location=None, verbose=0),
+                 memory_level=1, verbose=0, strategy="mean",
+                 reports=True):
         self.labels_img = labels_img
         self.labels = labels
         self.background_label = background_label
@@ -184,7 +187,8 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         self.reports = reports
         self._report_content = dict()
         self._report_content['description'] = (
-            'This reports shows the regions defined by the labels of the mask.')
+            'This reports shows the regions '
+            'defined by the labels of the mask.')
         self._report_content['warning_message'] = None
 
         available_reduction_strategies = {'mean', 'median', 'sum',
@@ -240,12 +244,12 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             labels_image_data = image.get_data(labels_image)
             labels_image_affine = image.load_img(labels_image).affine
             # Number of regions excluding the background
-            number_of_regions = np.sum(np.unique(labels_image_data) !=
-                                       self.background_label)
+            number_of_regions = np.sum(np.unique(labels_image_data)
+                                       != self.background_label)
             # Basic safety check to ensure we have as many labels as we
             # have regions (plus background).
-            if(self.labels is not None and
-               len(self.labels) != number_of_regions + 1):
+            if(self.labels is not None
+               and len(self.labels) != number_of_regions + 1):
                 raise ValueError(("Mismatch between the number of provided "
                                   "labels ({0}) and the number of regions "
                                   "in provided label image ({1})").format(
@@ -258,19 +262,20 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                        'relative size (in %)']
             if self.labels is None:
                 columns.remove('region name')
-            regions_summary = {c:[] for c in columns}
+            regions_summary = {c: [] for c in columns}
             for label in label_values:
                 regions_summary['label value'].append(label)
                 if self.labels is not None:
                     regions_summary['region name'].append(self.labels[label])
                 size = len(labels_image_data[labels_image_data == label])
                 voxel_volume = np.abs(np.linalg.det(
-                                    labels_image_affine[:3, :3]))
+                    labels_image_affine[:3, :3]))
                 regions_summary['size (in mm^3)'].append(round(
-                                        size * voxel_volume))
+                    size * voxel_volume))
                 regions_summary['relative size (in %)'].append(round(
-                    size / len(labels_image_data[labels_image_data != 0]) * 100,
-                    2))
+                    size / len(
+                        labels_image_data[labels_image_data != 0]
+                    ) * 100, 2))
             self._report_content['summary'] = regions_summary
 
             img = self._reporting_data['img']
@@ -361,14 +366,16 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
 
             mask_data, mask_affine = masking._load_mask_img(self.mask_img_)
 
-        if not hasattr(self, '_resampled_labels_img_'):
+        if not hasattr(self,
+                       '_resampled_labels_img_'):
             # obviates need to run .transform() before .inverse_transform()
             self._resampled_labels_img_ = self.labels_img_
 
         if self.reports:
-            self._reporting_data = {'labels_image': self._resampled_labels_img_,
-                                    'mask': self.mask_img_,
-                                    'img': imgs}
+            self._reporting_data = {
+                'labels_image': self._resampled_labels_img_,
+                'mask': self.mask_img_,
+                'img': imgs}
         else:
             self._reporting_data = None
 

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -287,7 +287,8 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             # and give a warning to the user
             else:
                 msg = ("No image provided to fit in NiftiLabelsMasker. "
-                       "Plotting ROI of label image for reporting.")
+                       "Plotting ROIs of label image on the "
+                       "MNI152Template for reporting.")
                 warnings.warn(msg)
                 self._report_content['warning_message'] = msg
                 display = plotting.plot_roi(labels_image)

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -179,6 +179,8 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         self.verbose = verbose
         self.reports = reports
         self._report_content = dict()
+        self._report_content['description'] = (
+            'This reports shows the regions defined by the labels of the mask.')
         self._report_content['warning_message'] = None
 
         available_reduction_strategies = {'mean', 'median', 'sum',
@@ -221,7 +223,11 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                               message=mpl_unavail_msg)
                 return [None]
 
-        labels_image = self._reporting_data['labels_image']
+        if self._reporting_data is not None:
+            labels_image = self._reporting_data['labels_image']
+        else:
+            labels_image = None
+
         if labels_image is not None:
             labels_image_data = image.get_data(labels_image)
             labels_image_affine = image.load_img(labels_image).affine
@@ -236,8 +242,6 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                                   "labels ({0}) and the number of regions "
                                   "in provided label image ({1})").format(
                                       len(self.labels), number_of_regions + 1))
-            self._report_content['description'] = (
-            'This reports shows the regions defined by the labels of the mask.')
             self._report_content['number_of_regions'] = number_of_regions
 
             label_values = np.unique(labels_image_data)

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -310,8 +310,14 @@ class NiftiMasker(BaseMasker, CacheMixin):
                             message=mpl_unavail_msg)
                 return [None]
 
+        # Handle the edge case where this function is
+        # called with a masker having report capabilities disabled
+        if self._reporting_data is None:
+            return [None]
+
         img = self._reporting_data['images']
         mask = self._reporting_data['mask']
+
         if img is not None:
             dim = image.load_img(img).shape
             if len(dim) == 4:
@@ -329,8 +335,9 @@ class NiftiMasker(BaseMasker, CacheMixin):
         init_display = plotting.plot_img(img,
                                          black_bg=False,
                                          cmap='CMRmap_r')
-        init_display.add_contours(mask, levels=[.5], colors='g',
-                                  linewidths=2.5)
+        if mask is not None:
+            init_display.add_contours(mask, levels=[.5], colors='g',
+                                      linewidths=2.5)
 
         if 'transform' not in self._reporting_data:
             return [init_display]

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -261,14 +261,15 @@ class NiftiMasker(BaseMasker, CacheMixin):
         self.memory_level = memory_level
         self.verbose = verbose
         self.reports = reports
-        self._report_description = ('This report shows the input Nifti '
-                                    'image overlaid with the outlines of the '
-                                    'mask (in green). We recommend to inspect '
-                                    'the report for the overlap between the '
-                                    'mask and its input image. ')
+        self._report_content = dict()
+        self._report_content['description'] = (
+            'This report shows the input Nifti image overlaid '
+            'with the outlines of the mask (in green). We '
+            'recommend to inspect the report for the overlap '
+            'between the mask and its input image. ')
+        self._report_content['warning_message'] = None
         self._overlay_text = ('\n To see the input Nifti image before '
                               'resampling, hover over the displayed image.')
-        self._warning_message = ""
         self._shelving = False
 
     @property
@@ -320,7 +321,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
             msg = ("No image provided to fit in NiftiMasker. "
                    "Setting image to mask for reporting.")
             warnings.warn(msg)
-            self._warning_message = msg
+            self._report_content['warning_message'] = msg
             img = mask
 
         # create display of retained input mask, image
@@ -335,8 +336,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
             return [init_display]
 
         else:  # if resampling was performed
-            self._report_description = (self._report_description +
-                                        self._overlay_text)
+            self._report_content['description'] += self._overlay_text
 
             # create display of resampled NiftiImage and mask
             # assuming that resampl_img has same dim as img

--- a/nilearn/reporting/data/html/report_body_template.html
+++ b/nilearn/reporting/data/html/report_body_template.html
@@ -202,8 +202,12 @@ div.nilearn_report .image:hover .overlay {
       </div>
   </div>
   <div class="pure-u-1 pure-u-md-1-3 raise">
-    <p class="elem-warn">{{warning_message}}</p>
-    <p class="elem-desc">{{description}}</p>
+    {{if warning_message}}
+      <p class="elem-warn">{{warning_message}}</p>
+    {{endif}}
+    {{if description}}
+      <p class="elem-desc">{{description}}</p>
+    {{endif}}
     <p></p>
     <details>
       <summary class="pure-button">Parameters</summary>

--- a/nilearn/reporting/data/html/report_body_template_niftilabelsmasker.html
+++ b/nilearn/reporting/data/html/report_body_template_niftilabelsmasker.html
@@ -184,6 +184,13 @@ div.nilearn_report .image:hover .overlay {
     font-weight: bold;
 }
 
+.note {
+    font-size: 8pt;
+    font-style: italic;
+    text-align: center;
+    padding-left: 5px;
+}
+
 </style>
 <div class="nilearn_report">
   <h1 class="withtooltip">
@@ -262,4 +269,8 @@ div.nilearn_report .image:hover .overlay {
     </details>
     </div>
   </div>
+  <div class="note">
+    <p>This report was generated based on information provided at instantiation and fit time. Note that the masker can potentially perform resampling at transform time.</p>
+  </div>
 </div>
+

--- a/nilearn/reporting/data/html/report_body_template_niftilabelsmasker.html
+++ b/nilearn/reporting/data/html/report_body_template_niftilabelsmasker.html
@@ -1,0 +1,265 @@
+<!-- CSS for the report -->
+<link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/pure-min.css" integrity="sha384-nn4HPE8lTHyVtfCBi5yW9d20FjT8BJwUXyWZT9InLYax14RDjBj46LmSztkmNP9w" crossorigin="anonymous">
+<link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
+<style type="text/css">
+
+/* Add a gutter to Pure's Columns */
+.pure-g > div {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+.pure-g > div {
+  padding: 0 0.5em;
+}
+
+/*!
+Pure-button class copied from pure-min.css,
+in case reports are displayed offline.
+
+Pure v1.0.0
+Copyright 2013 Yahoo!
+Licensed under the BSD License.
+https://github.com/yahoo/pure/blob/master/LICENSE.md
+*/
+
+.pure-button {
+    /* Structure */
+    display: inline-block;
+    zoom: 1;
+    line-height: normal;
+    white-space: nowrap;
+    vertical-align: middle;
+    text-align: center;
+    cursor: pointer;
+    -webkit-user-drag: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+    box-sizing: border-box;
+}
+
+.pure-button {
+    /* Button styling */
+    font-family: inherit;
+    font-size: 100%;
+    padding: 0.5em 1em;
+    color: #444; /* rgba not supported (IE 8) */
+    color: rgba(0, 0, 0, 0.80); /* rgba supported */
+    border: 1px solid #999;  /*IE 6/7/8*/
+    border: none rgba(0, 0, 0, 0);  /*IE9 + everything else*/
+    background-color: #E6E6E6;
+    text-decoration: none;
+    border-radius: 2px;
+}
+
+/*!
+End pure-button class definition from pure-min.css
+*/
+
+div.nilearn_report {
+    padding-top: 0px;
+    border: solid rgb(150, 150, 150);
+    border-width: 1pt;
+    border-radius: 6pt;
+    overflow: hidden;  /* Needed to avoid scrolling in jupyter :( */
+    color: black;
+    background-color: white;
+}
+
+.terminal div.nilearn_report {
+    max-width: min(50ex, 100vw); /* Needed in vscode */
+}
+
+/* Isolate us a bit from the styles specified by other stylesheets */
+
+div.nilearn_report h1 {
+    text-align: left;
+    margin-left: 0pt;
+    margin-right: 0pt;
+    padding-top: 5pt;
+    font-size: 1.8em;
+    padding-left: 5pt;
+}
+
+div.nilearn_report h1:first-child {
+    margin-top: 0pt;
+    background-color: #f5f5f5;
+    border-radius: 6pt 6pt 0pt 0pt;
+    padding-left: 5pt;
+}
+
+div.nilearn_report summary::-webkit-details-marker {
+    margin-right: 2px;
+}
+
+div.nilearn_report summary:focus {
+    outline-style: none;
+}
+
+div.nilearn_report table {
+    max-width: 100%;
+    border-collapse: collapse;
+    margin:50px auto;
+    float: right;
+}
+
+div.nilearn_report thead th {
+  text-align: center;
+}
+
+div.nilearn_report tbody tr:nth-child(even) {
+   background-color: #ddd;
+}
+
+div.nilearn_report details {
+    overflow-x: visible;
+}
+
+div.nilearn_report div.raise {
+    z-index: 1;
+
+}
+
+/* Tooltip container */
+div.nilearn_report .withtooltip {
+  position: relative;
+  border-bottom: 1px dotted black; /* If you want dots under the hoverable text */
+}
+
+/* Tooltip text */
+div.nilearn_report .withtooltip .tooltiptext {
+  visibility: hidden;
+  max-width: 35em;
+  width: 90%;
+  background-color: rgba(24,24,24,0.9);
+  color: #fff;
+  text-align: left;
+  font-size: 12pt;
+  font-weight: 200;
+  border-radius: 6px;
+  padding: 5px;css=resource_path.joinpath('css'),
+
+  margin-left: 3pt;
+
+  /* Position the tooltip text - see examples below! */
+  position: absolute;
+  z-index: 2;
+
+  width: 99%;
+  left: 2pt;
+  top: 133%;
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+div.nilearn_report .withtooltip:hover .tooltiptext {
+  visibility: visible;
+}
+
+div.nilearn_report .image {
+  position: relative;
+  height: auto;
+  width: 100%;
+}
+
+div.nilearn_report .image .overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  transition: .5s ease;
+  height: auto;
+  width: 100%;
+  -webkit-transition: .5s ease;
+}
+
+div.nilearn_report .image:hover .overlay {
+  opacity: 1;
+}
+
+.elem-warn {
+    color: #FF0000;
+    font-weight: bold;
+}
+
+</style>
+<div class="nilearn_report">
+  <h1 class="withtooltip">
+    {{title}}
+    <span class="tooltiptext">{{docstring}}</span>
+  </h1>
+  <div class="pure-g">
+  <div class="pure-u-1 pure-u-md-2-3">
+      <div class="image">
+      <img class="pure-img" width="100%" src="data:image/svg+xml;base64,{{content}}" alt="image"/>
+      {{if overlay}}
+      <div class="overlay">
+        <img class="pure-img" width="100%" src="data:image/svg+xml;base64,{{overlay}}" alt="overlay"/>
+      </div>
+      {{endif}}
+      </div>
+  </div>
+  <div class="pure-u-1 pure-u-md-1-3 raise">
+    {{if warning_message}}
+    <p class="elem-warn">{{warning_message}}</p>
+    {{endif}}
+    {{if description}}
+    <p class="elem-desc">{{description}}</p>
+    {{endif}}
+    {{if number_of_regions}}
+    <p class="elem-desc">The masker has <b>{{number_of_regions}}</b> different non-overlapping regions.</p>
+    {{endif}}
+    <p></p>
+    <p></p>
+    <details>
+    {{if summary}}
+      <summary class="pure-button">Regions summary</summary>
+      <table class="pure-table">
+        <thead>
+          <tr>
+          {{py: region = summary.items()}}
+          {{for k, v in region}}
+            <th>{{k}}</th>
+          {{endfor}}
+          </tr>
+        </thead>
+        <tbody>
+        {{for idx in range(number_of_regions)}}
+          <tr>
+          {{for k, v in region}}
+            <td data-column={{k}}>{{v[idx]}}</td>
+          {{endfor}}
+          </tr>
+        {{endfor}}
+        </tbody>
+    </table>
+    </details>
+    {{endif}}
+    {{if parameters}}   
+      <details> 
+      <summary class="pure-button">Parameters</summary>
+      <table class="pure-table">
+        <thead>
+          <tr>
+            <th>Parameter</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          {{py: params = parameters.items()}}
+          {{for p, v in params}}
+            <tr>
+              <td data-column="Parameter">{{p}}</td>
+              <td data-column="Value">{{v}}</td>
+            </tr>
+          {{endfor}}
+        </tbody>
+      </table>
+    {{endif}}
+    </details>
+    </div>
+  </div>
+</div>

--- a/nilearn/reporting/html_report.py
+++ b/nilearn/reporting/html_report.py
@@ -125,7 +125,7 @@ def _update_template(title, docstring, content, overlay,
     else:
         body_template_name = template_name
     body_template_path = resource_path.joinpath(body_template_name)
-    if not os.path.exists(body_template_path):
+    if not os.path.exists(str(body_template_path)):
         raise FileNotFoundError("No template {}".format(
                     body_template_name))
     tpl = tempita.HTMLTemplate.from_filename(str(body_template_path),

--- a/nilearn/reporting/html_report.py
+++ b/nilearn/reporting/html_report.py
@@ -95,19 +95,22 @@ def _update_template(title, docstring, content, overlay,
     data : dict
         A dictionary holding the data to be added to the report.
         The keys must match exactly the ones used in the template.
+        The default template accepts the following:
+            - description (str) : Description of the content.
+            - warning_message (str) : An optional warning
+              message to be displayed in red. This is used
+              for example when no image was provided to the
+              estimator when fitting.
+        The NiftiLabelsMasker template accepts the additional
+        fields:
+            - summary (dict) : A summary description of the
+              region labels and sizes. This will be displayed
+              as an expandable table in the report.
 
     template_name : str, optional
         The name of the template to use. If not provided, the
         default template `report_body_template.html` will be
         used.
-
-    description : str, optional
-        An optional description of the content.
-
-    warning_message : str, optional
-        An optional warning message to be displayed in red.
-        This is used for example when no image was provided
-        to the estimator when fitting.
 
     Returns
     -------

--- a/nilearn/reporting/html_report.py
+++ b/nilearn/reporting/html_report.py
@@ -14,6 +14,7 @@ ESTIMATOR_TEMPLATES = {
     'NiftiLabelsMasker': 'report_body_template_niftilabelsmasker.html',
     'default': 'report_body_template.html'}
 
+
 def _get_estimator_template(estimator):
     """Returns the HTML template to use for a given
     estimator if a specific template was defined in
@@ -127,15 +128,14 @@ def _update_template(title, docstring, content, overlay,
     body_template_path = resource_path.joinpath(body_template_name)
     if not os.path.exists(str(body_template_path)):
         raise FileNotFoundError("No template {}".format(
-                    body_template_name))
+            body_template_name))
     tpl = tempita.HTMLTemplate.from_filename(str(body_template_path),
                                              encoding='utf-8')
     body = tpl.substitute(title=title, content=content,
                           overlay=overlay,
                           docstring=docstring,
                           parameters=parameters,
-                          **data
-                        )
+                          **data)
 
     head_template_name = 'report_head_template.html'
     head_template_path = resource_path.joinpath(head_template_name)
@@ -218,8 +218,7 @@ def generate_report(estimator):
                                   overlay=_embed_img(overlay),
                                   parameters=parameters,
                                   data=data,
-                                  template_name=html_template,
-                                 )
+                                  template_name=html_template)
     return report
 
 

--- a/nilearn/reporting/html_report.py
+++ b/nilearn/reporting/html_report.py
@@ -22,8 +22,8 @@ def _get_estimator_template(estimator):
 
     Parameters
     ----------
-    estimator : ll
-        fff
+    estimator : object instance of BaseEstimator
+        The object we wish to retrieve template of.
 
     Returns
     -------
@@ -167,6 +167,11 @@ def generate_report(estimator):
     Reports are useful to visualize steps in a processing pipeline.
     Example use case: visualize the overlap of a mask and reference image
     in NiftiMasker.
+
+    Parameters
+    ----------
+    estimator : Object instance of BaseEstimator.
+        Object for which the report should be generated.
 
     Returns
     -------

--- a/nilearn/reporting/html_report.py
+++ b/nilearn/reporting/html_report.py
@@ -173,6 +173,10 @@ def generate_report(estimator):
     report : HTMLReport
 
     """
+    if hasattr(estimator, '_report_content'):
+        data = estimator._report_content
+    else:
+        data = dict()
     if not hasattr(estimator, '_reporting_data'):
         warnings.warn('This object has not been fitted yet ! '
                       'Make sure to run `fit` before inspecting reports.')
@@ -183,7 +187,7 @@ def generate_report(estimator):
                                   content=_embed_img(None),
                                   overlay=None,
                                   parameters=dict(),
-                                  data=dict())
+                                  data=data)
 
     elif estimator._reporting_data is None:
         warnings.warn('Report generation not enabled ! '
@@ -195,12 +199,11 @@ def generate_report(estimator):
                                   content=_embed_img(None),
                                   overlay=None,
                                   parameters=dict(),
-                                  data=dict())
+                                  data=data)
 
     else:  # We can create a report
         html_template = _get_estimator_template(estimator)
         overlay, image = _define_overlay(estimator)
-        data = estimator._report_content
         parameters = _str_params(estimator.get_params())
         docstring = estimator.__doc__
         snippet = docstring.partition('Parameters\n    ----------\n')[0]

--- a/nilearn/reporting/tests/test_html_report.py
+++ b/nilearn/reporting/tests/test_html_report.py
@@ -63,8 +63,8 @@ def test_nifti_labels_masker_report():
     shape = (13, 11, 12)
     affine = np.diag([2, 2, 2, 1])
     n_regions = 9
-    labels = ['background'] + ['region_{}'.format(i) for i in range(1, n_regions+1)]
-    length = 3
+    labels = ['background'] + ['region_{}'.format(i)
+                               for i in range(1, n_regions + 1)]
     EXPECTED_COLUMNS = ['label value',
                         'region name',
                         'size (in mm^3)',
@@ -74,10 +74,10 @@ def test_nifti_labels_masker_report():
                                                    n_regions=n_regions)
     # Check that providing incorrect labels raises an error
     masker = input_data.NiftiLabelsMasker(labels_img,
-                                          labels = labels[:-1])
+                                          labels=labels[:-1])
     masker.fit()
     with pytest.raises(ValueError,
-                      match="Mismatch between the number of provided labels"):
+                       match="Mismatch between the number of provided labels"):
         masker.generate_report()
     masker = input_data.NiftiLabelsMasker(labels_img,
                                           labels=labels)
@@ -126,15 +126,19 @@ def test_nifti_labels_masker_report():
     # Check that labels match
     assert masker._report_content['summary']['region name'] == labels[1:]
     # Relative sizes of regions should sum to 100%
-    assert_almost_equal(sum(masker._report_content['summary']['relative size (in %)']), 100)
+    assert_almost_equal(
+        sum(
+            masker._report_content['summary']['relative size (in %)']),
+        100)
     _check_html(report)
     assert "Regions summary" in str(report)
     # Check region sizes calculations
     expected_region_sizes = Counter(get_data(labels_img).ravel())
-    for r in range(1, n_regions+1):
-        assert_almost_equal(masker._report_content['summary']['size (in mm^3)'][r-1],
-               expected_region_sizes[r] *
-               np.abs(np.linalg.det(affine[:3, :3])))
+    for r in range(1, n_regions + 1):
+        assert_almost_equal(
+            masker._report_content['summary']['size (in mm^3)'][r - 1],
+            expected_region_sizes[r]
+            * np.abs(np.linalg.det(affine[:3, :3])))
 
     # Check that region labels are no displayed in the report
     # when they were not provided by the user.

--- a/nilearn/reporting/tests/test_html_report.py
+++ b/nilearn/reporting/tests/test_html_report.py
@@ -148,19 +148,28 @@ def test_4d_reports():
     _check_html(html)
 
 
-def _generate_empty_report():
+def test_empty_report():
+    # Data for NiftiMasker
     data = np.zeros((9, 9, 9))
     data[3:-3, 3:-3, 3:-3] = 10
     data_img_3d = Nifti1Image(data, np.eye(4))
-
+    # Data for NiftiLabelsMasker
+    shape = (13, 11, 12)
+    affine = np.diag([2, 2, 2, 1])
+    n_regions = 9
+    labels_img = data_gen.generate_labeled_regions(shape,
+                                                   affine=affine,
+                                                   n_regions=n_regions)
     # turn off reporting
-    mask = input_data.NiftiMasker(reports=False)
-    mask.fit(data_img_3d)
-    mask.generate_report()
-
-
-def test_empty_report():
-    pytest.warns(UserWarning, _generate_empty_report)
+    maskers = [input_data.NiftiMasker(reports=False),
+               input_data.NiftiLabelsMasker(labels_img, reports=False)]
+    for masker in maskers:
+        masker.fit(data_img_3d)
+        assert masker._reporting() == [None]
+        with pytest.warns(UserWarning,
+                          match=("Report generation not enabled ! "
+                                 "No visual outputs will be created.")):
+            masker.generate_report()
 
 
 def test_overlaid_report():

--- a/nilearn/reporting/tests/test_html_report.py
+++ b/nilearn/reporting/tests/test_html_report.py
@@ -37,19 +37,19 @@ def test_3d_reports():
     # check providing mask to init
     masker = input_data.NiftiMasker(mask_img=mask_img_3d)
     masker.fit(data_img_3d)
-    assert mask._warning_message == ""
+    assert masker._report_content['warning_message'] is None
     html = masker.generate_report()
     _check_html(html)
 
     # check providing mask to init and no images to .fit
     masker = input_data.NiftiMasker(mask_img=mask_img_3d)
-    assert masker._warning_message == ""
+    assert masker._report_content['warning_message'] is None
     masker.fit()
     warn_message = ("No image provided to fit in NiftiMasker. "
                     "Setting image to mask for reporting.")
     with pytest.warns(UserWarning, match=warn_message):
         html = masker.generate_report()
-    assert masker._warning_message == warn_message
+    assert masker._report_content['warning_message'] == warn_message
     _check_html(html)
 
 
@@ -69,14 +69,14 @@ def test_4d_reports():
     # test .fit method
     mask = input_data.NiftiMasker(mask_strategy='epi')
     mask.fit(data_img_4d)
-    assert mask._warning_message == ""
+    assert mask._report_content['warning_message'] is None
     html = mask.generate_report()
     _check_html(html)
 
     # test .fit_transform method
     masker = input_data.NiftiMasker(mask_img=mask_img, standardize=True)
     masker.fit_transform(data_img_4d)
-    assert mask._warning_message == ""
+    assert mask._report_content['warning_message'] is None
     html = masker.generate_report()
     _check_html(html)
 

--- a/nilearn/reporting/tests/test_html_report.py
+++ b/nilearn/reporting/tests/test_html_report.py
@@ -58,7 +58,7 @@ def test_3d_reports():
 
 def test_nifti_labels_masker_report():
     shape = (13, 11, 12)
-    affine = np.eye(4)
+    affine = np.diag([2, 2, 2, 1])
     n_regions = 9
     labels = ['background'] + ['region_{}'.format(i) for i in range(1, n_regions+1)]
     length = 3
@@ -75,7 +75,6 @@ def test_nifti_labels_masker_report():
     report = masker.generate_report()
     # Resolution and background label were left as default
     assert masker.background_label == 0
-    assert masker.resolution == 2.0
     assert masker._report_content['description'] == (
         'This reports shows the regions defined by the labels of the mask.')
     # Check that the number of regions is correct
@@ -93,8 +92,9 @@ def test_nifti_labels_masker_report():
     # Check region sizes calculations
     expected_region_sizes = Counter(get_data(labels_img).ravel())
     for r in range(1, n_regions+1):
-        assert(masker._report_content['summary']['size (in mm^3)'][r-1] ==
-               expected_region_sizes[r] * masker.resolution)
+        assert_almost_equal(masker._report_content['summary']['size (in mm^3)'][r-1],
+               expected_region_sizes[r] *
+               np.abs(np.linalg.det(affine[:3, :3])))
 
 
 def test_4d_reports():


### PR DESCRIPTION
See #2689 

**Description**

This draft PR proposes to add reporting capabilities to the `NiftiLabelsMasker`: 

- It reworks the template logic a little bit to be able to select different templates depending on the estimator
- It proposes a possible report format which is composed of a `plot_roi` of the regions as suggested by @GaelVaroquaux  in #2689, a count of the different regions, and adds a button to display information about each region. For now, only the label number, the name, the size (in number of voxels), and relative size are provided for each region.

*Note: Comments are welcome to improve the report!* 

**Example**

```python
from nilearn import datasets
from nilearn.input_data import NiftiLabelsMasker

atlas = datasets.fetch_atlas_harvard_oxford('cort-maxprob-thr25-2mm')
data = datasets.fetch_development_fmri(n_subjects=1)
masker = NiftiLabelsMasker(labels_img=atlas.maps,
                           labels=atlas.labels)
masker.fit(data.func[0])
report = masker.generate_report()
report
```
![niftilabelsmasker_report](https://user-images.githubusercontent.com/2639645/108543980-1b3d9f80-72e6-11eb-8f6e-49a0c23923ea.png)

Clicking on the "Regions summary" button gives the following:

![niftilabelsmasker_report2](https://user-images.githubusercontent.com/2639645/108543145-f5fc6180-72e4-11eb-95ea-6887345c4e2d.png)

**Todo**

- [x] Make sure everybody agrees on what information should be provided and update the report accordingly
- [x] Add tests
- [x] Update doc/examples