### PR TITLE
Add two_sided flag to get_clusters_table

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -66,8 +66,8 @@ Enhancements
 
 - `psc` standardization option of :func:`nilearn.signal.clean` now allows time series with negative mean values.
 
-- :func:`nilearn.reporting.glm_reporter.make_glm_report` and
-  :func:`nilearn.reporting._get_clusters_table.get_clusters_table` have a new argument,
+- :func:`nilearn.reporting.make_glm_report` and
+  :func:`nilearn.reporting.get_clusters_table` have a new argument,
   "two_sided", which allows for two-sided thresholding, which is disabled by default.
 
 .. _v0.7.0:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,6 +15,10 @@ NEW
   Distribution Function in the same way as `nilearn.glm.Contrast.p_value`
   computes the p-value using the Survival Function.
 
+- :func:`nilearn.reporting.glm_reporter.make_glm_report` and
+  :func:`nilearn.reporting._get_clusters_table.get_clusters_table` have a new argument,
+  "two_sided", which allows for two-sided thresholding, which is disabled by default.
+
 Fixes
 -----
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,10 +15,6 @@ NEW
   Distribution Function in the same way as `nilearn.glm.Contrast.p_value`
   computes the p-value using the Survival Function.
 
-- :func:`nilearn.reporting.glm_reporter.make_glm_report` and
-  :func:`nilearn.reporting._get_clusters_table.get_clusters_table` have a new argument,
-  "two_sided", which allows for two-sided thresholding, which is disabled by default.
-
 Fixes
 -----
 
@@ -67,9 +63,12 @@ Enhancements
   :func:`nilearn.plotting.plot_stat_map`, :func:`nilearn.plotting.plot_prob_atlas`
   is now implemented with new display mode Mosaic. That implies plotting 3D maps
   in multiple columns and rows in a single axes.
-  
-- `psc` standardization option of :func:`nilearn.signal.clean` now allows time series with negative mean values. 
 
+- `psc` standardization option of :func:`nilearn.signal.clean` now allows time series with negative mean values.
+
+- :func:`nilearn.reporting.glm_reporter.make_glm_report` and
+  :func:`nilearn.reporting._get_clusters_table.get_clusters_table` have a new argument,
+  "two_sided", which allows for two-sided thresholding, which is disabled by default.
 
 .. _v0.7.0:
 

--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -146,6 +146,10 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
     cluster_threshold : `int` or `None`, optional
         Cluster size threshold, in voxels.
 
+    two_sided : `bool`, optional
+        Whether to employ two-sided thresholding or to evaluate positive values
+        only. Default=True.
+
     min_distance : `float`, optional
         Minimum distance between subpeaks in mm. Default=8mm.
 

--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -131,7 +131,7 @@ def _get_val(row, input_arr):
 
 
 def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
-                       two_sided=True, min_distance=8.):
+                       two_sided=False, min_distance=8.):
     """Creates pandas dataframe with img cluster statistics.
 
     Parameters
@@ -148,7 +148,7 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
 
     two_sided : `bool`, optional
         Whether to employ two-sided thresholding or to evaluate positive values
-        only. Default=True.
+        only. Default=False.
 
     min_distance : `float`, optional
         Minimum distance between subpeaks in mm. Default=8mm.

--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -131,7 +131,7 @@ def _get_val(row, input_arr):
 
 
 def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
-                       min_distance=8.):
+                       two_sided=True, min_distance=8.):
     """Creates pandas dataframe with img cluster statistics.
 
     Parameters
@@ -169,75 +169,120 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
     else:
         stat_map = get_data(stat_img).copy()
 
-    conn_mat = np.zeros((3, 3, 3), int)  # 6-connectivity, aka NN1 or "faces"
+    # Define array for 6-connectivity, aka NN1 or "faces"
+    conn_mat = np.zeros((3, 3, 3), int)
     conn_mat[1, 1, :] = 1
     conn_mat[1, :, 1] = 1
     conn_mat[:, 1, 1] = 1
     voxel_size = np.prod(stat_img.header.get_zooms())
 
-    # Binarize using CDT
-    binarized = stat_map > stat_threshold
-    binarized = binarized.astype(int)
-
-    # If the stat threshold is too high simply return an empty dataframe
-    if np.sum(binarized) == 0:
-        warnings.warn('Attention: No clusters with stat higher than %f' %
-                      stat_threshold)
-        return pd.DataFrame(columns=cols)
-
-    # Extract connected components above cluster size threshold
-    label_map = ndimage.measurements.label(binarized, conn_mat)[0]
-    clust_ids = sorted(list(np.unique(label_map)[1:]))
-    for c_val in clust_ids:
-        if cluster_threshold is not None and np.sum(
-            label_map == c_val) < cluster_threshold:
-            stat_map[label_map == c_val] = 0
-            binarized[label_map == c_val] = 0
-
-    # If the cluster threshold is too high simply return an empty dataframe
-    # this checks for stats higher than threshold after small clusters
-    # were removed from stat_map
-    if np.sum(stat_map > stat_threshold) == 0:
-        warnings.warn('Attention: No clusters with more than %d voxels' %
-                      cluster_threshold)
-        return pd.DataFrame(columns=cols)
-
-    # Now re-label and create table
-    label_map = ndimage.measurements.label(binarized, conn_mat)[0]
-    clust_ids = sorted(list(np.unique(label_map)[1:]))
-    peak_vals = np.array(
-        [np.max(stat_map * (label_map == c)) for c in clust_ids])
-    clust_ids = [clust_ids[c] for c in
-                 (-peak_vals).argsort()]  # Sort by descending max value
-
+    signs = [1, -1] if two_sided else [1]
+    no_clusters_found = True
     rows = []
