### PR TITLE
Replace NaNs with zeros in NiftiLabelsMasker

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -6,12 +6,12 @@ NEW
 
 - New atlas fetcher
   :func:`nilearn.datasets.fetch_atlas_difumo` to download *Dictionaries of Functional Modes*,
-  or “DiFuMo”, that can serve as atlases to extract functional signals with different 
+  or “DiFuMo”, that can serve as atlases to extract functional signals with different
   dimensionalities (64, 128, 256, 512, and 1024). These modes are optimized to represent well
   raw BOLD timeseries, over a with range of experimental conditions.
 
-- :func:`nilearn.glm.Contrast.one_minus_pvalue` was added to ensure numerical 
-  stability of p-value estimation. It computes 1 - p-value using the Cumulative 
+- :func:`nilearn.glm.Contrast.one_minus_pvalue` was added to ensure numerical
+  stability of p-value estimation. It computes 1 - p-value using the Cumulative
   Distribution Function in the same way as `nilearn.glm.Contrast.p_value`
   computes the p-value using the Survival Function.
 
@@ -32,7 +32,7 @@ Enhancements
 - :class:`nilearn.decoding.Decoder`, :class:`nilearn.decoding.DecoderRegressor`,
   :class:`nilearn.decoding.FREMRegressor`, and :class:`nilearn.decoding.FREMClassifier`
   now override the `score` method to use whatever scoring strategy was defined through
-  the `scoring` attribute instead of the sklearn default. 
+  the `scoring` attribute instead of the sklearn default.
   If the `scoring` attribute of the decoder is set to None, the scoring strategy
   will default to accuracy for classifiers and to r2 score for regressors.
 
@@ -44,9 +44,12 @@ Enhancements
 - :class:`nilearn.input_data.NiftiMasker`, :class:`nilearn.input_data.NiftiLabelsMasker`,
   :class:`nilearn.input_data.MultiNiftiMasker`, :class:`nilearn.input_data.NiftiMapsMasker`,
   and :class:`nilearn.input_data.NiftiSpheresMasker` can now compute high variance confounds
-  on the images provided to `transform` and regress them out automatically. This behaviour is 
+  on the images provided to `transform` and regress them out automatically. This behaviour is
   controlled through the `high_variance_confounds` boolean parameter of these maskers which
   default to False.
+
+- :class:`nilearn.input_data.NiftiLabelsMasker` now automatically replaces NaNs in input data
+  with zeros, to match the behavior of other maskers.
 
 - :func:`nilearn.datasets.fetch_neurovault` now implements a `resample` boolean argument to either
   perform a fixed resampling during download or keep original images. This can be handy to reduce disk usage.

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -7,11 +7,13 @@ Neuroimaging file input and output.
 import copy
 import gc
 import collections.abc
+from warnings import warn
 
 import numpy as np
 import nibabel
 
 from pathlib import Path
+
 
 def _get_data(img):
     # copy-pasted from https://github.com/nipy/nibabel/blob/de44a105c1267b07ef9e28f6c35b31f851d5a005/nibabel/dataobj_images.py#L204
@@ -55,7 +57,11 @@ def _safe_get_data(img, ensure_finite=False, copy_data=False):
     data = _get_data(img)
     if ensure_finite:
         non_finite_mask = np.logical_not(np.isfinite(data))
-        if non_finite_mask.sum() > 0: # any non_finite_mask values?
+        if non_finite_mask.sum() > 0:  # any non_finite_mask values?
+            warn(
+                "Non-finite data detected. "
+                "These data will be replaced with zeros."
+            )
             data[non_finite_mask] = 0
 
     return data

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -59,8 +59,8 @@ def _safe_get_data(img, ensure_finite=False, copy_data=False):
         non_finite_mask = np.logical_not(np.isfinite(data))
         if non_finite_mask.sum() > 0:  # any non_finite_mask values?
             warn(
-                "Non-finite data detected. "
-                "These data will be replaced with zeros."
+                "Non-finite values detected. "
+                "These values will be replaced with zeros."
             )
             data[non_finite_mask] = 0
 
@@ -138,7 +138,7 @@ def load_niimg(niimg, dtype=None):
         if niimg.header is not None:
             niimg = new_img_like(niimg, _get_data(niimg).astype(dtype),
                                 niimg.affine, copy_header=True)
-            niimg.header.set_data_dtype(dtype)        
+            niimg.header.set_data_dtype(dtype)
         else:
             niimg = new_img_like(niimg, _get_data(niimg).astype(dtype),
                                 niimg.affine)

--- a/nilearn/input_data/tests/test_nifti_maps_masker.py
+++ b/nilearn/input_data/tests/test_nifti_maps_masker.py
@@ -122,7 +122,12 @@ def test_nifti_maps_masker():
                                   affine2)
 
 
