### PR TITLE
Detrending before low and high pass filtering for the confounders in clean function

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -7,6 +7,12 @@ NEW
 Fixes
 -----
 
+- Fix detrending and temporal filtering order for confounders
+  in :func:`nilearn.signal.clean`, so that these operations are applied
+  in the same order as for the signals, i.e., first detrending and
+  then temporal filtering (https://github.com/nilearn/nilearn/issues/2730).
+
+
 Enhancements
 ------------
 

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -600,6 +600,13 @@ def clean(signals, sessions=None, detrend=True, standardize='zscore',
     # Remove confounds
     if confounds is not None:
         confounds = _ensure_float(confounds)
+        
+        # Apply detrend to keep this operation orthogonal
+        # (according to Lindquist et al. (2018))
+        if detrend:
+            confounds = _standardize(confounds, standardize=False,
+                                     detrend=detrend)
+         
         # Apply low- and high-pass filters to keep filters orthogonal
         # (according to Lindquist et al. (2018))
         if low_pass is not None or high_pass is not None:
@@ -608,7 +615,7 @@ def clean(signals, sessions=None, detrend=True, standardize='zscore',
                                     low_pass=low_pass, high_pass=high_pass)
 
         confounds = _standardize(confounds, standardize=standardize_confounds,
-                                 detrend=detrend)
+                                 detrend=False)
 
         if not standardize_confounds:
             # Improve numerical stability by controlling the range of

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -433,7 +433,7 @@ def test_clean_confounds():
                                      detrend=True, standardize=False)
     coeffs = np.polyfit(np.arange(cleaned_signals.shape[0]),
                         cleaned_signals, 1)
-    assert (abs(coeffs) < 200. * eps).all()  # trend removed
+    assert (abs(coeffs) < 1000. * eps).all()  # trend removed
 
     # Test no-op
     input_signals = 10 * signals

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -499,10 +499,11 @@ def test_clean_confounds():
                                                   ).mean(),
                                    np.zeros((20, 2)))
 
-    # Test to check that confounders effects are effectively removed when 
-    # having detrending and a filtering operation. This did not happen 
-    # due to a different order in which these operation were being applied 
-    # to the data and confounders (it thus solves issue # 2730).
+    # Test to check that confounders effects are effectively removed from 
+    # the signals when having a detrending and filtering operation together. 
+    # This did not happen originally due to a different order in which 
+    # these operations were being applied to the data and confounders 
+    # (it thus solves issue # 2730).
     signals_clean = nisignal.clean(signals,
                                    detrend=True,
                                    high_pass=0.01, 

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -499,6 +499,24 @@ def test_clean_confounds():
                                                   ).mean(),
                                    np.zeros((20, 2)))
 
+    # Test to check that confounders effects are effectively removed when 
+    # having detrending and a filtering operation. This did not happen 
+    # due to a different order in which these operation were being applied 
+    # to the data and confounders (it thus solves issue # 2730).
+    signals_clean = nisignal.clean(signals,
+                                   detrend=True,
+                                   high_pass=0.01, 
+                                   low_pass=0.1,
+                                   standardize_confounds=True,
+                                   standardize=True,
+                                   confounds=confounds)
+    confounds_clean = nisignal.clean(confounds,
+                                     detrend=True,
+                                     high_pass=0.01,
+                                     low_pass=0.1,
+                                     standardize=True)
+    assert abs(np.dot(confounds_clean.T, signals_clean)).max() < 1000. * eps
+
 
 def test_clean_frequencies_using_power_spectrum_density():
 

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -506,15 +506,13 @@ def test_clean_confounds():
     # (it thus solves issue # 2730).
     signals_clean = nisignal.clean(signals,
                                    detrend=True,
-                                   high_pass=0.01, 
-                                   low_pass=0.1,
+                                   high_pass=0.01,
                                    standardize_confounds=True,
                                    standardize=True,
                                    confounds=confounds)
     confounds_clean = nisignal.clean(confounds,
                                      detrend=True,
                                      high_pass=0.01,
-                                     low_pass=0.1,
                                      standardize=True)
     assert abs(np.dot(confounds_clean.T, signals_clean)).max() < 1000. * eps
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixes the issue raised in #2730 
- In particular, it changes the order of detrending and low and high pass filtering in `clean` such that it is the same that takes place with the input signal, i.e, first detrend and then frequency filtering. Currently, confounders were first low or high-pass filtered and then detrended, if requested from the beginning.