-    for c_id, c_val in enumerate(clust_ids):
-        cluster_mask = label_map == c_val
-        masked_data = stat_map * cluster_mask
+    for sign in signs:
+        # Flip map if necessary
+        temp_stat_map = stat_map * sign
 
-        cluster_size_mm = int(np.sum(cluster_mask) * voxel_size)
+        # Binarize using CDT
+        binarized = temp_stat_map > stat_threshold
+        binarized = binarized.astype(int)
 
-        # Get peaks, subpeaks and associated statistics
-        subpeak_ijk, subpeak_vals = _local_max(masked_data, stat_img.affine,
-                                               min_distance=min_distance)
-        subpeak_xyz = np.asarray(coord_transform(subpeak_ijk[:, 0],
-                                                 subpeak_ijk[:, 1],
-                                                 subpeak_ijk[:, 2],
-                                                 stat_img.affine)).tolist()
-        subpeak_xyz = np.array(subpeak_xyz).T
+        # If the stat threshold is too high simply return an empty dataframe
+        if np.sum(binarized) == 0:
+            warnings.warn(
+                'Attention: No clusters with stat {0} than {1}'.format(
+                    'higher' if sign == 1 else 'lower',
+                    stat_threshold * sign,
+                )
+            )
+            continue
 
-        # Only report peak and, at most, top 3 subpeaks.
-        n_subpeaks = np.min((len(subpeak_vals), 4))
-        for subpeak in range(n_subpeaks):
-            if subpeak == 0:
-                row = [c_id + 1, subpeak_xyz[subpeak, 0],
-                       subpeak_xyz[subpeak, 1], subpeak_xyz[subpeak, 2],
-                       subpeak_vals[subpeak], cluster_size_mm]
-            else:
-                # Subpeak naming convention is cluster num+letter: 1a, 1b, etc
-                sp_id = '{0}{1}'.format(c_id + 1, ascii_lowercase[subpeak - 1])
-                row = [sp_id, subpeak_xyz[subpeak, 0], subpeak_xyz[subpeak, 1],
-                       subpeak_xyz[subpeak, 2], subpeak_vals[subpeak], '']
-            rows += [row]
-    df = pd.DataFrame(columns=cols, data=rows)
+        # Extract connected components above cluster size threshold
+        label_map = ndimage.measurements.label(binarized, conn_mat)[0]
+        clust_ids = sorted(list(np.unique(label_map)[1:]))
+        for c_val in clust_ids:
+            if cluster_threshold is not None and np.sum(
+                    label_map == c_val) < cluster_threshold:
+                temp_stat_map[label_map == c_val] = 0
+                binarized[label_map == c_val] = 0
+
+        # If the cluster threshold is too high simply return an empty dataframe
+        # this checks for stats higher than threshold after small clusters
+        # were removed from temp_stat_map
+        if np.sum(temp_stat_map > stat_threshold) == 0:
+            warnings.warn(
+                'Attention: No clusters with more than {0} voxels'.format(
+                    cluster_threshold,
+                )
+            )
+            continue
+
+        # Now re-label and create table
+        label_map = ndimage.measurements.label(binarized, conn_mat)[0]
+        clust_ids = sorted(list(np.unique(label_map)[1:]))
+        peak_vals = np.array(
+            [np.max(temp_stat_map * (label_map == c)) for c in clust_ids])
+        # Sort by descending max value
+        clust_ids = [clust_ids[c] for c in (-peak_vals).argsort()]
+
+        for c_id, c_val in enumerate(clust_ids):
+            cluster_mask = label_map == c_val
+            masked_data = temp_stat_map * cluster_mask
+
+            cluster_size_mm = int(np.sum(cluster_mask) * voxel_size)
+
+            # Get peaks, subpeaks and associated statistics
+            subpeak_ijk, subpeak_vals = _local_max(
+                masked_data,
+                stat_img.affine,
+                min_distance=min_distance,
+            )
+            subpeak_vals *= sign  # flip signs if necessary
+            subpeak_xyz = np.asarray(
+                coord_transform(
+                    subpeak_ijk[:, 0],
+                    subpeak_ijk[:, 1],
+                    subpeak_ijk[:, 2],
+                    stat_img.affine,
+                )
+            ).tolist()
+            subpeak_xyz = np.array(subpeak_xyz).T
+
+            # Only report peak and, at most, top 3 subpeaks.
+            n_subpeaks = np.min((len(subpeak_vals), 4))
+            for subpeak in range(n_subpeaks):
+                if subpeak == 0:
+                    row = [
+                        c_id + 1,
+                        subpeak_xyz[subpeak, 0],
+                        subpeak_xyz[subpeak, 1],
+                        subpeak_xyz[subpeak, 2],
+                        subpeak_vals[subpeak],
+                        cluster_size_mm,
+                    ]
+                else:
+                    # Subpeak naming convention is cluster num+letter:
+                    # 1a, 1b, etc
+                    sp_id = '{0}{1}'.format(
+                        c_id + 1,
+                        ascii_lowercase[subpeak - 1],
+                    )
+                    row = [
+                        sp_id,
+                        subpeak_xyz[subpeak, 0],
+                        subpeak_xyz[subpeak, 1],
+                        subpeak_xyz[subpeak, 2],
+                        subpeak_vals[subpeak],
+                        '',
+                    ]
+                rows += [row]
+
+        # If we reach this point, there are clusters in this sign
+        no_clusters_found = False
+
+    if no_clusters_found:
+        df = pd.DataFrame(columns=cols)
+    else:
+        df = pd.DataFrame(columns=cols, data=rows)
+
     return df

