### PR TITLE
Improve testing and coverage of glm second level

### DIFF
--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -119,11 +119,8 @@ def _check_confounds(confounds):
                              ' one called "subject_label" and the other'
                              ' with a given confound')
         # Make sure subject_label contain strings
-        labels_index = confounds.columns.tolist().index('subject_label')
-        labels_dtype = confounds.dtypes[labels_index]
-        if not isinstance(labels_dtype, np.object):
-            raise ValueError('subject_label column must be of dtype '
-                             'object instead of dtype %s' % labels_dtype)
+        if not all([isinstance(_, str) for _ in confounds['subject_label'].tolist()]):
+            raise ValueError('subject_label column must contain only strings')
 
 
 def _check_first_level_contrast(second_level_input, first_level_contrast):

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -82,12 +82,8 @@ def _check_second_level_input(second_level_input, design_matrix,
                                  ' columns subject_label, map_name and'
                                  ' effects_map_path')
         # Make sure subject_label contain strings
-        second_level_columns = second_level_input.columns.tolist()
-        labels_index = second_level_columns.index('subject_label')
-        labels_dtype = second_level_input.dtypes[labels_index]
-        if not isinstance(labels_dtype, np.object):
-            raise ValueError('subject_label column must be of dtype '
-                             'object instead of dtype %s' % labels_dtype)
+        if not all([isinstance(_, str) for _ in second_level_input['subject_label'].tolist()]):
+            raise ValueError('subject_label column must contain only strings')
     elif isinstance(second_level_input, (str, Nifti1Image)):
         if design_matrix is None:
             raise ValueError('List of niimgs as second_level_input'

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -48,6 +48,25 @@ def test_check_design_matrix():
     _check_design_matrix(pd.DataFrame())
 
 
+def test_check_confounds():
+    from nilearn.glm.second_level.second_level import _check_confounds
+    _check_confounds(None) # Should not do anything
+    with pytest.raises(ValueError,
+                       match="confounds must be a pandas DataFrame"):
+        _check_confounds("foo")
+    with pytest.raises(ValueError,
+                       match="confounds DataFrame must contain column"):
+        _check_confounds(pd.DataFrame())
+    with pytest.raises(ValueError,
+                       match="confounds should contain at least 2 columns"):
+        _check_confounds(pd.DataFrame(columns=['subject_label']))
+    with pytest.raises(ValueError,
+                       match="subject_label column must contain only strings"):
+        _check_confounds(pd.DataFrame(
+            {'subject_label': [None, None, None],
+             'conf': [4, 5, 6]}))
+
+
 def test_high_level_glm_with_paths():
     with InTemporaryDirectory():
         shapes = ((7, 8, 9, 1),)

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -76,6 +76,14 @@ def test_check_first_level_contrast():
     _check_first_level_contrast([FirstLevelModel()], "foo")
 
 
+def test_check_effect_maps():
+    from nilearn.glm.second_level.second_level import _check_effect_maps
+    _check_effect_maps([1, 2, 3], np.array([[1, 2], [3, 4], [5, 6]]))
+    with pytest.raises(ValueError,
+                       match="design_matrix does not match the number of maps considered"):
+        _check_effect_maps([1, 2], np.array([[1, 2], [3, 4], [5, 6]]))
+
+
 def test_high_level_glm_with_paths():
     with InTemporaryDirectory():
         shapes = ((7, 8, 9, 1),)

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -67,6 +67,15 @@ def test_check_confounds():
              'conf': [4, 5, 6]}))
 
 
+def test_check_first_level_contrast():
+    from nilearn.glm.second_level.second_level import _check_first_level_contrast
+    _check_first_level_contrast(["foo"], None) # Should not do anything
+    with pytest.raises(ValueError,
+                       match="If second_level_input was a list"):
+        _check_first_level_contrast([FirstLevelModel()], None)
+    _check_first_level_contrast([FirstLevelModel()], "foo")
+
+
 def test_high_level_glm_with_paths():
     with InTemporaryDirectory():
         shapes = ((7, 8, 9, 1),)

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -84,6 +84,25 @@ def test_check_effect_maps():
         _check_effect_maps([1, 2], np.array([[1, 2], [3, 4], [5, 6]]))
 
 
