### PR TITLE
[MAINT][MRG] Reduce CircleCI build time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,10 @@ jobs:
               chmod +x ~/miniconda.sh && ~/miniconda.sh -b;
               echo 'export PATH="$HOME/miniconda3/bin:$PATH"'  >> $BASH_ENV;
       - run:
+          name: Install apt packages
+          command: |
+              ./tools/circleci_dependencies_apt.sh
+      - run:
           name: Install packages in conda env
           command: |
               ./tools/circleci_dependencies.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
   build_docs:
     
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
 
     steps:
       - restore_cache:
@@ -38,22 +38,16 @@ jobs:
                   echo "Merging $(cat merge.txt)";
                   git pull --ff-only upstream "refs/pull/$(cat merge.txt)/merge";
               fi
-      - restore_cache:
-          keys:
-              - pip-cache
       - run:
-          name: Install dependencies
+          name: setup conda
+          command: |
+              wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh;
+              chmod +x ~/miniconda.sh && ~/miniconda.sh -b;
+              echo 'export PATH="$HOME/miniconda3/bin:$PATH"'  >> $BASH_ENV;
+      - run:
+          name: Install packages in conda env
           command: |
               ./tools/circleci_dependencies.sh
-      - save_cache:
-          key: pip-cache
-          paths:
-              - ~/.cache/pip
-      - save_cache:
-          key: user-install-bin-cache
-          paths:
-              - ~/.local/lib/python3.7/site-packages
-              - ~/.local/bin
       - run:
           name: Find build type
           command: |
@@ -66,6 +60,8 @@ jobs:
       - run:
           name: build doc
           command: |
+              source activate testenv;
+              echo "Conda active env = $CONDA_DEFAULT_ENV";
               cd doc;
               PATTERN=$(cat ../pattern.txt) make $(cat ../build.txt)
           no_output_timeout: 7h

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ workflows:
 
   default:
     jobs:
-      - build_docs:
+      - build_docs
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,8 @@ jobs:
               source activate testenv;
               echo "Conda active env = $CONDA_DEFAULT_ENV";
               cd doc;
-              PATTERN=$(cat ../pattern.txt) make $(cat ../build.txt)
+              set -o pipefail;
+              PATTERN=$(cat ../pattern.txt) make $(cat ../build.txt) 2>&1 | tee log.txt;
           no_output_timeout: 7h
       - store_test_results:
           path: doc/_build/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,8 +82,6 @@ jobs:
           path: doc/_build/html_stable
           destination: stable
       - store_artifacts:
-          path: coverage
-      - store_artifacts:
           path: doc/log.txt
       - persist_to_workspace:
           root: doc/_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,194 +5,98 @@
 
 version: 2.1
 