--- a/nilearn/reporting/glm_reporter.py
+++ b/nilearn/reporting/glm_reporter.py
@@ -734,6 +734,7 @@ def _make_stat_maps_contrast_clusters(stat_img, contrasts_plots, threshold,
             stat_threshold=threshold,
             cluster_threshold=cluster_threshold,
             min_distance=min_distance,
+            two_sided=True,
         )
 
         cluster_table_html = _dataframe_to_html(cluster_table,

--- a/nilearn/reporting/glm_reporter.py
+++ b/nilearn/reporting/glm_reporter.py
@@ -734,7 +734,6 @@ def _make_stat_maps_contrast_clusters(stat_img, contrasts_plots, threshold,
             stat_threshold=threshold,
             cluster_threshold=cluster_threshold,
             min_distance=min_distance,
-            two_sided=True,
         )
 
         cluster_table_html = _dataframe_to_html(cluster_table,

--- a/nilearn/reporting/glm_reporter.py
+++ b/nilearn/reporting/glm_reporter.py
@@ -54,6 +54,7 @@ def make_glm_report(model,
                     alpha=0.001,
                     cluster_threshold=0,
                     height_control='fpr',
+                    two_sided=False,
                     min_distance=8.,
                     plot_type='slice',
                     display_mode=None,
@@ -127,6 +128,10 @@ def make_glm_report(model,
         false positive control meaning of cluster forming
         threshold: 'fpr' (default) or 'fdr' or 'bonferroni' or None.
         Default='fpr'.
+
+    two_sided : `bool`, optional
+        Whether to employ two-sided thresholding or to evaluate positive values
+        only. Default=False.
 
     min_distance : float, optional
         For display purposes only.
@@ -220,6 +225,7 @@ def make_glm_report(model,
         alpha=alpha,
         cluster_threshold=cluster_threshold,
         height_control=height_control,
+        two_sided=two_sided,
         min_distance=min_distance,
         bg_img=bg_img,
         display_mode=display_mode,
@@ -630,6 +636,7 @@ def _mask_to_svg(mask_img, bg_img):
 def _make_stat_maps_contrast_clusters(stat_img, contrasts_plots, threshold,
                                       alpha,
                                       cluster_threshold, height_control,
+                                      two_sided,
                                       min_distance, bg_img,
                                       display_mode, plot_type):
     """Populates a smaller HTML sub-template with the proper values,
@@ -667,6 +674,10 @@ def _make_stat_maps_contrast_clusters(stat_img, contrasts_plots, threshold,
     height_control : string
         False positive control meaning of cluster forming
         threshold: 'fpr' or 'fdr' or 'bonferroni' or None.
+
+    two_sided : `bool`, optional
+        Whether to employ two-sided thresholding or to evaluate positive values
+        only. Default=False.
 
     min_distance : float
         For display purposes only.
@@ -734,6 +745,7 @@ def _make_stat_maps_contrast_clusters(stat_img, contrasts_plots, threshold,
             stat_threshold=threshold,
             cluster_threshold=cluster_threshold,
             min_distance=min_distance,
+            two_sided=two_sided,
         )
 
         cluster_table_html = _dataframe_to_html(cluster_table,


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #2547.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add a two_sided flag (default=True) to `nilearn.reporting._get_clusters_table()`.
- Update tests.
- Use two_sided thresholding in `glm_reporter`.
