### PR TITLE
handle nans in plot_surf_roi

### DIFF
--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -973,9 +973,9 @@ def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
 
     roi = load_surf_data(roi_map)
     if vmin is None:
-        vmin = np.min(roi)
+        vmin = np.nanmin(roi)
     if vmax is None:
-        vmax = 1 + np.max(roi)
+        vmax = 1 + np.nanmax(roi)
 
     mesh = load_surf_mesh(surf_mesh)
 

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -221,6 +221,13 @@ def test_plot_surf_roi():
         plot_surf_roi(mesh, roi_map=roi_map, ax=plt.gca(), figure=None,
                       output_file=tmp_file.name, colorbar=True)
 
+    # Test nans handling
+    parcellation[::2] = np.nan
+    img = plot_surf_roi(mesh, roi_map=parcellation)
+    # Check that the resulting plot facecolors contain no transparent faces
+    # (last column equals zero) even though the texture contains nan values
+    assert(mesh[1].shape[0] ==
+           ((img._axstack.as_list()[0].collections[0]._facecolors[:, 3]) != 0).sum())
     # Save execution time and memory
     plt.close()
 


### PR DESCRIPTION
See Neurostars post [here](https://neurostars.org/t/plot-3d-nifiti-on-surface-using-nilearn/18715).

Calling `plot_surf_roi` with a texture containing nans raises an error wile `plot_surf_stat_map` doesn't, although both functions rely on the same `plot_surf` function. This PR makes it possible to use `plot_surf_roi` with nans in the texture and makes the surface plotting more consistent.

## Code to reproduce

*Note: output figures order is reversed for some reason...*

```python
import numpy as np
from nilearn.surface import vol_to_surf
from nilearn.plotting import plot_surf_roi
from nilearn.datasets import fetch_surf_fsaverage, fetch_neurovault_motor_task

# Load the surface 
fsaverage = fetch_surf_fsaverage('fsaverage')

# Get a statistical map
stat_img = fetch_neurovault_motor_task()

# Compute the texture
texture = vol_to_surf(stat_img.images[0], 
                      fsaverage.pial_left)
assert np.sum(np.isnan(texture)) == 0
plot_surf_roi(fsaverage.infl_left, 
              roi_map = texture, 
              hemi = 'left', 
              bg_map = fsaverage["sulc_left"],
              colorbar = True)
texture[::2] = np.nan
assert np.sum(np.isnan(texture)) > 0 
plot_surf_roi(fsaverage.infl_left, 
              roi_map = texture, 
              hemi = 'left', 
              bg_map = fsaverage["sulc_left"],
              colorbar = True) # This will FAIL prior to this fix...
```
![surf-nan](https://user-images.githubusercontent.com/2639645/112844224-c7239900-90a3-11eb-9452-c3beb2d54da8.png)
