### PR TITLE
Raise warning for FirstLevelModel fit when confounds and design_matrices are both specified

### DIFF
--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -362,6 +362,9 @@ class FirstLevelModel(BaseGLM):
             takes precedence over events and confounds.
 
         """
+        # Raise a warning if both design_matrices and confounds are provided
+        if design_matrices is not None and confounds is not None:
+            warn('If the design matrices are given, it takes precedence over events and confounds.')
         # Local import to prevent circular imports
         from nilearn.input_data import NiftiMasker  # noqa
 
@@ -519,8 +522,6 @@ class FirstLevelModel(BaseGLM):
         if self.verbose > 0:
             sys.stderr.write("\nComputation of %d runs done in %i seconds\n\n"
                              % (n_runs, time.time() - t0))
-        if design_matrices is not None and confounds is not None:
-            warn('If the design matrices are given, it takes precedence over events and confounds.')
         return self
 
     def compute_contrast(self, contrast_def, stat_type=None,

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -519,7 +519,7 @@ class FirstLevelModel(BaseGLM):
         if self.verbose > 0:
             sys.stderr.write("\nComputation of %d runs done in %i seconds\n\n"
                              % (n_runs, time.time() - t0))
-
+        warn('If the design matrices are given, it takes precedence over events and confounds.')
         return self
 
     def compute_contrast(self, contrast_def, stat_type=None,

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -519,7 +519,8 @@ class FirstLevelModel(BaseGLM):
         if self.verbose > 0:
             sys.stderr.write("\nComputation of %d runs done in %i seconds\n\n"
                              % (n_runs, time.time() - t0))
-        warn('If the design matrices are given, it takes precedence over events and confounds.')
+        if design_matrices is not None and confounds is not None:
+            warn('If the design matrices are given, it takes precedence over events and confounds.')
         return self
 
     def compute_contrast(self, contrast_def, stat_type=None,

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -363,8 +363,8 @@ class FirstLevelModel(BaseGLM):
 
         """
         # Raise a warning if both design_matrices and confounds are provided
-        if design_matrices is not None and confounds is not None:
-            warn('If the design matrices are given, it takes precedence over events and confounds.')
+        if design_matrices is not None and (confounds is not None or events is not None):
+            warn('If design matrices are supplied, confounds and events will be ignored.')
         # Local import to prevent circular imports
         from nilearn.input_data import NiftiMasker  # noqa
 

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -314,9 +314,10 @@ def test_fmri_inputs():
                 FirstLevelModel(mask_img=None).fit([fi], design_matrices=d)
                 FirstLevelModel(mask_img=mask).fit(fi, design_matrices=[d])
                 FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d])
-                # test with confounds
-                FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d],
-                                                   confounds=conf)
+                with pytest.warns(UserWarning, match="If the design matrices are given"):
+                    # test with confounds
+                    FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d],
+                                                    confounds=conf)
                 # test with confounds as numpy array
                 FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d],
                                                    confounds=conf.values)
@@ -630,22 +631,3 @@ def test_first_level_predictions_r_square():
 
     r_square_2d = model.masker_.transform(r_square_3d)
     assert_array_less(0., r_square_2d)
-
-
-def test_warning_fit():
-    with InTemporaryDirectory():
-        shapes = ((7, 8, 9, 10),)
-        mask, FUNCFILE, _ = write_fake_fmri_data_and_design(shapes)
-        FUNCFILE = FUNCFILE[0]
-        func_img = load(FUNCFILE)
-        T = func_img.shape[-1]
-        conf = pd.DataFrame([0, 0])
-        des = pd.DataFrame(np.ones((T, 1)), columns=[''])
-        des_fname = 'design.csv'
-        des.to_csv(des_fname)
-        for fi in func_img, FUNCFILE:
-            for d in des, des_fname:
-                # test with confounds
-                with warnings.catch_warnings(record=True) as warning:
-                    FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d],confounds=conf)
-                    assert len(warning) > 0

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -630,3 +630,22 @@ def test_first_level_predictions_r_square():
 
     r_square_2d = model.masker_.transform(r_square_3d)
     assert_array_less(0., r_square_2d)
+
+
+def test_warning_fit():
+    with InTemporaryDirectory():
+        shapes = ((7, 8, 9, 10),)
+        mask, FUNCFILE, _ = write_fake_fmri_data_and_design(shapes)
+        FUNCFILE = FUNCFILE[0]
+        func_img = load(FUNCFILE)
+        T = func_img.shape[-1]
+        conf = pd.DataFrame([0, 0])
+        des = pd.DataFrame(np.ones((T, 1)), columns=[''])
+        des_fname = 'design.csv'
+        des.to_csv(des_fname)
+        for fi in func_img, FUNCFILE:
+            for d in des, des_fname:
+                # test with confounds
+                with warnings.catch_warnings(record=True) as w:
+                    FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d],confounds=conf)
+                    assert len(w) == 1

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -314,7 +314,7 @@ def test_fmri_inputs():
                 FirstLevelModel(mask_img=None).fit([fi], design_matrices=d)
                 FirstLevelModel(mask_img=mask).fit(fi, design_matrices=[d])
                 FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d])
-                with pytest.warns(UserWarning, match="If the design matrices are given"):
+                with pytest.warns(UserWarning, match="If design matrices are supplied"):
                     # test with confounds
                     FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d],
                                                     confounds=conf)

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -646,6 +646,6 @@ def test_warning_fit():
         for fi in func_img, FUNCFILE:
             for d in des, des_fname:
                 # test with confounds
-                with warnings.catch_warnings(record=True) as w:
+                with warnings.catch_warnings(record=True) as warning:
                     FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d],confounds=conf)
-                    assert len(w) > 0
+                    assert len(warning) > 0

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -648,4 +648,4 @@ def test_warning_fit():
                 # test with confounds
                 with warnings.catch_warnings(record=True) as w:
                     FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d],confounds=conf)
-                    assert len(w) > 1
+                    assert len(w) > 0

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -648,4 +648,4 @@ def test_warning_fit():
                 # test with confounds
                 with warnings.catch_warnings(record=True) as w:
                     FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d],confounds=conf)
-                    assert len(w) == 1
+                    assert len(w) > 1


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:
- Adding a warning in the fit function when both the design matrices and (confounds and events) are provided in #2704 