### PR TITLE
[MAINT] Run tests, doctests, and flake8 diff in their own steps

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,8 +33,6 @@ jobs:
         shell: bash
     env:
         MIN_REQUIREMENTS: true
-        FLAKE8: true
-        TEST_DOC: false
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -51,8 +49,14 @@ jobs:
         run: ./build_tools/github/install.sh
         name: 'Install nilearn'
       - shell: bash -l {0}
+        run: ./build_tools/github/test_docs.sh
+        name: 'Run doctests'
+      - shell: bash -l {0}
         run: ./build_tools/github/test.sh
         name: 'Run tests'
+      - shell: bash -l {0}
+        run: ./build_tools/flake8_diff.sh
+        name: 'Run flake8 diff'
       - uses: codecov/codecov-action@v1
         if: success()
         name: 'Upload coverage to CodeCov'
@@ -70,8 +74,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-        TEST_DOC: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -87,6 +89,9 @@ jobs:
       - shell: bash {0}
         run: ./build_tools/github/install.sh
         name: 'Install nilearn'
+      - shell: bash {0}
+        run: ./build_tools/github/test_docs.sh
+        name: 'Run doctests'
       - shell: bash {0}
         run: ./build_tools/github/test.sh
         name: 'Run tests'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -49,9 +49,6 @@ jobs:
         run: ./build_tools/github/install.sh
         name: 'Install nilearn'
       - shell: bash -l {0}
-        run: ./build_tools/github/test_docs.sh
-        name: 'Run doctests'
-      - shell: bash -l {0}
         run: ./build_tools/github/test.sh
         name: 'Run tests'
       - shell: bash -l {0}

--- a/build_tools/github/dependencies.sh
+++ b/build_tools/github/dependencies.sh
@@ -1,13 +1,8 @@
 #!/bin/bash -e
 
-python -m pip install --progress-bar off --upgrade pip setuptools wheel
+python -m pip install --progress-bar off --upgrade pip setuptools wheel flake8
 if [ ! -z "$MIN_REQUIREMENTS" ]; then
     pip install --progress-bar off --upgrade -r requirements-min.txt
 else
     pip install --progress-bar off --upgrade -r requirements-dev.txt
-fi
-
-if [[ -n "$FLAKE8" ]]; then
-    echo "Installing Flake8";
-    pip install flake8
 fi

--- a/build_tools/github/test.sh
+++ b/build_tools/github/test.sh
@@ -1,13 +1,3 @@
 #!/bin/bash -x
 
-if [[ -n "$FLAKE8" ]]; then
-    echo "Running flake8 diff script...";
-    source build_tools/flake8_diff.sh
-fi
-
 python -m pytest --pyargs nilearn --cov=nilearn
-
-if [[ $TEST_DOC == true ]]; then
-    echo "Running make test-doc...";
-    make test-doc
-fi

--- a/build_tools/github/test_docs.sh
+++ b/build_tools/github/test_docs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -x
+
+echo "Running doctests...";
+make test-doc


### PR DESCRIPTION
Following PR #2848 this PR makes sure tests, doctests, and flake8 checks are run in separate steps of the workflows instead of running them in a single step and using environment variables to configure which scripts are run.

I realized that if you run, for example, tests and doctests in the same step and tests fail while doctests pass, you will get a :heavy_check_mark:  instead of a :x: next to the github action, which is very confusing... See for example [here](https://github.com/nilearn/nilearn/pull/2815/checks?check_run_id=2689751187)