### PR TITLE
First Level get_voxelwise_model_attribute should return as many elements as # design matrices

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,6 +11,9 @@ Fixes
   in :func:`nilearn.signal.clean`, so that these operations are applied
   in the same order as for the signals, i.e., first detrending and
   then temporal filtering (https://github.com/nilearn/nilearn/issues/2730).
+- Fix number of attributes returned by the
+  :func:`nilearn.glm.first_level.FirstLevelModel._get_voxelwise_model_attribute` method in the first level model.
+  It used to return only the first attribute, and now returns as many attributes as design matrices.
 
 
 Enhancements

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -683,7 +683,7 @@ class FirstLevelModel(BaseGLM):
 
             output.append(self.masker_.inverse_transform(voxelwise_attribute))
 
-            return output
+        return output
 
     @auto_attr
     def residuals(self):


### PR DESCRIPTION
Closes #2772 


Fixed indentations in `_get_voxelwise_model_attribute` to return as many attributes as design matrices. Added test with either 1 or 2 design matrices to make sure it's working fine.