-commands:
-
-  preinstall:
-    description: "Cleans up unused packages; Updates system packages"
-    steps:
-      - run:
-          name: Remove conflicting packages
-          command: |
-            # Get rid of existing virtualenvs on circle ci as they conflict with conda.
-            # Trick found here:
-            # https://discuss.circleci.com/t/disable-autodetection-of-project-or-application-of-python-venv/235/10
-            cd && rm -rf ~/.pyenv && rm -rf ~/virtualenvs
-
-            # We need to remove conflicting texlive packages.
-            sudo -E apt-get -yq remove texlive-binaries --purge
-      - run:
-          name: Install packages for make -C doc check
-          command: |
-            # Installing required packages for `make -C doc check command` to work.
-            sudo -E apt-get -yq update
-            sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install dvipng texlive-latex-base texlive-latex-extra
-
-  restore_from_cache:
-    description: "Restores the cache of previously built docs & python packages if present"
-    steps:
-      - run:
-          name: Generate cache keys from today's date for built docs & week number for python packages
-          command: |
-            date +%F > today
-            date +%U > week_num
-      - restore_cache:
-          keys:
-            - v1-packages+datasets-{{ checksum "week_num" }}-{{ checksum ".circleci/packages-cache-timestamp" }}
-            - v1-packages+datasets-U3h5YwdTXfPsjYsVouLcVkFBnD0wYM_jIjjA+pc_eqM=
-            - v1-packages+datasets
-      - restore_cache:
-         key: v1-docs-{{ .Branch }}-{{ checksum "today" }}-{{ checksum ".circleci/docs-cache-timestamp" }}
-
-  cache_aware_conda_setup:
-    description: "Downloads & installs conda if not restored by cache"
-    steps:
-      - run:
-          name: Download & install conda if absent
-          command: |
-            if
-              ls $HOME/miniconda3/bin | grep conda -q
-            then
-              echo "(Mini)Conda already present from the cache."
-            else
-              wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-              chmod +x ~/miniconda.sh && ~/miniconda.sh -b
-            fi
-      - run:
-          name: Setup conda path in env variables
-          command: |
-            echo 'export PATH="$HOME/miniconda3/bin:$PATH"'  >> $BASH_ENV
-      - run:
-          name: Create new conda env
-          command: |
-            if
-              conda env list | grep testenv
-            then
-              echo "Conda env testenv already exists courtesy of the cache."
-            else
-              conda create -n testenv -yq
-            fi
-
-  cache_ignorant_conda_setup:
-    description: "Downloads & installs only the fresh copy of conda."
-    steps:
-      - run:
-          name: setup conda afresh
-          command: |
-            wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-            chmod +x ~/miniconda.sh && ~/miniconda.sh -b
-            echo 'export PATH="$HOME/miniconda3/bin:$PATH"'  >> $BASH_ENV
-      - run: conda create -n testenv
-
-  install_dependencies:
-    description: "Installs the necessary Python packages"
-    steps:
-      - run:
-          name: Install packages in conda env
-          command: |
-            conda install -n testenv python=3.7 numpy scipy scikit-learn matplotlib pandas \
-            lxml mkl sphinx numpydoc pillow pandas -yq
-            conda install -n testenv nibabel sphinx-gallery junit-xml -c conda-forge -yq
+jobs:
 
   build_docs:
-    description: "Installs Nilearn & builds documentation using Sphinx's make html-strict"
-    steps:
-      - run:
-          name: Building documentation
-          command: |
-            source activate testenv
-            pip install -e .
-            set -o pipefail && cd doc && make html-strict 2>&1 | tee log.txt
-          no_output_timeout: 7h
+    
+    docker:
+      - image: circleci/python:3.7
 
-  store_results:
-    description: "Stores build times and artifacts"
     steps:
