### PR TITLE
[ENH] Add `cbar_tick_format` to plotting functions

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -119,6 +119,12 @@ Enhancements
 - Importing :mod:`nilearn.plotting` will now raise a warning if the matplotlib
   backend has been changed from its original value, instead of silently modifying
   it.
+- Function :func:`~nilearn.plotting.plot_img` and deriving functions like
+  :func:`~nilearn.plotting.plot_anat`, :func:`~nilearn.plotting.plot_stat_map`, or
+  :func:`~nilearn.plotting.plot_epi` now accept an optional argument
+  ``cbar_tick_format`` to specify how numbers should be displayed on the colorbar.
+  This is consistent with the API of surface plotting functions (see release 0.7.1).
+  The default format is scientific notation.
 
 Changes
 -------

--- a/examples/01_plotting/plot_visualization.py
+++ b/examples/01_plotting/plot_visualization.py
@@ -29,7 +29,7 @@ func_filename = haxby_dataset.func[0]
 mean_haxby = mean_img(func_filename)
 
 from nilearn.plotting import plot_epi, show
-plot_epi(mean_haxby)
+plot_epi(mean_haxby, colorbar=True, cbar_tick_format="%i")
 
 ##############################################################################
 # Extracting a brain mask

--- a/examples/plot_single_subject_single_run.py
+++ b/examples/plot_single_subject_single_run.py
@@ -55,8 +55,8 @@ subject_data.func  # print the list of names of functional images
 ###############################################################################
 # We can display the first functional image and the subject's anatomy:
 from nilearn.plotting import plot_stat_map, plot_anat, plot_img
-plot_img(subject_data.func[0])
-plot_anat(subject_data.anat)
+plot_img(subject_data.func[0], colorbar=True, cbar_tick_format="%i")
+plot_anat(subject_data.anat, colorbar=True, cbar_tick_format="%i")
 
 ###############################################################################
 # Next, we concatenate all the 3D :term:`EPI` image into a single 4D image,

--- a/nilearn/plotting/displays/_slicers.py
+++ b/nilearn/plotting/displays/_slicers.py
@@ -239,8 +239,8 @@ class BaseSlicer(object):
 
         cbar_tick_format: str, optional
             Controls how to format the tick labels of the colorbar.
-            Ex: use "%i" to display as integers.
-            Default is '%.2g' for scientific notation.
+            Ex: use "%%i" to display as integers.
+            Default is '%%.2g' for scientific notation.
 
         colorbar : :obj:`bool`, optional
             If ``True``, display a colorbar on the right of the plots.

--- a/nilearn/plotting/displays/_slicers.py
+++ b/nilearn/plotting/displays/_slicers.py
@@ -65,6 +65,7 @@ class BaseSlicer(object):
         self._brain_color = brain_color
         self._colorbar = False
         self._colorbar_width = 0.05 * bb.width
+        self._cbar_tick_format = "%.2g"
         self._colorbar_margin = dict(left=0.25 * bb.width,
                                      right=0.02 * bb.width,
                                      top=0.05 * bb.height,
@@ -217,8 +218,9 @@ class BaseSlicer(object):
         ax.set_zorder(1000)
 
     @fill_doc
-    def add_overlay(self, img, threshold=1e-6, colorbar=False, **kwargs):
-        """Plot a 3D map in all the views.
+    def add_overlay(self, img, threshold=1e-6, colorbar=False,
+                    cbar_tick_format="%.2g", **kwargs):
+        """ Plot a 3D map in all the views.
 
         Parameters
         ----------
@@ -235,6 +237,11 @@ class BaseSlicer(object):
 
             Default=1e-6.
 
+        cbar_tick_format: str, optional
+            Controls how to format the tick labels of the colorbar.
+            Ex: use "%i" to display as integers.
+            Default is '%.2g' for scientific notation.
+
         colorbar : :obj:`bool`, optional
             If ``True``, display a colorbar on the right of the plots.
             Default=False.
@@ -248,6 +255,7 @@ class BaseSlicer(object):
                              "colorbar.")
         else:
             self._colorbar = colorbar
+            self._cbar_tick_format = cbar_tick_format
 
         img = check_niimg_3d(img)
 
