### PR TITLE
[FIX]  Allow every masker.inverse_transform to accept 1D input.

### DIFF
--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -344,9 +344,10 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
 
         Parameters
         ----------
-        signals : (2D numpy.ndarray)
+        signals : (1D/2D numpy.ndarray)
             Signal for each region.
             shape: (number of scans, number of regions)
+            If signals is one-dimensional, it is assumed that number of scans == 1.
 
         Returns
         -------

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -482,8 +482,9 @@ class Parcellations(MultiPCA):
 
         Parameters
         ----------
-        signals : List of 2D numpy.ndarray
+        signals : List of 1/2D numpy.ndarray
             Each 2D array with shape (number of scans, number of regions).
+            If array is one-dimensional, it is assumed that number of scans == 1.
 
         Returns
         -------

--- a/nilearn/regions/signal_extraction.py
+++ b/nilearn/regions/signal_extraction.py
@@ -146,6 +146,7 @@ def signals_to_img_labels(signals, labels_img, mask_img=None,
     ----------
     signals : numpy.ndarray
         2D array with shape: (scan number, number of regions in labels_img).
+        If signals is one-dimensional, it is assumed that scan number == 1.
 
     labels_img : Niimg-like object
         See http://nilearn.github.io/manipulating_images/input_output.html
@@ -178,6 +179,10 @@ def signals_to_img_labels(signals, labels_img, mask_img=None,
     labels_img = _utils.check_niimg_3d(labels_img)
 
     signals = np.asarray(signals)
+    orig_dim = signals.ndim
+    if orig_dim == 1:
+        signals = np.atleast_2d(signals)
+
     target_affine = labels_img.affine
     target_shape = labels_img.shape[:3]
 
@@ -215,7 +220,8 @@ def signals_to_img_labels(signals, labels_img, mask_img=None,
                 num = labels_dict.get(label, None)
                 if num is not None:
                     data[i, j, k, :] = signals[:, num]
-
+    if orig_dim == 1:
+        data = np.reshape(data, data.shape[:3], order=order)
     return new_img_like(labels_img, data, target_affine)
 
 

--- a/nilearn/regions/tests/test_signal_extraction.py
+++ b/nilearn/regions/tests/test_signal_extraction.py
@@ -114,6 +114,12 @@ def test_signals_extraction_with_labels():
     assert data_img.shape == (shape + (n_instants,))
     assert np.all(data.std(axis=-1) > 0)
 
+    # test one dimensional input (assumed shape of (1 instance, n_regions))
+    three_d_img = signal_extraction.signals_to_img_labels(signals[0, :], labels_img)
+    assert three_d_img.shape == shape
+    four_d_img = signal_extraction.signals_to_img_labels(signals[:1, :], labels_img)
+    assert np.all(np.squeeze(get_data(four_d_img)) == get_data(three_d_img))
+
     # verify that 4D label images are refused
     with pytest.raises(DimensionError, match=_TEST_DIM_ERROR_MSG):
         signal_extraction.img_to_signals_labels(data_img, labels_4d_img)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #2724.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- allow 1D inputs to `signals_to_img_labels`
- test the function with 1D input
- propagate documentation changes
