### PR TITLE
EHN signal.clean standardise option PSC to allow negative mean signal 

### DIFF
--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -70,14 +70,14 @@ def _standardize(signals, detrend=False, standardize='zscore'):
 
         elif standardize == 'psc':
             mean_signal = signals.mean(axis=0)
-            invalid_ix = mean_signal < np.finfo(np.float).eps
-            signals = (signals / mean_signal) * 100
-            signals -= 100
+            invalid_ix = np.absolute(mean_signal) < np.finfo(np.float).eps
+            signals = (signals - mean_signal) / np.absolute(mean_signal)
+            signals *= 100
 
             if np.any(invalid_ix):
                 warnings.warn('psc standardization strategy is meaningless '
-                              'for features that have a mean of 0 or '
-                              'less. These time series are set to 0.')
+                              'for features that have a mean of 0. '
+                              'These time series are set to 0.')
                 signals[:, invalid_ix] = 0
 
     return signals


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #2713 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Allow confound variables with a negative mean signal to pass through PSC option
- Imporve test on PSC