### PR TITLE
[MAINT] Remove numpy type deprecation warnings

### DIFF
--- a/nilearn/_utils/data_gen.py
+++ b/nilearn/_utils/data_gen.py
@@ -327,7 +327,7 @@ def generate_fake_fmri(shape=(10, 11, 12), length=17, kind="noise",
         target[t_start:t_start + block_size] = block + 1
         t_start += t_rest + block_size
     target = target if block_type == 'classification' \
-        else target.astype(np.float)
+        else target.astype(np.float64)
     fmri = np.zeros(fmri.shape)
     fmri[mask.astype(bool)] = flat_fmri
     return (nibabel.Nifti1Image(fmri, affine),

--- a/nilearn/connectome/group_sparse_cov.py
+++ b/nilearn/connectome/group_sparse_cov.py
@@ -252,7 +252,7 @@ def _group_sparse_covariance(emp_covs, n_samples, alpha, max_iter=10, tol=1e-3,
 
     if precisions_init is None:
         # Fortran order make omega[..., k] contiguous, which is often useful.
-        omega = np.ndarray(shape=emp_covs.shape, dtype=np.float,
+        omega = np.ndarray(shape=emp_covs.shape, dtype=np.float64,
                            order="F")
         for k in range(n_subjects):
             # Values on main diagonals are far from zero, because they
@@ -262,21 +262,21 @@ def _group_sparse_covariance(emp_covs, n_samples, alpha, max_iter=10, tol=1e-3,
         omega = precisions_init.copy()
 
     # Preallocate arrays
-    y = np.ndarray(shape=(n_subjects, n_features - 1), dtype=np.float)
-    u = np.ndarray(shape=(n_subjects, n_features - 1), dtype=np.float)
-    y_1 = np.ndarray(shape=(n_subjects, n_features - 2), dtype=np.float)
-    h_12 = np.ndarray(shape=(n_subjects, n_features - 2), dtype=np.float)
-    q = np.ndarray(shape=(n_subjects,), dtype=np.float)
-    aq = np.ndarray(shape=(n_subjects,), dtype=np.float)  # temp. array
-    c = np.ndarray(shape=(n_subjects,), dtype=np.float)
+    y = np.ndarray(shape=(n_subjects, n_features - 1), dtype=np.float64)
+    u = np.ndarray(shape=(n_subjects, n_features - 1), dtype=np.float64)
+    y_1 = np.ndarray(shape=(n_subjects, n_features - 2), dtype=np.float64)
+    h_12 = np.ndarray(shape=(n_subjects, n_features - 2), dtype=np.float64)
+    q = np.ndarray(shape=(n_subjects,), dtype=np.float64)
+    aq = np.ndarray(shape=(n_subjects,), dtype=np.float64)  # temp. array
+    c = np.ndarray(shape=(n_subjects,), dtype=np.float64)
     W = np.ndarray(shape=(omega.shape[0] - 1, omega.shape[1] - 1,
                           omega.shape[2]),
-                   dtype=np.float, order="F")
-    W_inv = np.ndarray(shape=W.shape, dtype=np.float, order="F")
+                   dtype=np.float64, order="F")
+    W_inv = np.ndarray(shape=W.shape, dtype=np.float64, order="F")
 
     # Auxilliary arrays.
-    v = np.ndarray((omega.shape[0] - 1,), dtype=np.float)
-    h = np.ndarray((omega.shape[1] - 1,), dtype=np.float)
+    v = np.ndarray((omega.shape[0] - 1,), dtype=np.float64)
+    h = np.ndarray((omega.shape[1] - 1,), dtype=np.float64)
 
     # Optional.
     tolerance_reached = False
@@ -312,7 +312,7 @@ def _group_sparse_covariance(emp_covs, n_samples, alpha, max_iter=10, tol=1e-3,
             if p == 0:
                 # Initial state: remove first col/row
                 W = omega[1:, 1:, :].copy()   # stack of W(k)
-                W_inv = np.ndarray(shape=W.shape, dtype=np.float)
+                W_inv = np.ndarray(shape=W.shape, dtype=np.float64)
                 for k in range(W.shape[2]):
                     # stack of W^-1(k)
                     W_inv[..., k] = scipy.linalg.inv(W[..., k])
@@ -573,7 +573,7 @@ def empirical_covariances(subjects, assume_centered=False, standardize=False):
         empirical covariances.
 
     n_samples : numpy.ndarray, shape: (subject number,)
-        number of samples for each subject. dtype is np.float.
+        number of samples for each subject. dtype is np.float64.
 
     """
     if not hasattr(subjects, "__iter__"):
@@ -601,7 +601,7 @@ def empirical_covariances(subjects, assume_centered=False, standardize=False):
         emp_covs[..., k] = M + M.T
     emp_covs /= 2
 
-    n_samples = np.asarray([s.shape[0] for s in subjects], dtype=np.float)
+    n_samples = np.asarray([s.shape[0] for s in subjects], dtype=np.float64)
 
     return emp_covs, n_samples
 
@@ -665,7 +665,7 @@ def group_sparse_scores(precisions, n_samples, emp_covs, alpha,
 
     # Compute duality gap if requested
     if duality_gap is True:
-        A = np.empty(precisions.shape, dtype=np.float, order="F")
+        A = np.empty(precisions.shape, dtype=np.float64, order="F")
         for k in range(n_subjects):
             # TODO: can be computed more efficiently using W_inv. See
             # Friedman, Jerome, Trevor Hastie, and Robert Tibshirani.
@@ -1029,7 +1029,7 @@ class GroupSparseCovarianceCV(BaseEstimator, CacheMixin):
             best_score = -np.inf
             last_finite_idx = 0
             for index, (alpha, this_score, _) in enumerate(path):
-                if this_score >= .1 / np.finfo(np.float).eps:
+                if this_score >= .1 / np.finfo(np.float64).eps:
                     this_score = np.nan
                 if np.isfinite(this_score):
                     last_finite_idx = index

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -1315,7 +1315,7 @@ def _load_mixed_gambles(zmap_imgs):
     X = X[mask, :].T
     tmp = np.zeros(list(mask.shape) + [len(X)])
     tmp[mask, :] = X.T
-    mask_img = nibabel.Nifti1Image(mask.astype(np.int), affine)
+    mask_img = nibabel.Nifti1Image(mask.astype(int), affine)
     X = nibabel.four_to_three(nibabel.Nifti1Image(tmp, affine))
     return X, y, mask_img
 

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -488,7 +488,7 @@ class _BaseDecoder(LinearRegression, CacheMixin):
         self.memory_ = _check_memory(self.memory, self.verbose)
 
         X = self._apply_mask(X)
-        X, y = check_X_y(X, y, dtype=np.float, multi_output=True)
+        X, y = check_X_y(X, y, dtype=np.float64, multi_output=True)
 
         if y.ndim == 1:
             self.n_outputs_ = 1
@@ -677,7 +677,7 @@ class _BaseDecoder(LinearRegression, CacheMixin):
 
         if self.is_classification:
             if len(scores.shape) == 1:
-                indices = (scores > 0).astype(np.int)
+                indices = (scores > 0).astype(int)
             else:
                 indices = scores.argmax(axis=1)
             return self.classes_[indices]
@@ -739,7 +739,7 @@ class _BaseDecoder(LinearRegression, CacheMixin):
             for k in params:
                 self.cv_params_[classes[class_index]].setdefault(
                     k, []).append(params[k])
- 
+
             if (n_problems <= 2) and self.is_classification:
                 # Binary classification
                 other_class = np.setdiff1d(classes, classes[class_index])[0]

--- a/nilearn/decoding/objective_functions.py
+++ b/nilearn/decoding/objective_functions.py
@@ -200,7 +200,7 @@ def _gradient_id(img, l1_ratio=.5):
             "l1_ratio must be in the interval [0, 1]; got %s" % l1_ratio)
 
     shape = [img.ndim + 1] + list(img.shape)
-    gradient = np.zeros(shape, dtype=np.float)
+    gradient = np.zeros(shape, dtype=np.float64)
 
     # the gradient part: 'Clever' code to have a view of the gradient
     # with dimension i stop at -1

--- a/nilearn/decoding/proximal_operators.py
+++ b/nilearn/decoding/proximal_operators.py
@@ -160,7 +160,7 @@ def _prox_tvl1(input_img, l1_ratio=.05, weight=50, dgap_tol=5.e-5, x_tol=None,
     input_img_flat.shape = input_img.size
     input_img_norm = np.dot(input_img_flat, input_img_flat)
     if not input_img.dtype.kind == 'f':
-        input_img = input_img.astype(np.float)
+        input_img = input_img.astype(np.float64)
     shape = [len(input_img.shape) + 1] + list(input_img.shape)
     grad_im = np.zeros(shape)
     grad_aux = np.zeros(shape)

--- a/nilearn/glm/first_level/hemodynamic_models.py
+++ b/nilearn/glm/first_level/hemodynamic_models.py
@@ -60,7 +60,7 @@ def _gamma_difference_hrf(tr, oversampling=50, time_length=32., onset=0.,
     """
     dt = tr / oversampling
     time_stamps = np.linspace(0, time_length,
-                              np.rint(float(time_length) / dt).astype(np.int))
+                              np.rint(float(time_length) / dt).astype(int))
     time_stamps -= onset
     hrf = (
         gamma.pdf(time_stamps, delay / dispersion, dt / dispersion)
@@ -291,7 +291,7 @@ def _sample_condition(exp_condition, frame_times, oversampling=50,
 
     hr_frame_times = np.linspace(frame_times.min() + min_onset,
                                  frame_times.max() * (1 + 1. / (n - 1)),
-                                 np.rint(n_hr).astype(np.int))
+                                 np.rint(n_hr).astype(int))
 
     # Get the condition information
     onsets, durations, values = tuple(map(np.asanyarray, exp_condition))
@@ -302,7 +302,7 @@ def _sample_condition(exp_condition, frame_times, oversampling=50,
 
     # Set up the regressor timecourse
     tmax = len(hr_frame_times)
-    regressor = np.zeros_like(hr_frame_times).astype(np.float)
+    regressor = np.zeros_like(hr_frame_times).astype(np.float64)
     t_onset = np.minimum(np.searchsorted(hr_frame_times, onsets), tmax - 1)
     for t, v in zip(t_onset, values):
         regressor[t] += v

--- a/nilearn/glm/regression.py
+++ b/nilearn/glm/regression.py
@@ -97,7 +97,7 @@ class OLSModel(object):
                                           np.transpose(self.calc_beta))
         self.df_total = self.whitened_design.shape[0]
 
-        eps = np.abs(self.design).sum() * np.finfo(np.float).eps
+        eps = np.abs(self.design).sum() * np.finfo(np.float64).eps
         self.df_model = matrix_rank(self.design, eps)
         self.df_residuals = self.df_total - self.df_model
 

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -488,7 +488,7 @@ def test_resampling_nan():
         # create deterministic data, padded with one
         # voxel thickness of zeros
         core_data = np.arange(np.prod(core_shape)
-                              ).reshape(core_shape).astype(np.float)
+                              ).reshape(core_shape).astype(np.float64)
         # Introduce a nan
         core_data[2, 2:4, 1] = np.nan
         full_data_shape = np.array(core_shape) + 2

--- a/nilearn/plotting/edge_detect.py
+++ b/nilearn/plotting/edge_detect.py
@@ -69,7 +69,7 @@ def _edge_detect(image, high_threshold=.75, low_threshold=.4):
     np_err = np.seterr(all='ignore')
     # Replace NaNs by 0s to avoid meaningless outputs
     image = np.nan_to_num(image)
-    img = signal.wiener(image.astype(np.float))
+    img = signal.wiener(image.astype(np.float64))
     np.seterr(**np_err)
     # Where the noise variance is 0, Wiener can create nans
     img[np.isnan(img)] = image[np.isnan(img)]

--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -302,7 +302,7 @@ def find_cut_slices(img, direction='z', n_cuts=7, spacing='auto'):
     # first convert it to float.
     data = orig_data.copy()
     if data.dtype.kind in ('i', 'u'):
-        data = data.astype(np.float)
+        data = data.astype(np.float64)
 
     data = _smooth_array(data, affine, fwhm='fast')
 

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -401,7 +401,7 @@ class _MNI152Template(SpatialImage):
             anat_img = load_mni152_template()
             anat_img = reorder_img(anat_img)
             data = get_data(anat_img)
-            data = data.astype(np.float)
+            data = data.astype(np.float64)
             anat_mask = ndimage.morphology.binary_fill_holes(data > 0)
             data = np.ma.masked_array(data, np.logical_not(anat_mask))
             self._affine = anat_img.affine

--- a/nilearn/regions/tests/test_signal_extraction.py
+++ b/nilearn/regions/tests/test_signal_extraction.py
@@ -87,7 +87,7 @@ def test_signals_extraction_with_labels():
     mask_4d_img = nibabel.Nifti1Image(np.ones(shape + (2, )), affine)
 
     # labels
-    labels_data = np.zeros(shape, dtype=np.int)
+    labels_data = np.zeros(shape, dtype=int)
     h0 = shape[0] // 2
     h1 = shape[1] // 2
     h2 = shape[2] // 2

--- a/nilearn/regions/tests/test_signal_extraction.py
+++ b/nilearn/regions/tests/test_signal_extraction.py
@@ -74,7 +74,7 @@ def test_signals_extraction_with_labels():
     n_instants = 11
     n_regions = 8  # must be 8
 
-    eps = np.finfo(np.float).eps
+    eps = np.finfo(np.float64).eps
     # data
     affine = np.eye(4)
     signals = generate_timeseries(n_instants, n_regions)

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -65,12 +65,12 @@ def _standardize(signals, detrend=False, standardize='zscore'):
                 signals = signals - signals.mean(axis=0)
 
             std = signals.std(axis=0)
-            std[std < np.finfo(np.float).eps] = 1.  # avoid numerical problems
+            std[std < np.finfo(np.float64).eps] = 1.  # avoid numerical problems
             signals /= std
 
         elif standardize == 'psc':
             mean_signal = signals.mean(axis=0)
-            invalid_ix = np.absolute(mean_signal) < np.finfo(np.float).eps
+            invalid_ix = np.absolute(mean_signal) < np.finfo(np.float64).eps
             signals = (signals - mean_signal) / np.absolute(mean_signal)
             signals *= 100
 
@@ -201,7 +201,7 @@ def _detrend(signals, inplace=False, type="linear", n_batches=10):
         regressor -= regressor.mean()
         std = np.sqrt((regressor ** 2).sum())
         # avoid numerical problems
-        if not std < np.finfo(np.float).eps:
+        if not std < np.finfo(np.float64).eps:
             regressor /= std
         regressor = regressor[:, np.newaxis]
 
@@ -620,7 +620,7 @@ def clean(signals, sessions=None, detrend=True, standardize='zscore',
 
         # Pivoting in qr decomposition was added in scipy 0.10
         Q, R, _ = linalg.qr(confounds, mode='economic', pivoting=True)
-        Q = Q[:, np.abs(np.diag(R)) > np.finfo(np.float).eps * 100.]
+        Q = Q[:, np.abs(np.diag(R)) > np.finfo(np.float64).eps * 100.]
         signals -= Q.dot(Q.T).dot(signals)
 
     # Standardize

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -342,7 +342,7 @@ def test_unmask():
             assert_array_equal(t[0], unmasked3D)
 
     # Error test: shape
-    vec_1D = np.empty((500,), dtype=np.int)
+    vec_1D = np.empty((500,), dtype=int)
     pytest.raises(TypeError, unmask, vec_1D, mask_img)
     pytest.raises(TypeError, unmask, [vec_1D], mask_img)
 
@@ -352,19 +352,19 @@ def test_unmask():
 
     # Error test: mask type
     with pytest.raises(TypeError, match='mask must be a boolean array'):
-        _unmask_3d(vec_1D, mask.astype(np.int))
+        _unmask_3d(vec_1D, mask.astype(int))
     with pytest.raises(TypeError, match='mask must be a boolean array'):
         _unmask_4d(vec_2D, mask.astype(np.float64))
 
     # Transposed vector
-    transposed_vector = np.ones((np.sum(mask), 1), dtype=np.bool)
+    transposed_vector = np.ones((np.sum(mask), 1), dtype=bool)
     with pytest.raises(TypeError, match='X must be of shape'):
         unmask(transposed_vector, mask_img)
 
 
 def test_intersect_masks_filename():
     # Create dummy masks
-    mask_a = np.zeros((4, 4, 1), dtype=np.bool)
+    mask_a = np.zeros((4, 4, 1), dtype=bool)
     mask_a[2:4, 2:4] = 1
     mask_a_img = Nifti1Image(mask_a.astype(int), np.eye(4))
 
@@ -378,7 +378,7 @@ def test_intersect_masks_filename():
     # |   |   | X | X |
     # +---+---+---+---+
 
-    mask_b = np.zeros((4, 4, 1), dtype=np.bool)
+    mask_b = np.zeros((4, 4, 1), dtype=bool)
     mask_b[1:3, 1:3] = 1
     mask_b_img = Nifti1Image(mask_b.astype(int), np.eye(4))
 
@@ -394,7 +394,7 @@ def test_intersect_masks_filename():
 
     with write_tmp_imgs(mask_a_img, mask_b_img, create_files=True)\
             as filenames:
-        mask_ab = np.zeros((4, 4, 1), dtype=np.bool)
+        mask_ab = np.zeros((4, 4, 1), dtype=bool)
         mask_ab[2, 2] = 1
         mask_ab_ = intersect_masks(filenames, threshold=1.)
         assert_array_equal(mask_ab, get_data(mask_ab_))
@@ -405,7 +405,7 @@ def test_intersect_masks():
     """
 
     # Create dummy masks
-    mask_a = np.zeros((4, 4, 1), dtype=np.bool)
+    mask_a = np.zeros((4, 4, 1), dtype=bool)
     mask_a[2:4, 2:4] = 1
     mask_a_img = Nifti1Image(mask_a.astype(int), np.eye(4))
 
@@ -419,7 +419,7 @@ def test_intersect_masks():
     # |   |   | X | X |
     # +---+---+---+---+
 
-    mask_b = np.zeros((4, 4, 1), dtype=np.bool)
+    mask_b = np.zeros((4, 4, 1), dtype=bool)
     mask_b[1:3, 1:3] = 1
     mask_b_img = Nifti1Image(mask_b.astype(int), np.eye(4))
 
@@ -433,7 +433,7 @@ def test_intersect_masks():
     # |   |   |   |   |
     # +---+---+---+---+
 
-    mask_c = np.zeros((4, 4, 1), dtype=np.bool)
+    mask_c = np.zeros((4, 4, 1), dtype=bool)
     mask_c[:, 2] = 1
     mask_c[0, 0] = 1
     mask_c_img = Nifti1Image(mask_c.astype(int), np.eye(4))
@@ -448,7 +448,7 @@ def test_intersect_masks():
     # |   |   | X |   |
     # +---+---+---+---+
 
-    mask_ab = np.zeros((4, 4, 1), dtype=np.bool)
+    mask_ab = np.zeros((4, 4, 1), dtype=bool)
     mask_ab[2, 2] = 1
     mask_ab_ = intersect_masks([mask_a_img, mask_b_img], threshold=1.)
     assert_array_equal(mask_ab, get_data(mask_ab_))
@@ -490,11 +490,11 @@ def test_compute_multi_epi_mask():
     pytest.raises(TypeError, compute_multi_epi_mask, [])
     # As it calls intersect_masks, we only test resampling here.
     # Same masks as test_intersect_masks
-    mask_a = np.zeros((4, 4, 1), dtype=np.bool)
+    mask_a = np.zeros((4, 4, 1), dtype=bool)
     mask_a[2:4, 2:4] = 1
     mask_a_img = Nifti1Image(mask_a.astype(int), np.eye(4))
 
-    mask_b = np.zeros((8, 8, 1), dtype=np.bool)
+    mask_b = np.zeros((8, 8, 1), dtype=bool)
     mask_b[2:6, 2:6] = 1
     mask_b_img = Nifti1Image(mask_b.astype(int), np.eye(4) / 2.)
 
@@ -502,7 +502,7 @@ def test_compute_multi_epi_mask():
         warnings.simplefilter("ignore", MaskWarning)
         pytest.raises(ValueError, compute_multi_epi_mask,
                       [mask_a_img, mask_b_img])
-    mask_ab = np.zeros((4, 4, 1), dtype=np.bool)
+    mask_ab = np.zeros((4, 4, 1), dtype=bool)
     mask_ab[2, 2] = 1
     mask_ab_ = compute_multi_epi_mask([mask_a_img, mask_b_img], threshold=1.,
                                       opening=0,
@@ -656,7 +656,7 @@ def test_unmask_from_to_3d_array(size=5):
     rng = np.random.RandomState(42)
     for ndim in range(1, 4):
         shape = [size] * ndim
-        mask = np.zeros(shape).astype(np.bool)
+        mask = np.zeros(shape).astype(bool)
         mask[rng.uniform(size=shape) > .8] = 1
         support = rng.standard_normal(size=mask.sum())
         full = _unmask_from_to_3d_array(support, mask)

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -219,7 +219,7 @@ def test_detrend():
     # Mean removal only (out-of-place)
     detrended = nisignal._detrend(x, inplace=False, type="constant")
     assert (abs(detrended.mean(axis=0)).max()
-                < 15. * np.finfo(np.float).eps)
+                < 15. * np.finfo(np.float64).eps)
 
     # out-of-place detrending. Use scipy as a reference implementation
     detrended = nisignal._detrend(x, inplace=False)
@@ -227,14 +227,14 @@ def test_detrend():
 
     # "x" must be left untouched
     np.testing.assert_almost_equal(original, x, decimal=14)
-    assert abs(detrended.mean(axis=0)).max() < 15. * np.finfo(np.float).eps
+    assert abs(detrended.mean(axis=0)).max() < 15. * np.finfo(np.float64).eps
     np.testing.assert_almost_equal(detrended_scipy, detrended, decimal=14)
     # for this to work, there must be no trends at all in "signals"
     np.testing.assert_almost_equal(detrended, signals, decimal=14)
 
     # inplace detrending
     nisignal._detrend(x, inplace=True)
-    assert abs(x.mean(axis=0)).max() < 15. * np.finfo(np.float).eps
+    assert abs(x.mean(axis=0)).max() < 15. * np.finfo(np.float64).eps
     # for this to work, there must be no trends at all in "signals"
     np.testing.assert_almost_equal(detrended_scipy, detrended, decimal=14)
     np.testing.assert_almost_equal(x, signals, decimal=14)
@@ -248,7 +248,7 @@ def test_detrend():
     detrended = nisignal._detrend(x.astype(np.int64), inplace=True,
                                   type="constant")
     assert (abs(detrended.mean(axis=0)).max() <
-                20. * np.finfo(np.float).eps)
+                20. * np.finfo(np.float64).eps)
 
 
 def test_mean_of_squares():
@@ -399,7 +399,7 @@ def test_clean_confounds():
     signals, noises, confounds = generate_signals(n_features=41,
                                                   n_confounds=5, length=45)
     # No signal: output must be zero.
-    eps = np.finfo(np.float).eps
+    eps = np.finfo(np.float64).eps
     noises1 = noises.copy()
     cleaned_signals = nisignal.clean(noises, confounds=confounds,
                                      detrend=True, standardize=False)


### PR DESCRIPTION
Remove remaining numpy type deprecation warnings.

Note: This reduces the number of warnings from around 39200 to around 1300 when running the tests.