### PR TITLE
[WIP] incorporating `pathlib` in `image.load_img` by extracting string from `pathlib` oject

### DIFF
--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -248,35 +248,12 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False, dtype=None,
     """
     from ..image import new_img_like  # avoid circular imports
 
-    if isinstance(niimg, str):
-        if wildcards and ni.EXPAND_PATH_WILDCARDS:
-            # Ascending sorting + expand user path
-            filenames = sorted(glob.glob(os.path.expanduser(niimg)))
-
-            # processing filenames matching globbing expression
-            if len(filenames) >= 1 and glob.has_magic(niimg):
-                niimg = filenames  # iterable case
-            # niimg is an existing filename
-            elif [niimg] == filenames:
-                niimg = filenames[0]
-            # No files found by glob
-            elif glob.has_magic(niimg):
-                # No files matching the glob expression, warn the user
-                message = ("No files matching the entered niimg expression: "
-                            "'%s'.\n You may have left wildcards usage "
-                           "activated: please set the global constant "
-                           "'nilearn.EXPAND_PATH_WILDCARDS' to False to "
-                           "deactivate this behavior.") % niimg
-                raise ValueError(message)
-            else:
-                raise ValueError("File not found: '%s'" % niimg)
-        elif not os.path.exists(niimg):
-            raise ValueError("File not found: '%s'" % niimg)
-    
     if isinstance(niimg, pathlib.Path):
         # get the string from pathlib object
         # and then process like a normal string
         niimg = niimg.absolute().as_posix()
+
+    if isinstance(niimg, str):
         if wildcards and ni.EXPAND_PATH_WILDCARDS:
             # Ascending sorting + expand user path
             filenames = sorted(glob.glob(os.path.expanduser(niimg)))

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -10,6 +10,7 @@ import nibabel
 from nibabel import Nifti1Image
 import numpy as np
 import pytest
+import pathlib
 
 from numpy.testing import assert_array_equal, assert_allclose
 from nilearn._utils.exceptions import DimensionError

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -26,6 +26,7 @@ from nilearn.image import iter_img, index_img
 from nilearn.image import math_img
 from nilearn.image import largest_connected_component_img
 from nilearn.image import get_data
+from nilearn.image import load_img
 
 try:
     import pandas as pd
@@ -36,7 +37,6 @@ X64 = (platform.architecture()[0] == '64bit')
 
 currdir = os.path.dirname(os.path.abspath(__file__))
 datadir = os.path.join(currdir, 'data')
-
 
 def test_get_data():
     img, *_ = data_gen.generate_fake_fmri(shape=(10, 11, 12))


### PR DESCRIPTION

<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
WIP for  #2642.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- `pathlib` object supported as an argument in `image.load_image`
