### PR TITLE
Improve testing/coverage of first level glm

### DIFF
--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -362,6 +362,9 @@ class FirstLevelModel(BaseGLM):
             takes precedence over events and confounds.
 
         """
+        # Initialize masker_ to None such that attribute exists
+        self.masker_ = None
+
         # Raise a warning if both design_matrices and confounds are provided
         if design_matrices is not None and (confounds is not None or events is not None):
             warn('If design matrices are supplied, confounds and events will be ignored.')

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -410,6 +410,8 @@ class FirstLevelModel(BaseGLM):
                                        )
             self.masker_.fit(run_imgs[0])
         else:
+            # Make sure masker has been fitted otherwise no attribute mask_img_
+            self.mask_img._check_fitted()
             if self.mask_img.mask_img_ is None and self.masker_ is None:
                 self.masker_ = clone(self.mask_img)
                 for param_name in ['target_affine', 'target_shape',

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -338,6 +338,7 @@ def test_fmri_inputs():
         des = pd.DataFrame(np.ones((T, 1)), columns=[''])
         des_fname = 'design.csv'
         des.to_csv(des_fname)
+        events = basic_paradigm()
         for fi in func_img, FUNCFILE:
             for d in des, des_fname:
                 FirstLevelModel().fit(fi, design_matrices=d)
@@ -348,6 +349,20 @@ def test_fmri_inputs():
                     # test with confounds
                     FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d],
                                                     confounds=conf)
+
+                # Provide t_r, confounds, and events but no design matrix
+                FirstLevelModel(mask_img=mask, t_r=2.0).fit(
+                    fi,
+                    confounds=pd.DataFrame([0] * 10, columns=['conf']),
+                    events=events)
+
+                # Same, but check that an error is raised if there is a
+                # mismatch in the dimensions of the inputs
+                with pytest.raises(ValueError,
+                                   match="Rows in confounds does not match"):
+                    FirstLevelModel(mask_img=mask, t_r=2.0).fit(
+                            fi, confounds=conf, events=events)
+
                 # test with confounds as numpy array
                 FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d],
                                                    confounds=conf.values)

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -555,6 +555,26 @@ def test_first_level_from_bids():
         with pytest.raises(TypeError):
             first_level_from_bids(bids_path, 'main', 'MNI',
                                          model_init=[])
+        with pytest.raises(TypeError,
+                           match="space_label must be a string"):
+            first_level_from_bids(bids_path, 'main',
+                                  space_label=42)
+
+        with pytest.raises(TypeError,
+                           match="img_filters must be a list"):
+            first_level_from_bids(bids_path, 'main',
+                                  img_filters="foo")
+
+        with pytest.raises(TypeError,
+                           match="filters in img"):
+            first_level_from_bids(bids_path, 'main',
+                                  img_filters=[(1, 2)])
+
+        with pytest.raises(ValueError,
+                           match="field foo is not a possible filter."):
+            first_level_from_bids(bids_path, 'main',
+                                  img_filters=[("foo", "bar")])
+
         # test output is as expected
         models, m_imgs, m_events, m_confounds = first_level_from_bids(
             bids_path, 'main', 'MNI', [('desc', 'preproc')])

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -499,6 +499,10 @@ def test_first_level_contrast_computation():
             model.compute_contrast(c1)
         # fit model
         model = model.fit([func_img, func_img], [events, events])
+        # Check that an error is raised for invalid contrast_def
+        with pytest.raises(ValueError,
+                           match="contrast_def must be an array or str or list"):
+            model.compute_contrast(37)
         # smoke test for different contrasts in fixed effects
         model.compute_contrast([c1, c2])
         # smoke test for same contrast in fixed effects

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -575,6 +575,12 @@ def test_first_level_with_no_signal_scaling():
                                         columns=list(
                                             'abcdefghijklmnopqrstuvwxyz')[:rk])
                            )
+    # Check error with invalid signal_scaling values
+    with pytest.raises(ValueError,
+                       match="signal_scaling must be"):
+        FirstLevelModel(mask_img=False, noise_model='ols',
+                        signal_scaling="foo")
+
     first_level = FirstLevelModel(mask_img=False, noise_model='ols',
                                         signal_scaling=False)
     fmri_data.append(Nifti1Image(np.zeros((1, 1, 1, 2)) + 6, np.eye(4)))

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -57,6 +57,11 @@ def test_high_level_glm_one_session():
                     fmri_data[0], design_matrices=design_matrices[0])
     assert single_session_model.masker_ == masker
 
+    # Call with verbose (improve coverage)
+    single_session_model = FirstLevelModel(mask_img=None,
+                                           verbose=1).fit(
+        fmri_data[0], design_matrices=design_matrices[0])
+
     single_session_model = FirstLevelModel(mask_img=None).fit(
         fmri_data[0], design_matrices=design_matrices[0])
     assert isinstance(single_session_model.masker_.mask_img_,


### PR DESCRIPTION
This PR proposes to improve the testing of `nilearn/glm/first_level/first_level.py` since the coverage of this file was significantly (around 74%) lower than for most others. 
It also adds a few safety checks in `fit` to avoid unexpected `AttributeErrors` to occur in some edge cases.