### PR TITLE
Fix whatsnew entry with public function reference

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -60,7 +60,7 @@ Enhancements
   is now implemented with new display mode Mosaic. That implies plotting 3D maps
   in multiple columns and rows in a single axes.
   
-- :func:`nilearn.signal._standardize` option `psc` now allow time series with negative mean value. 
+- `psc` standardization option of :func:`nilearn.signal.clean` now allows time series with negative mean values. 
 
 
 .. _v0.7.0:


### PR DESCRIPTION
Fix current CircleCI build failure by fixing latest entry of  `whats_new.rst` to reference public function `signal.clean` instead of `signal._standardize` (introduced in #2714).