@@ -458,7 +466,7 @@ class BaseSlicer(object):
         self._cbar = ColorbarBase(
             self._colorbar_ax, ticks=ticks, norm=norm,
             orientation='vertical', cmap=our_cmap, boundaries=bounds,
-            spacing='proportional', format='%.2g')
+            spacing='proportional', format=self._cbar_tick_format)
         self._cbar.ax.set_facecolor(self._brain_color)
 
         self._colorbar_ax.yaxis.tick_left()

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -296,8 +296,8 @@ def plot_img(img, cut_coords=None, output_file=None, display_mode='ortho',
         Default=False.
     cbar_tick_format: str, optional
         Controls how to format the tick labels of the colorbar.
-        Ex: use "%i" to display as integers.
-        Default is '%.2g' for scientific notation.
+        Ex: use "%%i" to display as integers.
+        Default is '%%.2g' for scientific notation.
     %(resampling_interpolation)s
         Default='continuous'.
     %(bg_img)s
@@ -491,10 +491,13 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
         Default='auto'.
     %(cmap)s
         Default=`plt.cm.gray`.
+    colorbar : boolean, optional
+        If True, display a colorbar on the right of the plots.
+        Default=False.
     cbar_tick_format: str, optional
         Controls how to format the tick labels of the colorbar.
-        Ex: use "%i" to display as integers.
-        Default is '%.2g' for scientific notation.
+        Ex: use "%%i" to display as integers.
+        Default is '%%.2g' for scientific notation.
     %(vmin)s
     %(vmax)s
 
@@ -548,10 +551,13 @@ def plot_epi(epi_img=None, cut_coords=None, output_file=None,
     %(draw_cross)s
     %(black_bg)s
         Default=True.
+    colorbar : boolean, optional
+        If True, display a colorbar on the right of the plots.
+        Default=False.
     cbar_tick_format: str, optional
         Controls how to format the tick labels of the colorbar.
-        Ex: use "%i" to display as integers.
-        Default is '%.2g' for scientific notation.
+        Ex: use "%%i" to display as integers.
+        Default is '%%.2g' for scientific notation.
     %(cmap)s
         Default=`plt.cm.nipy_spectral`.
     %(vmin)s
@@ -659,10 +665,13 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         Default=`plt.cm.gist_ncar`.
     %(dim)s
         Default='auto'.
+    colorbar : boolean, optional
+        If True, display a colorbar on the right of the plots.
+        Default=False.
     cbar_tick_format: str, optional
         Controls how to format the tick labels of the colorbar.
-        Ex: use "%i" to display as integers.
-        Default is '%.2g' for scientific notation.
+        Ex: use "%%i" to display as integers.
+        Default is '%%.2g' for scientific notation.
     %(vmin)s
     %(vmax)s
     %(resampling_interpolation)s
@@ -925,8 +934,8 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         Default=True.
     cbar_tick_format: str, optional
         Controls how to format the tick labels of the colorbar.
-        Ex: use "%i" to display as integers.
-        Default is '%.2g' for scientific notation.
+        Ex: use "%%i" to display as integers.
+        Default is '%%.2g' for scientific notation.
     %(figure)s
     %(axes)s
     %(title)s
@@ -1030,8 +1039,8 @@ def plot_glass_brain(stat_map_img,
         Default=False.
     cbar_tick_format: str, optional
         Controls how to format the tick labels of the colorbar.
-        Ex: use "%i" to display as integers.
-        Default is '%.2g' for scientific notation.
+        Ex: use "%%i" to display as integers.
+        Default is '%%.2g' for scientific notation.
     %(figure)s
     %(axes)s
     %(title)s

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -124,6 +124,7 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
                       bg_vmin=None, bg_vmax=None, interpolation="nearest",
                       display_factory=get_slicer,
                       cbar_vmin=None, cbar_vmax=None,
+                      cbar_tick_format="%.2g",
                       brain_color=(0.5, 0.5, 0.5),
                       decimals=False,
                       **kwargs):
@@ -201,6 +202,7 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
         display.add_overlay(new_img_like(img, data, affine),
                             threshold=threshold, interpolation=interpolation,
                             colorbar=colorbar, vmin=vmin, vmax=vmax,
+                            cbar_tick_format=cbar_tick_format,
                             **kwargs)
 
     if annotate:
@@ -268,6 +270,7 @@ def _crop_colorbar(cbar, cbar_vmin, cbar_vmax):
 def plot_img(img, cut_coords=None, output_file=None, display_mode='ortho',
              figure=None, axes=None, title=None, threshold=None,
              annotate=True, draw_cross=True, black_bg=False, colorbar=False,
+             cbar_tick_format="%.2g",
              resampling_interpolation='continuous',
              bg_img=None, vmin=None, vmax=None, **kwargs):
     """ Plot cuts of a given image (by default Frontal, Axial, and Lateral)
@@ -291,6 +294,10 @@ def plot_img(img, cut_coords=None, output_file=None, display_mode='ortho',
         Default=False.
     %(colorbar)s
         Default=False.
+    cbar_tick_format: str, optional
+        Controls how to format the tick labels of the colorbar.
+        Ex: use "%i" to display as integers.
+        Default is '%.2g' for scientific notation.
     %(resampling_interpolation)s
         Default='continuous'.
     %(bg_img)s
@@ -310,6 +317,7 @@ def plot_img(img, cut_coords=None, output_file=None, display_mode='ortho',
         draw_cross=draw_cross,
         resampling_interpolation=resampling_interpolation,
         black_bg=black_bg, colorbar=colorbar,
+        cbar_tick_format=cbar_tick_format,
         bg_img=bg_img, vmin=vmin, vmax=vmax, **kwargs)
 
     return display

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -630,7 +630,7 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
              output_file=None, display_mode='ortho', figure=None, axes=None,
              title=None, annotate=True, draw_cross=True, black_bg='auto',
              threshold=0.5, alpha=0.7, cmap=plt.cm.gist_ncar, dim='auto',
-             colorbar=False, cbar_tick_format="%.2g", vmin=None, vmax=None,
+             colorbar=False, cbar_tick_format="%i", vmin=None, vmax=None,
              resampling_interpolation='nearest', view_type='continuous',
              linewidths=2.5, **kwargs):
     """Plot cuts of an ROI/mask image (by default 3 cuts: Frontal, Axial, and
@@ -670,8 +670,8 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         Default=False.
     cbar_tick_format: str, optional
         Controls how to format the tick labels of the colorbar.
-        Ex: use "%%i" to display as integers.
-        Default is '%%.2g' for scientific notation.
+        Ex: use "%%.2g" to use scientific notation.
+        Default is '%%i' to display as integers.
     %(vmin)s
     %(vmax)s
     %(resampling_interpolation)s

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -464,7 +464,8 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
               output_file=None, display_mode='ortho', figure=None,
               axes=None, title=None, annotate=True, threshold=None,
               draw_cross=True, black_bg='auto', dim='auto', cmap=plt.cm.gray,
-              colorbar=False, cbar_tick_format="%.2g", vmin=None, vmax=None, **kwargs):
+              colorbar=False, cbar_tick_format="%.2g", vmin=None,
+              vmax=None, **kwargs):
     """Plot cuts of an anatomical image (by default 3 cuts:
     Frontal, Axial, and Lateral)
 

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -464,7 +464,7 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
               output_file=None, display_mode='ortho', figure=None,
               axes=None, title=None, annotate=True, threshold=None,
               draw_cross=True, black_bg='auto', dim='auto', cmap=plt.cm.gray,
-              vmin=None, vmax=None, **kwargs):
+              colorbar=False, cbar_tick_format="%.2g", vmin=None, vmax=None, **kwargs):
     """Plot cuts of an anatomical image (by default 3 cuts:
     Frontal, Axial, and Lateral)
 
@@ -490,6 +490,10 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
         Default='auto'.
     %(cmap)s
         Default=`plt.cm.gray`.
+    cbar_tick_format: str, optional
+        Controls how to format the tick labels of the colorbar.
+        Ex: use "%i" to display as integers.
+        Default is '%.2g' for scientific notation.
     %(vmin)s
     %(vmax)s
 
@@ -515,6 +519,7 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
                        figure=figure, axes=axes, title=title,
                        threshold=threshold, annotate=annotate,
                        draw_cross=draw_cross, black_bg=black_bg,
+                       colorbar=colorbar, cbar_tick_format=cbar_tick_format,
                        vmin=vmin, vmax=vmax, cmap=cmap, **kwargs)
     return display
 