+def test_get_contrast():
+    from nilearn.glm.second_level.second_level import _get_contrast
+    design_matrix = pd.DataFrame([1, 2, 3], columns=['conf'])
+    assert _get_contrast('conf', design_matrix) == 'conf'
+    with pytest.raises(ValueError,
+                       match='"foo" is not a valid contrast name'):
+        _get_contrast('foo', design_matrix)
+    design_matrix = pd.DataFrame({'conf1': [1, 2, 3],
+                                  'conf2': [4, 5, 6]})
+    with pytest.raises(ValueError,
+                       match="No second-level contrast is specified."):
+        _get_contrast(None, design_matrix)
+    with pytest.raises(ValueError,
+                       match="second_level_contrast must be a list of 0s and 1s"):
+        _get_contrast([0, 0], design_matrix)
+    assert _get_contrast([0, 1], design_matrix) == 'conf2'
+    assert _get_contrast([1, 0], design_matrix) == 'conf1'
+
+
 def test_high_level_glm_with_paths():
     with InTemporaryDirectory():
         shapes = ((7, 8, 9, 1),)

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -166,25 +166,25 @@ def test_get_contrast():
 def test_infer_effect_maps():
     from nilearn.glm.second_level.second_level import _infer_effect_maps
     with InTemporaryDirectory():
-        shapes = ((7, 8, 9, 1),)
-        mask, FUNCFILE, _ = write_fake_fmri_data_and_design(shapes)
-        FUNCFILE = FUNCFILE[0]
-        func_img = load(FUNCFILE)
+        shapes, rk = ((7, 8, 9, 1), (7, 8, 7, 16)), 3
+        mask, fmri_data, design_matrices = write_fake_fmri_data_and_design(shapes, rk)
+        func_img = load(fmri_data[0])
         second_level_input = pd.DataFrame({'map_name': ["a", "b"] ,
-                                           'effects_map_path': [FUNCFILE, "bar"]})
-        assert _infer_effect_maps(second_level_input, "a") == [FUNCFILE]
+                                           'effects_map_path': [fmri_data[0], "bar"]})
+        assert _infer_effect_maps(second_level_input, "a") == [fmri_data[0]]
         with pytest.raises(ValueError,
                            match="File not found: 'bar'"):
             _infer_effect_maps(second_level_input, "b")
-        assert _infer_effect_maps([FUNCFILE], None) == [FUNCFILE]
-        shapes, rk = ((7, 8, 7, 15), (7, 8, 7, 16)), 3
-        mask, fmri_data, design_matrices = write_fake_fmri_data_and_design(shapes, rk)
+        assert _infer_effect_maps([fmri_data[0]], None) == [fmri_data[0]]
         contrast = np.eye(rk)[1]
         second_level_input = [FirstLevelModel(mask_img=mask)] * 2
         for i,model in enumerate(second_level_input):
             model.fit(fmri_data[i],
                       design_matrices=design_matrices[i])
         assert len(_infer_effect_maps(second_level_input, contrast)) == 2
+        # Delete objects attached to files to avoid WindowsError when deleting
+        # temporary directory (in Windows)
+        del mask, fmri_data, func_img, second_level_input
 
 
 def test_high_level_glm_with_paths():

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -165,26 +165,26 @@ def test_get_contrast():
 
 def test_infer_effect_maps():
     from nilearn.glm.second_level.second_level import _infer_effect_maps
