### PR TITLE
[WIP] Add min and max as possible avg_method in plot_surf (#2790)

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -16,7 +16,8 @@ Fixes
 Enhancements
 ------------
 
-- :func:`nilearn.plotting.view_markers` now accept an optional argument `marker_labels` to provide labels to each marker.
+- :func:`nilearn.plotting.view_markers` now accepts an optional argument `marker_labels` to provide labels to each marker.
+- :func:`nilearn.plotting.plot_surf` now accepts new values for `avg_method` argument, such as `min`, `max`, or even a custom python function to compute the value displayed for each face of the plotted mesh.
 
 .. _v0.7.1:
 

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -72,7 +72,7 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
     colorbar : bool, optional
         If True, a colorbar of surf_map is displayed. Default=False.
 
-    avg_method : {'mean', 'median'}, optional
+    avg_method : {'mean', 'median', 'min', 'max'}, optional
         How to average vertex values to derive the face value, mean results
         in smooth, median in sharp boundaries. Default='mean'.
 
@@ -270,6 +270,10 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
             surf_map_faces = np.mean(surf_map_data[faces], axis=1)
         elif avg_method == 'median':
             surf_map_faces = np.median(surf_map_data[faces], axis=1)
+        elif avg_method == 'min':
+            surf_map_faces = np.min(surf_map_data[faces], axis=1)
+        elif avg_method == 'max':
+            surf_map_faces = np.max(surf_map_data[faces], axis=1)
 
         # if no vmin/vmax are passed figure them out from data
         if vmin is None:

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -294,7 +294,7 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
                 raise ValueError('Array computed with the custom function from avg_method should be an array of numbers (int or float)')
 
         else:
-            raise ValueError(f"avg_method should be either ['mean', 'median', 'max', 'min'] or a custom function")
+            raise ValueError("avg_method should be either ['mean', 'median', 'max', 'min'] or a custom function")
 
         # if no vmin/vmax are passed figure them out from data
         if vmin is None:

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -286,15 +286,20 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
 
             ## check that surf_map_faces has the same length as face_colors
             if surf_map_faces.shape != (face_colors.shape[0],):
-                raise ValueError('Array computed with the custom function from avg_method does not have the correct shape: {} != {}'.format(surf_map_faces.shape[0], face_colors.shape[0])
+                raise ValueError('Array computed with the custom function '
+                'from avg_method does not have the correct shape: '
+                '{} != {}'.format(surf_map_faces.shape[0], face_colors.shape[0])
                 )
 
             ## check that dtype is either int or float
             if not ("int" in str(surf_map_faces.dtype) or "float" in str(surf_map_faces.dtype)):
-                raise ValueError('Array computed with the custom function from avg_method should be an array of numbers (int or float)')
+                raise ValueError('Array computed with the custom function '
+                'from avg_method should be an array of numbers (int or float)')
 
         else:
-            raise ValueError("avg_method should be either ['mean', 'median', 'max', 'min'] or a custom function")
+            raise ValueError("avg_method should be either "
+            "['mean', 'median', 'max', 'min'] "
+            "or a custom function")
 
         # if no vmin/vmax are passed figure them out from data
         if vmin is None:

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -289,6 +289,10 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
                 raise ValueError('Array computed with the custom function from avg_method does not have the correct shape: {} != {}'.format(surf_map_faces.shape[0], face_colors.shape[0])
                 )
 
+            ## check that dtype is either int or float
+            if not ("int" in str(surf_map_faces.dtype) or "float" in str(surf_map_faces.dtype)):
+                raise ValueError('Array computed with the custom function from avg_method should be an array of numbers (int or float)')
+
         else:
             raise ValueError(f"avg_method should be either ['mean', 'median', 'max', 'min'] or a custom function")
 

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -281,8 +281,13 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
             surf_map_faces = np.min(surf_map_data[faces], axis=1)
         elif avg_method == 'max':
             surf_map_faces = np.max(surf_map_data[faces], axis=1)
-        elif avg_method is not None:
+        elif callable(avg_method):
             surf_map_faces = np.apply_along_axis(avg_method, 1, surf_map_data[faces])
+            ## check that surf_map_faces has the same length as face_colors
+            if surf_map_faces.shape != (face_colors.shape[0],):
+                raise ValueError(f'Array computed with the custom function from avg_method does not have the correct shape: {surf_map_faces.shape[0]} != {face_colors.shape[0]}')
+        else:
+            raise ValueError(f"avg_method should be either ['mean', 'median', 'max', 'min'] or a custom function")
 
         # if no vmin/vmax are passed figure them out from data
         if vmin is None:

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -72,9 +72,16 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
     colorbar : bool, optional
         If True, a colorbar of surf_map is displayed. Default=False.
 
-    avg_method : {'mean', 'median', 'min', 'max'}, optional
+    avg_method : {'mean', 'median', 'min', 'max', custom function}, optional
         How to average vertex values to derive the face value, mean results
-        in smooth, median in sharp boundaries. Default='mean'.
+        in smooth, median in sharp boundaries, min or max for sparse matrices.
+        You can also pass a custom function which will be executed though `numpy.apply_along_axis`. Here is an example of a custom function:
+        ```
+        def custom_function(vertices):
+            "Assigns the value of each face of the mesh depending on the values of all vertices of the face."
+            return vertices[0] * vertices[1] * vertices[2]
+        ```.
+        Default='mean'.
 
     threshold : a number or None, default is None.
         If None is given, the image is not thresholded.
@@ -274,6 +281,8 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
             surf_map_faces = np.min(surf_map_data[faces], axis=1)
         elif avg_method == 'max':
             surf_map_faces = np.max(surf_map_data[faces], axis=1)
+        elif avg_method is not None:
+            surf_map_faces = np.apply_along_axis(avg_method, 1, surf_map_data[faces])
 
         # if no vmin/vmax are passed figure them out from data
         if vmin is None:

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -73,12 +73,14 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
         If True, a colorbar of surf_map is displayed. Default=False.
 
     avg_method : {'mean', 'median', 'min', 'max', custom function}, optional
-        How to average vertex values to derive the face value, mean results
-        in smooth, median in sharp boundaries, min or max for sparse matrices.
-        You can also pass a custom function which will be executed though `numpy.apply_along_axis`. Here is an example of a custom function:
+        How to average vertex values to derive the face value,
+        mean results in smooth, median in sharp boundaries,
+        min or max for sparse matrices.
+        You can also pass a custom function which will be
+        executed though `numpy.apply_along_axis`.
+        Here is an example of a custom function:
         ```
         def custom_function(vertices):
-            "Assigns the value of each face of the mesh depending on the values of all vertices of the face."
             return vertices[0] * vertices[1] * vertices[2]
         ```.
         Default='mean'.

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -282,24 +282,38 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
         elif avg_method == 'max':
             surf_map_faces = np.max(surf_map_data[faces], axis=1)
         elif callable(avg_method):
-            surf_map_faces = np.apply_along_axis(avg_method, 1, surf_map_data[faces])
+            surf_map_faces = np.apply_along_axis(
+                avg_method, 1, surf_map_data[faces]
+            )
 
             ## check that surf_map_faces has the same length as face_colors
             if surf_map_faces.shape != (face_colors.shape[0],):
-                raise ValueError('Array computed with the custom function '
-                'from avg_method does not have the correct shape: '
-                '{} != {}'.format(surf_map_faces.shape[0], face_colors.shape[0])
+                raise ValueError(
+                    'Array computed with the custom function '
+                    'from avg_method does not have the correct shape: '
+                    '{} != {}'.format(
+                        surf_map_faces.shape[0],
+                        face_colors.shape[0]
+                    )
                 )
 
             ## check that dtype is either int or float
-            if not ("int" in str(surf_map_faces.dtype) or "float" in str(surf_map_faces.dtype)):
-                raise ValueError('Array computed with the custom function '
-                'from avg_method should be an array of numbers (int or float)')
+            if not (
+                "int" in str(surf_map_faces.dtype) or
+                "float" in str(surf_map_faces.dtype)
+            ):
+                raise ValueError(
+                    'Array computed with the custom function '
+                    'from avg_method should be an array of numbers '
+                    '(int or float)'
+                )
 
         else:
-            raise ValueError("avg_method should be either "
-            "['mean', 'median', 'max', 'min'] "
-            "or a custom function")
+            raise ValueError(
+                "avg_method should be either "
+                "['mean', 'median', 'max', 'min'] "
+                "or a custom function"
+            )
 
         # if no vmin/vmax are passed figure them out from data
         if vmin is None:

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -283,9 +283,12 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
             surf_map_faces = np.max(surf_map_data[faces], axis=1)
         elif callable(avg_method):
             surf_map_faces = np.apply_along_axis(avg_method, 1, surf_map_data[faces])
+
             ## check that surf_map_faces has the same length as face_colors
             if surf_map_faces.shape != (face_colors.shape[0],):
-                raise ValueError(f'Array computed with the custom function from avg_method does not have the correct shape: {surf_map_faces.shape[0]} != {face_colors.shape[0]}')
+                raise ValueError('Array computed with the custom function from avg_method does not have the correct shape: {} != {}'.format(surf_map_faces.shape[0], face_colors.shape[0])
+                )
+
         else:
             raise ValueError(f"avg_method should be either ['mean', 'median', 'max', 'min'] or a custom function")
 

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -118,6 +118,14 @@ def test_plot_surf_error():
 
         plot_surf(mesh, surf_map=rng.standard_normal(size=mesh[0].shape[0]), avg_method=custom_avg_function)
 
+    with pytest.raises(
+        ValueError, match=re.escape("Array computed with the custom function from avg_method should be an array of numbers (int or float)")
+    ):
+        def custom_avg_function(vertices):
+            return "string"
+
+        plot_surf(mesh, surf_map=rng.standard_normal(size=mesh[0].shape[0]), avg_method=custom_avg_function)
+
 def test_plot_surf_stat_map():
     mesh = generate_surf()
     rng = np.random.RandomState(42)

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -60,13 +60,19 @@ def test_plot_surf():
         agg_faces -= vmin
         agg_faces /= (vmax - vmin)
         cmap = plt.cm.get_cmap(plt.rcParamsDefault['image.cmap'])
-        assert_array_equal(cmap(agg_faces),
-                           display._axstack.as_list()[0].collections[0]._facecolors)
+        assert_array_equal(
+            cmap(agg_faces),
+            display._axstack.as_list()[0].collections[0]._facecolors
+        )
 
     ## Try custom avg_method
     def custom_avg_function(vertices):
         return vertices[0] * vertices[1] * vertices[2]
-    plot_surf(mesh, surf_map=rng.standard_normal(size=mesh[0].shape[0]), avg_method=custom_avg_function)
+    plot_surf(
+        mesh,
+        surf_map=rng.standard_normal(size=mesh[0].shape[0]),
+        avg_method=custom_avg_function
+    )
 
     # Save execution time and memory
     plt.close()
@@ -104,7 +110,12 @@ def test_plot_surf_error():
         )
 
     with pytest.raises(
-        ValueError, match="Array computed with the custom function from avg_method does not have the correct shape"
+        ValueError,
+        match=(
+            "Array computed with the custom "
+            "function from avg_method does "
+            "not have the correct shape"
+        )
     ):
         def custom_avg_function(vertices):
             return [vertices[0] * vertices[1], vertices[2]]
@@ -112,14 +123,24 @@ def test_plot_surf_error():
         plot_surf(mesh, surf_map=rng.standard_normal(size=mesh[0].shape[0]), avg_method=custom_avg_function)
 
     with pytest.raises(
-        ValueError, match=re.escape("avg_method should be either ['mean', 'median', 'max', 'min'] or a custom function")
+        ValueError,
+        match=re.escape(
+            "avg_method should be either "
+            "['mean', 'median', 'max', 'min'] "
+            "or a custom function"
+        )
     ):
         custom_avg_function = dict()
 
         plot_surf(mesh, surf_map=rng.standard_normal(size=mesh[0].shape[0]), avg_method=custom_avg_function)
 
     with pytest.raises(
-        ValueError, match=re.escape("Array computed with the custom function from avg_method should be an array of numbers (int or float)")
+        ValueError,
+        match=re.escape(
+            "Array computed with the custom function "
+            "from avg_method should be an array of "
+            "numbers (int or float)"
+        )
     ):
         def custom_avg_function(vertices):
             return "string"

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -36,6 +36,14 @@ def test_plot_surf():
     plot_surf(mesh, bg_map=bg, colorbar=True, cbar_vmin=0,
               cbar_vmax=150, cbar_tick_format="%i")
 
+    # Plot with avg_method
+    plot_surf(mesh, surf_map=rng.standard_normal(size=mesh[0].shape[0]), avg_method='mean')
+    plot_surf(mesh, surf_map=rng.standard_normal(size=mesh[0].shape[0]), avg_method='min')
+    ## Try custom avg_method
+    def custom_avg_function(vertices):
+        return vertices[0] * vertices[1] * vertices[2]
+    plot_surf(mesh, surf_map=rng.standard_normal(size=mesh[0].shape[0]), avg_method=custom_avg_function)
+
     # Save execution time and memory
     plt.close()
 


### PR DESCRIPTION
This PR closes #2790.

So far, this PR adds 2 possible entries for the `avg_method` argument in `plotting.plot_surf`: `min` and `max`.
We are still considering adding the possibility to pass a custom aggregation function for `avg_method`.
