### PR TITLE
[DOC]: Fix Default's explication for fetchers

### DIFF
--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -50,8 +50,8 @@ def fetch_atlas_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True
         available are {2, 3}. Default=2mm.
 
     data_dir : string, optional
-        Path where data should be downloaded. By default,
-        files are downloaded in home directory.
+        Path where data should be downloaded. if None, files are downloaded 
+        in (nilearn_data) folder in the home directory.
 
     resume : bool, optional
         Whether to resumed download of a partly-downloaded file.
@@ -135,7 +135,8 @@ def fetch_atlas_craddock_2012(data_dir=None, url=None, resume=True, verbose=1):
     Parameters
     ----------
     data_dir : string, optional
-        Directory where data should be downloaded and unpacked.
+        Directory where data should be downloaded and unpacked. if None,
+        files are downloaded in (nilearn_data) folder in the home directory
 
     url : string, optional
         url of file to download.
@@ -209,7 +210,8 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
 
     data_dir : string, optional
         Path of the data directory. Use to forec data storage in a non-
-        standard location. Default: None (meaning: default)
+        standard location. if None, files are downloaded in (nilearn_data) 
+        folder in the home directory
 
     url : string, optional
         Download URL of the dataset. Overwrite the default URL.
@@ -297,7 +299,8 @@ def fetch_atlas_harvard_oxford(atlas_name, data_dir=None,
         Example, if FSL is installed in /usr/share/fsl/ then
         specifying as '/usr/share/' can get you Harvard Oxford atlas
         from your installed directory. Since we mimic same root directory
-        as FSL to load it easily from your installation.
+        as FSL to load it easily from your installation. if None,
+        files are downloaded in (nilearn_data) folder in the home directory
 
     symmetric_split : bool, optional
         If True, lateralized atlases of cort or sub with maxprob will be
@@ -436,7 +439,8 @@ def fetch_atlas_msdl(data_dir=None, url=None, resume=True, verbose=1):
     ----------
     data_dir : string, optional
         Path of the data directory. Used to force data storage in a specified
-        location. Default: None
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     url : string, optional
         Override download URL. Used for test only (or if you setup a mirror of
@@ -533,7 +537,8 @@ def fetch_atlas_smith_2009(data_dir=None, mirror='origin', url=None,
     ----------
     data_dir : string, optional
         Path of the data directory. Used to force data storage in a non-
-        standard location. Default: None (meaning: default)
+        standard location. if None, files are downloaded in (nilearn_data) 
+        folder in the home directory
 
     mirror : string, optional
         By default, the dataset is downloaded from the original website of the
@@ -641,7 +646,8 @@ def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
     Parameters
     ----------
     data_dir : string, optional
-        Directory where data should be downloaded and unpacked.
+        Directory where data should be downloaded and unpacked. if None,
+        files are downloaded in (nilearn_data) folder in the home directory
 
     url : string, optional
         Url of file to download.
@@ -732,7 +738,8 @@ def fetch_atlas_aal(version='SPM12', data_dir=None, url=None, resume=True,
         Default='SPM12'.
 
     data_dir : string, optional
-        Directory where data should be downloaded and unpacked.
+        Directory where data should be downloaded and unpacked. if None,
+        files are downloaded in (nilearn_data) folder in the home directory
 
     url : string, optional
         Url of file to download.
@@ -840,7 +847,8 @@ def fetch_atlas_basc_multiscale_2015(version='sym', data_dir=None, url=None,
         Default='sym'.
 
     data_dir : str, optional
-        Directory where data should be downloaded and unpacked.
+        Directory where data should be downloaded and unpacked. if None,
+        files are downloaded in (nilearn_data) folder in the home directory
 
     url : str, optional
         Url of file to download.
@@ -1047,7 +1055,8 @@ def fetch_atlas_allen_2011(data_dir=None, url=None, resume=True, verbose=1):
     Parameters
     ----------
     data_dir : str, optional
-        Directory where data should be downloaded and unpacked.
+        Directory where data should be downloaded and unpacked. if None,
+        files are downloaded in (nilearn_data) folder in the home directory
 
     url : str, optional
         Url of file to download.
@@ -1138,7 +1147,8 @@ def fetch_atlas_surf_destrieux(data_dir=None, url=None,
     ----------
     data_dir : str, optional
         Path of the data directory. Use to force data storage in a non-
-        standard location. Default: None
+        standard location. if None, files are downloaded in (nilearn_data) 
+        folder in the home directory
 
     url : str, optional
         Download URL of the dataset. Overwrite the default URL.
@@ -1313,7 +1323,8 @@ def fetch_atlas_talairach(level_name, data_dir=None, verbose=1):
 
     data_dir : str, optional
         Path of the data directory. Used to force data storage in a specified
-        location.
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     verbose : int, optional
         Verbosity level (0 means no message). Default=1.
@@ -1369,7 +1380,8 @@ def fetch_atlas_pauli_2017(version='prob', data_dir=None, verbose=1):
 
     data_dir : str, optional
         Path of the data directory. Used to force data storage in a specified
-        location.
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     verbose : int, optional
         Verbosity level (0 means no message). Default=1.
@@ -1453,7 +1465,8 @@ def fetch_atlas_schaefer_2018(n_rois=400, yeo_networks=7, resolution_mm=1,
         Default=1mm.
 
     data_dir : string, optional
-        Directory where data should be downloaded and unpacked.
+        Directory where data should be downloaded and unpacked. if None,
+        files are downloaded in (nilearn_data) folder in the home directory
 
     base_url : string, optional
         base_url of files to download (None results in default base_url).

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -35,7 +35,8 @@ def fetch_haxby(data_dir=None, subjects=(2,),
     ----------
     data_dir : string, optional
         Path of the data directory. Used to force data storage in a specified
-        location. Default: None
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     subjects : list or int, optional
         Either a list of subjects or the number of subjects to load, from 1 to
@@ -198,7 +199,8 @@ def fetch_nyu_rest(n_subjects=None, sessions=[1], data_dir=None, resume=True,
 
     data_dir : string, optional
         Path of the data directory. Used to force data storage in a specified
-        location. Default: None
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     resume : bool, optional
         Whether to resume download of a partly-downloaded file.
@@ -392,7 +394,8 @@ def fetch_adhd(n_subjects=30, data_dir=None, url=None, resume=True,
 
     data_dir : string, optional
         Path of the data directory. Used to force data storage in a specified
-        location. Default: None
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     url : string, optional
         Override download URL. Used for test only (or if you setup a mirror of
@@ -490,7 +493,8 @@ def fetch_miyawaki2008(data_dir=None, url=None, resume=True, verbose=1):
     ----------
     data_dir : string, optional
         Path of the data directory. Used to force data storage in a specified
-        location. Default: None
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     url : string, optional
         Override download URL. Used for test only (or if you setup a mirror of
@@ -747,7 +751,8 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
 
     data_dir : string, optional
         Path of the data directory. Used to force data storage in a specified
-        location.
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     url : string, optional
         Override download URL. Used for test only (or if you setup a mirror of
@@ -1009,7 +1014,8 @@ def fetch_localizer_calculation_task(n_subjects=1, data_dir=None, url=None,
 
     data_dir : string, optional
         Path of the data directory. Used to force data storage in a specified
-        location.
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     url : string, optional
         Override download URL. Used for test only (or if you setup a mirror of
@@ -1052,7 +1058,8 @@ def fetch_localizer_button_task(data_dir=None, url=None,
     ----------
     data_dir : string, optional
         Path of the data directory. Used to force data storage in a specified
-        location.
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     url : string, optional
         Override download URL. Used for test only (or if you setup a mirror of
@@ -1108,7 +1115,8 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
     ----------
     data_dir : string, optional
         Path of the data directory. Used to force data storage in a specified
-        location. Default: None
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     n_subjects : int, optional
         The number of subjects to load. If None is given,
@@ -1332,7 +1340,8 @@ def fetch_mixed_gambles(n_subjects=1, data_dir=None, url=None, resume=True,
 
     data_dir : string, optional
         Path of the data directory. Used to force data storage in a specified
-        location. Default: None.
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     url : string, optional
         Override download URL. Used for test only (or if you setup a mirror of
@@ -1429,7 +1438,8 @@ def fetch_megatrawls_netmats(dimensionality=100, timeseries='eigen_regression',
 
     data_dir : str, optional
         Path of the data directory. Used to force data storage in a specified
-        location.
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     resume : bool, optional
         This parameter is required if a partially downloaded file is needed
@@ -1568,7 +1578,8 @@ def fetch_cobre(n_subjects=10, data_dir=None, url=None, verbose=1):
 
     data_dir : str, optional
         Path to the data directory. Used to force data storage in a
-        specified location. Default: None
+        specified location. if None, files are downloaded in (nilearn_data) 
+        folder in the home directory
 
     url : str, optional
         Override download url. Used for test only (or if you setup a
@@ -1720,7 +1731,8 @@ def fetch_surf_nki_enhanced(n_subjects=10, data_dir=None,
 
     data_dir : str, optional
         Path of the data directory. Used to force data storage in a specified
-        location. Default: None
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     url : str, optional
         Override download URL. Used for test only (or if you setup a mirror of
@@ -1856,7 +1868,8 @@ def _fetch_development_fmri_participants(data_dir, url, verbose):
     ----------
     data_dir : str
         Path of the data directory. Used to force data storage in a specified
-        location. If None is given, data are stored in home directory.
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     url : str
         Override download URL. Used for test only (or if you setup a mirror of
@@ -2188,8 +2201,8 @@ def fetch_language_localizer_demo_dataset(data_dir=None, verbose=1):
     Parameters
     ----------
     data_dir : string, optional
-        Path to store the downloaded dataset. if None employ nilearn
-        datasets default download directory.
+        Path to store the downloaded dataset. if None, files are downloaded 
+        in (nilearn_data) folder in the home directory
 
     verbose : int, optional
         Verbosity level (0 means no message). Default=1.
@@ -2230,8 +2243,8 @@ def fetch_bids_langloc_dataset(data_dir=None, verbose=1):
     Parameters
     ----------
     data_dir : string, optional
-        Path to store the downloaded dataset. if None employ nilearn
-        datasets default download directory.
+        Path to store the downloaded dataset. if None, files are downloaded 
+        in (nilearn_data) folder in the home directory
 
     verbose : int, optional
         Verbosity level (0 means no message). Default=1.
@@ -2273,8 +2286,8 @@ def fetch_openneuro_dataset_index(data_dir=None,
     Parameters
     ----------
     data_dir : string, optional
-        Path to store the downloaded dataset. if None employ nilearn
-        datasets default download directory.
+        Path to store the downloaded dataset. if None, files are downloaded 
+        in (nilearn_data) folder in the home directory
 
     dataset_version : string, optional
         Dataset version name. Assumes it is of the form [name]_[version].
@@ -2419,8 +2432,8 @@ def fetch_openneuro_dataset(
         all files of the specified dataset will be downloaded.
 
     data_dir : string, optional
-        Path to store the downloaded dataset. if None employ nilearn
-        datasets default download directory.
+        Path to store the downloaded dataset. if None, files are downloaded 
+        in (nilearn_data) folder in the home directory
 
     dataset_version : string, optional
         Dataset version name. Assumes it is of the form [name]_[version].
@@ -2486,7 +2499,8 @@ def fetch_localizer_first_level(data_dir=None, verbose=1):
     Parameters
     ----------
     data_dir : string
-        Directory where data should be downloaded and unpacked.
+        Directory where data should be downloaded and unpacked. if None,
+        files are downloaded in (nilearn_data) folder in the home directory
 
     verbose : int, optional
         Verbosity level (0 means no message). Default=1.
@@ -2644,7 +2658,8 @@ def fetch_spm_auditory(data_dir=None, data_name='spm_auditory',
     data_dir : string, optional.
         Path of the data directory. Used to force data storage in a specified
         location. If the data is already present there, then will simply
-        glob it.
+        glob it. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     data_name : string, optional
         Name of the dataset. Default='spm_auditory'.
@@ -2823,7 +2838,8 @@ def fetch_spm_multimodal_fmri(data_dir=None, data_name='spm_multimodal_fmri',
     ----------
     data_dir : string, optional.
         Path of the data directory. Used to force data storage in a specified
-        location. If the data is already present there, then will simply glob it.
+        location. If the data is already present there, then will simply glob it. if None,
+        files are downloaded in (nilearn_data) folder in the home directory
 
     data_name : string, optional
         Name of the dataset. Default='spm_multimodal_fmri'.
@@ -2867,7 +2883,8 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
     Parameters
     ----------
     data_dir : string, optional
-        Directory where data should be downloaded and unpacked.
+        Directory where data should be downloaded and unpacked. if None,
+        files are downloaded in (nilearn_data) folder in the home directory
 
     verbose : int, optional
         Verbosity level (0 means no message). Default=1.

--- a/nilearn/datasets/struct.py
+++ b/nilearn/datasets/struct.py
@@ -31,7 +31,8 @@ def fetch_icbm152_2009(data_dir=None, url=None, resume=True, verbose=1):
     ----------
     data_dir : string, optional
         Path of the data directory. Used to force data storage in a non-
-        standard location. Default: None (meaning: default)
+        standard location. if None, files are downloaded in (nilearn_data) 
+        folder in the home directory.
 
     url : string, optional
         Download URL of the dataset. Overwrite the default URL.
@@ -179,7 +180,8 @@ def fetch_icbm152_brain_gm_mask(data_dir=None, threshold=0.2, resume=True,
     ----------
     data_dir : str, optional
         Path of the data directory. Used to force storage in a specified
-        location. Defaults to None.
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory
 
     threshold : float, optional
         The parameter which amounts to include the values in the mask image.
@@ -249,7 +251,8 @@ def fetch_oasis_vbm(n_subjects=None, dartel_version=True, data_dir=None,
 
     data_dir : string, optional
         Path of the data directory. Used to force data storage in a specified
-        location. Default: None
+        location. if None, files are downloaded in (nilearn_data) folder 
+        in the home directory.
 
     url : string, optional
         Override download URL. Used for test only (or if you setup a mirror of
@@ -465,7 +468,7 @@ def fetch_surf_fsaverage(mesh='fsaverage5', data_dir=None):
 
     data_dir : str, optional
         Path of the data directory. Used to force data storage in a specified
-        location.
+        location. if None, files are downloaded in (nilearn_data) folder in the home directory
 
     Returns
     -------


### PR DESCRIPTION
This PR tackles the explication of the ```default``` value of ```data_dir``` in the datasets fetchers:
Closes #2041 
