### PR TITLE
Move `sample_mask` to `transform` method in maskers, handle `sample_mask` in `signal.clean`

### DIFF
--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -196,9 +196,9 @@ preparation::
          high_variance_confounds=False, low_pass=None, mask_args=None,
          mask_img=None, mask_strategy='background',
          memory=Memory(location=None), memory_level=1, reports=True,
-         sample_mask=None, sessions=None, smoothing_fwhm=None,
-         standardize=False, standardize_confounds=True, t_r=None, 
-         target_affine=None, target_shape=None, verbose=0)
+         sessions=None, smoothing_fwhm=None, standardize=False,
+         standardize_confounds=True, t_r=None, target_affine=None,
+         target_shape=None, verbose=0)
 
 .. note::
 

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -196,8 +196,8 @@ preparation::
          high_variance_confounds=False, low_pass=None, mask_args=None,
          mask_img=None, mask_strategy='background',
          memory=Memory(location=None), memory_level=1, reports=True,
-         sample_mask=None, runs=None, smoothing_fwhm=None,
-         standardize=False,standardize_confounds=True, t_r=None,
+         runs=None, sample_mask=None, smoothing_fwhm=None,
+         standardize=False, standardize_confounds=True, t_r=None,
          target_affine=None, target_shape=None, verbose=0)
 
 .. note::

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -196,9 +196,9 @@ preparation::
          high_variance_confounds=False, low_pass=None, mask_args=None,
          mask_img=None, mask_strategy='background',
          memory=Memory(location=None), memory_level=1, reports=True,
-         sessions=None, smoothing_fwhm=None, standardize=False,
-         standardize_confounds=True, t_r=None, target_affine=None,
-         target_shape=None, verbose=0)
+         sample_mask=None, runs=None, smoothing_fwhm=None,
+         standardize=False,standardize_confounds=True, t_r=None,
+         target_affine=None, target_shape=None, verbose=0)
 
 .. note::
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -58,7 +58,7 @@ Enhancements
   deprecates attribute `sessions` in 0.9.0. Match the relevant change in
   :func:`nilearn.signal.clean`.
 - Moves parameter `sample_mask` from :class:`nilearn.input_data.NiftiMasker`
-  to method `transform` in base class :class:`nilearn.input_data.base_masker`.
+  to method `transform` in base class :class:`nilearn.input_data.BaseMasker`.
 
 .. _v0.7.1:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -5,11 +5,11 @@ NEW
 ---
 
 - :func:`nilearn.signal.clean` accepts new parameter `sample_mask`.
-  Masks the niimgs along time/fourth dimension to perform scrubbing (remove
-  volumes with high motion) and/or non-steady-state volumes. This masking step
-  is applied before signal cleaning.
   shape: (number of scans - number of volumes removed, )
-- All inheritent classes of :class:`nilearn.input_data.base_masker` can use
+  Masks the niimgs along time/fourth dimension to perform scrubbing (remove
+  volumes with high motion) and/or non-steady-state volumes. Masking is applied
+  before signal cleaning.
+- All inherent classes of :class:`nilearn.input_data.base_masker` can use
   parameter `sample_mask` for sub-sample masking.
 
 Fixes

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -8,7 +8,7 @@ NEW
   volumes with high motion) and/or non-steady-state volumes. This masking step
   is applied before signal cleaning.
   shape: (number of scans - number of volumes removed, )
