### PR TITLE
Remove deprecated function `sym_to_vec`

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -59,6 +59,8 @@ Enhancements
   :func:`nilearn.signal.clean`.
 - Moves parameter `sample_mask` from :class:`nilearn.input_data.NiftiMasker`
   to method `transform` in base class `nilearn.input_data.BaseMasker`.
+- Function sym_to_vec from :mod:`nilearn.connectome` was deprecated since release 0.4 and
+  has been removed.
 
 .. _v0.7.1:
 

--- a/nilearn/connectome/__init__.py
+++ b/nilearn/connectome/__init__.py
@@ -4,15 +4,17 @@ implementation of algorithm for sparse multi subjects learning
 of Gaussian graphical models.
 """
 
-from .connectivity_matrices import (sym_matrix_to_vec, vec_to_sym_matrix,
-                                    sym_to_vec, ConnectivityMeasure,
-                                    cov_to_corr, prec_to_partial)
+from .connectivity_matrices import (sym_matrix_to_vec,
+                                    vec_to_sym_matrix,
+                                    ConnectivityMeasure,
+                                    cov_to_corr,
+                                    prec_to_partial)
 
 from .group_sparse_cov import (GroupSparseCovariance,
                                GroupSparseCovarianceCV,
                                group_sparse_covariance)
 
-__all__ = ['sym_matrix_to_vec', 'vec_to_sym_matrix', 'sym_to_vec',
+__all__ = ['sym_matrix_to_vec', 'vec_to_sym_matrix',
            'ConnectivityMeasure', 'cov_to_corr', 'prec_to_partial',
            'GroupSparseCovariance', 'GroupSparseCovarianceCV',
            'group_sparse_covariance']

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -6,7 +6,6 @@ from scipy import linalg
 
 from sklearn.base import BaseEstimator, TransformerMixin, clone
 from sklearn.covariance import LedoitWolf
-from sklearn.utils import deprecated
 from .. import signal
 from .._utils.extmath import is_spd
 
@@ -197,38 +196,6 @@ def _geometric_mean(matrices, init=None, max_iter=10, tol=1e-7):
                       "{1}.".format(max_iter, tol))
 
     return gmean
-
-
-@deprecated("Function 'sym_to_vec' has been renamed to "
-            "'sym_matrix_to_vec' and will be removed in 0.8")
-def sym_to_vec(symmetric, discard_diagonal=False):
-    """Return the flattened lower triangular part of an array.
-    If diagonal is kept, diagonal elements are divided by sqrt(2) to conserve
-    the norm.
-
-    Acts on the last two dimensions of the array if not 2-dimensional.
-
-    .. versionadded:: 0.2
-
-    Parameters
-    ----------
-    symmetric : numpy.ndarray, shape (..., n_features, n_features)
-        Input array.
-
-    discard_diagonal : boolean, optional
-        If True, the values of the diagonal are not returned.
-        Default=False.
-
-    Returns
-    -------
-    output : numpy.ndarray
-        The output flattened lower triangular part of symmetric. Shape is
-        (..., n_features * (n_features + 1) / 2) if discard_diagonal is False
-        and (..., (n_features - 1) * n_features / 2) otherwise.
-
-    """
-    return sym_matrix_to_vec(symmetric=symmetric,
-                             discard_diagonal=discard_diagonal)
 
 
 def sym_matrix_to_vec(symmetric, discard_diagonal=False):


### PR DESCRIPTION
Function `sym_to_vec` is deprecated since release 0.4 and scheduled to be removed in 0.8.