+      - restore_cache:
+          keys:
+              - source-cache
+      - checkout
+      - run:
+          name: Complete checkout
+          command: |
+              if ! git remote -v | grep upstream; then
+                  git remote add upstream git://github.com/nilearn/nilearn.git
+              fi
+              git fetch upstream
+      - save_cache:
+          key: source-cache
+          paths:
+              - ".git"
+      - run:
+          name: Merge with upstream
+          command: |
+              echo $(git log -1 --pretty=%B) | tee gitlog.txt
+              echo "gitlog.txt = $(cat gitlog.txt)"
+              echo ${CI_PULL_REQUEST//*pull\//} | tee merge.txt
+              if [[ $(cat merge.txt) != "" ]]; then
+                  echo "Merging $(cat merge.txt)";
+                  git pull --ff-only upstream "refs/pull/$(cat merge.txt)/merge";
+              fi
+      - restore_cache:
+          keys:
+              - pip-cache
+      - run:
+          name: Install dependencies
+          command: |
+              ./tools/circleci_dependencies.sh
+      - save_cache:
+          key: pip-cache
+          paths:
+              - ~/.cache/pip
+      - save_cache:
+          key: user-install-bin-cache
+          paths:
+              - ~/.local/lib/python3.7/site-packages
+              - ~/.local/bin
+      - run:
+          name: Find build type
+          command: |
+              ./tools/circleci_build_type.sh
+      - run:
+          name: Verify build type
+          command: |
+              echo "PATTERN = $(cat pattern.txt)"
+              echo "BUILD = $(cat build.txt)"
+      - run:
+          name: build doc
+          command: |
+              cd doc;
+              PATTERN=$(cat ../pattern.txt) make $(cat ../build.txt)
+          no_output_timeout: 7h
       - store_test_results:
           path: doc/_build/test-results
       - store_artifacts:
           path: doc/_build/test-results
+          destination: test-results
       - store_artifacts:
-          path: doc/_build/html
+          path: doc/_build/html/
+          destination: dev
+      - store_artifacts:
+          path: doc/_build/html_stable
+          destination: stable
       - store_artifacts:
           path: coverage
       - store_artifacts:
           path: doc/log.txt
-
-  save_to_cache:
-    description: "Caches the downloaded packages & buit docs."
-    steps:
-      - save_cache:
-          key: v1-packages+datasets-{{ checksum "week_num" }}-{{ checksum ".circleci/packages-cache-timestamp" }}
+      - persist_to_workspace:
+          root: doc/_build
           paths:
-            - ../nilearn_data
-            - ../miniconda3
-      - save_cache:
-          key: v1-docs-{{ .Branch }}-{{ checksum "today" }}-{{ checksum ".circleci/docs-cache-timestamp" }}
-          paths:
-            - doc
-
-
-jobs:
-
-  quick-build:
-    docker:
-      - image: circleci/python:3.7
-    environment:
-      DISTRIB: "conda"
-      PYTHON_VERSION: "3.7"
-      NUMPY_VERSION: "*"
-      SCIPY_VERSION: "*"
-      SCIKIT_LEARN_VERSION: "*"
-      JOBLIB_VERSION: "*"
-      MATPLOTLIB_VERSION: "*"
-
-    steps:
-      - checkout
-      - preinstall
-      - restore_from_cache
-      - cache_aware_conda_setup
-      - install_dependencies
-      - build_docs
-      - store_results
-      - save_to_cache
-
-  full-build:
-    docker:
-      - image: circleci/python:3.7
-    environment:
-      DISTRIB: "conda"
-      PYTHON_VERSION: "3.7"
-      NUMPY_VERSION: "*"
-      SCIPY_VERSION: "*"
-      SCIKIT_LEARN_VERSION: "*"
-      MATPLOTLIB_VERSION: "*"
-
-    steps:
-      - checkout
-      - preinstall
-      - cache_ignorant_conda_setup
-      - install_dependencies
-      - build_docs
-      - store_results
+              - html
+              - html_stable
 
 
 workflows:
   version: 2
-  push:
-    jobs:
-      - quick-build:
-          filters:
-            branches:
-              ignore:
-                - master
-                - test-circleci  # test branch to check if merges occur on master as expected.
 
-      - full-build:
-          filters:
-            branches:
-              only:
-                - master
-                - test-circleci  # test branch to check if merges occur on master as expected.
+  default:
+    jobs:
+      - build_docs:
 
   nightly:
     triggers:
@@ -203,4 +107,4 @@ workflows:
               only:
                 - master
     jobs:
-      - full-build
+      - build_docs

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -72,7 +72,7 @@ html-strict:	sym_links
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-html-pattern: 	sym_links
+html-modified-examples-only: 	sym_links
 	$(SPHINXBUILD) -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -D sphinx_gallery_conf.run_stale_examples=True -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	touch $(BUILDDIR)/html/.nojekyll
 	@echo

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -72,6 +72,12 @@ html-strict:	sym_links
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
+html-pattern: 	sym_links
+	$(SPHINXBUILD) -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -D sphinx_gallery_conf.run_stale_examples=True -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	touch $(BUILDDIR)/html/.nojekyll
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
 html-noplot:
 	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	touch $(BUILDDIR)/html/.nojekyll

--- a/tools/circleci_build_type.sh
+++ b/tools/circleci_build_type.sh
@@ -15,6 +15,7 @@ else
     done;
     echo PATTERN="$PATTERN";
     if [[ $PATTERN ]]; then
+        # Remove trailing \| introduced by the for loop above
         PATTERN="\(${PATTERN::-2}\)";
         echo html-pattern > build.txt;
     else

--- a/tools/circleci_build_type.sh
+++ b/tools/circleci_build_type.sh
@@ -17,7 +17,7 @@ else
     if [[ $PATTERN ]]; then
         # Remove trailing \| introduced by the for loop above
         PATTERN="\(${PATTERN::-2}\)";
-        echo html-pattern > build.txt;
+        echo html-modified-examples-only > build.txt;
     else
         echo html-noplot > build.txt;
     fi;

--- a/tools/circleci_build_type.sh
+++ b/tools/circleci_build_type.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -ef
+
+if [ "CIRCLE_BRANCH" == "master" ] || [[ $(cat gitlog.txt) == *"[circle full]"* ]]; then
+    echo "Doing a full build";
+    echo html-strict > build.txt;
+else
+    echo "Doing a partial build";
+    FILENAMES=$(git diff --name-only $(git merge-base $CIRCLE_BRANCH upstream/master) $CIRCLE_BRANCH);
+    echo FILENAMES="$FILENAMES";
+    for FILENAME in $FILENAMES; do
+        if [[ `expr match $FILENAME "\(examples\)/.*plot_.*\.py"` ]]; then
+            echo "Checking example $FILENAME ...";
+            PATTERN=`basename $FILENAME`"\\|"$PATTERN;
+        fi;
+    done;
+    echo PATTERN="$PATTERN";
+    if [[ $PATTERN ]]; then
+        PATTERN="\(${PATTERN::-2}\)";
+        echo html-pattern > build.txt;
+    else
+        echo html-noplot > build.txt;
+    fi;
+fi;
+echo "$PATTERN" > pattern.txt;
+

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -3,5 +3,5 @@
 sudo -E apt-get -yq update
 sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install dvipng texlive-latex-base texlive-latex-extra
 python -m pip install --user --upgrade --progress-bar off pip setuptools
-python -m pip install --user --upgrade --progress-bar off -r requirements.txt -r requirements-dev.txt -r requirements-build-docs.txt
+python -m pip install --user --upgrade --progress-bar off -r requirements-dev.txt -r requirements-build-docs.txt
 python -m pip install --user -e .

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -7,4 +7,4 @@ conda install -n testenv -yq python=3.8 numpy scipy scikit-learn matplotlib pand
 conda install -n testenv -yq nibabel sphinx-gallery junit-xml -c conda-forge
 source activate testenv
 python -m pip install --user --upgrade --progress-bar off pip setuptools
-python -m pip install --user -e .
+python -m pip install .

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -ef
 
-sudo -E apt-get -yq update
-sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install dvipng texlive-latex-base texlive-latex-extra
 conda init bash
 echo "conda version = $(conda --version)"
 conda create -n testenv

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -2,6 +2,11 @@
 
 sudo -E apt-get -yq update
 sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install dvipng texlive-latex-base texlive-latex-extra
+conda init bash
+echo "conda version = $(conda --version)"
+conda create -n testenv
+conda install -n testenv -yq python=3.8 numpy scipy scikit-learn matplotlib pandas lxml mkl sphinx numpydoc pillow pandas
+conda install -n testenv -yq nibabel sphinx-gallery junit-xml -c conda-forge
+source activate testenv
 python -m pip install --user --upgrade --progress-bar off pip setuptools
-python -m pip install --user --upgrade --progress-bar off -r requirements-dev.txt -r requirements-build-docs.txt
 python -m pip install --user -e .

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ef
+
+sudo -E apt-get -yq update
+sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install dvipng texlive-latex-base texlive-latex-extra
+python -m pip install --user --upgrade --progress-bar off pip setuptools
+python -m pip install --user --upgrade --progress-bar off -r requirements.txt -r requirements-dev.txt -r requirements-build-docs.txt
+python -m pip install --user -e .

--- a/tools/circleci_dependencies_apt.sh
+++ b/tools/circleci_dependencies_apt.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -ef
 
 sudo -E apt-get -yq update
-sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-unauthenticated --allow-downgrades --allow-remove-essential --allow-change-held-packages install dvipng texlive-latex-base texlive-latex-extra
+sudo -E apt-get -yq --no-install-suggests --no-install-recommends install dvipng texlive-latex-base texlive-latex-extra

--- a/tools/circleci_dependencies_apt.sh
+++ b/tools/circleci_dependencies_apt.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -ef
+
+sudo -E apt-get -yq update
+sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-unauthenticated --allow-downgrades --allow-remove-essential --allow-change-held-packages install dvipng texlive-latex-base texlive-latex-extra


### PR DESCRIPTION
This is an attempt to reduce the documentation generation time on CircleCI, and is largely inspired by the way MNE handles this. 

The main idea is to adapt the build type depending on the branch and the files that have been modified. The behaviour should be the following:

- *Full build* on master
- *Full build* on other branches if the commit message contains the tag `[circle full]`

otherwise, do a *partial build*:

- Build only the examples that were modified in the branch
- Make a "no-plot" build if examples weren't modified 

I am also cleaning the current CircleCI workflow since I'm not sure everything is still mandatory or useful.

*Note: This is WIP, failures expected...*