### PR TITLE
WIP: Pass through vol_to_surf_kwargs

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -20,6 +20,11 @@ Enhancements
 ------------
 
 - :func:`nilearn.plotting.view_markers` now accept an optional argument `marker_labels` to provide labels to each marker.
+- :func:`nilearn.plotting.view_img_on_surf` can now optionally pass through
+  parameters to :func:`nilearn.surface.vol_to_surf` using the
+  `vol_to_surf_kwargs` argument. One application is better HTML visualization of
+  atlases.
+  (http://nilearn.github.io/auto_examples/01_plotting/plot_3d_map_to_surface_projection.html)
 
 .. _v0.7.1:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,7 +24,7 @@ Enhancements
   parameters to :func:`nilearn.surface.vol_to_surf` using the
   `vol_to_surf_kwargs` argument. One application is better HTML visualization of
   atlases.
-  (http://nilearn.github.io/auto_examples/01_plotting/plot_3d_map_to_surface_projection.html)
+  (https://nilearn.github.io/auto_examples/01_plotting/plot_3d_map_to_surface_projection.html)
 
 .. _v0.7.1:
 

--- a/examples/01_plotting/plot_3d_map_to_surface_projection.py
+++ b/examples/01_plotting/plot_3d_map_to_surface_projection.py
@@ -148,3 +148,24 @@ view = plotting.view_img_on_surf(stat_img, threshold='90%')
 # view.open_in_browser()
 
 view
+
+##############################################################################
+# Impact of plot parameters on visualization
+# ------------------------------------------
+# You can specify arguments to be passed on to the function
+# :func:`nilearn.plotting.vol_to_surf` using `vol_to_surf_kwargs`. This allows
+# fine-grained control of how the input 3D image is resampled and interpolated -
+# for example if you are viewing a volumetric atlas, using nearest-neighbor
+# interpolation will produce a plot with discrete regions.
+
+destrieux = datasets.fetch_atlas_destrieux_2009()
+
+view = plotting.view_img_on_surf(
+    destrieux.maps,
+    surf_mesh="fsaverage",
+    vol_to_surf_kwargs={"n_samples": 1, "radius": 0.0, "interpolation": "nearest"},
+    symmetric_cmap=False,
+)
+
+# view.open_in_browser()
+view

--- a/examples/01_plotting/plot_3d_map_to_surface_projection.py
+++ b/examples/01_plotting/plot_3d_map_to_surface_projection.py
@@ -155,8 +155,9 @@ view
 # You can specify arguments to be passed on to the function
 # :func:`nilearn.plotting.vol_to_surf` using `vol_to_surf_kwargs`. This allows
 # fine-grained control of how the input 3D image is resampled and interpolated -
-# for example if you are viewing a volumetric atlas, using nearest-neighbor
-# interpolation will produce a plot with discrete regions.
+# for example if you are viewing a volumetric atlas, you would want to avoid
+# averaging the labels between neighboring regions. Using nearest-neighbor
+# interpolation with zero radius will achieve this.
 
 destrieux = datasets.fetch_atlas_destrieux_2009()
 

--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -192,6 +192,11 @@ def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
     title_fontsize : int, optional
         Fontsize of the title. Default=25.
 
+    vol_to_surf_kwargs : dict, optional
+        Dictionary of keyword arguments that are passed on to
+        :func:`nilearn.surface.vol_to_surf` when extracting a surface from
+        the input image. See the function documentation for details.
+
     Returns
     -------
     SurfaceView : plot of the stat map.

--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -129,7 +129,7 @@ def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
                      threshold=None, cmap=cm.cold_hot,
                      black_bg=False, vmax=None, vmin=None, symmetric_cmap=True,
                      colorbar=True, colorbar_height=.5, colorbar_fontsize=25,
-                     title=None, title_fontsize=25):
+                     title=None, title_fontsize=25, vol_to_surf_kwargs={}):
     """Insert a surface plot of a statistical map into an HTML page.
 
     Parameters
@@ -211,7 +211,7 @@ def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
     info = full_brain_info(
         volume_img=stat_map_img, mesh=surf_mesh, threshold=threshold,
         cmap=cmap, black_bg=black_bg, vmax=vmax, vmin=vmin,
-        symmetric_cmap=symmetric_cmap)
+        symmetric_cmap=symmetric_cmap, vol_to_surf_kwargs=vol_to_surf_kwargs)
     info['colorbar'] = colorbar
     info['cbar_height'] = colorbar_height
     info['cbar_fontsize'] = colorbar_fontsize

--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -195,7 +195,9 @@ def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
     vol_to_surf_kwargs : dict, optional
         Dictionary of keyword arguments that are passed on to
         :func:`nilearn.surface.vol_to_surf` when extracting a surface from
-        the input image. See the function documentation for details.
+        the input image. See the function documentation for details.This
+        parameter is especially useful when plotting an atlas. See
+        https://nilearn.github.io/auto_examples/01_plotting/plot_3d_map_to_surface_projection.html
 
     Returns
     -------

--- a/nilearn/plotting/tests/test_html_surface.py
+++ b/nilearn/plotting/tests/test_html_surface.py
@@ -159,3 +159,9 @@ def test_view_img_on_surf():
     np.clip(get_data(img), 0, None, out=get_data(img))
     html = html_surface.view_img_on_surf(img, symmetric_cmap=False)
     check_html(html)
+    html = html_surface.view_img_on_surf(img, symmetric_cmap=False,
+                                         vol_to_surf_kwargs={
+                                             "n_samples": 1,
+                                             "radius": 0.,
+                                             "interpolation": "nearest"})
+    check_html(html)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

See here for more information on what is expected for pull requests:
https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #2180  .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Added an optional parameter `vol_to_surf_kwargs` to `view_img_on_surf` and pass this through to `full_brain_info`.
