### PR TITLE
[MAINT] Restrict data caching to full builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,6 +301,11 @@ jobs:
           paths:
               - html
               - html_stable
+      - run: |
+          if [[ "$(cat build.txt)" != "html-strict" ]]; then
+                echo "Partial build : No caching of data will be done!";
+                circleci-agent step halt
+          fi
       - save_data_cache
 
 workflows:


### PR DESCRIPTION
See #2846 

On circleCI, partial builds can cache data although they usually have only partial data. 
This PR aims at restricting the data caching to full builds only.