### PR TITLE
Add issue assignment action

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,3 +1,6 @@
+# Source: Scikit-learn
+# See: https://github.com/scikit-learn/scikit-learn/blob/main/.github/workflows/assign.yml
+
 name: Assign
 on:
   issue_comment:

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,18 @@
+name: Assign
+on:
+  issue_comment:
+    types: created
+
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event.comment.body == 'take' ||
+       github.event.comment.body == 'Take')
+      && !github.event.issue.assignee
+    steps:
+      - run: |
+          echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X "DELETE" https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/help%20wanted
+

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,6 +12,7 @@ The best way to contribute and to help the project is to start working on known
 issues.
 See `Good first issues <https://github.com/nilearn/nilearn/labels/Good%20first%20issue>`_ to get
 started.
+If the issue is not already assigned to someone, you can request it by commenting "take". This will automatically assign you the issue.
 
 If an issue does not already exist for a potential contribution, we ask that
 you first open an `issue <https://github.com/nilearn/nilearn/issues>`_ before


### PR DESCRIPTION
Fixes #2794 

This PR proposes to use a github action to assign issues automatically when commenting "take" on them. It also removes the label "help wanted" in case it was associated to the issue.
This comes from scikit-learn so I can add a comment citing the source at the beginning of the file if we decide to use it.