-    with InTemporaryDirectory():
-        shapes, rk = ((7, 8, 9, 1), (7, 8, 7, 16)), 3
-        mask, fmri_data, design_matrices = write_fake_fmri_data_and_design(shapes, rk)
-        func_img = load(fmri_data[0])
-        second_level_input = pd.DataFrame({'map_name': ["a", "b"] ,
-                                           'effects_map_path': [fmri_data[0], "bar"]})
-        assert _infer_effect_maps(second_level_input, "a") == [fmri_data[0]]
-        with pytest.raises(ValueError,
-                           match="File not found: 'bar'"):
-            _infer_effect_maps(second_level_input, "b")
-        assert _infer_effect_maps([fmri_data[0]], None) == [fmri_data[0]]
-        contrast = np.eye(rk)[1]
-        second_level_input = [FirstLevelModel(mask_img=mask)] * 2
-        for i,model in enumerate(second_level_input):
-            model.fit(fmri_data[i],
-                      design_matrices=design_matrices[i])
-        assert len(_infer_effect_maps(second_level_input, contrast)) == 2
-        # Delete objects attached to files to avoid WindowsError when deleting
-        # temporary directory (in Windows)
-        del mask, fmri_data, func_img, second_level_input
+    #with InTemporaryDirectory():
+    shapes, rk = ((7, 8, 9, 1), (7, 8, 7, 16)), 3
+    mask, fmri_data, design_matrices = write_fake_fmri_data_and_design(shapes, rk)
+    func_img = load(fmri_data[0])
+    second_level_input = pd.DataFrame({'map_name': ["a", "b"] ,
+                                        'effects_map_path': [fmri_data[0], "bar"]})
+    assert _infer_effect_maps(second_level_input, "a") == [fmri_data[0]]
+    with pytest.raises(ValueError,
+                       match="File not found: 'bar'"):
+        _infer_effect_maps(second_level_input, "b")
+    assert _infer_effect_maps([fmri_data[0]], None) == [fmri_data[0]]
+    contrast = np.eye(rk)[1]
+    second_level_input = [FirstLevelModel(mask_img=mask)] * 2
+    for i,model in enumerate(second_level_input):
+        model.fit(fmri_data[i],
+                  design_matrices=design_matrices[i])
+    assert len(_infer_effect_maps(second_level_input, contrast)) == 2
+    # Delete objects attached to files to avoid WindowsError when deleting
+    # temporary directory (in Windows)
+    del mask, fmri_data, func_img, second_level_input
 
 
 def test_high_level_glm_with_paths():

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -178,7 +178,7 @@ def test_infer_effect_maps():
     assert _infer_effect_maps([fmri_data[0]], None) == [fmri_data[0]]
     contrast = np.eye(rk)[1]
     second_level_input = [FirstLevelModel(mask_img=mask)] * 2
-    for i,model in enumerate(second_level_input):
+    for i, model in enumerate(second_level_input):
         model.fit(fmri_data[i],
                   design_matrices=design_matrices[i])
     assert len(_infer_effect_maps(second_level_input, contrast)) == 2

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -31,6 +31,13 @@ from nilearn.glm.second_level import (SecondLevelModel,
 BASEDIR = os.path.dirname(os.path.abspath(__file__))
 FUNCFILE = os.path.join(BASEDIR, 'functional.nii.gz')
 
+def test_check_output_type():
+    from nilearn.glm.second_level.second_level import _check_output_type
+    _check_output_type(int, [str, int, float])
+    with pytest.raises(ValueError,
+                       match="output_type must be one of"):
+        _check_output_type("foo", [str, int, float])
+
 
 def test_high_level_glm_with_paths():
     with InTemporaryDirectory():

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -43,7 +43,7 @@ def test_check_second_level_input():
     with pytest.raises(ValueError,
                        match="Model sub_1 at index 0 has not been fit yet"):
         _check_second_level_input([FirstLevelModel(subject_label="sub_{}".format(i))
-                                   for i in range(1,3)], pd.DataFrame())
+                                   for i in range(1, 3)], pd.DataFrame())
     with InTemporaryDirectory():
         shapes, rk = [(7, 8, 9, 15)], 3
         mask, fmri_data, design_matrices = generate_fake_fmri_data_and_design(shapes, rk)
@@ -177,8 +177,6 @@ def test_infer_effect_maps():
                            match="File not found: 'bar'"):
             _infer_effect_maps(second_level_input, "b")
         assert _infer_effect_maps([FUNCFILE], None) == [FUNCFILE]
-
-    with InTemporaryDirectory():
         shapes, rk = ((7, 8, 7, 15), (7, 8, 7, 16)), 3
         mask, fmri_data, design_matrices = write_fake_fmri_data_and_design(shapes, rk)
         contrast = np.eye(rk)[1]

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -39,6 +39,15 @@ def test_check_output_type():
         _check_output_type("foo", [str, int, float])
 
 
+def test_check_design_matrix():
+    from nilearn.glm.second_level.second_level import _check_design_matrix
+    _check_design_matrix(None) # Should not do anything
+    with pytest.raises(ValueError,
+                       match="design matrix must be a pandas DataFrame"):
+        _check_design_matrix("foo")
+    _check_design_matrix(pd.DataFrame())
+
+
 def test_high_level_glm_with_paths():
     with InTemporaryDirectory():
         shapes = ((7, 8, 9, 1),)


### PR DESCRIPTION
Following #2764 this PR proposes to improve testing and coverage for `nilearn/glm/second_level/second_level.py`.
Helper functions from this file are also unit-tested in a consistent way.