### PR TITLE
[FIX][MAINT] Fix typo in CircleCI script

### DIFF
--- a/tools/circleci_build_type.sh
+++ b/tools/circleci_build_type.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ef
 
-if [ "CIRCLE_BRANCH" == "master" ] || [[ $(cat gitlog.txt) == *"[circle full]"* ]]; then
+if [ "$CIRCLE_BRANCH" == "master" ] || [[ $(cat gitlog.txt) == *"[circle full]"* ]]; then
     echo "Doing a full build";
     echo html-strict > build.txt;
 else


### PR DESCRIPTION
Typo currently causing circleCI to make "no-plot" builds on master... :sweat: 