@@ -523,6 +528,7 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
 def plot_epi(epi_img=None, cut_coords=None, output_file=None,
              display_mode='ortho', figure=None, axes=None, title=None,
              annotate=True, draw_cross=True, black_bg=True,
+             colorbar=False, cbar_tick_format="%.2g",
              cmap=plt.cm.nipy_spectral, vmin=None, vmax=None, **kwargs):
     """Plot cuts of an EPI image (by default 3 cuts:
     Frontal, Axial, and Lateral)
@@ -541,6 +547,10 @@ def plot_epi(epi_img=None, cut_coords=None, output_file=None,
     %(draw_cross)s
     %(black_bg)s
         Default=True.
+    cbar_tick_format: str, optional
+        Controls how to format the tick labels of the colorbar.
+        Ex: use "%i" to display as integers.
+        Default is '%.2g' for scientific notation.
     %(cmap)s
         Default=`plt.cm.nipy_spectral`.
     %(vmin)s
@@ -556,6 +566,7 @@ def plot_epi(epi_img=None, cut_coords=None, output_file=None,
                        figure=figure, axes=axes, title=title,
                        threshold=None, annotate=annotate,
                        draw_cross=draw_cross, black_bg=black_bg,
+                       colorbar=colorbar, cbar_tick_format=cbar_tick_format,
                        cmap=cmap, vmin=vmin, vmax=vmax, **kwargs)
     return display
 
@@ -612,8 +623,9 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
              output_file=None, display_mode='ortho', figure=None, axes=None,
              title=None, annotate=True, draw_cross=True, black_bg='auto',
              threshold=0.5, alpha=0.7, cmap=plt.cm.gist_ncar, dim='auto',
-             vmin=None, vmax=None, resampling_interpolation='nearest',
-             view_type='continuous', linewidths=2.5, **kwargs):
+             colorbar=False, cbar_tick_format="%.2g", vmin=None, vmax=None,
+             resampling_interpolation='nearest', view_type='continuous',
+             linewidths=2.5, **kwargs):
     """Plot cuts of an ROI/mask image (by default 3 cuts: Frontal, Axial, and
     Lateral)
 
