### PR TITLE
Fix deprecation of decomposition `components_`

### DIFF
--- a/examples/03_connectivity/plot_extract_regions_dictlearning_maps.py
+++ b/examples/03_connectivity/plot_extract_regions_dictlearning_maps.py
@@ -17,13 +17,6 @@ ICA decomposition using :class:`nilearn.decomposition.CanICA`
 Please see the related documentation of :class:`nilearn.regions.RegionExtractor`
 for more details.
 
-.. note::
-
-    The use of the attribute `components_img_` from dictionary learning
-    estimator is implemented from version 0.4.1. For older versions,
-    unmask the deprecated attribute `components_` to get the components
-    image using attribute `masker_` embedded in estimator.
-    See the :ref:`section Inverse transform: unmasking data <unmasking_step>`.
 """
 
 ################################################################################
@@ -52,8 +45,6 @@ dict_learn = DictLearning(n_components=8, smoothing_fwhm=6.,
 # Fit to the data
 dict_learn.fit(func_filenames)
 # Resting state networks/maps in attribute `components_img_`
-# Note that this attribute is implemented from version 0.4.1.
-# For older versions, see the note section above for details.
 components_img = dict_learn.components_img_
 
 # Visualization of functional networks

--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -128,16 +128,18 @@ class CanICA(MultiPCA):
     Attributes
     ----------
     `components_` : 2D numpy array (n_components x n-voxels)
-        Masked ICA components extracted from the input images. They can be
-        unmasked thanks to the `masker_` attribute.
+        Masked ICA components extracted from the input images.
 
-        Deprecated since version 0.4.1. Use `components_img_` instead.
+        .. note::
+
+            Use attribute `components_img_` rather than manually unmasking
+            `components_` with `masker_` attribute.
 
     `components_img_` : 4D Nifti image
         4D image giving the extracted ICA components. Each 3D image is a
         component.
 
-        New in version 0.4.1.
+        .. versionadded:: 0.4.1
 
     `masker_` : instance of MultiNiftiMasker
         Masker used to filter and mask data as first step. If an instance of

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -152,12 +152,15 @@ class DictLearning(BaseDecomposition):
     `components_` : 2D numpy array (n_components x n-voxels)
         Masked dictionary components extracted from the input images.
 
-        Deprecated since version 0.4.1. Use `components_img_` instead
+        .. note::
+
+            Use attribute `components_img_` rather than manually unmasking
+            `components_` with `masker_` attribute.
 
     `components_img_` : 4D Nifti image
         4D image giving the extracted components. Each 3D image is a component.
 
-        New in version 0.4.1.
+        .. versionadded:: 0.4.1
 
     `masker_` : instance of MultiNiftiMasker
         Masker used to filter and mask data as first step. If an instance of

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -119,16 +119,18 @@ class MultiPCA(BaseDecomposition):
         the automatically computed mask.
 
     `components_` : 2D numpy array (n_components x n-voxels)
-        Array of masked extracted components. They can be unmasked thanks to
-        the `masker_` attribute.
+        Array of masked extracted components.
 
-        Deprecated since version 0.4.1. Use `components_img_` instead.
+        .. note::
+
+            Use attribute `components_img_` rather than manually unmasking
+            `components_` with `masker_` attribute.
 
     `components_img_` : 4D Nifti image
         4D image giving the extracted PCA components. Each 3D image is a
         component.
 
-        New in version 0.4.1.
+        .. versionadded:: 0.4.1
 
     `variance_` : numpy array (n_components,)
         The amount of variance explained by each of the selected components.


### PR DESCRIPTION
Closes #2862 

This PR:

- Removes the deprecation message for attribute `components_` and replaces it with a usage note explaining that `components_img_` can be used instead. Both attributes are kept to conform with other objects in Nilearn (Decoder for example).
- Uses `components_img_` instead of unmasking `components_`
- Moves the definition and fitting of NiftiMapsMasker from `transform` and `inverse_transform` to `fit`