### PR TITLE
[DOC] Convert references in nilearn/connectome to bibtex format

### DIFF
--- a/doc/references.bib
+++ b/doc/references.bib
@@ -12,6 +12,49 @@ keywords = {Brain imaging atlases, Functional networks, Functional parcellations
 abstract = {Population imaging markedly increased the size of functional-imaging datasets, shedding new light on the neural basis of inter-individual differences. Analyzing these large data entails new scalability challenges, computational and statistical. For this reason, brain images are typically summarized in a few signals, for instance reducing voxel-level measures with brain atlases or functional modes. A good choice of the corresponding brain networks is important, as most data analyses start from these reduced signals. We contribute finely-resolved atlases of functional modes, comprising from 64 to 1024 networks. These dictionaries of functional modes (DiFuMo) are trained on millions of fMRI functional brain volumes of total size 2.4 ​TB, spanned over 27 studies and many research groups. We demonstrate the benefits of extracting reduced signals on our fine-grain atlases for many classic functional data analysis pipelines: stimuli decoding from 12,334 brain responses, standard GLM analysis of fMRI across sessions and individuals, extraction of resting-state functional-connectomes biomarkers for 2500 individuals, data compression and meta-analysis over more than 15,000 statistical maps. In each of these analysis scenarii, we compare the performance of our functional atlases with that of other popular references, and to a simple voxel-level analysis. Results highlight the importance of using high-dimensional “soft” functional atlases, to represent and analyze brain activity while capturing its functional gradients. Analyses on high-dimensional modes achieve similar statistical performance as at the voxel level, but with much reduced computational cost and higher interpretability. In addition to making them available, we provide meaningful names for these modes, based on their anatomical location. It will facilitate reporting of results.}
 }
 