-  - Moving parameter `sample_mask` from :class:`nilearn.input_data.NiftiMasker`
+- Moving parameter `sample_mask` from :class:`nilearn.input_data.NiftiMasker`
   to method `transform` in base class :class:`nilearn.input_data.base_masker`.
   All inheritent classes of :class:`nilearn.input_data.base_masker` can use
   parameter `sample_mask` for sub-sample masking.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -54,7 +54,7 @@ Enhancements
   'stratified' (https://github.com/nilearn/nilearn/pull/2826/).
 - :class:`nilearn.glm.first_level.run_glm` now allows auto regressive noise
   models of order greater than one.
-- :class:`nilearn.input_data.NiftiMasker` replace `sessions` with `runs` and
+- :class:`nilearn.input_data.NiftiMasker` replaces `sessions` with `runs` and
   deprecates attribute `sessions` in 0.9.0. Match the relevant change in
   :func:`nilearn.signal.clean`.
 - Moves parameter `sample_mask` from :class:`nilearn.input_data.NiftiMasker`

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -9,7 +9,7 @@ NEW
   Masks the niimgs along time/fourth dimension to perform scrubbing (remove
   volumes with high motion) and/or non-steady-state volumes. Masking is applied
   before signal cleaning.
-- All inherent classes of :class:`nilearn.input_data.BaseMasker` can use
+- All inherent classes of `nilearn.input_data.BaseMasker` can use
   parameter `sample_mask` for sub-sample masking.
 
 Fixes
@@ -58,7 +58,7 @@ Enhancements
   deprecates attribute `sessions` in 0.9.0. Match the relevant change in
   :func:`nilearn.signal.clean`.
 - Moves parameter `sample_mask` from :class:`nilearn.input_data.NiftiMasker`
-  to method `transform` in base class :class:`nilearn.input_data.BaseMasker`.
+  to method `transform` in base class `nilearn.input_data.BaseMasker`.
 
 .. _v0.7.1:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -52,7 +52,7 @@ Enhancements
   is applied before signal cleaning.
   shape: (number of scans - number of volumes removed, )
 - :class:`nilearn.input_data.NiftiMasker` replace `sessions` with `runs` and
-  depricates attribute `sessions` in 0.9.0. Match the relevant change in
+  deprecates attribute `sessions` in 0.9.0. Match the relevant change in
   :func:`nilearn.signal.clean`.
 - Moving parameter `sample_mask` from :class:`nilearn.input_data.NiftiMasker`
   to method `transform` in base class :class:`nilearn.input_data.base_masker`.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -3,14 +3,13 @@
 
 NEW
 ---
-- :func:`nilearn.signal.clean` accept new parameter `sample_mask`.
+
+- :func:`nilearn.signal.clean` accepts new parameter `sample_mask`.
   Masks the niimgs along time/fourth dimension to perform scrubbing (remove
   volumes with high motion) and/or non-steady-state volumes. This masking step
   is applied before signal cleaning.
   shape: (number of scans - number of volumes removed, )
-- Moving parameter `sample_mask` from :class:`nilearn.input_data.NiftiMasker`
-  to method `transform` in base class :class:`nilearn.input_data.base_masker`.
-  All inheritent classes of :class:`nilearn.input_data.base_masker` can use
+- All inheritent classes of :class:`nilearn.input_data.base_masker` can use
   parameter `sample_mask` for sub-sample masking.
 
 Fixes
@@ -58,6 +57,8 @@ Enhancements
 - :class:`nilearn.input_data.NiftiMasker` replace `sessions` with `runs` and
   deprecates attribute `sessions` in 0.9.0. Match the relevant change in
   :func:`nilearn.signal.clean`.
+- Moves parameter `sample_mask` from :class:`nilearn.input_data.NiftiMasker`
+  to method `transform` in base class :class:`nilearn.input_data.base_masker`.
 
 .. _v0.7.1:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -9,7 +9,7 @@ NEW
   Masks the niimgs along time/fourth dimension to perform scrubbing (remove
   volumes with high motion) and/or non-steady-state volumes. Masking is applied
   before signal cleaning.
-- All inherent classes of :class:`nilearn.input_data.base_masker` can use
+- All inherent classes of :class:`nilearn.input_data.BaseMasker` can use
   parameter `sample_mask` for sub-sample masking.
 
 Fixes

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -3,11 +3,20 @@
 
 NEW
 ---
+- :func:`nilearn.signal.clean` accept new parameter `sample_mask`.
+  Masks the niimgs along time/fourth dimension to perform scrubbing (remove
+  volumes with high motion) and/or non-steady-state volumes. This masking step
+  is applied before signal cleaning.
+  shape: (number of scans - number of volumes removed, )
+  - Moving parameter `sample_mask` from :class:`nilearn.input_data.NiftiMasker`
+  to method `transform` in base class :class:`nilearn.input_data.base_masker`.
+  All inheritent classes of :class:`nilearn.input_data.base_masker` can use
+  parameter `sample_mask` for sub-sample masking.
 
 Fixes
 -----
 
-- Convert references in atlas.py, func.py, neurovault.py, and struct.py 
+- Convert references in atlas.py, func.py, neurovault.py, and struct.py
   to use footcite / footbibliography.
 - Fix detrending and temporal filtering order for confounders
   in :func:`nilearn.signal.clean`, so that these operations are applied
@@ -20,7 +29,7 @@ Fixes
   :func:`nilearn.plotting.plot_stat_map`) will now plot the slices in the user
   specified order, rather than automatically sorting into ascending order
   (https://github.com/nilearn/nilearn/issues/1155).
-- Fix the axes zoom on plot_img_on_surf function so brain would not be cutoff, and edited function so less white space surrounds brain views & smaller colorbar using gridspec (https://github.com/nilearn/nilearn/pull/2798). 
+- Fix the axes zoom on plot_img_on_surf function so brain would not be cutoff, and edited function so less white space surrounds brain views & smaller colorbar using gridspec (https://github.com/nilearn/nilearn/pull/2798).
 - Fix inconsistency in prediction values of Dummy Classifier for Decoder
   object (https://github.com/nilearn/nilearn/issues/2767).
 
@@ -46,18 +55,9 @@ Enhancements
   'stratified' (https://github.com/nilearn/nilearn/pull/2826/).
 - :class:`nilearn.glm.first_level.run_glm` now allows auto regressive noise
   models of order greater than one.
-- :func:`nilearn.signal.clean` accept new parameter `sample_mask`.
-  Masks the niimgs along time/fourth dimension to perform scrubbing (remove
-  volumes with high motion) and/or non-steady-state volumes. This masking step
-  is applied before signal cleaning.
-  shape: (number of scans - number of volumes removed, )
 - :class:`nilearn.input_data.NiftiMasker` replace `sessions` with `runs` and
   deprecates attribute `sessions` in 0.9.0. Match the relevant change in
   :func:`nilearn.signal.clean`.
-- Moving parameter `sample_mask` from :class:`nilearn.input_data.NiftiMasker`
-  to method `transform` in base class :class:`nilearn.input_data.base_masker`.
-  All inheritent classes of :class:`nilearn.input_data.base_masker` can use
-  parameter `sample_mask` for sub-sample masking.
 
 .. _v0.7.1:
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,7 +18,7 @@ Fixes
   :func:`nilearn.plotting.plot_stat_map`) will now plot the slices in the user
   specified order, rather than automatically sorting into ascending order
   (https://github.com/nilearn/nilearn/issues/1155).
-- Fix the axes zoom on plot_img_on_surf function so brain would not be cutoff, and edited function so less white space surrounds brain views & smaller colorbar using gridspec (https://github.com/nilearn/nilearn/pull/2798). 
+- Fix the axes zoom on plot_img_on_surf function so brain would not be cutoff, and edited function so less white space surrounds brain views & smaller colorbar using gridspec (https://github.com/nilearn/nilearn/pull/2798).
 
 
 Enhancements
@@ -39,6 +39,19 @@ Enhancements
   * "butterwoth" (butterworth filter)
   * "cosine" (discrete cosine transformation)
   * `False` (no filtering)
+- :func:`nilearn.signal.clean` accept new parameter `sample_mask`.
+  Masks the niimgs along time/fourth dimension to perform scrubbing (remove
+  volumes with high motion) and/or non-steady-state volumes. This masking step
+  is applied before signal cleaning.
+  shape: (number of scans - number of volumes removed, )
+- :class:`nilearn.input_data.NiftiMasker` replace `sessions` with `runs` and
+  depricates attribute `sessions` in 0.9.0. Match the relevant change in
+  :func:`nilearn.signal.clean`.
+- Moving parameter `sample_mask` from :class:`nilearn.input_data.NiftiMasker`
+  to method `transform` in base class :class:`nilearn.input_data.base_masker`.
+  All inheritent classes of :class:`nilearn.input_data.base_masker` can use
+  parameter `sample_mask` for sub-sample masking.
+
 
 .. _v0.7.1:
 

--- a/nilearn/_utils/__init__.py
+++ b/nilearn/_utils/__init__.py
@@ -8,10 +8,10 @@ from .numpy_conversions import as_ndarray
 from .cache_mixin import CacheMixin
 
 from .logger import _compose_err_msg
-from nilearn._utils.helpers import rename_parameters, deprecated_parameters
+from nilearn._utils.helpers import rename_parameters, remove_parameters
 
 __all__ = ['check_niimg', 'check_niimg_3d', 'concat_niimgs', 'check_niimg_4d',
            '_repr_niimgs', 'copy_img', 'load_niimg',
            'as_ndarray', 'CacheMixin', '_compose_err_msg', 'rename_parameters',
-           'deprecated_parameters',
+           'remove_parameters',
            ]

--- a/nilearn/_utils/__init__.py
+++ b/nilearn/_utils/__init__.py
@@ -8,9 +8,10 @@ from .numpy_conversions import as_ndarray
 from .cache_mixin import CacheMixin
 
 from .logger import _compose_err_msg
-from nilearn._utils.helpers import rename_parameters
+from nilearn._utils.helpers import rename_parameters, deprecated_parameters
 
 __all__ = ['check_niimg', 'check_niimg_3d', 'concat_niimgs', 'check_niimg_4d',
            '_repr_niimgs', 'copy_img', 'load_niimg',
            'as_ndarray', 'CacheMixin', '_compose_err_msg', 'rename_parameters',
+           'deprecated_parameters',
            ]

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -118,7 +118,7 @@ def remove_parameters(removed_params,
     Parameters
     ----------
     removed_params : list[string]
-        List of old parameters to be rmoved.
+        List of old parameters to be removed.
         Example: [old_param1, old_param2, ...]
 
     reason : str

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -135,11 +135,11 @@ def remove_parameters(removed_params,
         def wrapper(*args, **kwargs):
             found = set(removed_params).intersection(kwargs)
             if found:
-                message = ('Parameter(s) {} deprecated from version {}; '
+                message = ('Parameter(s) {} will be removed in version {}; '
                            '{}'.format(', '.join(found),
                                        end_version, reason)
                            )
-                warnings.warn(category=FutureWarning,
+                warnings.warn(category=DeprecationWarning,
                               message=message,
                               stacklevel=3)
             return func(*args, **kwargs)

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -1,5 +1,4 @@
 import functools
-from platform import version
 import warnings
 
 

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -3,29 +3,6 @@ from platform import version
 import warnings
 
 
-def deprecated_parameters(removed_params,
-                          reason,
-                          end_version='future'):
-    def _remove_params(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            found = set(removed_params).intersection(kwargs)
-            if found:
-                message = ("Parameter(s) {} deprecated from version {}; "
-                           "{}".format(
-                               ', '.join(found),
-                               end_version,
-                               reason
-                               )
-                           )
-                warnings.warn(category=FutureWarning,
-                              message=message,
-                              stacklevel=3)
-            return func(*args, **kwargs)
-        return wrapper
-    return _remove_params
-
-
 def rename_parameters(replacement_params,
                       end_version='future',
                       lib_name='Nilearn',
@@ -131,3 +108,41 @@ def _transfer_deprecated_param_vals(replacement_params, kwargs):
             kwargs[new_param] = old_param_val
         kwargs.pop(old_param)
     return kwargs
+
+
+def remove_parameters(removed_params,
+                      reason,
+                      end_version='future'):
+    """Decorator to deprecate but not renamed parameters in the decorated
+    functions and methods.
+
+    Parameters
+    ----------
+    removed_params : list[string]
+        List of old parameters to be rmoved.
+        Example: [old_param1, old_param2, ...]
+
+    reason : str
+        Detailed reason of deprecated parameter and alternative solutions.
+
+    end_version : str {'future' | 'next' | <version>}, optional
+        Version when using the deprecated parameters will raise an error.
+        For informational purpose in the warning text.
+        Default='future'.
+
+    """
+    def _remove_params(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            found = set(removed_params).intersection(kwargs)
+            if found:
+                message = ('Parameter(s) {} deprecated from version {}; '
+                           '{}'.format(', '.join(found),
+                                       end_version, reason)
+                           )
+                warnings.warn(category=FutureWarning,
+                              message=message,
+                              stacklevel=3)
+            return func(*args, **kwargs)
+        return wrapper
+    return _remove_params

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -1,5 +1,29 @@
 import functools
+from platform import version
 import warnings
+
+
+def deprecated_parameters(removed_params,
+                          reason,
+                          end_version='future'):
+    def _remove_params(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            found = set(removed_params).intersection(kwargs)
+            if found:
+                message = ("Parameter(s) {} deprecated from version {}; "
+                           "{}".format(
+                               ', '.join(found),
+                               end_version,
+                               reason
+                               )
+                           )
+                warnings.warn(category=FutureWarning,
+                              message=message,
+                              stacklevel=3)
+            return func(*args, **kwargs)
+        return wrapper
+    return _remove_params
 
 
 def rename_parameters(replacement_params,

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -108,7 +108,7 @@ def filter_and_extract(imgs, extraction_function,
     # Normalizing
     if verbose > 0:
         print("[%s] Cleaning extracted signals" % class_name)
-    runs = parameters.get('runs')
+    runs = parameters['runs']
     region_signals = cache(
         signal.clean, memory=memory, func_memory_level=2,
         memory_level=memory_level)(

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -69,6 +69,9 @@ def filter_and_extract(imgs, extraction_function,
     imgs = _utils.check_niimg(imgs, atleast_4d=True, ensure_ndim=4,
                               dtype=dtype)
 
+    if sample_mask is None:
+        sample_mask = parameters.get('sample_mask', None)
+
     target_shape = parameters.get('target_shape')
     target_affine = parameters.get('target_affine')
     if target_shape is not None or target_affine is not None:

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -108,7 +108,7 @@ def filter_and_extract(imgs, extraction_function,
     # Normalizing
     if verbose > 0:
         print("[%s] Cleaning extracted signals" % class_name)
-    runs = parameters['runs']
+    runs = parameters.get('runs', None)
     region_signals = cache(
         signal.clean, memory=memory, func_memory_level=2,
         memory_level=memory_level)(

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -26,6 +26,7 @@ def filter_and_extract(imgs, extraction_function,
                        memory_level=0, memory=Memory(location=None),
                        verbose=0,
                        confounds=None,
+                       sample_mask=None,
                        copy=True,
                        dtype=None):
     """Extract representative time series using given function.
@@ -67,10 +68,6 @@ def filter_and_extract(imgs, extraction_function,
             _utils._repr_niimgs(imgs, shorten=False)))
     imgs = _utils.check_niimg(imgs, atleast_4d=True, ensure_ndim=4,
                               dtype=dtype)
-
-    sample_mask = parameters.get('sample_mask')
-    if sample_mask is not None:
-        imgs = image.index_img(imgs, sample_mask)
 
     target_shape = parameters.get('target_shape')
     target_affine = parameters.get('target_affine')
@@ -120,6 +117,7 @@ def filter_and_extract(imgs, extraction_function,
             low_pass=parameters['low_pass'],
             high_pass=parameters['high_pass'],
             confounds=confounds,
+            sample_mask=sample_mask,
             sessions=sessions)
 
     return region_signals, aux
@@ -130,7 +128,8 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
     """
 
     @abc.abstractmethod
-    def transform_single_imgs(self, imgs, confounds=None, copy=True):
+    def transform_single_imgs(self, imgs, confounds=None, sample_mask=None,
+                              copy=True):
         """Extract signals from a single 4D niimg.
 
         Parameters
@@ -157,7 +156,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         """
         raise NotImplementedError()
 
-    def transform(self, imgs, confounds=None):
+    def transform(self, imgs, confounds=None, sample_mask=None):
         """Apply mask, spatial and temporal preprocessing
 
         Parameters
@@ -182,7 +181,9 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         self._check_fitted()
 
         if confounds is None and not self.high_variance_confounds:
-            return self.transform_single_imgs(imgs, confounds)
+            return self.transform_single_imgs(imgs,
+                                              confounds=confounds,
+                                              sample_mask=sample_mask)
 
         # Compute high variance confounds if requested
         all_confounds = []
@@ -196,9 +197,11 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
             else:
                 all_confounds.append(confounds)
 
-        return self.transform_single_imgs(imgs, all_confounds)
+        return self.transform_single_imgs(imgs, confounds=all_confounds,
+                                          sample_mask=sample_mask)
 
-    def fit_transform(self, X, y=None, confounds=None, **fit_params):
+    def fit_transform(self, X, y=None, confounds=None, sample_mask=None,
+                      **fit_params):
         """Fit to data, then transform it
 
         Parameters
@@ -225,20 +228,27 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
             # fit method of arity 1 (unsupervised transformation)
             if self.mask_img is None:
                 return self.fit(X, **fit_params
-                                ).transform(X, confounds=confounds)
+                                ).transform(X, confounds=confounds,
+                                            sample_mask=sample_mask)
             else:
-                return self.fit(**fit_params).transform(X, confounds=confounds)
+                return self.fit(**fit_params).transform(X,
+                                                        confounds=confounds,
+                                                        sample_mask=sample_mask
+                                                        )
         else:
             # fit method of arity 2 (supervised transformation)
             if self.mask_img is None:
                 return self.fit(X, y, **fit_params
-                                ).transform(X, confounds=confounds)
+                                ).transform(X, confounds=confounds,
+                                            sample_mask=sample_mask)
             else:
                 warnings.warn('[%s.fit] Generation of a mask has been'
                               ' requested (y != None) while a mask has'
                               ' been provided at masker creation. Given mask'
                               ' will be used.' % self.__class__.__name__)
-                return self.fit(**fit_params).transform(X, confounds=confounds)
+                return self.fit(**fit_params).transform(X, confounds=confounds,
+                                                        sample_mask=sample_mask
+                                                        )
 
     def inverse_transform(self, X):
         """ Transform the 2D data matrix back to an image in brain space.

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -148,10 +148,10 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
             shape: (number of scans, number of confounds)
 
         sample_mask : Any type compatible with numpy-array indexing, optional
+            shape: (number of scans - number of volumes removed, )
             Masks the niimgs along time/fourth dimension to perform scrubbing
             (remove volumes with high motion) and/or non-steady-state volumes.
             This parameter is passed to signal.clean.
-            shape: (number of scans - number of volumes removed, )
 
         copy : Boolean, optional
             Indicates whether a copy is returned or not. Default=True.
@@ -181,10 +181,10 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
             shape: (number of scans, number of confounds)
 
         sample_mask : Any type compatible with numpy-array indexing, optional
+            shape: (number of scans - number of volumes removed, )
             Masks the niimgs along time/fourth dimension to perform scrubbing
             (remove volumes with high motion) and/or non-steady-state volumes.
             This parameter is passed to signal.clean.
-            shape: (number of scans - number of volumes removed, )
 
         Returns
         -------

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -69,9 +69,6 @@ def filter_and_extract(imgs, extraction_function,
     imgs = _utils.check_niimg(imgs, atleast_4d=True, ensure_ndim=4,
                               dtype=dtype)
 
-    if sample_mask is None:
-        sample_mask = parameters.get('sample_mask', None)
-
     target_shape = parameters.get('target_shape')
     target_affine = parameters.get('target_affine')
     if target_shape is not None or target_affine is not None:
@@ -152,6 +149,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
             Masks the niimgs along time/fourth dimension to perform scrubbing
             (remove volumes with high motion) and/or non-steady-state volumes.
             This parameter is passed to signal.clean.
+                .. versionadded:: 0.7.2
 
         copy : Boolean, optional
             Indicates whether a copy is returned or not. Default=True.
@@ -185,6 +183,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
             Masks the niimgs along time/fourth dimension to perform scrubbing
             (remove volumes with high motion) and/or non-steady-state volumes.
             This parameter is passed to signal.clean.
+                .. versionadded:: 0.7.2
 
         Returns
         -------
@@ -234,6 +233,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         sample_mask : list of sample_mask, optional
             List of sample_mask (1D arrays) if scrubbing motion outliers.
             Must be of same length than imgs_list.
+                .. versionadded:: 0.7.2
 
         Returns
         -------

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -108,7 +108,7 @@ def filter_and_extract(imgs, extraction_function,
     # Normalizing
     if verbose > 0:
         print("[%s] Cleaning extracted signals" % class_name)
-    sessions = parameters.get('sessions')
+    runs = parameters.get('runs')
     region_signals = cache(
         signal.clean, memory=memory, func_memory_level=2,
         memory_level=memory_level)(
@@ -121,7 +121,7 @@ def filter_and_extract(imgs, extraction_function,
             high_pass=parameters['high_pass'],
             confounds=confounds,
             sample_mask=sample_mask,
-            sessions=sessions)
+            runs=runs)
 
     return region_signals, aux
 

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -144,6 +144,12 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
             documentation for details.
             shape: (number of scans, number of confounds)
 
+        sample_mask : Any type compatible with numpy-array indexing, optional
+            Masks the niimgs along time/fourth dimension to perform scrubbing
+            (remove volumes with high motion) and/or non-steady-state volumes.
+            This parameter is passed to signal.clean.
+            shape: (number of scans - number of volumes removed, )
+
         copy : Boolean, optional
             Indicates whether a copy is returned or not. Default=True.
 
@@ -170,6 +176,12 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
             This parameter is passed to signal.clean. Please see the related
             documentation for details.
             shape: (number of scans, number of confounds)
+
+        sample_mask : Any type compatible with numpy-array indexing, optional
+            Masks the niimgs along time/fourth dimension to perform scrubbing
+            (remove volumes with high motion) and/or non-steady-state volumes.
+            This parameter is passed to signal.clean.
+            shape: (number of scans - number of volumes removed, )
 
         Returns
         -------
@@ -215,6 +227,10 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         confounds : list of confounds, optional
             List of confounds (2D arrays or filenames pointing to CSV
             files). Must be of same length than imgs_list.
+
+        sample_mask : list of sample_mask, optional
+            List of sample_mask (1D arrays) if scrubbing motion outliers.
+            Must be of same length than imgs_list.
 
         Returns
         -------

--- a/nilearn/input_data/base_masker.py
+++ b/nilearn/input_data/base_masker.py
@@ -149,6 +149,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
             Masks the niimgs along time/fourth dimension to perform scrubbing
             (remove volumes with high motion) and/or non-steady-state volumes.
             This parameter is passed to signal.clean.
+
                 .. versionadded:: 0.7.2
 
         copy : Boolean, optional
@@ -183,6 +184,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
             Masks the niimgs along time/fourth dimension to perform scrubbing
             (remove volumes with high motion) and/or non-steady-state volumes.
             This parameter is passed to signal.clean.
+
                 .. versionadded:: 0.7.2
 
         Returns
@@ -233,6 +235,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         sample_mask : list of sample_mask, optional
             List of sample_mask (1D arrays) if scrubbing motion outliers.
             Must be of same length than imgs_list.
+
                 .. versionadded:: 0.7.2
 
         Returns

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -265,6 +265,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         sample_mask : list of sample_mask, optional
             List of sample_mask (1D arrays) if scrubbing motion outliers.
             Must be of same length than imgs_list.
+
                 .. versionadded:: 0.7.2
 
         copy : boolean, optional
@@ -341,6 +342,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         sample_mask : list of sample_mask, optional
             List of sample_mask (1D arrays) if scrubbing motion outliers.
             Must be of same length than imgs_list.
+
                 .. versionadded:: 0.7.2
 
         Returns

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -265,6 +265,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         sample_mask : list of sample_mask, optional
             List of sample_mask (1D arrays) if scrubbing motion outliers.
             Must be of same length than imgs_list.
+                .. versionadded:: 0.7.2
 
         copy : boolean, optional
             If True, guarantees that output array has no memory in common with
@@ -340,6 +341,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         sample_mask : list of sample_mask, optional
             List of sample_mask (1D arrays) if scrubbing motion outliers.
             Must be of same length than imgs_list.
+                .. versionadded:: 0.7.2
 
         Returns
         -------

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -247,7 +247,8 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         get_data(self.mask_img_)
         return self
 
-    def transform_imgs(self, imgs_list, confounds=None, copy=True, n_jobs=1):
+    def transform_imgs(self, imgs_list, confounds=None, sample_mask=None,
+                       copy=True, n_jobs=1):
         """Prepare multi subject data in parallel
 
         Parameters
@@ -319,7 +320,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
             for imgs, cfs in zip(niimg_iter, confounds))
         return data
 
-    def transform(self, imgs, confounds=None):
+    def transform(self, imgs, confounds=None, sample_mask=None):
         """ Apply mask, spatial and temporal preprocessing
 
         Parameters
@@ -332,6 +333,10 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
             This parameter is passed to signal.clean. Please see the
             corresponding documentation for details.
 
+        sample_mask : list of sample_mask, optional
+            List of sample_mask (1D arrays) if scrubbing motion outliers.
+            Must be of same length than imgs_list.
+
         Returns
         -------
         data : {list of numpy arrays}
@@ -342,4 +347,6 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         if not hasattr(imgs, '__iter__') \
                 or isinstance(imgs, str):
             return self.transform_single_imgs(imgs)
-        return self.transform_imgs(imgs, confounds, n_jobs=self.n_jobs)
+        return self.transform_imgs(imgs, confounds=confounds,
+                                   sample_mask=sample_mask,
+                                   n_jobs=self.n_jobs)

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -262,6 +262,10 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
             List of confounds (2D arrays or filenames pointing to CSV
             files or pandas DataFrames). Must be of same length than imgs_list.
 
+        sample_mask : list of sample_mask, optional
+            List of sample_mask (1D arrays) if scrubbing motion outliers.
+            Must be of same length than imgs_list.
+
         copy : boolean, optional
             If True, guarantees that output array has no memory in common with
             input array. Default=True.

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -271,10 +271,10 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             shape: (number of scans, number of confounds)
 
         sample_mask : Any type compatible with numpy-array indexing, optional
+            shape: (number of scans - number of volumes removed, )
             Masks the niimgs along time/fourth dimension to perform scrubbing
             (remove volumes with high motion) and/or non-steady-state volumes.
             This parameter is passed to signal.clean.
-            shape: (number of scans - number of volumes removed, )
 
         Returns
         -------

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -275,6 +275,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             Masks the niimgs along time/fourth dimension to perform scrubbing
             (remove volumes with high motion) and/or non-steady-state volumes.
             This parameter is passed to signal.clean.
+
                 .. versionadded:: 0.7.2
 
         Returns

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -242,11 +242,12 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
 
         return self
 
-    def fit_transform(self, imgs, confounds=None):
+    def fit_transform(self, imgs, confounds=None, sample_mask=None):
         """ Prepare and perform signal extraction from regions.
 
         """
-        return self.fit().transform(imgs, confounds=confounds)
+        return self.fit().transform(imgs, confounds=confounds,
+                                    sample_mask=sample_mask)
 
     def _check_fitted(self):
         if not hasattr(self, "labels_img_"):
@@ -254,7 +255,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                              'You must call fit() before calling transform().'
                              % self.__class__.__name__)
 
-    def transform_single_imgs(self, imgs, confounds=None):
+    def transform_single_imgs(self, imgs, confounds=None, sample_mask=None):
         """Extract signals from a single 4D niimg.
 
         Parameters
@@ -327,6 +328,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             # Pre-processing
             params,
             confounds=confounds,
+            sample_mask=sample_mask,
             dtype=self.dtype,
             # Caching
             memory=self.memory,

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -270,6 +270,12 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             documentation for details.
             shape: (number of scans, number of confounds)
 
+        sample_mask : Any type compatible with numpy-array indexing, optional
+            Masks the niimgs along time/fourth dimension to perform scrubbing
+            (remove volumes with high motion) and/or non-steady-state volumes.
+            This parameter is passed to signal.clean.
+            shape: (number of scans - number of volumes removed, )
+
         Returns
         -------
         region_signals : 2D numpy.ndarray

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -275,6 +275,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             Masks the niimgs along time/fourth dimension to perform scrubbing
             (remove volumes with high motion) and/or non-steady-state volumes.
             This parameter is passed to signal.clean.
+                .. versionadded:: 0.7.2
 
         Returns
         -------

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -264,6 +264,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
             Masks the niimgs along time/fourth dimension to perform scrubbing
             (remove volumes with high motion) and/or non-steady-state volumes.
             This parameter is passed to signal.clean.
+
                 .. versionadded:: 0.7.2
 
         Returns

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -260,10 +260,10 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
             shape: (number of scans, number of confounds)
 
         sample_mask : Any type compatible with numpy-array indexing, optional
+            shape: (number of scans - number of volumes removed, )
             Masks the niimgs along time/fourth dimension to perform scrubbing
             (remove volumes with high motion) and/or non-steady-state volumes.
             This parameter is passed to signal.clean.
-            shape: (number of scans - number of volumes removed, )
 
         Returns
         -------

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -237,13 +237,14 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
                              'You must call fit() before calling transform().'
                              % self.__class__.__name__)
 
-    def fit_transform(self, imgs, confounds=None):
+    def fit_transform(self, imgs, confounds=None, sample_mask=None):
         """Prepare and perform signal extraction.
 
         """
-        return self.fit().transform(imgs, confounds=confounds)
+        return self.fit().transform(imgs, confounds=confounds,
+                                    sample_mask=sample_mask)
 
-    def transform_single_imgs(self, imgs, confounds=None):
+    def transform_single_imgs(self, imgs, confounds=None, sample_mask=None):
         """Extract signals from a single 4D niimg.
 
         Parameters
@@ -344,6 +345,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
                 # Pre-treatments
                 params,
                 confounds=confounds,
+                sample_mask=sample_mask,
                 dtype=self.dtype,
                 # Caching
                 memory=self.memory,

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -264,6 +264,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
             Masks the niimgs along time/fourth dimension to perform scrubbing
             (remove volumes with high motion) and/or non-steady-state volumes.
             This parameter is passed to signal.clean.
+                .. versionadded:: 0.7.2
 
         Returns
         -------

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -259,6 +259,12 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
             documentation for details.
             shape: (number of scans, number of confounds)
 
+        sample_mask : Any type compatible with numpy-array indexing, optional
+            Masks the niimgs along time/fourth dimension to perform scrubbing
+            (remove volumes with high motion) and/or non-steady-state volumes.
+            This parameter is passed to signal.clean.
+            shape: (number of scans - number of volumes removed, )
+
         Returns
         -------
         region_signals : 2D numpy.ndarray

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -419,6 +419,12 @@ class NiftiMasker(BaseMasker, CacheMixin):
             documentation for details: :func:`nilearn.signal.clean`.
             shape: (number of scans, number of confounds)
 
+        sample_mask : Any type compatible with numpy-array indexing, optional
+            Masks the niimgs along time/fourth dimension to perform scrubbing
+            (remove volumes with high motion) and/or non-steady-state volumes.
+            This parameter is passed to signal.clean.
+            shape: (number of scans - number of volumes removed, )
+
         copy : Boolean, optional
             Indicates whether a copy is returned or not. Default=True.
 

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -213,9 +213,9 @@ class NiftiMasker(BaseMasker, CacheMixin):
     nilearn.signal.clean
 
     """
-    @deprecated_parameters(["sample_mask"],
+    @deprecated_parameters(['sample_mask'],
                            "supply sample_masker in transform method",
-                           "0.9.0")
+                           '0.9.0')
     def __init__(self, mask_img=None, sessions=None, smoothing_fwhm=None,
                  standardize=False, standardize_confounds=True, detrend=False,
                  high_variance_confounds=False, low_pass=None, high_pass=None,

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -436,10 +436,10 @@ class NiftiMasker(BaseMasker, CacheMixin):
             shape: (number of scans, number of confounds)
 
         sample_mask : Any type compatible with numpy-array indexing, optional
+            shape: (number of scans - number of volumes removed, )
             Masks the niimgs along time/fourth dimension to perform scrubbing
             (remove volumes with high motion) and/or non-steady-state volumes.
             This parameter is passed to signal.clean.
-            shape: (number of scans - number of volumes removed, )
 
         copy : Boolean, optional
             Indicates whether a copy is returned or not. Default=True.

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -15,6 +15,7 @@ from .. import image
 from .. import masking
 from .._utils import CacheMixin
 from .._utils.class_inspect import get_params
+from .._utils.helpers import deprecated_parameters
 from .._utils.niimg import img_data_dtype
 from .._utils.niimg_conversions import _check_same_fov
 from nilearn.image import get_data
@@ -212,11 +213,14 @@ class NiftiMasker(BaseMasker, CacheMixin):
     nilearn.signal.clean
 
     """
+    @deprecated_parameters(["sample_mask"],
+                           "supply sample_masker in transform method",
+                           "0.9.0")
     def __init__(self, mask_img=None, sessions=None, smoothing_fwhm=None,
                  standardize=False, standardize_confounds=True, detrend=False,
                  high_variance_confounds=False, low_pass=None, high_pass=None,
                  t_r=None, target_affine=None, target_shape=None,
-                 mask_strategy='background', mask_args=None,
+                 mask_strategy='background', mask_args=None, sample_mask=None,
                  dtype=None, memory_level=1, memory=Memory(location=None),
                  verbose=0, reports=True,
                  ):
@@ -236,6 +240,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
         self.target_shape = target_shape
         self.mask_strategy = mask_strategy
         self.mask_args = mask_args
+        self.sample_mask = sample_mask
         self.dtype = dtype
 
         self.memory = memory

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -35,6 +35,7 @@ def filter_and_mask(imgs, mask_img_, parameters,
                     memory_level=0, memory=Memory(location=None),
                     verbose=0,
                     confounds=None,
+                    sample_mask=None,
                     copy=True,
                     dtype=None):
     """Extract representative time series using given mask.
@@ -70,7 +71,9 @@ def filter_and_mask(imgs, mask_img_, parameters,
                                       memory_level=memory_level,
                                       memory=memory,
                                       verbose=verbose,
-                                      confounds=confounds, copy=copy,
+                                      confounds=confounds,
+                                      sample_mask=sample_mask,
+                                      copy=copy,
                                       dtype=dtype)
 
     # For _later_: missing value removal or imputing of missing data
@@ -169,13 +172,6 @@ class NiftiMasker(BaseMasker, CacheMixin):
         to fine-tune mask computation. Please see the related documentation
         for details.
 
-    sample_mask : Any type compatible with numpy-array indexing, optional
-        Masks the niimgs along time/fourth dimension. This complements
-        3D masking by the mask_img argument. This masking step is applied
-        before data preprocessing at the beginning of NiftiMasker.transform.
-        This is useful to perform data subselection as part of a scikit-learn
-        pipeline.
-
     dtype : {dtype, "auto"}, optional
         Data type toward which the data should be converted. If "auto", the
         data will be converted to int32 if dtype is discrete and float32 if it
@@ -220,7 +216,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
                  standardize=False, standardize_confounds=True, detrend=False,
                  high_variance_confounds=False, low_pass=None, high_pass=None,
                  t_r=None, target_affine=None, target_shape=None,
-                 mask_strategy='background', mask_args=None, sample_mask=None,
+                 mask_strategy='background', mask_args=None,
                  dtype=None, memory_level=1, memory=Memory(location=None),
                  verbose=0, reports=True,
                  ):
@@ -240,7 +236,6 @@ class NiftiMasker(BaseMasker, CacheMixin):
         self.target_shape = target_shape
         self.mask_strategy = mask_strategy
         self.mask_args = mask_args
-        self.sample_mask = sample_mask
         self.dtype = dtype
 
         self.memory = memory
@@ -408,7 +403,8 @@ class NiftiMasker(BaseMasker, CacheMixin):
 
         return self
 
-    def transform_single_imgs(self, imgs, confounds=None, copy=True):
+    def transform_single_imgs(self, imgs, confounds=None, sample_mask=None,
+                              copy=True):
         """Apply mask, spatial and temporal preprocessing
 
         Parameters
@@ -449,6 +445,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
             memory=self.memory,
             verbose=self.verbose,
             confounds=confounds,
+            sample_mask=sample_mask,
             copy=copy,
             dtype=self.dtype
         )

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -457,7 +457,6 @@ class NiftiMasker(BaseMasker, CacheMixin):
         # target_shape and target_affine are conveyed implicitly in mask_img
         params = get_params(self.__class__, self,
                             ignore=['mask_img', 'mask_args', 'mask_strategy'])
-
         data = self._cache(filter_and_mask,
                            ignore=['verbose', 'memory', 'memory_level',
                                    'copy'],

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -181,6 +181,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
         before data preprocessing at the beginning of NiftiMasker.transform.
         This is useful to perform data subselection as part of a scikit-learn
         pipeline.
+
             .. deprecated:: 0.7.2
                 `sample_mask` is deprecated in 0.7.2 and will be removed in
                 0.9.0.

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -479,9 +479,9 @@ class NiftiMasker(BaseMasker, CacheMixin):
         if hasattr(self, '_sample_mask') and self._sample_mask is not None:
             if sample_mask is not None:
                 warnings.warn(
-                    UserWarning("Overwriting depricated attribute "
+                    UserWarning("Overwriting deprecated attribute "
                                 "`NiftiMasker.sample_mask` with parameter "
-                                "`sample_masker` in method `transform`.")
+                                "`sample_mask` in method `transform`.")
                 )
             else:
                 sample_mask = self._sample_mask

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -37,6 +37,7 @@ def filter_and_mask(imgs, mask_img_, parameters,
                     verbose=0,
                     confounds=None,
                     sample_mask=None,
+                    runs=None,
                     copy=True,
                     dtype=None):
     """Extract representative time series using given mask.
@@ -230,7 +231,6 @@ class NiftiMasker(BaseMasker, CacheMixin):
                  ):
         # Mask is provided or computed
         self.mask_img = mask_img
-
         self.runs = runs
         self.smoothing_fwhm = smoothing_fwhm
         self.standardize = standardize
@@ -260,6 +260,13 @@ class NiftiMasker(BaseMasker, CacheMixin):
                               'resampling, hover over the displayed image.')
         self._warning_message = ""
         self._shelving = False
+
+    @property
+    def sessions(self):
+        warnings.warn(FutureWarning("'sessions' attribute is deprecated and "
+                                    "will be removed in 0.9.0, use 'runs' "
+                                    "instead."))
+        return self.runs
 
     def generate_report(self):
         from nilearn.reporting.html_report import generate_report

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -15,7 +15,7 @@ from .. import image
 from .. import masking
 from .._utils import CacheMixin
 from .._utils.class_inspect import get_params
-from .._utils.helpers import deprecated_parameters
+from .._utils.helpers import remove_parameters, rename_parameters
 from .._utils.niimg import img_data_dtype
 from .._utils.niimg_conversions import _check_same_fov
 from nilearn.image import get_data
@@ -103,9 +103,11 @@ class NiftiMasker(BaseMasker, CacheMixin):
         and/or target_affine are provided, the mask is resampled first.
         After this, the images are resampled to the resampled mask.
 
-    sessions : numpy array, optional
-        Add a session level to the preprocessing. Each session will be
+    runs : numpy array, optional
+        Add a run level to the preprocessing. Each run will be
         detrended independently. Must be a 1D array of n_samples elements.
+        'runs' replaces 'sessions' after release 0.9.0.
+        Using 'session' will result in an error after release 0.9.0.
 
     smoothing_fwhm : float, optional
         If smoothing_fwhm is not None, it gives the full-width half maximum in
@@ -213,10 +215,12 @@ class NiftiMasker(BaseMasker, CacheMixin):
     nilearn.signal.clean
 
     """
-    @deprecated_parameters(['sample_mask'],
-                           "supply sample_masker in transform method",
-                           '0.9.0')
-    def __init__(self, mask_img=None, sessions=None, smoothing_fwhm=None,
+    @remove_parameters(['sample_mask'],
+                       ('supply sample_masker through transform or '
+                        'fit_transform methods instead.'),
+                       '0.9.0')
+    @rename_parameters({'sessions': 'runs'}, '0.9.0')
+    def __init__(self, mask_img=None, runs=None, smoothing_fwhm=None,
                  standardize=False, standardize_confounds=True, detrend=False,
                  high_variance_confounds=False, low_pass=None, high_pass=None,
                  t_r=None, target_affine=None, target_shape=None,
@@ -227,7 +231,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
         # Mask is provided or computed
         self.mask_img = mask_img
 
-        self.sessions = sessions
+        self.runs = runs
         self.smoothing_fwhm = smoothing_fwhm
         self.standardize = standardize
         self.standardize_confounds = standardize_confounds

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -169,6 +169,12 @@ class NiftiMasker(BaseMasker, CacheMixin):
         masking.compute_background_mask, masking.compute_epi_mask or
         masking.compute_brain_mask. Default='background'.
 
+    mask_args : dict, optional
+        If mask is None, these are additional parameters passed to
+        masking.compute_background_mask or masking.compute_epi_mask
+        to fine-tune mask computation. Please see the related documentation
+        for details.
+
     sample_mask : Any type compatible with numpy-array indexing, optional
         Masks the niimgs along time/fourth dimension. This complements
         3D masking by the mask_img argument. This masking step is applied
@@ -178,12 +184,6 @@ class NiftiMasker(BaseMasker, CacheMixin):
             .. deprecated:: 0.7.2
                 `sample_mask` is deprecated in 0.7.2 and will be removed in
                 0.9.0.
-
-    mask_args : dict, optional
-        If mask is None, these are additional parameters passed to
-        masking.compute_background_mask or masking.compute_epi_mask
-        to fine-tune mask computation. Please see the related documentation
-        for details.
 
     dtype : {dtype, "auto"}, optional
         Data type toward which the data should be converted. If "auto", the

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -386,6 +386,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
             (remove volumes with high motion) and/or non-steady-state volumes.
             This parameter is passed to signal.clean.
             shape: (number of scans - number of volumes removed, )
+
                 .. versionadded:: 0.7.2
 
         Returns

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -355,9 +355,10 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
 
         return self
 
-    def fit_transform(self, imgs, confounds=None):
+    def fit_transform(self, imgs, confounds=None, sample_mask=None):
         """Prepare and perform signal extraction"""
-        return self.fit().transform(imgs, confounds=confounds)
+        return self.fit().transform(imgs, confounds=confounds,
+                                    sample_mask=sample_mask)
 
     def _check_fitted(self):
         if not hasattr(self, "seeds_"):
@@ -365,7 +366,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
                              'You must call fit() before calling transform().'
                              % self.__class__.__name__)
 
-    def transform_single_imgs(self, imgs, confounds=None):
+    def transform_single_imgs(self, imgs, confounds=None, sample_mask=None):
         """Extract signals from a single 4D niimg.
 
         Parameters
@@ -400,6 +401,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
             # Pre-processing
             params,
             confounds=confounds,
+            sample_mask=sample_mask,
             dtype=self.dtype,
             # Caching
             memory=self.memory,

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -386,7 +386,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
             (remove volumes with high motion) and/or non-steady-state volumes.
             This parameter is passed to signal.clean.
             shape: (number of scans - number of volumes removed, )
-
+                .. versionadded:: 0.7.2
 
         Returns
         -------

--- a/nilearn/input_data/nifti_spheres_masker.py
+++ b/nilearn/input_data/nifti_spheres_masker.py
@@ -381,6 +381,13 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
             documentation for details.
             shape: (number of scans, number of confounds)
 
+        sample_mask : Any type compatible with numpy-array indexing, optional
+            Masks the niimgs along time/fourth dimension to perform scrubbing
+            (remove volumes with high motion) and/or non-steady-state volumes.
+            This parameter is passed to signal.clean.
+            shape: (number of scans - number of volumes removed, )
+
+
         Returns
         -------
         region_signals : 2D numpy.ndarray

--- a/nilearn/input_data/tests/test_nifti_masker.py
+++ b/nilearn/input_data/tests/test_nifti_masker.py
@@ -173,6 +173,11 @@ def test_mask_4d():
     data_trans2 = masker.transform(data_img_4d, sample_mask=sample_mask)
     assert_array_equal(data_trans2, data_trans_direct)
 
+    # check deprication warning
+    with pytest.warns(FutureWarning) as record:
+        masker = NiftiMasker(mask_img=mask_img, sample_mask=sample_mask)
+    assert "sample_mask deprecated" in record[0].message.args[0]
+
 
 def test_4d_single_scan():
     mask = np.zeros((10, 10, 10))

--- a/nilearn/input_data/tests/test_nifti_masker.py
+++ b/nilearn/input_data/tests/test_nifti_masker.py
@@ -239,9 +239,10 @@ def test_sessions():
     pytest.raises(ValueError, masker.fit_transform, data_img)
 
     # check deprication warning of attribute session
-    with pytest.warns(FutureWarning,
-                      match="'sessions' attribute is deprecated") as record:
+    with pytest.warns(FutureWarning) as record:
         masker.sessions
+    assert "'sessions' attribute is deprecated" in str(record[0].message)
+
 
 def test_joblib_cache():
     from joblib import hash, Memory

--- a/nilearn/input_data/tests/test_nifti_masker.py
+++ b/nilearn/input_data/tests/test_nifti_masker.py
@@ -173,7 +173,7 @@ def test_mask_4d():
     data_trans2 = masker.transform(data_img_4d, sample_mask=sample_mask)
     assert_array_equal(data_trans2, data_trans_direct)
 
-    # check deprication warning, and the old API shoud still work
+    # check deprecation warning, and the old API should still work
     with pytest.warns(DeprecationWarning) as record:
         masker = NiftiMasker(mask_img=mask_img, sample_mask=sample_mask)
         masker.fit()
@@ -192,7 +192,7 @@ def test_mask_4d():
         data_trans3 = masker.transform(data_img_4d,
                                        sample_mask=diff_sample_mask)
     assert_array_equal(data_trans3, data_trans_direct_diff)
-    assert "Overwriting depricated attribute " in record[0].message.args[0]
+    assert "Overwriting deprecated attribute " in record[0].message.args[0]
 
 def test_4d_single_scan():
     mask = np.zeros((10, 10, 10))
@@ -253,7 +253,7 @@ def test_sessions():
     masker = NiftiMasker(sessions=np.ones(3, dtype=np.int))
     pytest.raises(ValueError, masker.fit_transform, data_img)
 
-    # check deprication warning of attribute session
+    # check deprecation warning of attribute sessions
     with pytest.warns(DeprecationWarning) as record:
         masker.sessions
     assert "`sessions` attribute is deprecated" in record[0].message.args[0]

--- a/nilearn/input_data/tests/test_nifti_masker.py
+++ b/nilearn/input_data/tests/test_nifti_masker.py
@@ -238,6 +238,10 @@ def test_sessions():
     masker = NiftiMasker(sessions=np.ones(3, dtype=np.int))
     pytest.raises(ValueError, masker.fit_transform, data_img)
 
+    # check deprication warning of attribute session
+    with pytest.warns(FutureWarning,
+                      match="'sessions' attribute is deprecated") as record:
+        masker.sessions
 
 def test_joblib_cache():
     from joblib import hash, Memory

--- a/nilearn/input_data/tests/test_nifti_masker.py
+++ b/nilearn/input_data/tests/test_nifti_masker.py
@@ -160,17 +160,17 @@ def test_mask_4d():
 
     # check whether transform is indeed selecting niimgs subset
     sample_mask = np.array([0, 2])
-    masker = NiftiMasker(mask_img=mask_img, sample_mask=sample_mask)
+    masker = NiftiMasker(mask_img=mask_img)
     masker.fit()
-    data_trans = masker.transform(data_imgs)
+    data_trans = masker.transform(data_imgs, sample_mask=sample_mask)
     data_trans_img = index_img(data_img_4d, sample_mask)
     data_trans_direct = get_data(data_trans_img)[mask_bool, :]
     data_trans_direct = np.swapaxes(data_trans_direct, 0, 1)
     assert_array_equal(data_trans, data_trans_direct)
 
-    masker = NiftiMasker(mask_img=mask_img, sample_mask=sample_mask)
+    masker = NiftiMasker(mask_img=mask_img)
     masker.fit()
-    data_trans2 = masker.transform(data_img_4d)
+    data_trans2 = masker.transform(data_img_4d, sample_mask=sample_mask)
     assert_array_equal(data_trans2, data_trans_direct)
 
 

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -468,6 +468,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
         This masking step is applied before signal cleaning. When supplying run
         information, sample_mask must be a list containing sets of indexes for
         each run.
+
             .. versionadded:: 0.7.2
 
     t_r: float

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -462,12 +462,12 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
 
     sample_mask: None, numpy.ndarray, list, tuple, or list of
         Default is None.
+        shape: (number of scans - number of volumes removed, )
         Masks the niimgs along time/fourth dimension to perform scrubbing
         (remove volumes with high motion) and/or non-steady-state volumes.
         This masking step is applied before signal cleaning. When supplying run
         information, sample_mask must be a list containing sets of indexes for
         each run.
-        shape: (number of scans - number of volumes removed, )
 
     t_r: float
         Repetition time, in second (sampling period). Set to None if not.

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -462,11 +462,12 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
 
     sample_mask: None, numpy.ndarray, list, tuple, or list of
         Default is None.
-        Masks the niimgs along time/fourth dimension. Containing indices in a
-        1D array of the time points to keep. This masking step is applied
-        before data cleaning. When supplying run information, sample_mask
-        must be a list containing sets of indexes that matches each run.
-        This is useful to perform signal scrubbing/censoring.
+        Masks the niimgs along time/fourth dimension to perform scrubbing
+        (remove volumes with high motion) and/or non-steady-state volumes.
+        This masking step is applied before signal cleaning. When supplying run
+        information, sample_mask must be a list containing sets of indexes for
+        each run.
+        shape: (number of scans - number of volumes removed, )
 
     t_r: float
         Repetition time, in second (sampling period). Set to None if not.

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -462,7 +462,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
 
     sample_mask: None, numpy.ndarray, list, tuple, or list of
         Default is None.
-        Masks the niimgs along time/fourth dimension. Containing indeice in a
+        Masks the niimgs along time/fourth dimension. Containing indices in a
         1D array of the time points to keep. This masking step is applied
         before data cleaning. When supplying run information, sample_mask
         must be a list containing sets of indexes that matches each run.

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -621,6 +621,24 @@ def _process_runs(signals, runs, detrend, standardize, confounds,
     return signals
 
 
+def _sanitize_inputs(signals, runs, confounds, sample_mask, ensure_finite):
+    """Clean up signals and confounds before processing."""
+    n_time = len(signals)  # original length of the signal
+    n_runs, runs = _sanitize_runs(n_time, runs)
+    confounds = _sanitize_confounds(n_time, n_runs, confounds)
+    sample_mask = _sanitize_sample_mask(n_time, n_runs, runs, sample_mask)
+    signals = _sanitize_signals(signals, ensure_finite)
+
+    if sample_mask is None:
+        return signals, runs, confounds
+
+    if confounds is not None:
+        confounds = confounds[sample_mask, :]
+    if runs is not None:
+        runs = runs[sample_mask]
+    return signals[sample_mask, :], runs, confounds
+
+
 def _sanitize_confounds(n_time, n_runs, confounds):
     """Check confounds are the correct type. When passing mutiple runs, ensure the
     number of runs matches the sets of confound regressors.
@@ -642,24 +660,6 @@ def _sanitize_confounds(n_time, n_runs, confounds):
         all_confounds.append(confound)
     confounds = np.hstack(all_confounds)
     return _ensure_float(confounds)
-
-
-def _sanitize_inputs(signals, runs, confounds, sample_mask, ensure_finite):
-    """Clean up signals and confounds before processing."""
-    n_time = len(signals)  # original length of the signal
-    n_runs, runs = _sanitize_runs(n_time, runs)
-    confounds = _sanitize_confounds(n_time, n_runs, confounds)
-    sample_mask = _sanitize_sample_mask(n_time, n_runs, runs, sample_mask)
-    signals = _sanitize_signals(signals, ensure_finite)
-
-    if sample_mask is None:
-        return signals, runs, confounds
-
-    if confounds is not None:
-        confounds = confounds[sample_mask, :]
-    if runs is not None:
-        runs = runs[sample_mask]
-    return signals[sample_mask, :], runs, confounds
 
 
 def _sanitize_sample_mask(n_time, n_runs, runs, sample_mask):

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -414,8 +414,9 @@ def _ensure_float(data):
 
 @rename_parameters({'sessions': 'runs'}, '0.9.0')
 def clean(signals, runs=None, detrend=True, standardize='zscore',
-          confounds=None, standardize_confounds=True, filter='butterworth',
-          low_pass=None, high_pass=None, t_r=2.5, ensure_finite=False):
+          sample_mask=None, confounds=None, standardize_confounds=True,
+          filter='butterworth', low_pass=None, high_pass=None, t_r=2.5,
+          ensure_finite=False):
     """Improve SNR on masked fMRI signals.
 
     This function can do several things on the input signals, in
@@ -458,6 +459,14 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
         containing signals as columns, with an optional one-line header.
         If a list is provided, all confounds are removed from the input
         signal, as if all were in the same array.
+
+    sample_mask: None, numpy.ndarray, list, tuple, or list of
+        Default is None.
+        Masks the niimgs along time/fourth dimension. Containing indeice in a
+        1D array of the time points to keep. This masking step is applied
+        before data cleaning. When supplying run information, sample_mask
+        must be a list containing sets of indexes that matches each run.
+        This is useful to perform signal scrubbing/censoring.
 
     t_r: float
         Repetition time, in second (sampling period). Set to None if not.
@@ -516,7 +525,9 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
         nilearn.image.clean_img
     """
     # Read confounds and signals
-    signals, confounds = _sanitize_inputs(signals, confounds, ensure_finite)
+    signals, runs, confounds = _sanitize_inputs(
+        signals, runs, confounds, sample_mask, ensure_finite
+    )
     use_filter = _check_filter_parameters(filter, low_pass, high_pass, t_r)
     # Restrict the signal to the orthogonal of the confounds
     if runs is not None:
@@ -610,27 +621,117 @@ def _process_runs(signals, runs, detrend, standardize, confounds,
     return signals
 
 
-def _sanitize_inputs(signals, confounds, ensure_finite):
-    """Clean up signals and confounds before processing."""
-    signals = _sanitize_signals(signals, ensure_finite)
-
-    if not isinstance(confounds,
-                      (list, tuple, str, np.ndarray, pd.DataFrame,
-                       type(None))):
-        raise TypeError("confounds keyword has an unhandled type: %s"
-                        % confounds.__class__)
+def _sanitize_confounds(n_time, n_runs, confounds):
+    """Check confounds are the correct type. When passing mutiple runs, ensure the
+    number of runs matches the sets of confound regressors.
+    """
     if confounds is None:
-        return signals, confounds
+        return confounds
+
+    if not isinstance(confounds, (list, tuple, str, np.ndarray, pd.DataFrame)):
+        raise TypeError(
+            "confounds keyword has an unhandled type: %s" % confounds.__class__
+        )
 
     if not isinstance(confounds, (list, tuple)):
-        confounds = (confounds, )
+        confounds = (confounds,)
+
     all_confounds = []
-    n_time = signals.shape[0]
     for confound in confounds:
         confound = _sanitize_confound_dtype(n_time, confound)
         all_confounds.append(confound)
     confounds = np.hstack(all_confounds)
-    return signals, _ensure_float(confounds)
+    return _ensure_float(confounds)
+
+
+def _sanitize_inputs(signals, runs, confounds, sample_mask, ensure_finite):
+    """Clean up signals and confounds before processing."""
+    n_time = len(signals)  # original length of the signal
+    n_runs, runs = _sanitize_runs(n_time, runs)
+    confounds = _sanitize_confounds(n_time, n_runs, confounds)
+    sample_mask = _sanitize_sample_mask(n_time, n_runs, runs, sample_mask)
+    signals = _sanitize_signals(signals, ensure_finite)
+
+    if sample_mask is None:
+        return signals, runs, confounds
+
+    if confounds is not None:
+        confounds = confounds[sample_mask, :]
+    if runs is not None:
+        runs = runs[sample_mask]
+    return signals[sample_mask, :], runs, confounds
+
+
+def _sanitize_sample_mask(n_time, n_runs, runs, sample_mask):
+    """Check sample_mask is the right data type and matches the run index."""
+    if sample_mask is None:
+        return sample_mask
+    if not isinstance(sample_mask, (list, tuple, np.ndarray)):
+        raise TypeError(
+            "sample_mask has an unhandled type: %s" % sample_mask.__class__
+        )
+    if not isinstance(sample_mask, (list, tuple)):
+        sample_mask = (sample_mask, )
+
+    if len(sample_mask) != n_runs:
+        raise ValueError(
+            "Number of sample_mask ({}) not matching "
+            "number of runs ({}).".format(len(sample_mask), n_runs)
+        )
+
+    if runs is None:
+        runs = np.zeros(n_time)
+
+    # handle multiple runs
+    masks = []
+    starting_index = 0
+    for i, current_mask in enumerate(sample_mask):
+        _check_sample_mask_index(i, n_runs, runs, current_mask)
+        current_mask += starting_index
+        masks.append(current_mask)
+        starting_index = sum(i == runs)
+    sample_mask = np.hstack(masks)
+    return sample_mask
+
+
+def _check_sample_mask_index(i, n_runs, runs, current_mask):
+    """Ensure the index in sample mask is valid."""
+    len_run = sum(i == runs)
+    len_current_mask = len(current_mask)
+    # sample_mask longer than signal
+    if len_current_mask > len_run:
+        raise IndexError(
+            "sample_mask {} of {} is has more timepoints than the current "
+            "run ;sample_mask contains {} index but the run has {} "
+            "timepoints.".format(
+                (i + 1), n_runs, len_current_mask, len_run
+            )
+        )
+    # sample_mask index exceed signal timepoints
+    invalid_index = current_mask[current_mask > len_run]
+    if invalid_index.size > 0:
+        raise IndexError(
+            "sample_mask {} of {} contains invalid index {}; "
+            "The signal contains {} time points.".format(
+                (i + 1), n_runs, invalid_index, len_run
+            )
+        )
+
+
+def _sanitize_runs(n_time, runs):
+    """Check runs are supplied in the correct format and detect the number of
+    unique runs.
+    """
+    if runs is not None and len(runs) != n_time:
+        raise ValueError(
+            (
+                "The length of the session vector (%i) "
+                "does not match the length of the signals (%i)"
+            )
+            % (len(runs), n_time)
+        )
+    n_runs = 1 if runs is None else len(np.unique(runs))
+    return n_runs, runs
 
 
 def _sanitize_confound_dtype(n_signal, confound):

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -468,6 +468,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
         This masking step is applied before signal cleaning. When supplying run
         information, sample_mask must be a list containing sets of indexes for
         each run.
+            .. versionadded:: 0.7.2
 
     t_r: float
         Repetition time, in second (sampling period). Set to None if not.

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -730,7 +730,6 @@ def test_cosine_filter():
     np.testing.assert_almost_equal(drift_terms_only, cosine_drift)
 
 
-
 def test_sample_mask():
     """Test sample_mask related feature."""
     signals, _, confounds = generate_signals(n_features=11,

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -386,7 +386,7 @@ def test_clean_runs():
                              length=n_samples)
     x = signals + trends
     x_orig = x.copy()
-    # Create session info
+    # Create run info
     runs = np.ones(n_samples)
     runs[0:n_samples // 2] = 0
     x_detrended = nisignal.clean(x, confounds=confounds, standardize=False, detrend=True,
@@ -728,3 +728,58 @@ def test_cosine_filter():
         signals, None, filter, low_pass, high_pass, t_r)
     np.testing.assert_array_equal(signals_unchanged, signals)
     np.testing.assert_almost_equal(drift_terms_only, cosine_drift)
+
+
+
+def test_sample_mask():
+    """Test sample_mask related feature."""
+    signals, _, confounds = generate_signals(n_features=11,
+                                             n_confounds=5, length=40)
+
+    sample_mask = np.arange(signals.shape[0])
+    scrub_index = [2, 3, 6, 7, 8, 30, 31, 32]
+    sample_mask = np.delete(sample_mask, scrub_index)
+
+    scrub_clean = clean(signals, confounds=confounds, sample_mask=sample_mask)
+    assert scrub_clean.shape[0] == sample_mask.shape[0]
+
+    # list of sample_mask for each run
+    runs = np.ones(signals.shape[0])
+    runs[0:signals.shape[0] // 2] = 0
+    sample_mask_sep = [np.arange(20), np.arange(20)]
+    scrub_index = [[6, 7, 8], [10, 11, 12]]
+    sample_mask_sep = [np.delete(sm, si)
+                       for sm, si in zip(sample_mask_sep, scrub_index)]
+    scrub_sep_mask = clean(signals, confounds=confounds,
+                           sample_mask=sample_mask_sep, runs=runs)
+    assert scrub_sep_mask.shape[0] == signals.shape[0] - 6
+
+    # 1D sample mask with runs labels
+    with pytest.raises(ValueError,
+                       match=r'Number of sample_mask \(\d\) not matching'):
+        clean(signals, sample_mask=sample_mask, runs=runs)
+
+    # invalid input for sample_mask
+    with pytest.raises(TypeError, match='unhandled type'):
+        clean(signals, sample_mask='not_supported')
+
+    # sample_mask too long
+    with pytest.raises(IndexError,
+                       match='more timepoints than the current run'):
+        clean(signals, sample_mask=np.hstack((sample_mask, sample_mask)))
+
+    # list of sample_mask with one that's too long
+    invalid_sample_mask_sep = [np.arange(10), np.arange(30)]
+    with pytest.raises(IndexError,
+                       match='more timepoints than the current run'):
+        clean(signals, sample_mask=invalid_sample_mask_sep, runs=runs)
+
+    # list of sample_mask  with invalid indexing in one
+    sample_mask_sep[-1][-1] = 100
+    with pytest.raises(IndexError, match='invalid index'):
+        clean(signals, sample_mask=sample_mask_sep, runs=runs)
+
+    # invalid index in 1D sample_mask
+    sample_mask[-1] = 999
+    with pytest.raises(IndexError, match=r'invalid index \[\d*\]'):
+        clean(signals, sample_mask=sample_mask)


### PR DESCRIPTION
Closes #1012. Replace #2857 due to formatting was messed up. 

Changes proposed in this pull request:

- In `base_masker`, move parameter `sample_mask` from initialization to `transform` method, and all the Masker modules.
- Handle `sample_masks` with `signal.clean`
- Move input validation related to `runs` to a separate private function from `_process_runs`  and `_sanitize_inputs` to `_sanitize_runs` 

While implementing the discussed changes, I found how sample_mask should be handled when there are multiple runs more complicated than anticipated.
Here's a summary of the current implementation:  
* accept any input valid for indexing NumPy array as `sample_mask`
* for multiple runs, user must pass a list of sample masks to `sample_mask` (a set of index per run).

I have tried to implement `sample_mask` to match `confounds` for multiple runs, which allows sample_mask to be a 1D array when runs are provided. User needs to correct the index for multiple runs to fit into a 1D array. I think it's too error-prone. This makes me wonder, should we do the same for confounds? Or we want to rethink how multiple runs are handled?

This PR has a lot of difficult things to handle. If there's any redundant checks in signal.clean, or any better idea of handling the `sample_mask`, `runs`, and `confounds` please let me know.
