### PR TITLE
[MAINT] Rename master into main

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -8,7 +8,7 @@ On Pull Requests, CircleCI run "partial builds" by default which render all the 
 
 Occasionally, some changes necessitate rebuilding the documentation from scratch, for example to see the full effect of the changes. These are called "full builds".
 
-Note that **CircleCI will always run full builds on master.**
+Note that **CircleCI will always run full builds on main.**
 
 You can request a CircleCI full build from a Pull Request at any time by including the tag "[circle full]" in your commit message. Note that this will trigger a full build of the documentation which usually takes around 90 minutes.
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # quick-build rebuilds changes using the cached documentation.
 # The cache is emptied everyday, forcing a full build on the day's first push.
-# It doesn't operate on master branch. New branches are always built from scratch.
-# full-build always rebuilds from scratch, without any cache. Only for changes in master branch.
+# It doesn't operate on main branch. New branches are always built from scratch.
+# full-build always rebuilds from scratch, without any cache. Only for changes in main branch.
 
 version: 2.1
 
@@ -322,6 +322,6 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - build_docs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ It's designed to capture information we've found to be useful in reviewing pull 
 If there is other information that would be helpful to include, please don't hesitate to add it!
 
 See here for more information on what is expected for pull requests:
-https://github.com/nilearn/nilearn/blob/master/CONTRIBUTING.rst#pull-requests
+https://github.com/nilearn/nilearn/blob/main/CONTRIBUTING.rst#pull-requests
 -->
 
 <!-- Please indicate after the # which issue you're closing with this PR.

--- a/.github/workflows/pep8.yml
+++ b/.github/workflows/pep8.yml
@@ -3,7 +3,7 @@ name: 'PEP8'
 on:
   push:
     branches:
-      - "master"
+      - "main"
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,7 @@ name: 'build'
 on:
   push:
     branches:
-      - "master"
+      - "main"
   pull_request:
     branches:
       - '*'

--- a/README.rst
+++ b/README.rst
@@ -8,16 +8,16 @@
     :target: https://pypi.org/project/nilearn/
     :alt: PyPI - Python Version
 
-.. image:: https://github.com/nilearn/nilearn/workflows/build/badge.svg?branch=master&event=push
+.. image:: https://github.com/nilearn/nilearn/workflows/build/badge.svg?branch=main&event=push
    :target: https://github.com/nilearn/nilearn/actions
    :alt: Github Actions Build Status
 
-.. image:: https://codecov.io/gh/nilearn/nilearn/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/nilearn/nilearn/branch/main/graph/badge.svg
    :target: https://codecov.io/gh/nilearn/nilearn
    :alt: Coverage Status
 
-.. image:: https://dev.azure.com/Parietal/Nilearn/_apis/build/status/nilearn.nilearn?branchName=master
-   :target: https://dev.azure.com/Parietal/Nilearn/_apis/build/status/nilearn.nilearn?branchName=master
+.. image:: https://dev.azure.com/Parietal/Nilearn/_apis/build/status/nilearn.nilearn?branchName=main
+   :target: https://dev.azure.com/Parietal/Nilearn/_apis/build/status/nilearn.nilearn?branchName=main
    :alt: Azure Build Status
 
 nilearn

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
 trigger:
-- master
+- main
 
 jobs:
 

--- a/build_tools/circle/build_type.sh
+++ b/build_tools/circle/build_type.sh
@@ -1,11 +1,11 @@
 #!/bin/bash -ef
 
-if [ "$CIRCLE_BRANCH" == "master" ] || [[ $(cat gitlog.txt) == *"[circle full]"* ]]; then
+if [ "$CIRCLE_BRANCH" == "main" ] || [[ $(cat gitlog.txt) == *"[circle full]"* ]]; then
     echo "Doing a full build";
     echo html-strict > build.txt;
 else
     echo "Doing a partial build";
-    FILENAMES=$(git diff --name-only $(git merge-base $CIRCLE_BRANCH upstream/master) $CIRCLE_BRANCH);
+    FILENAMES=$(git diff --name-only $(git merge-base $CIRCLE_BRANCH upstream/main) $CIRCLE_BRANCH);
     echo FILENAMES="$FILENAMES";
     for FILENAME in $FILENAMES; do
         if [[ `expr match $FILENAME "\(examples\)/.*plot_.*\.py"` ]]; then

--- a/build_tools/flake8_diff.sh
+++ b/build_tools/flake8_diff.sh
@@ -25,11 +25,11 @@ if [[ "$TRAVIS" == "true" ]]; then
     then
         # Travis does the git clone with a limited depth (50 at the time of
         # writing). This may not be enough to find the common ancestor with
-        # $REMOTE/master so we unshallow the git checkout
+        # $REMOTE/main so we unshallow the git checkout
         git fetch --unshallow || echo "Unshallowing the git checkout failed"
     else
         # We want to fetch the code as it is in the PR branch and not