@@ -646,6 +658,10 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         Default=`plt.cm.gist_ncar`.
     %(dim)s
         Default='auto'.
+    cbar_tick_format: str, optional
+        Controls how to format the tick labels of the colorbar.
+        Ex: use "%i" to display as integers.
+        Default is '%.2g' for scientific notation.
     %(vmin)s
     %(vmax)s
     %(resampling_interpolation)s
@@ -692,6 +708,7 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         draw_cross=draw_cross, black_bg=black_bg,
         threshold=threshold, bg_vmin=bg_vmin, bg_vmax=bg_vmax,
         resampling_interpolation=resampling_interpolation,
+        colorbar=colorbar, cbar_tick_format=cbar_tick_format,
         alpha=alpha, cmap=cmap, vmin=vmin, vmax=vmax, **kwargs)
 
     if view_type == 'contours':
@@ -883,9 +900,9 @@ def plot_prob_atlas(maps_img, bg_img=MNI152TEMPLATE, view_type='auto',
 @fill_doc
 def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
                   output_file=None, display_mode='ortho', colorbar=True,
-                  figure=None, axes=None, title=None, threshold=1e-6,
-                  annotate=True, draw_cross=True, black_bg='auto',
-                  cmap=cm.cold_hot, symmetric_cbar="auto",
+                  cbar_tick_format="%.2g", figure=None, axes=None,
+                  title=None, threshold=1e-6, annotate=True, draw_cross=True,
+                  black_bg='auto', cmap=cm.cold_hot, symmetric_cbar="auto",
                   dim='auto', vmax=None, resampling_interpolation='continuous',
                   **kwargs):
     """Plot cuts of an ROI/mask image (by default 3 cuts: Frontal, Axial, and
@@ -905,6 +922,10 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
     %(display_mode)s
     %(colorbar)s
         Default=True.
+    cbar_tick_format: str, optional
+        Controls how to format the tick labels of the colorbar.
+        Ex: use "%i" to display as integers.
+        Default is '%.2g' for scientific notation.
     %(figure)s
     %(axes)s
     %(title)s
@@ -960,7 +981,8 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         figure=figure, axes=axes, title=title, annotate=annotate,
         draw_cross=draw_cross, black_bg=black_bg, threshold=threshold,
         bg_vmin=bg_vmin, bg_vmax=bg_vmax, cmap=cmap, vmin=vmin, vmax=vmax,
-        colorbar=colorbar, cbar_vmin=cbar_vmin, cbar_vmax=cbar_vmax,
+        colorbar=colorbar, cbar_tick_format=cbar_tick_format,
+        cbar_vmin=cbar_vmin, cbar_vmax=cbar_vmax,
         resampling_interpolation=resampling_interpolation, **kwargs)
 
     return display
@@ -969,6 +991,7 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
 @fill_doc
 def plot_glass_brain(stat_map_img,
                      output_file=None, display_mode='ortho', colorbar=False,
+                     cbar_tick_format="%.2g",
                      figure=None, axes=None, title=None, threshold='auto',
                      annotate=True,
                      black_bg=False,
@@ -1004,6 +1027,10 @@ def plot_glass_brain(stat_map_img,
         'lzry', 'lyrz'. Default='ortho'.
     %(colorbar)s
         Default=False.
+    cbar_tick_format: str, optional
+        Controls how to format the tick labels of the colorbar.
+        Ex: use "%i" to display as integers.
+        Default is '%.2g' for scientific notation.
     %(figure)s
     %(axes)s
     %(title)s
@@ -1064,8 +1091,8 @@ def plot_glass_brain(stat_map_img,
         img=stat_map_img, output_file=output_file, display_mode=display_mode,
         figure=figure, axes=axes, title=title, annotate=annotate,
         black_bg=black_bg, threshold=threshold, cmap=cmap, colorbar=colorbar,
-        display_factory=display_factory, vmin=vmin, vmax=vmax,
-        cbar_vmin=cbar_vmin, cbar_vmax=cbar_vmax,
+        cbar_tick_format=cbar_tick_format, display_factory=display_factory,
+        vmin=vmin, vmax=vmax, cbar_vmin=cbar_vmin, cbar_vmax=cbar_vmax,
         resampling_interpolation=resampling_interpolation, **kwargs)
 
     if stat_map_img is None and 'l' in display.axes:

--- a/nilearn/plotting/tests/test_img_plotting/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_img_plotting.py
@@ -52,7 +52,7 @@ def test_plot_functions_3d_default_params(plot_func, testdata_3d, tmpdir):  # no
 
 @pytest.mark.parametrize("plot_func", PLOTTING_FUNCS_3D)
 @pytest.mark.parametrize("cbar_tick_format", ["%f", "%i"])
-def test_cbar_tick_format(plot_func, testdata_3d, cbar_tick_format, tmpdir):
+def test_cbar_tick_format(plot_func, testdata_3d, cbar_tick_format, tmpdir):  # noqa
     """Test different colorbar tick format with 3D plotting functions."""
     filename = str(tmpdir.join('temp.png'))
     plot_func(

--- a/nilearn/plotting/tests/test_img_plotting/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_img_plotting.py
@@ -50,6 +50,18 @@ def test_plot_functions_3d_default_params(plot_func, testdata_3d, tmpdir):  # no
     plt.close()
 
 
+@pytest.mark.parametrize("plot_func", PLOTTING_FUNCS_3D)
+@pytest.mark.parametrize("cbar_tick_format", ["%f", "%i"])
+def test_cbar_tick_format(plot_func, testdata_3d, cbar_tick_format, tmpdir):
+    """Test different colorbar tick format with 3D plotting functions."""
+    filename = str(tmpdir.join('temp.png'))
+    plot_func(
+        testdata_3d['img'], output_file=filename, colorbar=True,
+        cbar_tick_format=cbar_tick_format
+    )
+    plt.close()
+
+
 @pytest.mark.parametrize("plot_func", PLOTTING_FUNCS_4D)
 def test_plot_functions_4d_default_params(plot_func, testdata_3d, testdata_4d, tmpdir):  # noqa
     """Smoke-test for 4D plotting functions with default arguments."""

--- a/nilearn/plotting/tests/test_img_plotting/test_plot_anat.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_plot_anat.py
@@ -17,6 +17,20 @@ def test_plot_anat_MNI(anat_img, display_mode, tmpdir):
     plt.close()
 
 
+@pytest.mark.parametrize("anat_img", [False, MNI152TEMPLATE])
+@pytest.mark.parametrize("display_mode", ['z', 'ortho'])
+@pytest.mark.parametrize("cbar_tick_format", ["%.2g", "%i"])
+def test_plot_anat_colorbar(anat_img, display_mode, cbar_tick_format, tmpdir):
+    """Tests for plot_anat with MNI template and colorbar."""
+    slicer = plot_anat(
+        anat_img=anat_img, display_mode=display_mode, colorbar=True,
+        cbar_tick_format=cbar_tick_format
+    )
+    filename = str(tmpdir.join('test.png'))
+    slicer.savefig(filename)
+    plt.close()
+
+
 def test_plot_anat_3d_img(testdata_3d, tmpdir):  # noqa:F811
     """Smoke test for plot_anat."""
     filename = str(tmpdir.join('test.png'))


### PR DESCRIPTION
This PR adds the possibility to control the number formatting on the colorbars of volume plots through a `cbar_tick_format` argument. This extends what has been done in #2643 for surface plots.