+@article{Duchi2012,
+title = {Projected subgradient methods for learning sparse gaussians},
+author = {Duchi, John and Gould, Stephen and Koller, Daphne},
+year = {2012},
+month = jun,
+abstract = {Gaussian Markov random fields (GMRFs) are useful in a broad range of applications. In this paper we tackle the problem of learning a sparse GMRF in a high-dimensional space. Our approach uses the l1-norm as a regularization on the inverse covariance matrix. We utilize a novel projected gradient method, which is faster than previous methods in practice and equal to the best performing of these in asymptotic complexity. We also extend the l1-regularized objective to the problem of sparsifying entire blocks within the inverse covariance matrix. Our methods generalize fairly easily to this case, while other methods do not. We demonstrate that our extensions give better generalization performance on two real domains--biological network analysis and a 2D-shape modeling image task.},
+url = {https://arxiv.org/abs/1206.3249},
+archiveprefix = {arXiv},
+eprint = {1206.3249},
+eprinttype = {arxiv},
+journal = {arXiv:1206.3249 [cs, stat]},
+primaryclass = {cs, stat}
+}
+
+@article{Fletcher2007,
+title = {Riemannian geometry for the statistical analysis of diffusion tensor data},
+journal = {Signal Processing},
+volume = {87},
+number = {2},
+pages = {250-262},
+year = {2007},
+note = {Tensor Signal Processing},
+issn = {0165-1684},
+doi = {https://doi.org/10.1016/j.sigpro.2005.12.018},
+url = {https://www.sciencedirect.com/science/article/pii/S0165168406001691},
+author = {P. Thomas Fletcher and Sarang Joshi},
+keywords = {Diffusion tensor MRI, Statistics, Riemannian manifolds},
+abstract = {The tensors produced by diffusion tensor magnetic resonance imaging (DT-MRI) represent the covariance in a Brownian motion model of water diffusion. Under this physical interpretation, diffusion tensors are required to be symmetric, positive-definite. However, current approaches to statistical analysis of diffusion tensor data, which treat the tensors as linear entities, do not take this positive-definite constraint into account. This difficulty is due to the fact that the space of diffusion tensors does not form a vector space. In this paper we show that the space of diffusion tensors is a type of curved manifold known as a Riemannian symmetric space. We then develop methods for producing statistics, namely averages and modes of variation, in this space. We show that these statistics preserve natural geometric properties of the tensors, including the constraint that their eigenvalues be positive. The symmetric space formulation also leads to a natural definition for interpolation of diffusion tensors and a new measure of anisotropy. We expect that these methods will be useful in the registration of diffusion tensor images, the production of statistical atlases from diffusion tensor data, and the quantification of the anatomical variability caused by disease. The framework presented in this paper should also be useful in other applications where symmetric, positive-definite tensors arise, such as mechanics and computer vision.}
+}
+
+@article{Honorio2015,
+title = {On the statistical efficiency of l1,p multi-task learning of Gaussian graphical models},
+author = {Honorio, Jean and Jaakkola, Tommi and Samaras, Dimitris},
+year = {2015},
+month = oct,
+abstract = {In this paper, we present l1,p multi-task structure learning for Gaussian graphical models. We analyze the sufficient number of samples for the correct recovery of the support union and edge signs. We also analyze the necessary number of samples for any conceivable method by providing information-theoretic lower bounds. We compare the statistical efficiency of multi-task learning versus that of single-task learning. For experiments, we use a block coordinate descent method that is provably convergent and generates a sequence of positive definite solutions. We provide experimental validation on synthetic data as well as on two publicly available real-world data sets, including functional magnetic resonance imaging and gene expression data.},
+url = {https://arxiv.org/abs/1207.4255},
+archiveprefix = {arXiv},
+eprint = {1207.4255},
+eprinttype = {arxiv},
+journal = {arXiv:1207.4255 [cs, stat]},
+primaryclass = {cs, stat}
+}
 
 @article{Hoyos2019,
 author = {Hoyos-Idrobo, Andres and Varoquaux, Gael and Kahn, Jonas and Thirion, Bertrand},
@@ -92,3 +135,31 @@ author = {Jonathan D. Power},
 abstract = {This short “how to” article describes a plot I find useful for assessing fMRI data quality. I discuss the reasoning behind the plot and how it is constructed. I create the plot in scans from several publicly available datasets to illustrate different kinds of fMRI signal variance, ranging from thermal noise to motion artifacts to respiratory-related signals. I also show how the plot can be used to understand the variance removed during denoising. Code to make the plot is provided with the article, and supplemental movies show plots for hundreds of additional subjects.}
 }
 
+@article{Varoquaux2010a,
+title = {Brain covariance selection: Better individual functional connectivity models using population prior},
+author = {Varoquaux, Gael and Gramfort, Alexandre and Poline, Jean Baptiste and Thirion, Bertrand},
+year = {2010},
+month = nov,
+abstract = {Spontaneous brain activity, as observed in functional neuroimaging, has been shown to display reproducible structure that expresses brain architecture and carries markers of brain pathologies. An important view of modern neuroscience is that such large-scale structure of coherent activity reflects modularity properties of brain connectivity graphs. However, to date, there has been no demonstration that the limited and noisy data available in spontaneous activity observations could be used to learn full-brain probabilistic models that generalize to new data. Learning such models entails two main challenges: i) modeling full brain connectivity is a difficult estimation problem that faces the curse of dimensionality and ii) variability between subjects, coupled with the variability of functional signals between experimental runs, makes the use of multiple datasets challenging. We describe subject-level brain functional connectivity structure as a multivariate Gaussian process and introduce a new strategy to estimate it from group data, by imposing a common structure on the graphical model in the population. We show that individual models learned from functional Magnetic Resonance Imaging (fMRI) data using this population prior generalize better to unseen data than models based on alternative regularization schemes. To our knowledge, this is the first report of a cross-validated model of spontaneous brain activity. Finally, we use the estimated graphical model to explore the large-scale characteristics of functional architecture and show for the first time that known cognitive networks appear as the integrated communities of functional connectivity graph.},
+url = {https://arxiv.org/abs/1008.5071},
+archiveprefix = {arXiv},
+eprint = {1008.5071},
+eprinttype = {arxiv},
+journal = {arXiv:1008.5071 [q-bio, stat]},
+primaryclass = {q-bio, stat}
+}
+
+@inproceedings{Varoquaux2010b,
+title = {Detection of brain functional-connectivity difference in post-stroke patients using group-level covariance modeling},
+booktitle = {Medical image computing and computer-assisted intervention - {{MICCAI}} 2010},
+author = {Varoquaux, Gael and Baronnet, Flore and Kleinschmidt, Andreas and Fillard, Pierre and Thirion, Bertrand},
+editor = {Jiang, Tianzi and Navab, Nassir and Pluim, Josien P. W. and Viergever, Max A.},
+year = {2010},
+pages = {200--208},
+publisher = {{Springer}},
+address = {{Berlin, Heidelberg}},
+doi = {10/cn2h9c},
+abstract = {Functional brain connectivity, as revealed through distant correlations in the signals measured by functional Magnetic Resonance Imaging (fMRI), is a promising source of biomarkers of brain pathologies. However, establishing and using diagnostic markers requires probabilistic inter-subject comparisons. Principled comparison of functional-connectivity structures is still a challenging issue. We give a new matrix-variate probabilistic model suitable for inter-subject comparison of functional connectivity matrices on the manifold of Symmetric Positive Definite (SPD) matrices. We show that this model leads to a new algorithm for principled comparison of connectivity coefficients between pairs of regions. We apply this model to comparing separately post-stroke patients to a group of healthy controls. We find neurologically-relevant connection differences and show that our model is more sensitive that the standard procedure. To the best of our knowledge, these results are the first report of functional connectivity differences between a single-patient and a group and thus establish an important step toward using functional connectivity as a diagnostic tool.},
+isbn = {978-3-642-15705-9},
+series = {Lecture notes in computer science}
+}

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -107,12 +107,11 @@ def _geometric_mean(matrices, init=None, max_iter=10, tol=1e-7):
 
     In case of positive numbers, this mean is the usual geometric mean.
 
-    See Algorithm 3 of [1]_.
+    See Algorithm 3 of :footcite:`Fletcher2007`.
 
     References
     ----------
-    .. [1] P. Thomas Fletcher, Sarang Joshi. Riemannian Geometry for the
-       Statistical Analysis of Diffusion Tensor Data. Signal Processing, 2007.
+    .. footbibliography::
 
     Parameters
     ----------
@@ -406,7 +405,7 @@ class ConnectivityMeasure(BaseEstimator, TransformerMixin):
 
     kind : {"covariance", "correlation", "partial correlation",\
             "tangent", "precision"}, optional
-        The matrix kind. For the use of "tangent" see [1]_.
+        The matrix kind. For the use of "tangent" see :footcite:`Varoquaux2010b`.
         Default='covariance'.
 
     vectorize : bool, optional
@@ -435,8 +434,7 @@ class ConnectivityMeasure(BaseEstimator, TransformerMixin):
 
     References
     ----------
-    .. [1] G. Varoquaux et al. "Detection of brain functional-connectivity difference
-       in post-stroke patients using group-level covariance modeling, MICCAI 2010.
+    .. footbibliography::
 
     """
 

--- a/nilearn/connectome/group_sparse_cov.py
+++ b/nilearn/connectome/group_sparse_cov.py
@@ -34,7 +34,7 @@ def compute_alpha_max(emp_covs, n_samples):
     matrices are fully dense (i.e. minimal number of zero coefficients).
 
     The formula used in this function was derived using the same method
-    as in [1]_.
+    as in :footcite:`Duchi2012`.
 
     Parameters
     ----------
@@ -55,11 +55,9 @@ def compute_alpha_max(emp_covs, n_samples):
         minimal value for the regularization parameter that gives a fully
         dense matrix.
 
-    Reference
+    References
     ---------
-    .. [1] Duchi, John, Stephen Gould, and Daphne Koller. 'Projected Subgradient
-       Methods for Learning Sparse Gaussians'. ArXiv E-prints 1206 (1 June
-       2012): 3249.
+    .. footbibliography::
 
     """
     A = np.copy(emp_covs)
@@ -145,7 +143,7 @@ def group_sparse_covariance(subjects, alpha, max_iter=50, tol=1e-3, verbose=0,
     Running time is linear on max_iter, and number of subjects (len(subjects)),
     but cubic on number of features (subjects[0].shape[1]).
 
-    The present algorithm is based on [1]_.
+    The present algorithm is based on :footcite:`Honorio2015`.
 
     Parameters
     ----------
@@ -205,9 +203,7 @@ def group_sparse_covariance(subjects, alpha, max_iter=50, tol=1e-3, verbose=0,
 
     References
     ----------
-    .. [1] Jean Honorio and Dimitris Samaras, "Simultaneous and Group-Sparse
-       Multi-Task Learning of Gaussian Graphical Models". arXiv:1207.4255
-       (17 July 2012). http://arxiv.org/abs/1207.4255.
+    .. footbibliography::
 
     """
 
@@ -456,8 +452,8 @@ def _group_sparse_covariance(emp_covs, n_samples, alpha, max_iter=10, tol=1e-3,
 class GroupSparseCovariance(BaseEstimator, CacheMixin):
     """Covariance and precision matrix estimator.
 
-    The model used has been introduced in [1]_, and the algorithm used is
-    based on what is described in [2]_.
+    The model used has been introduced in :footcite:`Varoquaux2010a`, and the
+    algorithm used is based on what is described in :footcite:`Honorio2015`.
 
     Parameters
     ----------
@@ -497,12 +493,7 @@ class GroupSparseCovariance(BaseEstimator, CacheMixin):
 
     References
     ----------
-    .. [1] Gael Varoquaux, et al. `Brain Covariance Selection: Better Individual
-       Functional Connectivity Models Using Population Prior
-       <http://arxiv.org/abs/1008.5071>`_'.
-
-    .. [2] Jean Honorio and Dimitris Samaras, "Simultaneous and Group-Sparse
-       Multi-Task Learning of Gaussian Graphical Models". http://arxiv.org/abs/1207.4255.
+    .. footbibliography::
 
     """
 


### PR DESCRIPTION
Closes #2780

Changes proposed in this pull request:

- Converted the references in `nilearn/connectome/connectivity_matrices.py` and `nilearn/connectome/group_sparse_cov.py` to bibtex format and added them to `doc/references.bib`
