### PR TITLE
[DOC] Mention vol_to_surf in plot_surf* function docstrings

### DIFF
--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -144,6 +144,8 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
     nilearn.plotting.plot_surf_stat_map : for plotting statistical maps on
         brain surfaces.
 
+    nilearn.surface.vol_to_surf : For info on the generation of surfaces.
+
     """
     _default_figsize = [6, 4]
 
@@ -441,6 +443,8 @@ def plot_surf_contours(surf_mesh, roi_map, axes=None, figure=None, levels=None,
     nilearn.plotting.plot_surf_stat_map : for plotting statistical maps on
         brain surfaces.
 
+    nilearn.surface.vol_to_surf : For info on the generation of surfaces.
+
     """
     if figure is None and axes is None:
         figure = plot_surf(surf_mesh, **kwargs)
@@ -612,6 +616,8 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
         used as background map for this plotting function.
 
     nilearn.plotting.plot_surf: For brain surface visualization.
+
+    nilearn.surface.vol_to_surf : For info on the generation of surfaces.
 
     """
     loaded_stat_map = load_surf_data(stat_map)
@@ -966,6 +972,8 @@ def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
         used as background map for this plotting function.
 
     nilearn.plotting.plot_surf: For brain surface visualization.
+
+    nilearn.surface.vol_to_surf : For info on the generation of surfaces.
 
     """
     # preload roi and mesh to determine vmin, vmax and give more useful error


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #1755 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- To the docstrings of a few functions that plot surface images, links have been added to `nilearn.surface.vol_to_surf`
