### PR TITLE
[DOC][MRG] Configure bibtex references

### DIFF
--- a/doc/bibliography.rst
+++ b/doc/bibliography.rst
@@ -1,0 +1,12 @@
+:orphan:
+
+.. _general_bibliography:
+
+General bibliography
+====================
+
+The references below are arranged alphabetically by first author.
+
+.. bibliography:: ./references.bib
+   :all:
+   :list: enumerated

--- a/doc/bibliography.rst
+++ b/doc/bibliography.rst
@@ -5,7 +5,7 @@
 General bibliography
 ====================
 
-The references below are arranged alphabetically by first author.
+The references below are arranged alphabetically by first author. You can download the bib file :download:`here <./references.bib>`.
 
 .. bibliography:: ./references.bib
    :all:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,6 +51,7 @@ extensions = [
               'sphinx.ext.autosummary',
               'sphinx.ext.imgmath',
               'sphinx.ext.intersphinx',
+              'sphinxcontrib.bibtex',
               'numpydoc',
               ]
 
@@ -87,6 +88,11 @@ plot_gallery = 'True'
 
 # The master toctree document.
 master_doc = 'index'
+
+# sphinxcontrib-bibtex
+bibtex_bibfiles = ['./references.bib']
+bibtex_style = 'unsrt'
+bibtex_footbibliography_header = ''
 
 # General information about the project.
 project = u'Nilearn'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -92,6 +92,7 @@ master_doc = 'index'
 # sphinxcontrib-bibtex
 bibtex_bibfiles = ['./references.bib']
 bibtex_style = 'unsrt'