-def test_nifti_maps_masker_with_nans():
+def test_nifti_maps_masker_with_nans_and_infs():
+    """Apply a NiftiMapsMasker containing NaNs and infs.
+
+    The masker should replace those NaNs and infs with zeros,
+    without raising a warning.
+    """
     length = 3
     n_regions = 8
     fmri_img, mask_img = generate_random_img((13, 11, 12),
@@ -130,21 +135,88 @@ def test_nifti_maps_masker_with_nans():
     maps_img, maps_mask_img = data_gen.generate_maps((13, 11, 12), n_regions,
                                                      affine=np.eye(4))
 
-    # nans
-    maps_data = get_data(maps_img)
-    mask_data = np.array(get_data(mask_img),
-                         dtype=np.float64)
+    # Add NaNs and infs to atlas
+    maps_data = get_data(maps_img).astype(np.float32)
+    mask_data = get_data(mask_img).astype(np.float32)
+    maps_data = maps_data * mask_data[..., None]
 
-    maps_data[:, 9, 9] = np.nan
-    maps_data[:, 5, 5] = np.inf
+    # Choose a good voxel from the first label
+    vox_idx = np.where(maps_data[..., 0] > 0)
+    i1, j1, k1 = vox_idx[0][0], vox_idx[1][0], vox_idx[2][0]
+    i2, j2, k2 = vox_idx[0][1], vox_idx[1][1], vox_idx[2][1]
+
+    maps_data[:, :, :, 0] = np.nan
+    maps_data[i2, j2, k2, 0] = np.inf
+    maps_data[i1, j1, k1, 0] = 1
+
+    maps_img = nibabel.Nifti1Image(maps_data, np.eye(4))
+
+    # No warning, because maps_img is run through clean_img
+    # *before* _safe_get_data.
+    masker = NiftiMapsMasker(maps_img, mask_img=mask_img)
+
+    sig = masker.fit_transform(fmri_img)
+
+    assert sig.shape == (length, n_regions)
+    assert np.all(np.isfinite(sig))
+
+
+def test_nifti_maps_masker_with_nans_and_infs_in_mask():
+    """Apply a NiftiMapsMasker with a mask containing NaNs and infs.
+
+    The masker should replace those NaNs and infs with zeros,
+    while raising a warning.
+    """
+    length = 3
+    n_regions = 8
+    fmri_img, mask_img = generate_random_img((13, 11, 12),
+                                             affine=np.eye(4), length=length)
+    maps_img, maps_mask_img = data_gen.generate_maps((13, 11, 12), n_regions,
+                                                     affine=np.eye(4))
+
+    # Add NaNs and infs to mask
+    mask_data = np.array(get_data(mask_img), dtype=np.float64)
+
     mask_data[:, :, 7] = np.nan
     mask_data[:, :, 5] = np.inf
 
-    maps_img = nibabel.Nifti1Image(maps_data, np.eye(4))
     mask_img = nibabel.Nifti1Image(mask_data, np.eye(4))
 
     masker = NiftiMapsMasker(maps_img, mask_img=mask_img)
-    sig = masker.fit_transform(fmri_img)
+
+    with pytest.warns(UserWarning, match="Non-finite values detected."):
+        sig = masker.fit_transform(fmri_img)
+
+    assert sig.shape == (length, n_regions)
+    assert np.all(np.isfinite(sig))
+
+
+def test_nifti_maps_masker_with_nans_and_infs_in_data():
+    """Apply a NiftiMapsMasker to 4D data containing NaNs and infs.
+
+    The masker should replace those NaNs and infs with zeros,
+    while raising a warning.
+    """
+    length = 3
+    n_regions = 8
+    fmri_img, mask_img = generate_random_img((13, 11, 12),
+                                             affine=np.eye(4), length=length)
+    maps_img, maps_mask_img = data_gen.generate_maps((13, 11, 12), n_regions,
+                                                     affine=np.eye(4))
+
+    # Add NaNs and infs to data
+    fmri_data = get_data(fmri_img)
+
+    fmri_data[:, 9, 9, :] = np.nan
+    fmri_data[:, 5, 5, :] = np.inf
+
+    fmri_img = nibabel.Nifti1Image(fmri_data, np.eye(4))
+
+    masker = NiftiMapsMasker(maps_img, mask_img=mask_img)
+
+    with pytest.warns(UserWarning, match="Non-finite values detected."):
+        sig = masker.fit_transform(fmri_img)
+
     assert sig.shape == (length, n_regions)
     assert np.all(np.isfinite(sig))
 

--- a/nilearn/regions/signal_extraction.py
+++ b/nilearn/regions/signal_extraction.py
@@ -115,7 +115,7 @@ def img_to_signals_labels(imgs, labels_img, mask_img=None,
         labels_data = labels_data.copy()
         labels_data[np.logical_not(mask_data)] = background_label
 
-    data = _safe_get_data(imgs)
+    data = _safe_get_data(imgs, ensure_finite=True)
     target_datatype = np.float32 if data.dtype == np.float32 else np.float64
     # Nilearn issue: 2135, PR: 2195 for why this is necessary.
     signals = np.ndarray((data.shape[-1], len(labels)), order=order,

--- a/nilearn/regions/tests/test_signal_extraction.py
+++ b/nilearn/regions/tests/test_signal_extraction.py
@@ -336,13 +336,13 @@ def test_signal_extraction_with_maps_and_labels():
         maps_signals, maps_img, mask_img=mask_img)
     assert maps_img_r.shape == shape + (length,)
 
-    # Check that NaNs in regions inside mask are preserved
+    # Check that NaNs in regions inside mask are replaced with zeros
     region1 = labels_data == 2
     indices = [ind[:1] for ind in np.where(region1)]
-    get_data(fmri_img)[indices + [slice(None)]] = float('nan')
+    get_data(fmri_img)[indices + [slice(None)]] = np.nan
     labels_signals, labels_labels = signal_extraction.img_to_signals_labels(
         fmri_img, labels_img, mask_img=mask_img)
-    assert np.all(np.isnan(labels_signals[:, labels_labels.index(2)]))
+    assert np.all(labels_signals[:, labels_labels.index(2)] == 0.)
 
 
 def test_generate_maps():


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #2711.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Use `_safe_get_data`'s `ensure_finite` parameter to replace NaNs with zeros in the `NiftiLabelsMasker`. This matches the behavior of the `NiftiMapsMasker` and, most likely, the others as well.
- Add a warning to `_safe_get_data` when `ensure_finite` is used and non-finite values are detected in the data.