-        # the result of the merge into master. This way line numbers
+        # the result of the merge into main. This way line numbers
         # reported by Travis will match with the local code.
         BRANCH_NAME=travis_pr_$TRAVIS_PULL_REQUEST
         git fetch $REMOTE pull/$TRAVIS_PULL_REQUEST/head:$BRANCH_NAME
@@ -50,12 +50,12 @@ echo -e '\nLast 2 commits:'
 echo '--------------------------------------------------------------------------------'
 git log -2 --pretty=short
 
-git fetch $REMOTE master
-REMOTE_MASTER_REF="$REMOTE/master"
+git fetch $REMOTE main
+REMOTE_MAIN_REF="$REMOTE/main"
 
-# Find common ancestor between HEAD and remotes/$REMOTE/master
-COMMIT=$(git merge-base @ $REMOTE_MASTER_REF) || \
-    echo "No common ancestor found for $(git show @ -q) and $(git show $REMOTE_MASTER_REF -q)"
+# Find common ancestor between HEAD and remotes/$REMOTE/main
+COMMIT=$(git merge-base @ $REMOTE_MAIN_REF) || \
+    echo "No common ancestor found for $(git show @ -q) and $(git show $REMOTE_MAIN_REF -q)"
 
 if [[ -n "$TMP_REMOTE" ]]; then
     git remote remove $TMP_REMOTE
@@ -65,7 +65,7 @@ if [[ -z "$COMMIT" ]]; then
     exit 1
 fi
 
-echo -e "\nCommon ancestor between HEAD and $REMOTE_MASTER_REF is:"
+echo -e "\nCommon ancestor between HEAD and $REMOTE_MAIN_REF is:"
 echo '--------------------------------------------------------------------------------'
 git show --no-patch $COMMIT
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ coverage:
   status:
     project:
       default:
-        # Commits pushed to master should not make the overall
+        # Commits pushed to main should not make the overall
         # project coverage decrease by more than 1%:
         target: auto
         threshold: 1%

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -331,7 +331,7 @@ sphinx_gallery_conf = {
         'org': 'nilearn',
         'repo': 'nilearn.github.io',
         'binderhub_url': 'https://mybinder.org',
-        'branch': 'master',
+        'branch': 'main',
         'dependencies': ['../requirements-build-docs.txt',
                          'binder/requirements.txt'],
         'notebooks_dir': 'examples'
@@ -363,5 +363,5 @@ def setup(app):
 linkcode_resolve = make_linkcode_resolve('nilearn',
                                          'https://github.com/nilearn/'
                                          'nilearn/blob/{revision}/'
-                                         '{package}/{path}#L{lineno}') 
+                                         '{package}/{path}#L{lineno}')
 

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -151,11 +151,11 @@ atlases):
   label, in the same (numerical) order as the atlas labels
 - ``maps`` (list or string): the path to the nifti image, or a list of paths
 
-In addition, the atlas will need to be called by a fetcher. For example, see `here <https://github.com/nilearn/nilearn/blob/master/nilearn/datasets/atlas.py>`__.
+In addition, the atlas will need to be called by a fetcher. For example, see `here <https://github.com/nilearn/nilearn/blob/main/nilearn/datasets/atlas.py>`__.
 
 Finally, as with other features, please provide a test for your atlas.
 Examples can be found `here
-<https://github.com/nilearn/nilearn/blob/master/nilearn/datasets/tests/test_atlas.py>`__
+<https://github.com/nilearn/nilearn/blob/main/nilearn/datasets/tests/test_atlas.py>`__
 
 Who makes decisions
 --------------------
@@ -254,12 +254,12 @@ Add these changes and submit a PR:
     git push origin REL-x.y.z
 
 
-Once the PR has been reviewed and merged, pull from master and tag the merge commit:
+Once the PR has been reviewed and merged, pull from main and tag the merge commit:
 
 .. code:: bash
 
-    git checkout master
-    git pull upstream master
+    git checkout main
+    git pull upstream main
     git tag x.y.z
     git push upstream --tags
 

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -564,7 +564,7 @@ def test_clean_frequencies_using_power_spectrum_density():
 def test_clean_finite_no_inplace_mod():
     """
     Test for verifying that the passed in signal array is not modified.
-    For PR #2125 . This test is failing on master, passing in this PR.
+    For PR #2125 . This test is failing on main, passing in this PR.
     """
     n_samples = 2
     # n_features  Must be higher than 500


### PR DESCRIPTION
Fixes #2841 

This PR prepares the renaming of branch `master` into `main`. 
I am not sure when we want to pull the trigger, but the steps will be the following:

- Rename branch `master` into `main` on the repo's main page (this should update the target branch of ongoing PRs including this one)
- Check that everything runs fine here and merge
- All clones will have to run locally:

```bash
$ git branch -m master main
$ git fetch origin
$ git branch -u origin/main main
$ git remote set-head origin -a
```

Note that GitHub will display a note on the main page saying that the main branch has been renamed, and that you should run these commands to update your clone.