+bibtex_reference_style = 'author_year'
 bibtex_footbibliography_header = ''
 
 # General information about the project.

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1,0 +1,37 @@
+@article{DADI2020117126,
+title = {Fine-grain atlases of functional modes for fMRI analysis},
+journal = {NeuroImage},
+volume = {221},
+pages = {117126},
+year = {2020},
+issn = {1053-8119},
+doi = {https://doi.org/10.1016/j.neuroimage.2020.117126},
+url = {https://www.sciencedirect.com/science/article/pii/S1053811920306121},
+author = {Kamalaker Dadi and Gaël Varoquaux and Antonia Machlouzarides-Shalit and Krzysztof J. Gorgolewski and Demian Wassermann and Bertrand Thirion and Arthur Mensch},
+keywords = {Brain imaging atlases, Functional networks, Functional parcellations, Multi-resolution},
+abstract = {Population imaging markedly increased the size of functional-imaging datasets, shedding new light on the neural basis of inter-individual differences. Analyzing these large data entails new scalability challenges, computational and statistical. For this reason, brain images are typically summarized in a few signals, for instance reducing voxel-level measures with brain atlases or functional modes. A good choice of the corresponding brain networks is important, as most data analyses start from these reduced signals. We contribute finely-resolved atlases of functional modes, comprising from 64 to 1024 networks. These dictionaries of functional modes (DiFuMo) are trained on millions of fMRI functional brain volumes of total size 2.4 ​TB, spanned over 27 studies and many research groups. We demonstrate the benefits of extracting reduced signals on our fine-grain atlases for many classic functional data analysis pipelines: stimuli decoding from 12,334 brain responses, standard GLM analysis of fMRI across sessions and individuals, extraction of resting-state functional-connectomes biomarkers for 2500 individuals, data compression and meta-analysis over more than 15,000 statistical maps. In each of these analysis scenarii, we compare the performance of our functional atlases with that of other popular references, and to a simple voxel-level analysis. Results highlight the importance of using high-dimensional “soft” functional atlases, to represent and analyze brain activity while capturing its functional gradients. Analyses on high-dimensional modes achieve similar statistical performance as at the voxel level, but with much reduced computational cost and higher interpretability. In addition to making them available, we provide meaningful names for these modes, based on their anatomical location. It will facilitate reporting of results.}
+}
+
+
+@article{Hoyos2019,
+author = {Hoyos-Idrobo, Andres and Varoquaux, Gael and Kahn, Jonas and Thirion, Bertrand},
+title = {Recursive Nearest Agglomeration (ReNA): Fast Clustering for Approximation of Structured Signals},
+year = {2019},
+issue_date = {March 2019},
+publisher = {IEEE Computer Society},
+address = {USA},
+volume = {41},
+number = {3},
+issn = {0162-8828},
+url = {https://doi.org/10.1109/TPAMI.2018.2815524},
+doi = {10.1109/TPAMI.2018.2815524},
+abstract = {In this work, we revisit fast dimension reduction approaches, as with random projections and random sampling. Our goal is to summarize the data to decrease computational costs and memory footprint of subsequent analysis. Such dimension reduction can be very efficient when the signals of interest have a strong structure, such as with images. We focus on this setting and investigate feature clustering schemes for data reductions that capture this structure. An impediment to fast dimension reduction is then that good clustering comes with large algorithmic costs. We address it by contributing a linear-time agglomerative clustering scheme, Recursive Nearest Agglomeration (ReNA). Unlike existing fast agglomerative schemes, it avoids the creation of giant clusters. We empirically validate that it approximates the data as well as traditional variance-minimizing clustering schemes that have a quadratic complexity. In addition, we analyze signal approximation with feature clustering and show that it can remove noise, improving subsequent analysis steps. As a consequence, data reduction by clustering features with ReNA yields very fast and accurate models, enabling to process large datasets on budget. Our theoretical analysis is backed by extensive experiments on publicly-available data that illustrate the computation efficiency and the denoising properties of the resulting dimension reduction scheme.},
+journal = {IEEE Trans. Pattern Anal. Mach. Intell.},
+month = mar,
+pages = {669–681},
+numpages = {13}
+}
+
+
+
+

--- a/doc/themes/nilearn/layout.html
+++ b/doc/themes/nilearn/layout.html
@@ -34,6 +34,7 @@
 <li><a href="{{pathto('modules/reference')}}">Reference</a> |&nbsp;</li>
 <li id="navbar-about"><a href="{{pathto('authors')}}">About</a>|&nbsp;</li>
 <li><a href="{{pathto('glossary')}}">Glossary</a>|&nbsp;</li>
+<li><a href="{{pathto('bibliography')}}">Bibliography</a>|&nbsp;</li>
 <li id="navbar-ecosystem"><a href="http://www.nipy.org/">Nipy ecosystem</a></li>
 {% endblock %}
 

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -26,7 +26,7 @@ def fetch_atlas_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True
     Dictionaries of Functional Modes, or “DiFuMo”, can serve as atlases to extract
     functional signals with different dimensionalities (64, 128, 256, 512, and 1024).
     These modes are optimized to represent well raw BOLD timeseries,
-    over a with range of experimental conditions. See [1]_.
+    over a with range of experimental conditions. See :footcite:`DADI2020117126`.
 
     Notes
     -----
@@ -71,10 +71,7 @@ def fetch_atlas_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True
 
     References
     ----------
-    .. [1] Dadi, K., Varoquaux, G., Machlouzarides-Shalit,
-       A., Gorgolewski, KJ., Wassermann, D., Thirion, B., Mensch,
-       A. Fine-grain atlases of functional modes for fMRI analysis.
-       NeuroImage, Elsevier, 2020, pp.117126, https://hal.inria.fr/hal-02904869
+    .. footbibliography::
 
     """
     dic = {64: 'pqu9r',

--- a/nilearn/regions/rena_clustering.py
+++ b/nilearn/regions/rena_clustering.py
@@ -350,7 +350,8 @@ def recursive_neighbor_agglomeration(X, mask_img, n_clusters,
                                      n_iter=10, threshold=1e-7,
                                      verbose=0):
     """Recursive neighbor agglomeration (ReNA): it performs iteratively
-    the nearest neighbor grouping [1]_.
+    the nearest neighbor grouping.
+    See :footcite:`Hoyos2019`.
 
     Parameters
     ----------
@@ -383,11 +384,7 @@ def recursive_neighbor_agglomeration(X, mask_img, n_clusters,
 
     References
     ----------
-    .. [1] A. Hoyos-Idrobo, G. Varoquaux, J. Kahn and B. Thirion, "Recursive
-       Nearest Agglomeration (ReNA): Fast Clustering for Approximation of
-       Structured Signals," in IEEE Transactions on Pattern Analysis and
-       Machine Intelligence, vol. 41, no. 3, pp. 669-681, 1 March 2019.
-       https://hal.archives-ouvertes.fr/hal-01366651/
+    .. footbibliography::
 
     """
     connectivity = weighted_connectivity_graph(X, mask_img)
@@ -418,7 +415,8 @@ def recursive_neighbor_agglomeration(X, mask_img, n_clusters,
 class ReNA(BaseEstimator, ClusterMixin, TransformerMixin):
     """Recursive Neighbor Agglomeration (ReNA):
     Recursively merges the pair of clusters according to 1-nearest neighbors
-    criterion [1]_.
+    criterion.
+    See :footcite:`Hoyos2019`.
 
     Parameters
     ----------
@@ -465,11 +463,7 @@ class ReNA(BaseEstimator, ClusterMixin, TransformerMixin):
 
     References
     ----------
-    .. [1] A. Hoyos-Idrobo, G. Varoquaux, J. Kahn and B. Thirion, "Recursive
-       Nearest Agglomeration (ReNA): Fast Clustering for Approximation of
-       Structured Signals," in IEEE Transactions on Pattern Analysis and
-       Machine Intelligence, vol. 41, no. 3, pp. 669-681, 1 March 2019.
-       https://hal.archives-ouvertes.fr/hal-01366651/
+    .. footbibliography::
 
     """
     def __init__(self, mask_img, n_clusters=2, scaling=False, n_iter=10,

--- a/requirements-build-docs.txt
+++ b/requirements-build-docs.txt
@@ -6,6 +6,7 @@ lxml
 mkl
 sphinx
 sphinx-gallery
+sphinxcontrib-bibtex
 numpydoc
 coverage
 pillow

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -4,7 +4,7 @@ conda init bash
 echo "conda version = $(conda --version)"
 conda create -n testenv
 conda install -n testenv -yq python=3.8 numpy scipy scikit-learn matplotlib pandas lxml mkl sphinx numpydoc pillow pandas
-conda install -n testenv -yq nibabel sphinx-gallery junit-xml -c conda-forge
+conda install -n testenv -yq nibabel sphinx-gallery sphinxcontrib-bibtex junit-xml -c conda-forge
 source activate testenv
 python -m pip install --user --upgrade --progress-bar off pip setuptools
 python -m pip install .


### PR DESCRIPTION
## Description

This PR proposes to use [sphinxcontrib-bibtex](https://github.com/mcmtroffaes/sphinxcontrib-bibtex) to manage references in the documentation. This PR configures the extension and provides a couple examples. 
Other references will have to be added to the bib file and the docstrings will have to be updated. I will open small "good first issues" for the sprint targeting the different files which need to be updated. This is what [MNE](https://github.com/mne-tools/mne-python) did for their last sprint and I think it was a very good way to onboard new people with a very simple first PR. 
WDYT?

## Advantages

This will have the following advantages:

- consistent formatting of references across doc
- no more copy-pasting of references, they are all stored in `references.bib`
- easier maintenance
- Auto generated global bibliography page (this PR adds a link in the website navbar, but we can have it somewhere else...)

![biblio](https://user-images.githubusercontent.com/2639645/114522320-9155e700-9c43-11eb-8a72-386d6f3e9ddd.png)


## Drawbacks

But the following drawbacks:

- The raw docstrings won't render the reference, you will only see the bib key.