### PR TITLE
[MAINT] Add missing versions in some deprecation warnings

### DIFF
--- a/nilearn/glm/model.py
+++ b/nilearn/glm/model.py
@@ -86,7 +86,8 @@ class LikelihoodModelResults(object):
     @auto_attr
     def df_resid(self):
         warnings.warn("'df_resid' from LikelihoodModelResults "
-                      "has been deprecated and will be removed. "
+                      "has been deprecated in 0.7.0 and will "
+                      "be removed in 0.9.0. "
                       "Please use 'df_residuals'.",
                       FutureWarning)
         return self.df_residuals

--- a/nilearn/glm/regression.py
+++ b/nilearn/glm/regression.py
@@ -43,11 +43,11 @@ def _deprecation_warning(old_param,
                           message=("'{}' has been deprecated in version {} "
                                    "and will be removed in version {}. "
                                    "Please use '{}' instead.".format(
-                               old_param,
-                               start_version,
-                               end_version,
-                               new_param
-                           )))
+                                       old_param,
+                                       start_version,
+                                       end_version,
+                                       new_param
+                                   )))
             return func(*args, **kwargs)
         return wrapper
     return _warned_func

--- a/nilearn/glm/regression.py
+++ b/nilearn/glm/regression.py
@@ -40,9 +40,9 @@ def _deprecation_warning(old_param,
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             warnings.warn(category=FutureWarning,
-                          message=("{} has been deprecated in version {} "
+                          message=("'{}' has been deprecated in version {} "
                                    "and will be removed in version {}. "
-                                   "Please use {} instead.".format(
+                                   "Please use '{}' instead.".format(
                                old_param,
                                start_version,
                                end_version,

--- a/nilearn/glm/regression.py
+++ b/nilearn/glm/regression.py
@@ -539,6 +539,7 @@ class SimpleRegressionResults(LikelihoodModelResults):
                 * positive_reciprocal(np.sqrt(self.dispersion))
                 )
 
+    @auto_attr
     def predicted(self):
         """ Return linear predictor values from a design matrix.
         """

--- a/nilearn/glm/regression.py
+++ b/nilearn/glm/regression.py
@@ -334,7 +334,7 @@ class RegressionResults(LikelihoodModelResults):
     """
     @rename_parameters(
         {'wresid': 'whitened_residuals', 'wY': 'whitened_Y'},
-        lib_name='Nistats',
+        lib_name='Nilearn',
         end_version='0.9.0',
     )
     def __init__(self, theta, Y, model, whitened_Y, whitened_residuals,

--- a/nilearn/glm/regression.py
+++ b/nilearn/glm/regression.py
@@ -19,6 +19,7 @@ General reference for regression models:
 __docformat__ = 'restructuredtext en'
 
 import warnings
+import functools
 
 import numpy as np
 
@@ -29,6 +30,27 @@ import scipy.linalg as spl
 from nilearn._utils.helpers import rename_parameters
 from nilearn.glm.model import LikelihoodModelResults
 from nilearn._utils.glm import positive_reciprocal
+
+
+def _deprecation_warning(old_param,
+                         new_param,
+                         start_version,
+                         end_version='future'):
+    def _warned_func(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            warnings.warn(category=FutureWarning,
+                          message=("{} has been deprecated in version {} "
+                                   "and will be removed in version {}. "
+                                   "Please use {} instead.".format(
+                               old_param,
+                               start_version,
+                               end_version,
+                               new_param
+                           )))
+            return func(*args, **kwargs)
+        return wrapper
+    return _warned_func
 
 
 class OLSModel(object):
@@ -102,19 +124,19 @@ class OLSModel(object):
         self.df_residuals = self.df_total - self.df_model
 
     @auto_attr
+    @_deprecation_warning('df_resid',
+                          'df_residuals',
+                          '0.7.0',
+                          '0.9.0')
     def df_resid(self):
-        warnings.warn("'df_resid' from OLSModel"
-                      "has been deprecated and will be removed. "
-                      "Please use 'df_residuals'.",
-                      FutureWarning)
         return self.df_residuals
 
     @auto_attr
+    @_deprecation_warning('wdesign',
+                          'whitened_design',
+                          '0.7.0',
+                          '0.9.0')
     def wdesign(self):
-        warnings.warn("'wdesign' from OLSModel"
-                      "has been deprecated and will be removed. "
-                      "Please use 'whitened_design'.",
-                      FutureWarning)
         return self.whitened_design
 
     def logL(self, beta, Y, nuisance=None):
@@ -312,7 +334,8 @@ class RegressionResults(LikelihoodModelResults):
     """
     @rename_parameters(
         {'wresid': 'whitened_residuals', 'wY': 'whitened_Y'},
-        lib_name='Nistats'
+        lib_name='Nistats',
+        end_version='0.9.0',
     )
     def __init__(self, theta, Y, model, whitened_Y, whitened_residuals,
                  cov=None, dispersion=1., nuisance=None):
@@ -329,38 +352,35 @@ class RegressionResults(LikelihoodModelResults):
         self.whitened_design = model.whitened_design
 
     @auto_attr
+    @_deprecation_warning('wdesign',
+                          'whitened_design',
+                          '0.7.0',
+                          '0.9.0')
     def wdesign(self):
-        warnings.warn("'wdesign' from RegressionResults"
-                      "has been deprecated and will be removed. "
-                      "Please use 'whitened_design'.",
-                      FutureWarning)
         return self.whitened_design
 
     @auto_attr
+    @_deprecation_warning('wY',
+                          'whitened_Y',
+                          '0.7.0',
+                          '0.9.0')
     def wY(self):
-        warnings.warn("'wY' from RegressionResults "
-                      "has been deprecated and will be removed. "
-                      "Please use 'whitened_Y' instead.",
-                      FutureWarning,
-                      )
         return self.whitened_Y
 
     @auto_attr
+    @_deprecation_warning('wresid',
+                          'whitened_residuals',
+                          '0.7.0',
+                          '0.9.0')
     def wresid(self):
-        warnings.warn("'wresid' from RegressionResults "
-                      "has been deprecated and will be removed. "
-                      "Please use 'whitened_residuals' instead.",
-                      FutureWarning,
-                      )
         return self.whitened_residuals
 
     @auto_attr
+    @_deprecation_warning('resid',
+                          'residuals',
+                          '0.7.0',
+                          '0.9.0')
     def resid(self):
-        warnings.warn("'resid' from RegressionResults "
-                      "has been deprecated and will be removed. "
-                      "Please use 'residuals' instead.",
-                      FutureWarning,
-                      )
         return self.residuals
 
     @auto_attr
@@ -371,12 +391,11 @@ class RegressionResults(LikelihoodModelResults):
         return self.Y - self.predicted
 
     @auto_attr
+    @_deprecation_warning('norm_resid',
+                          'normalized_residuals',
+                          '0.7.0',
+                          '0.9.0')
     def norm_resid(self):
-        warnings.warn("'norm_resid' from RegressionResults "
-                      "has been deprecated and will be removed. "
-                      "Please use 'normalized_residuals' instead.",
-                      FutureWarning,
-                      )
         return self.normalized_residuals
 
     @auto_attr
@@ -466,12 +485,11 @@ class SimpleRegressionResults(LikelihoodModelResults):
         """
         raise ValueError('can not use this method for simple results')
 
+    @_deprecation_warning('resid',
+                          'residuals',
+                          '0.7.0',
+                          '0.9.0')
     def resid(self, Y):
-        warnings.warn("'resid()' from SimpleRegressionResults"
-                      " has been deprecated and will be removed. "
-                      "Please use 'residuals()'.",
-                      FutureWarning,
-                      )
         return self.residuals(Y)
 
     def residuals(self, Y):
@@ -481,19 +499,18 @@ class SimpleRegressionResults(LikelihoodModelResults):
         return Y - self.predicted
 
     @auto_attr
+    @_deprecation_warning('df_resid',
+                          'df_residuals',
+                          '0.7.0',
+                          '0.9.0')
     def df_resid(self):
-        warnings.warn("The attribute 'df_resid' from OLSModel"
-                      "has been deprecated and will be removed. "
-                      "Please use 'df_residuals'.",
-                      FutureWarning)
         return self.df_residuals
 
+    @_deprecation_warning('norm_resid',
+                          'normalized_residuals',
+                          '0.7.0',
+                          '0.9.0')
     def norm_resid(self, Y):
-        warnings.warn("'SimpleRegressionResults.norm_resid' method "
-                      "has been deprecated and will be removed. "
-                      "Please use 'normalized_residuals'.",
-                      FutureWarning,
-                      )
         return self.normalized_residuals(Y)
 
     def normalized_residuals(self, Y):

--- a/nilearn/glm/tests/test_regression.py
+++ b/nilearn/glm/tests/test_regression.py
@@ -80,16 +80,46 @@ def test_AR_degenerate():
 def test_resid_rename_warnings_ols():
     model = OLSModel(design=X)
     results_ols = model.fit(Y)
-    with pytest.warns(FutureWarning, match="'df_resid'"):
-        assert_array_equal(results_ols.df_resid, results_ols.df_residuals)
-    with pytest.warns(FutureWarning, match="'resid'"):
-        assert_array_equal(results_ols.resid, results_ols.residuals)
-    with pytest.warns(FutureWarning, match="'wY'"):
-        assert_array_equal(results_ols.wY, results_ols.whitened_Y)
-    with pytest.warns(FutureWarning, match="'wdesign'"):
-        assert_array_equal(results_ols.wdesign, results_ols.whitened_design)
-    with pytest.warns(FutureWarning, match="'wdesign'"):
-        assert_array_equal(model.wdesign, model.whitened_design)
+
+    with pytest.warns(FutureWarning,
+                      match="'df_resid'"):
+        assert_array_equal(results_ols.df_resid,
+                           results_ols.df_residuals)
+
+    with pytest.warns(FutureWarning,
+                      match="'resid'"):
+        assert_array_equal(results_ols.resid,
+                           results_ols.residuals)
+
+    with pytest.warns(FutureWarning,
+                      match="'wresid'"):
+        assert_array_equal(results_ols.wresid,
+                           results_ols.whitened_residuals)
+
+    with pytest.warns(FutureWarning,
+                      match="'norm_resid'"):
+        assert_array_equal(results_ols.norm_resid,
+                           results_ols.normalized_residuals)
+
+    with pytest.warns(FutureWarning,
+                      match="'wY'"):
+        assert_array_equal(results_ols.wY,
+                           results_ols.whitened_Y)
+
+    with pytest.warns(FutureWarning,
+                      match="'wdesign'"):
+        assert_array_equal(results_ols.wdesign,
+                           results_ols.whitened_design)
+
+    with pytest.warns(FutureWarning,
+                      match="'df_resid'"):
+        assert_array_equal(model.df_resid,
+                           model.df_residuals)
+
+    with pytest.warns(FutureWarning,
+                      match="'wdesign'"):
+        assert_array_equal(model.wdesign,
+                           model.whitened_design)
 
 
 def test_resid_rename_warnings_ar():


### PR DESCRIPTION
Some attributes in the GLM module are deprecated but the deprecation warnings were missing the version numbers. I assumed these are deprecated since 0.7.0 and will be removed in 0.9.0.
These was also a `@auto_attr` decorator missing for one of the `predicted` method.