### PR TITLE
[MAINT] Add `fill_doc` decorator

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,6 +47,11 @@ Enhancements
   whole-brain, 1mm-resolution, MNI152 T1 template instead of the averaged,
   whole-brain, 2mm-resolution MNI152 T1 template; it also accepts as input the
   grey-matter and white-matter ICBM152 1mm-resolution templates dated from 2009.
+- Common parts of docstrings accross Nilearn can now be filled automatically using
+  the decorator `nilearn._utils.fill_doc`. This can be applied to common function
+  parameters or common lists of options for example. The standard parts are defined
+  in a single location (`nilearn._utils.docs.py`) which makes them easier to
+  maintain and update. (See `#2875 <https://github.com/nilearn/nilearn/pull/2875`_)
 
 Changes
 -------

--- a/nilearn/_utils/__init__.py
+++ b/nilearn/_utils/__init__.py
@@ -3,6 +3,8 @@ from .niimg_conversions import (check_niimg, check_niimg_3d, concat_niimgs,
 
 from .niimg import _repr_niimgs, copy_img, load_niimg
 
+from .docs import fill_doc
+
 from .numpy_conversions import as_ndarray
 
 from .cache_mixin import CacheMixin
@@ -13,5 +15,5 @@ from nilearn._utils.helpers import rename_parameters, remove_parameters
 __all__ = ['check_niimg', 'check_niimg_3d', 'concat_niimgs', 'check_niimg_4d',
            '_repr_niimgs', 'copy_img', 'load_niimg',
            'as_ndarray', 'CacheMixin', '_compose_err_msg', 'rename_parameters',
-           'remove_parameters',
+           'remove_parameters', 'fill_doc',
            ]

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""Functions related to the documentation.
+
+docdict contains the standard documentation entries
+used accross Nilearn.
+
+source: Eric Larson and MNE-python team.
+https://github.com/mne-tools/mne-python/blob/main/mne/utils/docs.py
+"""
+
+import sys
+
+###################################
+# Standard documentation entries
+#
+docdict = dict()
+
+# Verbose
+docdict['verbose'] = """
+verbose : int, optional
+    Verbosity level (0 means no message).
+    Default=1."""
+
+# Resume
+docdict['resume'] = """
+resume : bool, optional
+    Whether to resumed download of a partly-downloaded file.
+    Default=True."""
+
+# Data_dir
+docdict['data_dir'] = """
+data_dir : string, optional
+    Path where data should be downloaded. By default,
+    files are downloaded in home directory."""
+
+# URL
+docdict['url'] = """
+url : string, optional
+    URL of file to download.
+    Override download URL. Used for test only (or if you
+    setup a mirror of the data).
+    Default: None."""
+
+docdict_indented = {}
+
+def _indentcount_lines(lines):
+    """Minimum indent for all lines in line list
+
+    >>> lines = [' one', '  two', '   three']
+    >>> indentcount_lines(lines)
+    1
+    >>> lines = []
+    >>> indentcount_lines(lines)
+    0
+    >>> lines = [' one']
+    >>> indentcount_lines(lines)
+    1
+    >>> indentcount_lines(['    '])
+    0
+
+    """
+    indentno = sys.maxsize
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped:
+            indentno = min(indentno, len(line) - len(stripped))
+    if indentno == sys.maxsize:
+        return 0
+    return indentno
+
+
+def fill_doc(f):
+    """Fill a docstring with docdict entries.
+
+    Parameters
+    ----------
+    f : callable
+        The function to fill the docstring of. Will be modified in place.
+
+    Returns
+    -------
+    f : callable
+        The function, potentially with an updated ``__doc__``.
+
+    """
+    docstring = f.__doc__
+    if not docstring:
+        return f
+    lines = docstring.splitlines()
+    # Find the minimum indent of the main docstring, after first line
+    if len(lines) < 2:
+        icount = 0
+    else:
+        icount = _indentcount_lines(lines[1:])
+    # Insert this indent to dictionary docstrings
+    try:
+        indented = docdict_indented[icount]
+    except KeyError:
+        indent = ' ' * icount
+        docdict_indented[icount] = indented = {}
+        for name, dstr in docdict.items():
+            lines = dstr.splitlines()
+            try:
+                newlines = [lines[0]]
+                for line in lines[1:]:
+                    newlines.append(indent + line)
+                indented[name] = '\n'.join(newlines)
+            except IndexError:
+                indented[name] = dstr
+    try:
+        f.__doc__ = docstring % indented
+    except (TypeError, ValueError, KeyError) as exp:
+        funcname = f.__name__
+        funcname = docstring.split('\n')[0] if funcname is None else funcname
+        raise RuntimeError('Error documenting %s:\n%s'
+                           % (funcname, str(exp)))
+    return f
+

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -48,15 +48,15 @@ def _indentcount_lines(lines):
     """Minimum indent for all lines in line list
 
     >>> lines = [' one', '  two', '   three']
-    >>> indentcount_lines(lines)
+    >>> _indentcount_lines(lines)
     1
     >>> lines = []
-    >>> indentcount_lines(lines)
+    >>> _indentcount_lines(lines)
     0
     >>> lines = [' one']
-    >>> indentcount_lines(lines)
+    >>> _indentcount_lines(lines)
     1
-    >>> indentcount_lines(['    '])
+    >>> _indentcount_lines(['    '])
     0
 
     """

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -18,8 +18,7 @@ docdict = dict()
 # Verbose
 docdict['verbose'] = """
 verbose : int, optional
-    Verbosity level (0 means no message).
-    Default=1."""
+    Verbosity level (0 means no message)."""
 
 # Resume
 docdict['resume'] = """
@@ -39,7 +38,73 @@ url : string, optional
     URL of file to download.
     Override download URL. Used for test only (or if you
     setup a mirror of the data).
-    Default: None."""
+    Default=None."""
+
+# Smoothing_fwhm
+docdict['smoothing_fwhm'] = """
+smoothing_fwhm : float, optional.
+    If smoothing_fwhm is not None, it gives the size in millimeters of the
+    spatial smoothing to apply to the signal.
+    Default=None."""
+
+# Standardize
+docdict['standardize'] = """
+standardize : bool, optional.
+    If standardize is True, the time-series are centered and normed:
+    their variance is put to 1 in the time dimension.
+    Default=True."""
+
+# Target_affine
+docdict['target_affine'] = """
+target_affine: 3x3 or 4x4 matrix, optional.
+    This parameter is passed to image.resample_img. Please see the
+    related documentation for details.
+    Default=None."""
+
+# Target_shape
+docdict['target_shape'] = """
+target_shape: 3-tuple of int, optional.
+    This parameter is passed to image.resample_img. Please see the
+    related documentation for details.
+    Default=None."""
+
+# Low_pass
+docdict['low_pass'] = """
+low_pass: float, optional
+    Low cutoff frequency in Hertz.
+    Default=None."""
+
+# High pass
+docdict['high_pass'] = """
+high_pass: float, optional
+    High cutoff frequency in Hertz.
+    Default=None."""
+
+# t_r
+docdict['t_r'] = """
+t_r: float, optional
+    Repetition time, in second (sampling period). Set to None if not.
+    Default=None."""
+
+# Memory
+docdict['memory'] = """
+memory : instance of joblib.Memory or str
+    Used to cache the masking process.
+    By default, no caching is done. If a str is given, it is the
+    path to the caching directory."""
+
+# Memory_level
+docdict['memory_level'] = """
+memory_level: int, optional.
+    Rough estimator of the amount of memory used by caching. Higher value
+    means more memory for caching.
+    Default=0."""
+
+# n_jobs
+docdict['n_jobs'] = """
+n_jobs : int, optional.
+    The number of CPUs to use to do the computation. -1 means 'all CPUs'.."""
+
 
 docdict_indented = {}
 

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -43,6 +43,7 @@ url : string, optional
 
 docdict_indented = {}
 
+
 def _indentcount_lines(lines):
     """Minimum indent for all lines in line list
 
@@ -115,4 +116,3 @@ def fill_doc(f):
         raise RuntimeError('Error documenting %s:\n%s'
                            % (funcname, str(exp)))
     return f
-

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -50,22 +50,27 @@ smoothing_fwhm : float, optional.
 # Standardize
 docdict['standardize'] = """
 standardize : bool, optional.
-    If standardize is True, the time-series are centered and normed:
+    If standardize is True, the data are centered and normed:
     their variance is put to 1 in the time dimension.
     Default=True."""
 
 # Target_affine
 docdict['target_affine'] = """
-target_affine: 3x3 or 4x4 matrix, optional.
-    This parameter is passed to image.resample_img. Please see the
-    related documentation for details.
+target_affine: numpy.ndarray, optional.
+    If specified, the image is resampled corresponding to this new affine.
+    target_affine can be a 3x3 or a 4x4 matrix.
     Default=None."""
 
 # Target_shape
 docdict['target_shape'] = """
-target_shape: 3-tuple of int, optional.
-    This parameter is passed to image.resample_img. Please see the
-    related documentation for details.
+target_shape: tuple or list, optional.
+    If specified, the image will be resized to match this new shape.
+    len(target_shape) must be equal to 3.
+
+    .. note::
+        If `target_shape` is specified, a `target_affine` of shape
+        (4, 4) must also be given.
+
     Default=None."""
 
 # Low_pass

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -16,9 +16,12 @@ import sys
 docdict = dict()
 
 # Verbose
-docdict['verbose'] = """
+verbose = """
 verbose : int, optional
-    Verbosity level (0 means no message)."""
+    Verbosity level (0 means no message).
+    Default={}."""
+docdict['verbose'] = verbose.format(1)
+docdict['verbose0'] = verbose.format(0)
 
 # Resume
 docdict['resume'] = """
@@ -48,11 +51,13 @@ smoothing_fwhm : float, optional.
     Default=None."""
 
 # Standardize
-docdict['standardize'] = """
+standardize = """
 standardize : bool, optional.
     If standardize is True, the data are centered and normed:
     their variance is put to 1 in the time dimension.
-    Default=True."""
+    Default={}."""
+docdict['standardize'] = standardize.format('True')
+docdict['standardize_false'] = standardize.format('False')
 
 # Target_affine
 docdict['target_affine'] = """
@@ -99,17 +104,110 @@ memory : instance of joblib.Memory or str
     path to the caching directory."""
 
 # Memory_level
-docdict['memory_level'] = """
+memory_level = """
 memory_level: int, optional.
     Rough estimator of the amount of memory used by caching. Higher value
     means more memory for caching.
-    Default=0."""
+    Default={}."""
+docdict['memory_level'] = memory_level.format(0)
+docdict['memory_level1'] = memory_level.format(1)
 
 # n_jobs
-docdict['n_jobs'] = """
+n_jobs = """
 n_jobs : int, optional.
-    The number of CPUs to use to do the computation. -1 means 'all CPUs'.."""
+    The number of CPUs to use to do the computation. -1 means 'all CPUs'.
+    Default={}."""
+docdict['n_jobs'] = n_jobs.format("1")
+docdict['n_jobs_all'] = n_jobs.format("-1")
 
+# fsaverage options
+docdict['fsaverage_options'] = """
+
+        - 'fsaverage3': the low-resolution fsaverage3 mesh (642 nodes)
+        - 'fsaverage4': the low-resolution fsaverage4 mesh (2562 nodes)
+        - 'fsaverage5': the low-resolution fsaverage5 mesh (10242 nodes)
+        - 'fsaverage5_sphere': the low-resolution fsaverage5 spheres
+
+            .. deprecated:: 0.8.0
+                This option has been deprecated and will be removed in v0.9.0.
+                fsaverage5 sphere coordinates can now be accessed through
+                attributes sphere_{left, right} using mesh='fsaverage5'
+
+        - 'fsaverage6': the medium-resolution fsaverage6 mesh (40962 nodes)
+        - 'fsaverage7': same as 'fsaverage'
+        - 'fsaverage': the high-resolution fsaverage mesh (163842 nodes)
+
+            .. note::
+                The high-resolution fsaverage will result in more computation
+                time and memory usage
+
+"""
+
+# Classifiers
+docdict['classifier_options'] = """
+
+        - `svc`: `Linear support vector classifier <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html>`_ with L2 penalty.
+            .. code-block:: python
+
+                svc = LinearSVC(penalty='l2', max_iter=1e4)
+
+        - `svc_l2`: `Linear support vector classifier <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html>`_ with L2 penalty.
+            .. note::
+                Same as option `svc`.
+
+        - `svc_l1`: `Linear support vector classifier <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html>`_ with L1 penalty.
+            .. code-block:: python
+
+                svc_l1 = LinearSVC(penalty='l1', dual=False, max_iter=1e4)
+
+        - `logistic`: `Logistic regression <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html>`_ with L2 penalty.
+            .. code-block:: python
+
+                logistic = LogisticRegression(penalty='l2',solver='liblinear')
+
+        - `logistic_l1`: `Logistic regression <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html>`_ with L1 penalty.
+            .. code-block:: python
+
+                logistic_l1 = LogisticRegression(penalty='l1', solver='liblinear')
+
+        - `logistic_l2`: `Logistic regression <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html>`_ with L2 penalty
+            .. note::
+                Same as option `logistic`.
+
+        - `ridge_classifier`: `Ridge classifier <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RidgeClassifierCV.html>`_.
+            .. code-block:: python
+
+                ridge_classifier = RidgeClassifierCV()
+
+        - `dummy_classifier`: `Dummy classifier <https://scikit-learn.org/stable/modules/generated/sklearn.dummy.DummyClassifier.html>`_ with stratified strategy.
+            .. code-block:: python
+
+                dummy = DummyClassifier(strategy='stratified', random_state=0)
+
+"""
+
+docdict['regressor_options'] = """
+
+        - `ridge`: `Ridge regression <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RidgeCV.html>`_.
+            .. code-block:: python
+
+                ridge = RidgeCV()
+
+        - `ridge_regressor`: `Ridge regression <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RidgeCV.html>`_.
+            .. note::
+                Same option as `ridge`.
+
+        - `svr`: `Support vector regression <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVR.html>`_.
+            .. code-block:: python
+
+                svr = SVR(kernel='linear', max_iter=1e4)
+
+        - `dummy_regressor`: `Dummy regressor <https://scikit-learn.org/stable/modules/generated/sklearn.dummy.DummyRegressor.html>`_.
+            .. code-block:: python
+
+                dummy = DummyRegressor(strategy='mean')
+
+"""
 
 docdict_indented = {}
 

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -144,76 +144,98 @@ docdict['fsaverage_options'] = """
 """
 
 # Classifiers
-docdict['classifier_options'] = """
+base_url = "https://scikit-learn.org/stable/modules/generated/sklearn"
+svc = "Linear support vector classifier"
+logistic = "Logistic regression"
+rc = "Ridge classifier"
+dc = "Dummy classifier with stratified strategy"
+SKLEARN_LINKS = {
+    'svc': f"{base_url}.svm.SVC.html",
+    'logistic': f"{base_url}.linear_model.LogisticRegression.html",
+    'ridge_classifier': f"{base_url}.linear_model.RidgeClassifierCV.html",
+    'dummy_classifier': f"{base_url}.dummy.DummyClassifier.html",
+    'ridge': f"{base_url}.linear_model.RidgeCV.html",
+    'svr': f"{base_url}.svm.SVR.html",
+    'dummy_regressor': f"{base_url}.dummy.DummyRegressor.html",
+}
 
-        - `svc`: `Linear support vector classifier <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html>`_ with L2 penalty.
+docdict['classifier_options'] = f"""
+
+        - `svc`: `{svc} <%(svc)s>`_ with L2 penalty.
             .. code-block:: python
 
-                svc = LinearSVC(penalty='l2', max_iter=1e4)
+                svc = LinearSVC(penalty='l2',
+                                max_iter=1e4)
 
-        - `svc_l2`: `Linear support vector classifier <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html>`_ with L2 penalty.
+        - `svc_l2`: `{svc} <%(svc)s>`_ with L2 penalty.
             .. note::
                 Same as option `svc`.
 
-        - `svc_l1`: `Linear support vector classifier <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html>`_ with L1 penalty.
+        - `svc_l1`: `{svc} <%(svc)s>`_ with L1 penalty.
             .. code-block:: python
 
-                svc_l1 = LinearSVC(penalty='l1', dual=False, max_iter=1e4)
+                svc_l1 = LinearSVC(penalty='l1',
+                                   dual=False,
+                                   max_iter=1e4)
 
-        - `logistic`: `Logistic regression <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html>`_ with L2 penalty.
+        - `logistic`: `{logistic} <%(logistic)s>`_ with L2 penalty.
             .. code-block:: python
 
-                logistic = LogisticRegression(penalty='l2',solver='liblinear')
+                logistic = LogisticRegression(penalty='l2',
+                                              solver='liblinear')
 
-        - `logistic_l1`: `Logistic regression <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html>`_ with L1 penalty.
+        - `logistic_l1`: `{logistic} <%(logistic)s>`_ with L1 penalty.
             .. code-block:: python
 
-                logistic_l1 = LogisticRegression(penalty='l1', solver='liblinear')
+                logistic_l1 = LogisticRegression(penalty='l1',
+                                                 solver='liblinear')
 
-        - `logistic_l2`: `Logistic regression <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html>`_ with L2 penalty
+        - `logistic_l2`: `{logistic} <%(logistic)s>`_ with L2 penalty
             .. note::
                 Same as option `logistic`.
 
-        - `ridge_classifier`: `Ridge classifier <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RidgeClassifierCV.html>`_.
+        - `ridge_classifier`: `{rc} <%(ridge_classifier)s>`_.
             .. code-block:: python
 
                 ridge_classifier = RidgeClassifierCV()
 
-        - `dummy_classifier`: `Dummy classifier <https://scikit-learn.org/stable/modules/generated/sklearn.dummy.DummyClassifier.html>`_ with stratified strategy.
+        - `dummy_classifier`: `{dc} <%(dummy_classifier)s>`_.
             .. code-block:: python
 
-                dummy = DummyClassifier(strategy='stratified', random_state=0)
+                dummy = DummyClassifier(strategy='stratified',
+                                        random_state=0)
 
-"""
+""" % SKLEARN_LINKS
 
 docdict['regressor_options'] = """
 
-        - `ridge`: `Ridge regression <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RidgeCV.html>`_.
+        - `ridge`: `Ridge regression <%(ridge)s>`_.
             .. code-block:: python
 
                 ridge = RidgeCV()
 
-        - `ridge_regressor`: `Ridge regression <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RidgeCV.html>`_.
+        - `ridge_regressor`: `Ridge regression <%(ridge)s>`_.
             .. note::
                 Same option as `ridge`.
 
-        - `svr`: `Support vector regression <https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVR.html>`_.
+        - `svr`: `Support vector regression <%(svr)s>`_.
             .. code-block:: python
 
-                svr = SVR(kernel='linear', max_iter=1e4)
+                svr = SVR(kernel='linear',
+                          max_iter=1e4)
 
-        - `dummy_regressor`: `Dummy regressor <https://scikit-learn.org/stable/modules/generated/sklearn.dummy.DummyRegressor.html>`_.
+        - `dummy_regressor`: `Dummy regressor <%(dummy_regressor)s>`_.
             .. code-block:: python
 
                 dummy = DummyRegressor(strategy='mean')
 
-"""
+""" % SKLEARN_LINKS
 
 docdict_indented = {}
 
 
 def _indentcount_lines(lines):
-    """Minimum indent for all lines in line list
+    """Minimum indent for all lines in line list.
 
     >>> lines = [' one', '  two', '   three']
     >>> _indentcount_lines(lines)

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -55,6 +55,7 @@ def fetch_atlas_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True
     %(data_dir)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -137,6 +138,7 @@ def fetch_atlas_craddock_2012(data_dir=None, url=None, resume=True, verbose=1):
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -197,6 +199,7 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -282,6 +285,7 @@ def fetch_atlas_harvard_oxford(atlas_name, data_dir=None,
         Default=False.
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -409,6 +413,7 @@ def fetch_atlas_msdl(data_dir=None, url=None, resume=True, verbose=1):
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -495,6 +500,7 @@ def fetch_atlas_smith_2009(data_dir=None, mirror='origin', url=None,
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -585,6 +591,7 @@ def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -665,6 +672,7 @@ def fetch_atlas_aal(version='SPM12', data_dir=None, url=None, resume=True,
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -760,6 +768,7 @@ def fetch_atlas_basc_multiscale_2015(version='sym', data_dir=None, url=None,
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -955,6 +964,7 @@ def fetch_atlas_allen_2011(data_dir=None, url=None, resume=True, verbose=1):
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -1039,6 +1049,7 @@ def fetch_atlas_surf_destrieux(data_dir=None, url=None,
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -1203,6 +1214,7 @@ def fetch_atlas_talairach(level_name, data_dir=None, verbose=1):
         the tissue type or the Brodmann area.
     %(data_dir)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -1248,6 +1260,7 @@ def fetch_atlas_pauli_2017(version='prob', data_dir=None, verbose=1):
         deterministic atlas. Default='prob'.
     %(data_dir)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -1329,6 +1342,7 @@ def fetch_atlas_schaefer_2018(n_rois=400, yeo_networks=7, resolution_mm=1,
         base_url of files to download (None results in default base_url).
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -55,7 +55,6 @@ def fetch_atlas_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True
     %(data_dir)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -138,7 +137,6 @@ def fetch_atlas_craddock_2012(data_dir=None, url=None, resume=True, verbose=1):
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -199,7 +197,6 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -281,11 +278,13 @@ def fetch_atlas_harvard_oxford(atlas_name, data_dir=None,
         returned. For subcortical types (sub-maxprob), we split every
         symmetric region in left and right parts. Effectively doubles the
         number of regions.
-        NOTE Not implemented for full probabilistic atlas (*-prob-* atlases).
+
+        .. note::
+            Not implemented for full probabilistic atlas (*-prob-* atlases).
+
         Default=False.
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -413,7 +412,6 @@ def fetch_atlas_msdl(data_dir=None, url=None, resume=True, verbose=1):
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -500,7 +498,6 @@ def fetch_atlas_smith_2009(data_dir=None, mirror='origin', url=None,
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -591,7 +588,6 @@ def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -672,7 +668,6 @@ def fetch_atlas_aal(version='SPM12', data_dir=None, url=None, resume=True,
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -768,7 +763,6 @@ def fetch_atlas_basc_multiscale_2015(version='sym', data_dir=None, url=None,
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -964,7 +958,6 @@ def fetch_atlas_allen_2011(data_dir=None, url=None, resume=True, verbose=1):
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -1049,7 +1042,6 @@ def fetch_atlas_surf_destrieux(data_dir=None, url=None,
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -1214,7 +1206,6 @@ def fetch_atlas_talairach(level_name, data_dir=None, verbose=1):
         the tissue type or the Brodmann area.
     %(data_dir)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -1260,7 +1251,6 @@ def fetch_atlas_pauli_2017(version='prob', data_dir=None, verbose=1):
         deterministic atlas. Default='prob'.
     %(data_dir)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -1342,7 +1332,6 @@ def fetch_atlas_schaefer_2018(n_rois=400, yeo_networks=7, resolution_mm=1,
         base_url of files to download (None results in default base_url).
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -14,20 +14,23 @@ from numpy.lib import recfunctions
 from sklearn.utils import Bunch
 
 from .utils import _get_dataset_dir, _fetch_files, _get_dataset_descr
-from .._utils import check_niimg
+from .._utils import check_niimg, fill_doc
 from ..image import new_img_like, get_data
 
 _TALAIRACH_LEVELS = ['hemisphere', 'lobe', 'gyrus', 'tissue', 'ba']
 
 
+@fill_doc
 def fetch_atlas_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True, verbose=1):
     """Fetch DiFuMo brain atlas
 
     Dictionaries of Functional Modes, or “DiFuMo”, can serve as atlases to extract
     functional signals with different dimensionalities (64, 128, 256, 512, and 1024).
     These modes are optimized to represent well raw BOLD timeseries,
-    over a with range of experimental conditions. 
+    over a with range of experimental conditions.
     See :footcite:`DADI2020117126`.
+
+    .. versionadded:: 0.7.1
 
     Notes
     -----
@@ -49,17 +52,9 @@ def fetch_atlas_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True
     resolution_mm : int, optional
         The resolution in mm of the atlas to fetch. Valid options
         available are {2, 3}. Default=2mm.
-
-    data_dir : string, optional
-        Path where data should be downloaded. By default,
-        files are downloaded in home directory.
-
-    resume : bool, optional
-        Whether to resumed download of a partly-downloaded file.
-        Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -125,6 +120,7 @@ def fetch_atlas_difumo(dimension=64, resolution_mm=2, data_dir=None, resume=True
     return Bunch(**params)
 
 
+@fill_doc
 def fetch_atlas_craddock_2012(data_dir=None, url=None, resume=True, verbose=1):
     """Download and return file names for the Craddock 2012 parcellation
 
@@ -137,18 +133,10 @@ def fetch_atlas_craddock_2012(data_dir=None, url=None, resume=True, verbose=1):
 
     Parameters
     ----------
-    data_dir : string, optional
-        Directory where data should be downloaded and unpacked.
-
-    url : string, optional
-        url of file to download.
-
-    resume : bool, optional
-        Whether to resumed download of a partly-downloaded file.
-        Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -192,10 +180,11 @@ def fetch_atlas_craddock_2012(data_dir=None, url=None, resume=True, verbose=1):
     return Bunch(**params)
 
 
+@fill_doc
 def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
                                resume=True, verbose=1):
     """Download and load the Destrieux cortical atlas (dated 2009)
-    
+
     see :footcite:`Fischl2004Automatically`,
     and :footcite:`Destrieux2009sulcal`.
 
@@ -204,20 +193,10 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
     lateralized : boolean, optional
         If True, returns an atlas with distinct regions for right and left
         hemispheres. Default=True.
-
-    data_dir : string, optional
-        Path of the data directory. Use to forec data storage in a non-
-        standard location. Default: None (meaning: default)
-
-    url : string, optional
-        Download URL of the dataset. Overwrite the default URL.
-
-    resume : bool, optional
-        Whether to resumed download of a partly-downloaded file.
-        Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -259,6 +238,7 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
     return Bunch(**params)
 
 
+@fill_doc
 def fetch_atlas_harvard_oxford(atlas_name, data_dir=None,
                                symmetric_split=False,
                                resume=True, verbose=1):
@@ -300,13 +280,8 @@ def fetch_atlas_harvard_oxford(atlas_name, data_dir=None,
         number of regions.
         NOTE Not implemented for full probabilistic atlas (*-prob-* atlases).
         Default=False.
-
-    resume : bool, optional
-        Whether to resumed download of a partly-downloaded file.
-        Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -420,6 +395,7 @@ def fetch_atlas_harvard_oxford(atlas_name, data_dir=None,
     return Bunch(maps=atlas_img, labels=new_names)
 
 
+@fill_doc
 def fetch_atlas_msdl(data_dir=None, url=None, resume=True, verbose=1):
     """Download and load the MSDL brain atlas.
 
@@ -429,20 +405,10 @@ def fetch_atlas_msdl(data_dir=None, url=None, resume=True, verbose=1):
 
     Parameters
     ----------
-    data_dir : string, optional
-        Path of the data directory. Used to force data storage in a specified
-        location. Default: None
-
-    url : string, optional
-        Override download URL. Used for test only (or if you setup a mirror of
-        the data).
-
-    resume : bool, optional
-        Whether to resumed download of a partly-downloaded file.
-        Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -488,7 +454,7 @@ def fetch_atlas_msdl(data_dir=None, url=None, resume=True, verbose=1):
 
 def fetch_coords_power_2011():
     """Download and load the Power et al. brain atlas composed of 264 ROIs
-    
+
     See :footcite:`Power2011Functional`.
 
     Returns
@@ -512,6 +478,7 @@ def fetch_coords_power_2011():
     return Bunch(**params)
 
 
+@fill_doc
 def fetch_atlas_smith_2009(data_dir=None, mirror='origin', url=None,
                            resume=True, verbose=1):
     """Download and load the Smith ICA and BrainMap atlas (dated 2009).
@@ -520,24 +487,14 @@ def fetch_atlas_smith_2009(data_dir=None, mirror='origin', url=None,
 
     Parameters
     ----------
-    data_dir : string, optional
-        Path of the data directory. Used to force data storage in a non-
-        standard location. Default: None (meaning: default)
-
+    %(data_dir)s
     mirror : string, optional
         By default, the dataset is downloaded from the original website of the
         atlas. Specifying "nitrc" will force download from a mirror, with
         potentially higher bandwith. Default='origin'.
-
-    url : string, optional
-        Download URL of the dataset. Overwrite the default URL.
-
-    resume : bool, optional
-        Whether to resumed download of a partly-downloaded file.
-        Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -624,18 +581,10 @@ def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
 
     Parameters
     ----------
-    data_dir : string, optional
-        Directory where data should be downloaded and unpacked.
-
-    url : string, optional
-        Url of file to download.
-
-    resume : bool, optional
-        Whether to resumed download of a partly-downloaded file.
-        Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -693,6 +642,7 @@ def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
     return Bunch(**params)
 
 
+@fill_doc
 def fetch_atlas_aal(version='SPM12', data_dir=None, url=None, resume=True,
                     verbose=1):
     """Downloads and returns the AAL template for SPM 12.
@@ -711,19 +661,10 @@ def fetch_atlas_aal(version='SPM12', data_dir=None, url=None, resume=True,
     version : string {'SPM12', 'SPM5', 'SPM8'}, optional
         The version of the AAL atlas. Must be SPM5, SPM8 or SPM12.
         Default='SPM12'.
-
-    data_dir : string, optional
-        Directory where data should be downloaded and unpacked.
-
-    url : string, optional
-        Url of file to download.
-
-    resume : bool, optional
-        Whether to resumed download of a partly-downloaded file.
-        Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -782,6 +723,7 @@ def fetch_atlas_aal(version='SPM12', data_dir=None, url=None, resume=True,
     return Bunch(**params)
 
 
+@fill_doc
 def fetch_atlas_basc_multiscale_2015(version='sym', data_dir=None, url=None,
                                      resume=True, verbose=1):
     """Downloads and loads multiscale functional brain parcellations
@@ -814,19 +756,10 @@ def fetch_atlas_basc_multiscale_2015(version='sym', data_dir=None, url=None,
         Available versions are 'sym' or 'asym'. By default all scales of
         brain parcellations of version 'sym' will be returned.
         Default='sym'.
-
-    data_dir : str, optional
-        Directory where data should be downloaded and unpacked.
-
-    url : str, optional
-        Url of file to download.
-
-    resume : bool, optional
-        Whether to resumed download of a partly-downloaded file.
-        Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -1007,6 +940,7 @@ def fetch_coords_seitzman_2018(ordered_regions=True):
     return Bunch(**params)
 
 
+@fill_doc
 def fetch_atlas_allen_2011(data_dir=None, url=None, resume=True, verbose=1):
     """Download and return file names for the Allen and MIALAB ICA atlas
     (dated 2011).
@@ -1017,18 +951,10 @@ def fetch_atlas_allen_2011(data_dir=None, url=None, resume=True, verbose=1):
 
     Parameters
     ----------
-    data_dir : str, optional
-        Directory where data should be downloaded and unpacked.
-
-    url : str, optional
-        Url of file to download.
-
-    resume : bool, optional
-        Whether to resumed download of a partly-downloaded file.
-        Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -1095,10 +1021,11 @@ def fetch_atlas_allen_2011(data_dir=None, url=None, resume=True, verbose=1):
     return Bunch(**dict(params))
 
 
+@fill_doc
 def fetch_atlas_surf_destrieux(data_dir=None, url=None,
                                resume=True, verbose=1):
     """Download and load Destrieux et al, 2010 cortical atlas
-    
+
     See :footcite:`DESTRIEUX20101`.
 
     This atlas returns 76 labels per hemisphere based on sulco-gryal patterns
@@ -1108,20 +1035,10 @@ def fetch_atlas_surf_destrieux(data_dir=None, url=None,
 
     Parameters
     ----------
-    data_dir : str, optional
-        Path of the data directory. Use to force data storage in a non-
-        standard location. Default: None
-
-    url : str, optional
-        Download URL of the dataset. Overwrite the default URL.
-
-    resume : bool, optional
-        If True, try resuming download if possible.
-        Default=True.
-
-    verbose : int, optional
-        Defines the level of verbosity of the output.
-        Default=1.
+    %(data_dir)s
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -1269,6 +1186,7 @@ def _get_talairach_all_levels(data_dir=None, verbose=1):
     return img_file, labels_file
 
 
+@fill_doc
 def fetch_atlas_talairach(level_name, data_dir=None, verbose=1):
     """Download the Talairach atlas.
 
@@ -1283,13 +1201,8 @@ def fetch_atlas_talairach(level_name, data_dir=None, verbose=1):
     level_name : string {'hemisphere', 'lobe', 'gyrus', 'tissue', 'ba'}
         Which level of the atlas to use: the hemisphere, the lobe, the gyrus,
         the tissue type or the Brodmann area.
-
-    data_dir : str, optional
-        Path of the data directory. Used to force data storage in a specified
-        location.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(verbose)s
 
     Returns
     -------
@@ -1320,6 +1233,7 @@ def fetch_atlas_talairach(level_name, data_dir=None, verbose=1):
     return Bunch(maps=atlas_img, labels=labels, description=description)
 
 
+@fill_doc
 def fetch_atlas_pauli_2017(version='prob', data_dir=None, verbose=1):
     """Download the Pauli et al. (2017) atlas with in total
     12 subcortical nodes
@@ -1332,13 +1246,8 @@ def fetch_atlas_pauli_2017(version='prob', data_dir=None, verbose=1):
         Which version of the atlas should be download. This can be
         'prob' for the probabilistic atlas or 'det' for the
         deterministic atlas. Default='prob'.
-
-    data_dir : str, optional
-        Path of the data directory. Used to force data storage in a specified
-        location.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(verbose)s
 
     Returns
     -------
@@ -1387,7 +1296,7 @@ def fetch_atlas_pauli_2017(version='prob', data_dir=None, verbose=1):
                  description=fdescr)
 
 
-
+@fill_doc
 def fetch_atlas_schaefer_2018(n_rois=400, yeo_networks=7, resolution_mm=1,
                               data_dir=None, base_url=None, resume=True,
                               verbose=1):
@@ -1415,19 +1324,11 @@ def fetch_atlas_schaefer_2018(n_rois=400, yeo_networks=7, resolution_mm=1,
     resolution_mm : int, optional
         Spatial resolution of atlas image in mm {1, 2}.
         Default=1mm.
-
-    data_dir : string, optional
-        Directory where data should be downloaded and unpacked.
-
+    %(data_dir)s
     base_url : string, optional
         base_url of files to download (None results in default base_url).
-
-    resume : bool, optional
-        Whether to resumed download of a partly-downloaded file.
-        Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -48,6 +48,7 @@ def fetch_haxby(data_dir=None, subjects=(2,),
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -185,6 +186,7 @@ def fetch_adhd(n_subjects=30, data_dir=None, url=None, resume=True,
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -277,6 +279,7 @@ def fetch_miyawaki2008(data_dir=None, url=None, resume=True, verbose=1):
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -522,6 +525,7 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -770,6 +774,7 @@ def fetch_localizer_calculation_task(n_subjects=1, data_dir=None, url=None,
     %(data_dir)s
     %(url)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -807,6 +812,7 @@ def fetch_localizer_button_task(data_dir=None, url=None,
     %(data_dir)s
     %(url)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -886,6 +892,7 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
         passed quality assessment for all raters. Default=True.
     %(url)s
     %(verbose)s
+        Default=1.
     kwargs : parameter list, optional
         Any extra keyword argument will be used to filter downloaded subjects
         according to the CSV phenotypic file. Some examples of filters are
@@ -1080,6 +1087,7 @@ def fetch_mixed_gambles(n_subjects=1, data_dir=None, url=None, resume=True,
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
     return_raw_data : bool, optional
         If false, then the data will transformed into and (X, y) pair, suitable
         for machine learning routines. X is a list of n_subjects * 48
@@ -1166,6 +1174,7 @@ def fetch_megatrawls_netmats(dimensionality=100, timeseries='eigen_regression',
     %(data_dir)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -1280,6 +1289,7 @@ def fetch_cobre(n_subjects=10, data_dir=None, url=None, verbose=1):
     %(data_dir)s
     %(url)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -1428,6 +1438,7 @@ def fetch_surf_nki_enhanced(n_subjects=10, data_dir=None,
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -1686,6 +1697,7 @@ def fetch_development_fmri(n_subjects=None, reduce_confounds=True,
     %(data_dir)s
     %(resume)s
     %(verbose)s
+        Default=1.
     age_group : str, optional
         Default='both'. Which age group to fetch
 
@@ -1858,6 +1870,7 @@ def fetch_language_localizer_demo_dataset(data_dir=None, verbose=1):
     ----------
     %(data_dir)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -1897,6 +1910,7 @@ def fetch_bids_langloc_dataset(data_dir=None, verbose=1):
     ----------
     %(data_dir)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -1940,6 +1954,7 @@ def fetch_openneuro_dataset_index(data_dir=None,
         Dataset version name. Assumes it is of the form [name]_[version].
         Default='ds000030_R1.0.4'.
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -2081,6 +2096,7 @@ def fetch_openneuro_dataset(
         Dataset version name. Assumes it is of the form [name]_[version].
         Default is `ds000030_R1.0.4`.
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -2141,6 +2157,7 @@ def fetch_localizer_first_level(data_dir=None, verbose=1):
     ----------
     %(data_dir)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -2302,6 +2319,7 @@ def fetch_spm_auditory(data_dir=None, data_name='spm_auditory',
         Indicates which subject to retrieve.
         Default='sub001'.
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -2477,6 +2495,7 @@ def fetch_spm_multimodal_fmri(data_dir=None, data_name='spm_multimodal_fmri',
     subject_id : string, optional
         Indicates which subject to retrieve. Default='sub001'.
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -2513,6 +2532,7 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
     ----------
     %(data_dir)s
     %(verbose)s
+        Default=1.
 
     """
     data_dir = _get_dataset_dir('fiac_nilearn.glm', data_dir=data_dir,

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -48,7 +48,6 @@ def fetch_haxby(data_dir=None, subjects=(2,),
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -186,7 +185,6 @@ def fetch_adhd(n_subjects=30, data_dir=None, url=None, resume=True,
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -279,7 +277,6 @@ def fetch_miyawaki2008(data_dir=None, url=None, resume=True, verbose=1):
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -525,7 +522,6 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -774,7 +770,6 @@ def fetch_localizer_calculation_task(n_subjects=1, data_dir=None, url=None,
     %(data_dir)s
     %(url)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -812,7 +807,6 @@ def fetch_localizer_button_task(data_dir=None, url=None,
     %(data_dir)s
     %(url)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -892,7 +886,6 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
         passed quality assessment for all raters. Default=True.
     %(url)s
     %(verbose)s
-        Default=1.
     kwargs : parameter list, optional
         Any extra keyword argument will be used to filter downloaded subjects
         according to the CSV phenotypic file. Some examples of filters are
@@ -1087,7 +1080,6 @@ def fetch_mixed_gambles(n_subjects=1, data_dir=None, url=None, resume=True,
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
     return_raw_data : bool, optional
         If false, then the data will transformed into and (X, y) pair, suitable
         for machine learning routines. X is a list of n_subjects * 48
@@ -1174,7 +1166,6 @@ def fetch_megatrawls_netmats(dimensionality=100, timeseries='eigen_regression',
     %(data_dir)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -1289,7 +1280,6 @@ def fetch_cobre(n_subjects=10, data_dir=None, url=None, verbose=1):
     %(data_dir)s
     %(url)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -1438,7 +1428,6 @@ def fetch_surf_nki_enhanced(n_subjects=10, data_dir=None,
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -1697,7 +1686,6 @@ def fetch_development_fmri(n_subjects=None, reduce_confounds=True,
     %(data_dir)s
     %(resume)s
     %(verbose)s
-        Default=1.
     age_group : str, optional
         Default='both'. Which age group to fetch
 
@@ -1870,7 +1858,6 @@ def fetch_language_localizer_demo_dataset(data_dir=None, verbose=1):
     ----------
     %(data_dir)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -1910,7 +1897,6 @@ def fetch_bids_langloc_dataset(data_dir=None, verbose=1):
     ----------
     %(data_dir)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -1954,7 +1940,6 @@ def fetch_openneuro_dataset_index(data_dir=None,
         Dataset version name. Assumes it is of the form [name]_[version].
         Default='ds000030_R1.0.4'.
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -2096,7 +2081,6 @@ def fetch_openneuro_dataset(
         Dataset version name. Assumes it is of the form [name]_[version].
         Default is `ds000030_R1.0.4`.
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -2157,7 +2141,6 @@ def fetch_localizer_first_level(data_dir=None, verbose=1):
     ----------
     %(data_dir)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -2319,7 +2302,6 @@ def fetch_spm_auditory(data_dir=None, data_name='spm_auditory',
         Indicates which subject to retrieve.
         Default='sub001'.
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -2495,7 +2477,6 @@ def fetch_spm_multimodal_fmri(data_dir=None, data_name='spm_multimodal_fmri',
     subject_id : string, optional
         Indicates which subject to retrieve. Default='sub001'.
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -2532,7 +2513,6 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
     ----------
     %(data_dir)s
     %(verbose)s
-        Default=1.
 
     """
     data_dir = _get_dataset_dir('fiac_nilearn.glm', data_dir=data_dir,

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -22,11 +22,12 @@ from sklearn.utils import Bunch, deprecated
 
 from .utils import (_get_dataset_dir, _fetch_files, _get_dataset_descr,
                     _read_md5_sum_file, _tree, _filter_columns, _fetch_file, _uncompress_file)
-from .._utils import check_niimg
+from .._utils import check_niimg, fill_doc
 from .._utils.numpy_conversions import csv_to_array
 from nilearn.image import get_data
 
 
+@fill_doc
 def fetch_haxby(data_dir=None, subjects=(2,),
                 fetch_stimuli=False, url=None, resume=True, verbose=1):
     """Download and loads complete haxby dataset.
@@ -35,10 +36,7 @@ def fetch_haxby(data_dir=None, subjects=(2,),
 
     Parameters
     ----------
-    data_dir : string, optional
-        Path of the data directory. Used to force data storage in a specified
-        location. Default: None
-
+    %(data_dir)s
     subjects : list or int, optional
         Either a list of subjects or the number of subjects to load, from 1 to
         6. By default, 2nd subject will be loaded. Empty list returns no subject
@@ -47,13 +45,9 @@ def fetch_haxby(data_dir=None, subjects=(2,),
     fetch_stimuli : boolean, optional
         Indicate if stimuli images must be downloaded. They will be presented
         as a dictionary of categories. Default=False.
-
-    resume : bool, optional
-        Whether to resume download of a partly-downloaded file.
-        Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -174,6 +168,7 @@ def fetch_haxby(data_dir=None, subjects=(2,),
             **kwargs)
 
 
+@fill_doc
 def fetch_adhd(n_subjects=30, data_dir=None, url=None, resume=True,
                verbose=1):
     """Download and load the ADHD resting-state dataset.
@@ -186,20 +181,10 @@ def fetch_adhd(n_subjects=30, data_dir=None, url=None, resume=True,
         The number of subjects to load from maximum of 40 subjects.
         By default, 30 subjects will be loaded. If None is given,
         all 40 subjects will be loaded. Default=30.
-
-    data_dir : string, optional
-        Path of the data directory. Used to force data storage in a specified
-        location. Default: None
-
-    url : string, optional
-        Override download URL. Used for test only (or if you setup a mirror of
-        the data). Default: None
-
-    resume : bool, optional
-        Whether to resume download of a partly-downloaded file. Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -280,6 +265,7 @@ def fetch_adhd(n_subjects=30, data_dir=None, url=None, resume=True,
                  phenotypic=phenotypic, description=fdescr)
 
 
+@fill_doc
 def fetch_miyawaki2008(data_dir=None, url=None, resume=True, verbose=1):
     """Download and loads Miyawaki et al. 2008 dataset (153MB).
 
@@ -287,19 +273,10 @@ def fetch_miyawaki2008(data_dir=None, url=None, resume=True, verbose=1):
 
     Parameters
     ----------
-    data_dir : string, optional
-        Path of the data directory. Used to force data storage in a specified
-        location. Default: None
-
-    url : string, optional
-        Override download URL. Used for test only (or if you setup a mirror of
-        the data). Default: None
-
-    resume : bool, optional
-        Whether to resume download of a partly-downloaded file. Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -429,6 +406,7 @@ def fetch_miyawaki2008(data_dir=None, url=None, resume=True, verbose=1):
         description=fdescr)
 
 
+@fill_doc
 def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
                               get_masks=False, get_anats=False,
                               data_dir=None, url=None, resume=True, verbose=1):
@@ -540,20 +518,10 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
     get_anats : boolean, optional
         Whether individual structural images should be fetched or not.
         Default=False.
-
-    data_dir : string, optional
-        Path of the data directory. Used to force data storage in a specified
-        location.
-
-    url : string, optional
-        Override download URL. Used for test only (or if you setup a mirror of
-        the data).
-
-    resume : bool, optional
-        Whether to resume download of a partly-downloaded file. Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -789,6 +757,7 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
     return Bunch(ext_vars=csv_data, description=fdescr, **files)
 
 
+@fill_doc
 def fetch_localizer_calculation_task(n_subjects=1, data_dir=None, url=None,
                                      verbose=1):
     """Fetch calculation task contrast maps from the localizer.
@@ -798,17 +767,9 @@ def fetch_localizer_calculation_task(n_subjects=1, data_dir=None, url=None,
     n_subjects : int, optional
         The number of subjects to load. If None is given,
         all 94 subjects are used. Default=1.
-
-    data_dir : string, optional
-        Path of the data directory. Used to force data storage in a specified
-        location.
-
-    url : string, optional
-        Override download URL. Used for test only (or if you setup a mirror of
-        the data).
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(url)s
+    %(verbose)s
 
     Returns
     -------
@@ -836,22 +797,16 @@ def fetch_localizer_calculation_task(n_subjects=1, data_dir=None, url=None,
     return data
 
 
+@fill_doc
 def fetch_localizer_button_task(data_dir=None, url=None,
                                 verbose=1):
     """Fetch left vs right button press contrast maps from the localizer.
 
     Parameters
     ----------
-    data_dir : string, optional
-        Path of the data directory. Used to force data storage in a specified
-        location.
-
-    url : string, optional
-        Override download URL. Used for test only (or if you setup a mirror of
-        the data).
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(url)s
+    %(verbose)s
 
     Returns
     -------
@@ -885,6 +840,7 @@ def fetch_localizer_button_task(data_dir=None, url=None,
     return data
 
 
+@fill_doc
 def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
                     band_pass_filtering=False, global_signal_regression=False,
                     derivatives=['func_preproc'],
@@ -898,10 +854,7 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
 
     Parameters
     ----------
-    data_dir : string, optional
-        Path of the data directory. Used to force data storage in a specified
-        location. Default: None
-
+    %(data_dir)s
     n_subjects : int, optional
         The number of subjects to load. If None is given,
         all available subjects are used (this number depends on the
@@ -931,7 +884,8 @@ def fetch_abide_pcp(data_dir=None, n_subjects=None, pipeline='cpac',
     quality_checked : boolean, optional
         If true (default), restrict the list of the subjects to the one that
         passed quality assessment for all raters. Default=True.
-
+    %(url)s
+    %(verbose)s
     kwargs : parameter list, optional
         Any extra keyword argument will be used to filter downloaded subjects
         according to the CSV phenotypic file. Some examples of filters are
@@ -1110,6 +1064,7 @@ def _load_mixed_gambles(zmap_imgs):
     return X, y, mask_img
 
 
+@fill_doc
 def fetch_mixed_gambles(n_subjects=1, data_dir=None, url=None, resume=True,
                         return_raw_data=False, verbose=1):
     """Fetch Jimura "mixed gambles" dataset.
@@ -1121,21 +1076,10 @@ def fetch_mixed_gambles(n_subjects=1, data_dir=None, url=None, resume=True,
     n_subjects : int, optional
         The number of subjects to load. If None is given, all the
         subjects are used. Default=1.
-
-    data_dir : string, optional
-        Path of the data directory. Used to force data storage in a specified
-        location. Default: None.
-
-    url : string, optional
-        Override download URL. Used for test only (or if you setup a mirror of
-        the data).
-
-    resume : bool, optional
-        If true, try resuming download if possible. Default=True.
-
-    verbose : int, optional
-        Defines the level of verbosity of the output. Default=1.
-
+    %(data_dir)s
+    %(url)s
+    %(resume)s
+    %(verbose)s
     return_raw_data : bool, optional
         If false, then the data will transformed into and (X, y) pair, suitable
         for machine learning routines. X is a list of n_subjects * 48
@@ -1183,6 +1127,7 @@ def fetch_mixed_gambles(n_subjects=1, data_dir=None, url=None, resume=True,
     return data
 
 
+@fill_doc
 def fetch_megatrawls_netmats(dimensionality=100, timeseries='eigen_regression',
                              matrices='partial_correlation', data_dir=None,
                              resume=True, verbose=1):
@@ -1218,20 +1163,9 @@ def fetch_megatrawls_netmats(dimensionality=100, timeseries='eigen_regression',
         partial correlation matrices will be returned otherwise if selected
         full correlation matrices will be returned.
         Default='partial_correlation'.
-
-    data_dir : str, optional
-        Path of the data directory. Used to force data storage in a specified
-        location.
-
-    resume : bool, optional
-        This parameter is required if a partially downloaded file is needed
-        to be resumed to download again. Default=True.
-
-    verbose : int, optional
-        This parameter is used to set the verbosity level to print the message
-        to give information about the processing.
-        0 indicates no information will be given.
-        Default=1.
+    %(data_dir)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -1301,6 +1235,7 @@ def fetch_megatrawls_netmats(dimensionality=100, timeseries='eigen_regression',
         description=description)
 
 
+@fill_doc
 @deprecated("'fetch_cobre' has been deprecated and will be removed "
             "in release 0.9 . "
             "Please consider using a different datasets or downloading it "
@@ -1342,17 +1277,9 @@ def fetch_cobre(n_subjects=10, data_dir=None, url=None, verbose=1):
         The number of subjects to load from maximum of 146 subjects.
         By default, 10 subjects will be loaded. If n_subjects=None,
         all subjects will be loaded. Default=10.
-
-    data_dir : str, optional
-        Path to the data directory. Used to force data storage in a
-        specified location. Default: None
-
-    url : str, optional
-        Override download url. Used for test only (or if you setup a
-        mirror of the data). Default: None
-
-    verbose : int, optional
-       Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(url)s
+    %(verbose)s
 
     Returns
     -------
@@ -1479,6 +1406,7 @@ def fetch_cobre(n_subjects=10, data_dir=None, url=None, verbose=1):
                  desc_phenotypic=files_keys_phen)
 
 
+@fill_doc
 def fetch_surf_nki_enhanced(n_subjects=10, data_dir=None,
                             url=None, resume=True, verbose=1):
     """Download and load the NKI enhanced resting-state dataset,
@@ -1496,20 +1424,10 @@ def fetch_surf_nki_enhanced(n_subjects=10, data_dir=None,
         The number of subjects to load from maximum of 102 subjects.
         By default, 10 subjects will be loaded. If None is given,
         all 102 subjects will be loaded. Default=10.
-
-    data_dir : str, optional
-        Path of the data directory. Used to force data storage in a specified
-        location. Default: None
-
-    url : str, optional
-        Override download URL. Used for test only (or if you setup a mirror of
-        the data). Default: None
-
-    resume : bool, optional
-        If True, try resuming download if possible. Default=True.
-
-    verbose : int, optional
-        Defines the level of verbosity of the output. Default=1.
+    %(data_dir)s
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -1618,6 +1536,7 @@ def fetch_surf_nki_enhanced(n_subjects=10, data_dir=None,
                  description=fdescr)
 
 
+@fill_doc
 def _fetch_development_fmri_participants(data_dir, url, verbose):
     """Helper function to fetch_development_fmri.
 
@@ -1629,16 +1548,9 @@ def _fetch_development_fmri_participants(data_dir, url, verbose):
 
     Parameters
     ----------
-    data_dir : str
-        Path of the data directory. Used to force data storage in a specified
-        location. If None is given, data are stored in home directory.
-
-    url : str
-        Override download URL. Used for test only (or if you setup a mirror of
-        the data).
-
-    verbose : int
-        Defines the level of verbosity of the output.
+    %(data_dir)s
+    %(url)s
+    %(verbose)s
 
     Returns
     -------
@@ -1667,6 +1579,7 @@ def _fetch_development_fmri_participants(data_dir, url, verbose):
     return participants
 
 
+@fill_doc
 def _fetch_development_fmri_functional(participants, data_dir, url, resume,
                                        verbose):
     """Helper function to fetch_development_fmri.
@@ -1681,20 +1594,10 @@ def _fetch_development_fmri_functional(participants, data_dir, url, resume,
     participants : numpy.ndarray
         Should contain column participant_id which represents subjects id. The
         number of files are fetched based on ids in this column.
-
-    data_dir : str
-        Path of the data directory. Used to force data storage in a specified
-        location. If None is given, data are stored in home directory.
-
-    url : str
-        Override download URL. Used for test only (or if you setup a mirror of
-        the data).
-
-    resume : bool
-        Whether to resume download of a partly-downloaded file.
-
-    verbose : int
-        Defines the level of verbosity of the output.
+    %(data_dir)s
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -1752,6 +1655,7 @@ def _fetch_development_fmri_functional(participants, data_dir, url, resume,
     return funcs, regressors
 
 
+@fill_doc
 def fetch_development_fmri(n_subjects=None, reduce_confounds=True,
                            data_dir=None, resume=True, verbose=1,
                            age_group='both'):
@@ -1779,18 +1683,9 @@ def fetch_development_fmri(n_subjects=None, reduce_confounds=True,
         question, other confounds might be more appropriate.
         If False, returns all fmriprep confounds.
         Default=True.
-
-    data_dir : str, optional
-        Path of the data directory. Used to force data storage in a specified
-        location. If None, data are stored in home directory.
-
-    resume : bool, optional
-        Whether to resume download of a partly-downloaded file.
-        Default=True.
-
-    verbose : int, optional
-        Defines the level of verbosity of the output. Default=1.
-
+    %(data_dir)s
+    %(resume)s
+    %(verbose)s
     age_group : str, optional
         Default='both'. Which age group to fetch
 
@@ -1955,17 +1850,14 @@ def _reduce_confounds(regressors, keep_confounds):
 # datasets originally belonging to nistats follow
 
 
+@fill_doc
 def fetch_language_localizer_demo_dataset(data_dir=None, verbose=1):
     """Download language localizer demo dataset.
 
     Parameters
     ----------
-    data_dir : string, optional
-        Path to store the downloaded dataset. if None employ nilearn
-        datasets default download directory.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(verbose)s
 
     Returns
     -------
@@ -1997,17 +1889,14 @@ def fetch_language_localizer_demo_dataset(data_dir=None, verbose=1):
     return data_dir, sorted(file_list)
 
 
+@fill_doc
 def fetch_bids_langloc_dataset(data_dir=None, verbose=1):
     """Download language localizer example :term:`bids<BIDS>` dataset.
 
     Parameters
     ----------
-    data_dir : string, optional
-        Path to store the downloaded dataset. if None employ nilearn
-        datasets default download directory.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(verbose)s
 
     Returns
     -------
@@ -2035,6 +1924,7 @@ def fetch_bids_langloc_dataset(data_dir=None, verbose=1):
     return os.path.join(data_dir, main_folder), sorted(file_list)
 
 
+@fill_doc
 def fetch_openneuro_dataset_index(data_dir=None,
                                   dataset_version='ds000030_R1.0.4',
                                   verbose=1):
@@ -2045,16 +1935,11 @@ def fetch_openneuro_dataset_index(data_dir=None,
 
     Parameters
     ----------
-    data_dir : string, optional
-        Path to store the downloaded dataset. if None employ nilearn
-        datasets default download directory.
-
+    %(data_dir)s
     dataset_version : string, optional
         Dataset version name. Assumes it is of the form [name]_[version].
         Default='ds000030_R1.0.4'.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(verbose)s
 
     Returns
     -------
@@ -2180,6 +2065,7 @@ def patch_openneuro_dataset(file_list):
                 name = name.replace(old, rep[old])
 
 
+@fill_doc
 def fetch_openneuro_dataset(
     urls=None, data_dir=None, dataset_version='ds000030_R1.0.4',
     verbose=1):
@@ -2190,17 +2076,11 @@ def fetch_openneuro_dataset(
     urls : list of string, optional
         Openneuro url list of dataset files to download. If not specified
         all files of the specified dataset will be downloaded.
-
-    data_dir : string, optional
-        Path to store the downloaded dataset. if None employ nilearn
-        datasets default download directory.
-
+    %(data_dir)s
     dataset_version : string, optional
         Dataset version name. Assumes it is of the form [name]_[version].
         Default is `ds000030_R1.0.4`.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(verbose)s
 
     Returns
     -------
@@ -2253,16 +2133,14 @@ def fetch_openneuro_dataset(
     return data_dir, sorted(downloaded)
 
 
+@fill_doc
 def fetch_localizer_first_level(data_dir=None, verbose=1):
     """Download a first-level localizer fMRI dataset
 
     Parameters
     ----------
-    data_dir : string
-        Directory where data should be downloaded and unpacked.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(verbose)s
 
     Returns
     -------
@@ -2407,6 +2285,7 @@ def _make_events_file_spm_auditory_data(events_filepath):
                   columns=['onset', 'duration', 'trial_type'])
 
 
+@fill_doc
 def fetch_spm_auditory(data_dir=None, data_name='spm_auditory',
                        subject_id='sub001', verbose=1):
     """Function to fetch SPM auditory single-subject data.
@@ -2415,20 +2294,14 @@ def fetch_spm_auditory(data_dir=None, data_name='spm_auditory',
 
     Parameters
     ----------
-    data_dir : string, optional.
-        Path of the data directory. Used to force data storage in a specified
-        location. If the data is already present there, then will simply
-        glob it.
-
+    %(data_dir)s
     data_name : string, optional
         Name of the dataset. Default='spm_auditory'.
 
     subject_id : string, optional
         Indicates which subject to retrieve.
         Default='sub001'.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(verbose)s
 
     Returns
     -------
@@ -2588,6 +2461,7 @@ def _make_events_file_spm_multimodal_fmri(_subject_data, session):
     return events
 
 
+@fill_doc
 def fetch_spm_multimodal_fmri(data_dir=None, data_name='spm_multimodal_fmri',
                               subject_id='sub001', verbose=1):
     """Fetcher for Multi-modal Face Dataset.
@@ -2596,18 +2470,13 @@ def fetch_spm_multimodal_fmri(data_dir=None, data_name='spm_multimodal_fmri',
 
     Parameters
     ----------
-    data_dir : string, optional.
-        Path of the data directory. Used to force data storage in a specified
-        location. If the data is already present there, then will simply glob it.
-
+    %(data_dir)s
     data_name : string, optional
         Name of the dataset. Default='spm_multimodal_fmri'.
 
     subject_id : string, optional
         Indicates which subject to retrieve. Default='sub001'.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(verbose)s
 
     Returns
     -------
@@ -2636,16 +2505,14 @@ def fetch_spm_multimodal_fmri(data_dir=None, data_name='spm_multimodal_fmri',
     return _download_data_spm_multimodal(data_dir, subject_dir, subject_id)
 
 
+@fill_doc
 def fetch_fiac_first_level(data_dir=None, verbose=1):
     """Download a first-level fiac fMRI dataset (2 sessions)
 
     Parameters
     ----------
-    data_dir : string, optional
-        Directory where data should be downloaded and unpacked.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(verbose)s
 
     """
     data_dir = _get_dataset_dir('fiac_nilearn.glm', data_dir=data_dir,

--- a/nilearn/datasets/struct.py
+++ b/nilearn/datasets/struct.py
@@ -52,6 +52,7 @@ def fetch_icbm152_2009(data_dir=None, url=None, resume=True, verbose=1):
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -477,6 +478,7 @@ def fetch_icbm152_brain_gm_mask(data_dir=None, threshold=0.2, resume=True,
         .. versionadded:: 0.8.1
 
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -490,7 +492,8 @@ def fetch_icbm152_brain_gm_mask(data_dir=None, threshold=0.2, resume=True,
     of the values. Then, do a bit post processing such as binary closing
     operation to more compact mask image.
 
-    Note: It is advised to check the mask image with your own data processing.
+    .. note::
+        It is advised to check the mask image with your own data processing.
 
     See Also
     --------
@@ -538,6 +541,7 @@ def fetch_oasis_vbm(n_subjects=None, dartel_version=True, data_dir=None,
     %(url)s
     %(resume)s
     %(verbose)s
+        Default=1.
 
     Returns
     -------

--- a/nilearn/datasets/struct.py
+++ b/nilearn/datasets/struct.py
@@ -18,6 +18,8 @@ from .utils import (_get_dataset_dir, _fetch_files, _get_dataset_descr)
 from .._utils import check_niimg
 from ..image import new_img_like, get_data, resampling
 
+from .._utils import check_niimg, niimg, fill_doc
+from ..image import new_img_like, get_data
 
 _package_directory = os.path.dirname(os.path.abspath(__file__))
 MNI152_FILE_PATH = os.path.join(
@@ -37,6 +39,7 @@ FSAVERAGE5_PATH = os.path.join(_package_directory, "data", "fsaverage5")
 _MNI_RES_WARNING_ALREADY_SHOWN = False
 
 
+@fill_doc
 def fetch_icbm152_2009(data_dir=None, url=None, resume=True, verbose=1):
     """Download and load the ICBM152 template (dated 2009).
 
@@ -45,19 +48,10 @@ def fetch_icbm152_2009(data_dir=None, url=None, resume=True, verbose=1):
 
     Parameters
     ----------
-    data_dir : string, optional
-        Path of the data directory. Used to force data storage in a non-
-        standard location. Default: None (meaning: default)
-
-    url : string, optional
-        Download URL of the dataset. Overwrite the default URL.
-
-    resume : bool, optional
-        If True, try resuming partially downloaded data.
-        Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -461,6 +455,7 @@ def load_mni152_wm_mask(resolution=None, threshold=0.2, n_iter=2):
     return wm_mask_img
 
 
+@fill_doc
 def fetch_icbm152_brain_gm_mask(data_dir=None, threshold=0.2, resume=True,
                                 n_iter=2, verbose=1):
     """Downloads ICBM152 template first, then loads the 'gm' mask.
@@ -469,26 +464,19 @@ def fetch_icbm152_brain_gm_mask(data_dir=None, threshold=0.2, resume=True,
 
     Parameters
     ----------
-    data_dir : str, optional
-        Path of the data directory. Used to force storage in a specified
-        location. Defaults to None.
-
+    %(data_dir)s
     threshold : float, optional
         Values of the ICBM152 grey-matter template above this threshold will be
         included. Default=0.2
 
-    resume : bool, optional
-        If True, try resuming partially downloaded data.
-        Default=True.
-
+    %(resume)s
     n_iter: int, optional, Default = 2
         Number of repetitions of dilation and erosion steps performed in
         scipy.ndimage.binary_closing function.
 
         .. versionadded:: 0.8.1
 
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(verbose)s
 
     Returns
     -------
@@ -529,6 +517,7 @@ def fetch_icbm152_brain_gm_mask(data_dir=None, threshold=0.2, resume=True,
     return gm_mask_img
 
 
+@fill_doc
 def fetch_oasis_vbm(n_subjects=None, dartel_version=True, data_dir=None,
                     url=None, resume=True, verbose=1):
     """Download and load Oasis "cross-sectional MRI" dataset (416 subjects).
@@ -545,20 +534,10 @@ def fetch_oasis_vbm(n_subjects=None, dartel_version=True, data_dir=None,
     dartel_version : boolean, optional
         Whether or not to use data normalized with DARTEL instead of standard
         SPM8 normalization. Default=True.
-
-    data_dir : string, optional
-        Path of the data directory. Used to force data storage in a specified
-        location. Default: None
-
-    url : string, optional
-        Override download URL. Used for test only (or if you setup a mirror of
-        the data).
-
-    resume : bool, optional
-        If true, try resuming download if possible. Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(data_dir)s
+    %(url)s
+    %(resume)s
+    %(verbose)s
 
     Returns
     -------
@@ -744,6 +723,7 @@ def fetch_oasis_vbm(n_subjects=None, dartel_version=True, data_dir=None,
         description=fdescr)
 
 
+@fill_doc
 def fetch_surf_fsaverage(mesh='fsaverage5', data_dir=None):
     """Download a Freesurfer fsaverage surface.
     File names are subject to change and only attribute names
@@ -768,9 +748,7 @@ def fetch_surf_fsaverage(mesh='fsaverage5', data_dir=None):
             (high-resolution fsaverage will result in more computation time and
             memory usage)
 
-    data_dir : str, optional
-        Path of the data directory. Used to force data storage in a specified
-        location.
+    %(data_dir)s
 
     Returns
     -------

--- a/nilearn/datasets/struct.py
+++ b/nilearn/datasets/struct.py
@@ -15,11 +15,8 @@ from sklearn.utils import Bunch
 
 from .utils import (_get_dataset_dir, _fetch_files, _get_dataset_descr)
 
-from .._utils import check_niimg
 from ..image import new_img_like, get_data, resampling
-
-from .._utils import check_niimg, niimg, fill_doc
-from ..image import new_img_like, get_data
+from .._utils import check_niimg, fill_doc
 
 _package_directory = os.path.dirname(os.path.abspath(__file__))
 MNI152_FILE_PATH = os.path.join(

--- a/nilearn/datasets/struct.py
+++ b/nilearn/datasets/struct.py
@@ -52,7 +52,6 @@ def fetch_icbm152_2009(data_dir=None, url=None, resume=True, verbose=1):
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -478,7 +477,6 @@ def fetch_icbm152_brain_gm_mask(data_dir=None, threshold=0.2, resume=True,
         .. versionadded:: 0.8.1
 
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -541,7 +539,6 @@ def fetch_oasis_vbm(n_subjects=None, dartel_version=True, data_dir=None,
     %(url)s
     %(resume)s
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -737,21 +734,9 @@ def fetch_surf_fsaverage(mesh='fsaverage5', data_dir=None):
     Parameters
     ----------
     mesh : str, optional
-        Which mesh to fetch. Default='fsaverage5'.
-
-        - 'fsaverage3': the low-resolution fsaverage3 mesh (642 nodes)
-        - 'fsaverage4': the low-resolution fsaverage4 mesh (2562 nodes)
-        - 'fsaverage5': the low-resolution fsaverage5 mesh (10242 nodes)
-        - 'fsaverage5_sphere': this option has been deprecated
-            and will be removed in v0.9.0.
-            fsaverage5 sphere coordinates can now be accessed through
-            attributes sphere_{left, right} using mesh='fsaverage5'
-        - 'fsaverage6': the medium-resolution fsaverage6 mesh (40962 nodes)
-        - 'fsaverage7': same as 'fsaverage'
-        - 'fsaverage': the high-resolution fsaverage mesh (163842 nodes)
-            (high-resolution fsaverage will result in more computation time and
-            memory usage)
-
+        Which mesh to fetch. Should be one of the following values:
+        %(fsaverage_options)s
+        Default='fsaverage5'.
     %(data_dir)s
 
     Returns

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -143,7 +143,6 @@ def _chunk_read_(response, local_file, chunk_size=8192, report_hook=None,
     total_size : int, optional
         Expected final size of download (None means it is unknown).
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -247,7 +246,6 @@ def _get_dataset_dir(dataset_name, data_dir=None, default_paths=None,
         Default system paths in which the dataset may already have been
         installed by a third party software. They will be checked first.
     %(verbose)s
-        Default=1.
 
     Returns
     -------
@@ -322,7 +320,6 @@ def _uncompress_file(file_, delete_archive=True, verbose=1):
         Wheteher or not to delete archive once it is uncompressed.
         Default=True.
     %(verbose)s
-        Default=1.
 
     Notes
     -----
@@ -506,7 +503,6 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
     password : string, optional
         Password used for basic HTTP authentication.
     %(verbose)s
-        Default=1.
     session : requests.Session, optional
         Session to use to send requests.
 
@@ -694,7 +690,6 @@ def _fetch_files(data_dir, files, resume=True, verbose=1, session=None):
             * 'overwrite' if the file should be re-downloaded even if it exists
     %(resume)s
     %(verbose)s
-        Default=1.
     session : `requests.Session`, optional
         Session to use to send requests.
 
@@ -874,7 +869,6 @@ def make_fresh_openneuro_dataset_urls_index(
         Dataset version name. Assumes it is of the form [name]_[version].
         Default is `ds000030_R1.0.4`.
     %(verbose)s
-        Default=1.
 
     Returns
     -------

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -19,6 +19,7 @@ import json
 
 import requests
 
+from .._utils import fill_doc
 
 _REQUESTS_TIMEOUT = (15.1, 61)
 
@@ -116,6 +117,7 @@ def _chunk_report_(bytes_so_far, total_size, initial_size, t0):
                _format_time(time_remaining)))
 
 
+@fill_doc
 def _chunk_read_(response, local_file, chunk_size=8192, report_hook=None,
                  initial_size=0, total_size=None, verbose=1):
     """Download a file chunk by chunk and show advancement
@@ -140,9 +142,7 @@ def _chunk_read_(response, local_file, chunk_size=8192, report_hook=None,
 
     total_size : int, optional
         Expected final size of download (None means it is unknown).
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(verbose)s
 
     Returns
     -------
@@ -181,6 +181,7 @@ def _chunk_read_(response, local_file, chunk_size=8192, report_hook=None,
     return
 
 
+@fill_doc
 def get_data_dirs(data_dir=None):
     """Returns the directories in which nilearn looks for data.
 
@@ -189,9 +190,7 @@ def get_data_dirs(data_dir=None):
 
     Parameters
     ----------
-    data_dir : string, optional
-        Path of the data directory. Used to force data storage in a specified
-        location. Default: None
+    %(data_dir)s
 
     Returns
     -------
@@ -233,6 +232,7 @@ def get_data_dirs(data_dir=None):
     return paths
 
 
+@fill_doc
 def _get_dataset_dir(dataset_name, data_dir=None, default_paths=None,
                      verbose=1):
     """Creates if necessary and returns data directory of given dataset.
@@ -241,17 +241,11 @@ def _get_dataset_dir(dataset_name, data_dir=None, default_paths=None,
     ----------
     dataset_name : string
         The unique name of the dataset.
-
-    data_dir : string, optional
-        Path of the data directory. Used to force data storage in a specified
-        location. Default: None
-
+    %(data_dir)s
     default_paths : list of string, optional
         Default system paths in which the dataset may already have been
         installed by a third party software. They will be checked first.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(verbose)s
 
     Returns
     -------
@@ -313,6 +307,7 @@ def _get_dataset_dir(dataset_name, data_dir=None, default_paths=None,
                   'directories, but:' + ''.join(errors))
 
 
+@fill_doc
 def _uncompress_file(file_, delete_archive=True, verbose=1):
     """Uncompress files contained in a data_set.
 
@@ -324,9 +319,7 @@ def _uncompress_file(file_, delete_archive=True, verbose=1):
     delete_archive : bool, optional
         Wheteher or not to delete archive once it is uncompressed.
         Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(verbose)s
 
     Notes
     -----
@@ -487,6 +480,7 @@ class _NaiveFTPAdapter(requests.adapters.BaseAdapter):
         pass
 
 
+@fill_doc
 def _fetch_file(url, data_dir, resume=True, overwrite=False,
                 md5sum=None, username=None, password=None,
                 verbose=1, session=None):
@@ -494,17 +488,9 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
 
     Parameters
     ----------
-    url : string
-        Contains the url of the file to be downloaded.
-
-    data_dir : string
-        Path of the data directory. Used for data storage in the specified
-        location.
-
-    resume : bool, optional
-        If true, try to resume partially downloaded files.
-        Default=True.
-
+    %(url)s
+    %(data_dir)s
+    %(resume)s
     overwrite : bool, optional
         If true and file already exists, delete it. Default=False.
 
@@ -516,10 +502,7 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
 
     password : string, optional
         Password used for basic HTTP authentication.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
-
+    %(verbose)s
     session : requests.Session, optional
         Session to use to send requests.
 
@@ -681,6 +664,7 @@ def movetree(src, dst):
         raise Exception(errors)
 
 
+@fill_doc
 def _fetch_files(data_dir, files, resume=True, verbose=1, session=None):
     """Load requested dataset, downloading it if needed or requested.
 
@@ -693,10 +677,7 @@ def _fetch_files(data_dir, files, resume=True, verbose=1, session=None):
 
     Parameters
     ----------
-    data_dir : string
-        Path of the data directory. Used for data storage in a specified
-        location.
-
+    %(data_dir)s
     files : list of (string, string, dict)
         List of files and their corresponding url with dictionary that contains
         options regarding the files. Eg. (file_path, url, opt). If a file_path
@@ -707,13 +688,8 @@ def _fetch_files(data_dir, files, resume=True, verbose=1, session=None):
             * 'uncompress' to indicate that the file is an archive
             * 'md5sum' to check the md5 sum of the file
             * 'overwrite' if the file should be re-downloaded even if it exists
-
-    resume : bool, optional
-        If true, try resuming download if possible. Default=True.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
-
+    %(resume)s
+    %(verbose)s
     session : `requests.Session`, optional
         Session to use to send requests.
 
@@ -853,6 +829,7 @@ def _tree(path, pattern=None, dictionary=False):
     return dirs
 
 
+@fill_doc
 def make_fresh_openneuro_dataset_urls_index(
         data_dir=None,
         dataset_version='ds000030_R1.0.4',
@@ -887,16 +864,11 @@ def make_fresh_openneuro_dataset_urls_index(
 
     Parameters
     ----------
-    data_dir : string, optional
-        Path to store the downloaded dataset.
-        If None downloads to user's Desktop.
-
+    %(data_dir)s
     dataset_version : string, optional
         Dataset version name. Assumes it is of the form [name]_[version].
         Default is `ds000030_R1.0.4`.
-
-    verbose : int, optional
-        Verbosity level (0 means no message). Default=1.
+    %(verbose)s
 
     Returns
     -------

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -143,6 +143,7 @@ def _chunk_read_(response, local_file, chunk_size=8192, report_hook=None,
     total_size : int, optional
         Expected final size of download (None means it is unknown).
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -246,6 +247,7 @@ def _get_dataset_dir(dataset_name, data_dir=None, default_paths=None,
         Default system paths in which the dataset may already have been
         installed by a third party software. They will be checked first.
     %(verbose)s
+        Default=1.
 
     Returns
     -------
@@ -320,6 +322,7 @@ def _uncompress_file(file_, delete_archive=True, verbose=1):
         Wheteher or not to delete archive once it is uncompressed.
         Default=True.
     %(verbose)s
+        Default=1.
 
     Notes
     -----
@@ -503,6 +506,7 @@ def _fetch_file(url, data_dir, resume=True, overwrite=False,
     password : string, optional
         Password used for basic HTTP authentication.
     %(verbose)s
+        Default=1.
     session : requests.Session, optional
         Session to use to send requests.
 
@@ -690,6 +694,7 @@ def _fetch_files(data_dir, files, resume=True, verbose=1, session=None):
             * 'overwrite' if the file should be re-downloaded even if it exists
     %(resume)s
     %(verbose)s
+        Default=1.
     session : `requests.Session`, optional
         Session to use to send requests.
 
@@ -869,6 +874,7 @@ def make_fresh_openneuro_dataset_urls_index(
         Dataset version name. Assumes it is of the form [name]_[version].
         Default is `ds000030_R1.0.4`.
     %(verbose)s
+        Default=1.
 
     Returns
     -------

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -61,17 +61,17 @@ SUPPORTED_ESTIMATORS = dict(
 )
 
 
+@fill_doc
 def _check_param_grid(estimator, X, y, param_grid=None):
     """Check param_grid and return sensible default if param_grid is None.
 
     Parameters
     -----------
     estimator: str, optional
-        The estimator to choose among: 'svc', 'svc_l2', 'svc_l1', 'logistic',
-        'logistic_l1', 'logistic_l2', 'ridge', 'ridge_classifier',
-        'ridge_regressor', and 'svr'. Note that the 'svc' and 'svc_l2';
-        'logistic' and 'logistic_l2'; 'ridge' and 'ridge_regressor'
-        correspond to the same estimator. Default 'svc'.
+        The estimator to choose among:
+        %(classifier_options)s
+        %(regressor_options)s
+        Default 'svc'.
 
     X: list of Niimg-like objects
         See http://nilearn.github.io/manipulating_images/input_output.html
@@ -235,12 +235,10 @@ class _BaseDecoder(LinearRegression, CacheMixin):
     Parameters
     -----------
     estimator: str, optional
-        The estimator to choose among: 'svc', 'svc_l2', 'svc_l1', 'logistic',
-        'logistic_l1', 'logistic_l2', 'ridge', 'ridge_classifier',
-        'ridge_regressor', and 'svr'. Note that the 'svc' and 'svc_l2';
-        'logistic' and 'logistic_l2'; 'ridge' and 'ridge_regressor',
-        correspond to the same estimator.
-        Dummy estimators are named as 'dummy_classifier', 'dummy_regressor'.
+        The estimator to use. For classification, choose among:
+        %(classifier_options)s
+        For regression, choose among:
+        %(regressor_options)s
         Default 'svc'.
 
     mask: filename, Nifti1Image, NiftiMasker, or MultiNiftiMasker, optional
@@ -313,9 +311,7 @@ class _BaseDecoder(LinearRegression, CacheMixin):
     %(memory)s
     %(memory_level)s
     %(n_jobs)s
-        Default=1.
-    %(verbose)s
-        Default=0.
+    %(verbose0)s
 
     See Also
     ------------
@@ -788,10 +784,9 @@ class Decoder(_BaseDecoder):
     Parameters
     -----------
     estimator: str, optional
-        The estimator to choose among: 'svc', 'svc_l2', 'svc_l1', 'logistic',
-        'logistic_l1', 'logistic_l2' and 'ridge_classifier'. Note that
-        'svc' and 'svc_l2'; 'logistic' and 'logistic_l2' correspond to the same
-        estimator. Dummy classifier is named as 'dummy_classifier'. Default 'svc'.
+        The estimator to choose among:
+        %(classifier_options)s
+        Default 'svc'.
 
     mask: filename, Nifti1Image, NiftiMasker, or MultiNiftiMasker, optional
         Mask to be used on data. If an instance of masker is passed,
@@ -855,9 +850,7 @@ class Decoder(_BaseDecoder):
     %(memory)s
     %(memory_level)s
     %(n_jobs)s
-        Default=1.
-    %(verbose)s
-        Default=0.
+    %(verbose0)s
 
     See Also
     ------------
@@ -897,9 +890,9 @@ class DecoderRegressor(_BaseDecoder):
     Parameters
     -----------
     estimator: str, optional
-        The estimator to choose among: 'ridge', 'ridge_regressor', and 'svr'.
-        Note that the 'ridge' and 'ridge_regressor' correspond to the same
-        estimator. Dummy regressor is named as 'dummy_regressor'. Default 'svr'.
+        The estimator to choose among:
+        %(regressor_options)s
+        Default 'svr'.
 
     mask: filename, Nifti1Image, NiftiMasker, or MultiNiftiMasker, optional
         Mask to be used on data. If an instance of masker is passed,
@@ -963,9 +956,7 @@ class DecoderRegressor(_BaseDecoder):
     %(memory)s
     %(memory_level)s
     %(n_jobs)s
-        Default=1.
-    %(verbose)s
-        Default=0.
+    %(verbose0)s
 
     See Also
     ------------
@@ -1006,9 +997,9 @@ class FREMRegressor(_BaseDecoder):
     Parameters
     -----------
     estimator : str, optional
-        The estimator to choose among: 'ridge', 'ridge_regressor', and 'svr'.
-        Note that the 'ridge' and 'ridge_regressor' correspond to the same
-        estimator. Default 'svr'.
+        The estimator to choose among:
+        %(regressor_options)s
+        Default 'svr'.
 
     mask : filename, Nifti1Image, NiftiMasker, or MultiNiftiMasker, optional
         Mask to be used on data. If an instance of masker is passed,
@@ -1078,9 +1069,7 @@ class FREMRegressor(_BaseDecoder):
     %(memory)s
     %(memory_level)s
     %(n_jobs)s
-        Default=1.
-    %(verbose)s
-        Default=0.
+    %(verbose0)s
 
     References
     ----------
@@ -1129,10 +1118,9 @@ class FREMClassifier(_BaseDecoder):
     Parameters
     -----------
     estimator : str, optional
-        The estimator to choose among: 'svc', 'svc_l2', 'svc_l1', 'logistic',
-        'logistic_l1', 'logistic_l2' and 'ridge_classifier'. Note that
-        'svc' and 'svc_l2'; 'logistic' and 'logistic_l2' correspond to the same
-        estimator. Default 'svc'.
+        The estimator to choose among:
+        %(classifier_options)s
+        Default 'svc'.
 
     mask : filename, Nifti1Image, NiftiMasker, or MultiNiftiMasker, optional
         Mask to be used on data. If an instance of masker is passed,
@@ -1202,9 +1190,7 @@ class FREMClassifier(_BaseDecoder):
     %(memory)s
     %(memory_level)s
     %(n_jobs)s
-        Default=1.
-    %(verbose)s
-        Default=0.
+    %(verbose0)s
 
     References
     ----------

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -18,7 +18,7 @@ import warnings
 
 import numpy as np
 from joblib import Parallel, delayed
-from nilearn._utils import CacheMixin
+from nilearn._utils import CacheMixin, fill_doc
 from nilearn._utils.cache_mixin import _check_memory
 from nilearn._utils.param_validation import check_feature_screening
 from nilearn.input_data.masker_validation import check_embedded_nifti_masker
@@ -220,6 +220,7 @@ def _parallel_fit(estimator, X, y, train, test, param_grid, is_classification,
     return class_index, best_coef, best_intercept, best_param, best_score, dummy_output
 
 
+@fill_doc
 class _BaseDecoder(LinearRegression, CacheMixin):
     """A wrapper for popular classification/regression strategies in
     neuroimaging.
@@ -292,35 +293,13 @@ class _BaseDecoder(LinearRegression, CacheMixin):
 
         For classification, valid entries are: 'accuracy', 'f1', 'precision',
         'recall' or 'roc_auc'. Default: 'roc_auc'.
-
-    smoothing_fwhm: float, optional. Default: None
-        If smoothing_fwhm is not None, it gives the size in millimeters of the
-        spatial smoothing to apply to the signal.
-
-    standardize: bool, optional. Default: True
-        If standardize is True, the time-series are centered and normed:
-        their variance is put to 1 in the time dimension.
-
-    target_affine: 3x3 or 4x4 matrix, optional. Default: None
-        This parameter is passed to image.resample_img. Please see the
-        related documentation for details.
-
-    target_shape: 3-tuple of int, optional. Default: None
-        This parameter is passed to image.resample_img. Please see the
-        related documentation for details.
-
-    low_pass: None or float, optional
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
-    high_pass: None or float, optional
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
-    t_r: float, optional. Default: None
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details.
-
+    %(smoothing_fwhm)s
+    %(standardize)s
+    %(target_affine)s
+    %(target_shape)s
+    %(low_pass)s
+    %(high_pass)s
+    %(t_r)s
     mask_strategy: {'background' or 'epi'}, optional. Default: 'background'
         The strategy used to compute the mask: use 'background' if your
         images present a clear homogeneous background, and 'epi' if they
@@ -328,23 +307,15 @@ class _BaseDecoder(LinearRegression, CacheMixin):
         computed from masking.compute_background_mask or
         masking.compute_epi_mask.
 
-        This parameter will be ignored if a mask image is provided.
+        .. note::
+            This parameter will be ignored if a mask image is provided.
 
-    memory: instance of joblib.Memory or str
-        Used to cache the masking process.
-        By default, no caching is done. If a str is given, it is the
-        path to the caching directory.
-
-    memory_level: int, optional. Default: 0
-        Rough estimator of the amount of memory used by caching. Higher value
-        means more memory for caching.
-
-    n_jobs: int, optional. Default: 1.
-        The number of CPUs to use to do the computation. -1 means
-        'all CPUs'.
-
-    verbose: int, optional. Default: 0.
-        Verbosity level.
+    %(memory)s
+    %(memory_level)s
+    %(n_jobs)s
+        Default=1.
+    %(verbose)s
+        Default=0.
 
     See Also
     ------------
@@ -804,6 +775,7 @@ class _BaseDecoder(LinearRegression, CacheMixin):
         return scores.ravel() if scores.shape[1] == 1 else scores
 
 
+@fill_doc
 class Decoder(_BaseDecoder):
     """A wrapper for popular classification strategies in neuroimaging.
 
@@ -863,35 +835,13 @@ class Decoder(_BaseDecoder):
 
         For classification, valid entries are: 'accuracy', 'f1', 'precision',
         'recall' or 'roc_auc'. Default: 'roc_auc'.
-
-    smoothing_fwhm: float, optional. Default: None
-        If smoothing_fwhm is not None, it gives the size in millimeters of the
-        spatial smoothing to apply to the signal.
-
-    standardize: bool, optional. Default: True
-        If standardize is True, the time-series are centered and normed:
-        their variance is put to 1 in the time dimension.
-
-    target_affine: 3x3 or 4x4 matrix, optional. Default: None
-        This parameter is passed to image.resample_img. Please see the
-        related documentation for details.
-
-    target_shape: 3-tuple of int, optional. Default: None
-        This parameter is passed to image.resample_img. Please see the
-        related documentation for details.
-
-    low_pass: None or float, optional
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
-    high_pass: None or float, optional
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
-    t_r: float, optional. Default: None
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details.
-
+    %(smoothing_fwhm)s
+    %(standardize)s
+    %(target_affine)s
+    %(target_shape)s
+    %(low_pass)s
+    %(high_pass)s
+    %(t_r)s
     mask_strategy: {'background' or 'epi'}, optional. Default: 'background'
         The strategy used to compute the mask: use 'background' if your
         images present a clear homogeneous background, and 'epi' if they
@@ -899,23 +849,15 @@ class Decoder(_BaseDecoder):
         computed from masking.compute_background_mask or
         masking.compute_epi_mask.
 
-        This parameter will be ignored if a mask image is provided.
+        .. note::
+            This parameter will be ignored if a mask image is provided.
 
-    memory: instance of joblib.Memory or str
-        Used to cache the masking process.
-        By default, no caching is done. If a str is given, it is the
-        path to the caching directory.
-
-    memory_level: int, optional. Default: 0
-        Rough estimator of the amount of memory used by caching. Higher value
-        means more memory for caching.
-
-    n_jobs: int, optional. Default: 1.
-        The number of CPUs to use to do the computation. -1 means
-        'all CPUs'.
-
-    verbose: int, optional. Default: 0.
-        Verbosity level.
+    %(memory)s
+    %(memory_level)s
+    %(n_jobs)s
+        Default=1.
+    %(verbose)s
+        Default=0.
 
     See Also
     ------------
@@ -942,6 +884,7 @@ class Decoder(_BaseDecoder):
             verbose=verbose, n_jobs=n_jobs)
 
 
+@fill_doc
 class DecoderRegressor(_BaseDecoder):
     """A wrapper for popular regression strategies in neuroimaging.
 
@@ -1000,35 +943,13 @@ class DecoderRegressor(_BaseDecoder):
 
         For regression, valid entries are: 'r2', 'neg_mean_absolute_error',
         or 'neg_mean_squared_error'. Default: 'r2'.
-
-    smoothing_fwhm: float, optional. Default: None
-        If smoothing_fwhm is not None, it gives the size in millimeters of the
-        spatial smoothing to apply to the signal.
-
-    standardize: bool, optional. Default: True
-        If standardize is True, the time-series are centered and normed:
-        their variance is put to 1 in the time dimension.
-
-    target_affine: 3x3 or 4x4 matrix, optional. Default: None
-        This parameter is passed to image.resample_img. Please see the
-        related documentation for details.
-
-    target_shape: 3-tuple of int, optional. Default: None
-        This parameter is passed to image.resample_img. Please see the
-        related documentation for details.
-
-    low_pass: None or float, optional
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
-    high_pass: None or float, optional
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
-    t_r: float, optional. Default: None
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details.
-
+    %(smoothing_fwhm)s
+    %(standardize)s
+    %(target_affine)s
+    %(target_shape)s
+    %(low_pass)s
+    %(high_pass)s
+    %(t_r)s
     mask_strategy: {'background' or 'epi'}, optional. Default: 'background'
         The strategy used to compute the mask: use 'background' if your
         images present a clear homogeneous background, and 'epi' if they
@@ -1036,23 +957,15 @@ class DecoderRegressor(_BaseDecoder):
         computed from masking.compute_background_mask or
         masking.compute_epi_mask.
 
-        This parameter will be ignored if a mask image is provided.
+        .. note::
+            This parameter will be ignored if a mask image is provided.
 
-    memory: instance of joblib.Memory or str
-        Used to cache the masking process.
-        By default, no caching is done. If a str is given, it is the
-        path to the caching directory.
-
-    memory_level: int, optional. Default: 0
-        Rough estimator of the amount of memory used by caching. Higher value
-        means more memory for caching.
-
-    n_jobs: int, optional. Default: 1.
-        The number of CPUs to use to do the computation. -1 means
-        'all CPUs'.
-
-    verbose: int, optional. Default: 0.
-        Verbosity level.
+    %(memory)s
+    %(memory_level)s
+    %(n_jobs)s
+        Default=1.
+    %(verbose)s
+        Default=0.
 
     See Also
     ------------
@@ -1081,6 +994,7 @@ class DecoderRegressor(_BaseDecoder):
             verbose=verbose, n_jobs=n_jobs)
 
 
+@fill_doc
 class FREMRegressor(_BaseDecoder):
     """ State of the art decoding scheme applied to usual regression estimators.
 
@@ -1144,35 +1058,13 @@ class FREMRegressor(_BaseDecoder):
 
         For regression, valid entries are: 'r2', 'neg_mean_absolute_error',
         or 'neg_mean_squared_error'. Default: 'r2'.
-
-    smoothing_fwhm : float, optional. Default: None
-        If smoothing_fwhm is not None, it gives the size in millimeters of the
-        spatial smoothing to apply to the signal.
-
-    standardize : bool, optional. Default: True
-        If standardize is True, the time-series are centered and normed:
-        their variance is put to 1 in the time dimension.
-
-    target_affine : 3x3 or 4x4 matrix, optional. Default: None
-        This parameter is passed to image.resample_img. Please see the
-        related documentation for details.
-
-    target_shape : 3-tuple of int, optional. Default: None
-        This parameter is passed to image.resample_img. Please see the
-        related documentation for details.
-
-    low_pass : None or float, optional
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
-    high_pass : None or float, optional
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
-    t_r : float, optional. Default: None
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details.
-
+    %(smoothing_fwhm)s
+    %(standardize)s
+    %(target_affine)s
+    %(target_shape)s
+    %(low_pass)s
+    %(high_pass)s
+    %(t_r)s
     mask_strategy : {'background' or 'epi'}, optional. Default: 'background'
         The strategy used to compute the mask: use 'background' if your
         images present a clear homogeneous background, and 'epi' if they
@@ -1180,23 +1072,15 @@ class FREMRegressor(_BaseDecoder):
         computed from masking.compute_background_mask or
         masking.compute_epi_mask.
 
-        This parameter will be ignored if a mask image is provided.
+        .. note::
+            This parameter will be ignored if a mask image is provided.
 
-    memory : instance of joblib.Memory or str
-        Used to cache the masking process.
-        By default, no caching is done. If a str is given, it is the
-        path to the caching directory.
-
-    memory_level : int, optional. Default: 0
-        Rough estimator of the amount of memory used by caching. Higher value
-        means more memory for caching.
-
-    n_jobs : int, optional. Default: 1.
-        The number of CPUs to use to do the computation. -1 means
-        'all CPUs'.
-
-    verbose : int, optional. Default: 0.
-        Verbosity level.
+    %(memory)s
+    %(memory_level)s
+    %(n_jobs)s
+        Default=1.
+    %(verbose)s
+        Default=0.
 
     References
     ----------
@@ -1233,6 +1117,7 @@ class FREMRegressor(_BaseDecoder):
             verbose=verbose, n_jobs=n_jobs)
 
 
+@fill_doc
 class FREMClassifier(_BaseDecoder):
     """ State of the art decoding scheme applied to usual classifiers.
 
@@ -1297,35 +1182,13 @@ class FREMClassifier(_BaseDecoder):
 
         For classification, valid entries are: 'accuracy', 'f1', 'precision',
         'recall' or 'roc_auc'. Default: 'roc_auc'.
-
-    smoothing_fwhm : float, optional. Default: None
-        If smoothing_fwhm is not None, it gives the size in millimeters of the
-        spatial smoothing to apply to the signal.
-
-    standardize : bool, optional. Default: True
-        If standardize is True, the time-series are centered and normed:
-        their variance is put to 1 in the time dimension.
-
-    target_affine : 3x3 or 4x4 matrix, optional. Default: None
-        This parameter is passed to image.resample_img. Please see the
-        related documentation for details.
-
-    target_shape : 3-tuple of int, optional. Default: None
-        This parameter is passed to image.resample_img. Please see the
-        related documentation for details.
-
-    low_pass : None or float, optional
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
-    high_pass : None or float, optional
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
-    t_r : float, optional. Default: None
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details.
-
+    %(smoothing_fwhm)s
+    %(standardize)s
+    %(target_affine)s
+    %(target_shape)s
+    %(low_pass)s
+    %(high_pass)s
+    %(t_r)s
     mask_strategy : {'background' or 'epi'}, optional. Default: 'background'
         The strategy used to compute the mask: use 'background' if your
         images present a clear homogeneous background, and 'epi' if they
@@ -1333,23 +1196,15 @@ class FREMClassifier(_BaseDecoder):
         computed from masking.compute_background_mask or
         masking.compute_epi_mask.
 
-        This parameter will be ignored if a mask image is provided.
+        .. note::
+            This parameter will be ignored if a mask image is provided.
 
-    memory : instance of joblib.Memory or str
-        Used to cache the masking process.
-        By default, no caching is done. If a str is given, it is the
-        path to the caching directory.
-
-    memory_level : int, optional. Default: 0
-        Rough estimator of the amount of memory used by caching. Higher value
-        means more memory for caching.
-
-    n_jobs : int, optional. Default: 1.
-        The number of CPUs to use to do the computation. -1 means
-        'all CPUs'.
-
-    verbose : int, optional. Default: 0.
-        Verbosity level.
+    %(memory)s
+    %(memory_level)s
+    %(n_jobs)s
+        Default=1.
+    %(verbose)s
+        Default=0.
 
     References
     ----------

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -67,10 +67,8 @@ def search_light(X, y, estimator, A, groups=None, scoring=None,
         A cross-validation generator. If None, a 3-fold cross
         validation is used or 3-fold stratified cross-validation
         when y is supplied.
-    %(n_jobs)s
-        Default=-1.
-    %(verbose)s
-        Default=0.
+    %(n_jobs_all)s
+    %(verbose0)s
 
     Returns
     -------
@@ -101,8 +99,6 @@ class GroupIterator(object):
     n_features : int
         Total number of features
     %(n_jobs)s
-    n_jobs : int, optional
-        Defaut=1.
 
     """
     def __init__(self, n_features, n_jobs=1):
@@ -217,7 +213,6 @@ class SearchLight(BaseEstimator):
     estimator : 'svr', 'svc', or an estimator object implementing 'fit'
         The object to use to fit the data
     %(n_jobs)s
-        Default=1.
     scoring : string or callable, optional
         The scoring strategy to use. See the scikit-learn documentation
         If callable, takes as arguments the fitted estimator, the
@@ -228,8 +223,7 @@ class SearchLight(BaseEstimator):
         A cross-validation generator. If None, a 3-fold cross
         validation is used or 3-fold stratified cross-validation
         when y is supplied.
-    %(verbose)s
-        Default=0.
+    %(verbose0)s
 
     Notes
     ------

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -24,12 +24,13 @@ from sklearn.exceptions import ConvergenceWarning
 from .. import masking
 from ..image.resampling import coord_transform
 from ..input_data.nifti_spheres_masker import _apply_mask_and_get_affinity
-from .._utils import check_niimg_4d
+from .._utils import check_niimg_4d, fill_doc
 from sklearn.model_selection import cross_val_score
 
 ESTIMATOR_CATALOG = dict(svc=svm.LinearSVC, svr=svm.SVR)
 
 
+@fill_doc
 def search_light(X, y, estimator, A, groups=None, scoring=None,
                  cv=None, n_jobs=-1, verbose=0):
     """Function for computing a search_light
@@ -51,7 +52,9 @@ def search_light(X, y, estimator, A, groups=None, scoring=None,
 
     groups : array-like, optional
         group label for each sample for cross validation. default None
-        NOTE: will have no effect for scikit learn < 0.18
+
+        .. note::
+            This will have no effect for scikit learn < 0.18
 
     scoring : string or callable, optional
         The scoring strategy to use. See the scikit-learn documentation
@@ -64,13 +67,10 @@ def search_light(X, y, estimator, A, groups=None, scoring=None,
         A cross-validation generator. If None, a 3-fold cross
         validation is used or 3-fold stratified cross-validation
         when y is supplied.
-
-    n_jobs : int, optional
-        The number of CPUs to use to do the computation. -1 means
-        'all CPUs'.
-
-    verbose : int, optional
-        The verbosity level. Defaut is 0
+    %(n_jobs)s
+        Default=-1.
+    %(verbose)s
+        Default=0.
 
     Returns
     -------
@@ -89,6 +89,7 @@ def search_light(X, y, estimator, A, groups=None, scoring=None,
     return np.concatenate(scores)
 
 
+@fill_doc
 class GroupIterator(object):
     """Group iterator
 
@@ -99,10 +100,10 @@ class GroupIterator(object):
     ----------
     n_features : int
         Total number of features
-
+    %(n_jobs)s
     n_jobs : int, optional
-        The number of CPUs to use to do the computation. -1 means
-        'all CPUs'. Defaut is 1
+        Defaut=1.
+
     """
     def __init__(self, n_features, n_jobs=1):
         self.n_features = n_features
@@ -195,6 +196,7 @@ def _group_iter_search_light(list_rows, estimator, X, y, groups,
 ##############################################################################
 # Class for search_light #####################################################
 ##############################################################################
+@fill_doc
 class SearchLight(BaseEstimator):
     """Implement search_light analysis using an arbitrary type of classifier.
 
@@ -214,11 +216,8 @@ class SearchLight(BaseEstimator):
 
     estimator : 'svr', 'svc', or an estimator object implementing 'fit'
         The object to use to fit the data
-
-    n_jobs : int, optional. Default is -1.
-        The number of CPUs to use to do the computation. -1 means
-        'all CPUs'.
-
+    %(n_jobs)s
+        Default=1.
     scoring : string or callable, optional
         The scoring strategy to use. See the scikit-learn documentation
         If callable, takes as arguments the fitted estimator, the
@@ -229,9 +228,8 @@ class SearchLight(BaseEstimator):
         A cross-validation generator. If None, a 3-fold cross
         validation is used or 3-fold stratified cross-validation
         when y is supplied.
-
-    verbose : int, optional
-        Verbosity level. Defaut is False
+    %(verbose)s
+        Default=0.
 
     Notes
     ------

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -28,6 +28,7 @@ from sklearn.preprocessing import LabelBinarizer
 from sklearn.metrics import accuracy_score
 from ..input_data.masker_validation import check_embedded_nifti_masker
 from .._utils.param_validation import _adjust_screening_percentile
+from .._utils import fill_doc
 from sklearn.utils import check_X_y
 from sklearn.model_selection import check_cv
 try:
@@ -60,6 +61,7 @@ def _crop_mask(mask):
     return mask[i_min:i_max + 1, j_min:j_max + 1, k_min:k_max + 1]
 
 
+@fill_doc
 def _univariate_feature_screening(
         X, y, mask, is_classif, screening_percentile, smoothing_fwhm=2.):
     """
@@ -82,10 +84,8 @@ def _univariate_feature_screening(
     screening_percentile : float in the closed interval [0., 100.]
         Only the `screening_percentile * 100" percent most import voxels will
         be retained.
-
-    smoothing_fwhm : float, optional (default 2.)
-        FWHM for isotropically smoothing the data X before F-testing. A value
-        of zero means "don't smooth".
+    %(smoothing_fwhm)s
+        Default=2.
 
     Returns
     -------
@@ -285,6 +285,7 @@ class _EarlyStoppingCallback(object):
             return pearson_score, spearman_score
 
 
+@fill_doc
 def path_scores(solver, X, y, mask, alphas, l1_ratios, train, test,
                 solver_params, is_classif=False, n_alphas=10, eps=1E-3,
                 key=None, debias=False, Xmean=None,
@@ -350,9 +351,8 @@ def path_scores(solver, X, y, mask, alphas, l1_ratios, train, test,
         (which is typically smaller). If '100' is given, all the features
         are used, regardless of the number of voxels.
         Default=20.
-
-    verbose : integer, optional
-        Indicate the level of verbosity. Default=1.
+    %(verbose)s
+        Default=1.
 
     """
     if l1_ratios is None:
@@ -479,6 +479,7 @@ def path_scores(solver, X, y, mask, alphas, l1_ratios, train, test,
             y_train_mean, key)
 
 
+@fill_doc
 class BaseSpaceNet(LinearRegression, CacheMixin):
     """
     Regression and classification learners with sparsity and spatial priors
@@ -524,29 +525,13 @@ class BaseSpaceNet(LinearRegression, CacheMixin):
         Mask to be used on data. If an instance of masker is passed,
         then its mask will be used. If no mask is it will be computed
         automatically by a NiftiMasker.
-
-    target_affine : 3x3 or 4x4 matrix, optional (default None)
-        This parameter is passed to image.resample_img. An important use-case
-        of this parameter is for downsampling the input data to a coarser
-        resolution (to speed of the model fit). Please see the related
-        documentation for details.
-
-    target_shape : 3-tuple of integers, optional (default None)
-        This parameter is passed to image.resample_img. Please see the
-        related documentation for details.
-
-    low_pass: None or float, optional
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
-    high_pass: None or float, optional
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
-    t_r : float, optional (default None)
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details.
-
+    %(target_affine)s
+        An important use-case of this parameter is for downsampling the
+        input data to a coarser resolution (to speed of the model fit).
+    %(target_shape)s
+    %(low_pass)s
+    %(high_pass)s
+    %(t_r)s
     screening_percentile : float in the interval [0, 100]; Optional (
     default 20)
         Percentile value for ANOVA univariate feature selection. A value of
@@ -569,22 +554,12 @@ class BaseSpaceNet(LinearRegression, CacheMixin):
 
     tol : float, optional (default 5e-4)
         Defines the tolerance for convergence for the backend FISTA solver.
-
-    verbose : int, optional (default 1)
-        Verbosity level.
-
-    n_jobs : int, optional (default 1)
-        Number of jobs in solving the sub-problems.
-
-    memory: instance of joblib.Memory or string
-        Used to cache the masking process.
-        By default, no caching is done. If a string is given, it is the
-        path to the caching directory.
-
-    memory_level: integer, optional (default 1)
-        Rough estimator of the amount of memory used by caching. Higher value
-        means more memory for caching.
-
+    %(verbose)s
+        Default=1.
+    %(n_jobs)s
+        Default=1.
+    %(memory)s
+    %(memory_level)s
     cv : int, a cv generator instance, or None (default 8)
         The input specifying which cross-validation generator to use.
         It can be an integer, in which case it is the number of folds in a
@@ -982,6 +957,7 @@ class BaseSpaceNet(LinearRegression, CacheMixin):
         return self.classes_[indices]
 
 
+@fill_doc
 class SpaceNetClassifier(BaseSpaceNet):
     """Classification learners with sparsity and spatial priors.
 
@@ -1023,27 +999,11 @@ class SpaceNetClassifier(BaseSpaceNet):
         Mask to be used on data. If an instance of masker is passed,
         then its mask will be used. If no mask is it will be computed
         automatically by a MultiNiftiMasker with default parameters.
-
-    target_affine : 3x3 or 4x4 matrix, optional (default None)
-        This parameter is passed to image.resample_img. Please see the
-        related documentation for details.
-
-    target_shape : 3-tuple of integers, optional (default None)
-        This parameter is passed to image.resample_img. Please see the
-        related documentation for details.
-
-    low_pass: None or float, optional
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
-    high_pass: None or float, optional
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
-    t_r : float, optional (default None)
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details.
-
+    %(target_affine)s
+    %(target_shape)s
+    %(low_pass)s
+    %(high_pass)s
+    %(t_r)s
     screening_percentile : float in the interval [0, 100]; Optional (default 20)
         Percentile value for ANOVA univariate feature selection. A value of
         100 means 'keep all features'. This percentile is is expressed
@@ -1065,22 +1025,12 @@ class SpaceNetClassifier(BaseSpaceNet):
 
     tol : float
         Defines the tolerance for convergence. Defaults to 1e-4.
-
-    verbose : int, optional (default 1)
-        Verbosity level.
-
-    n_jobs : int, optional (default 1)
-        Number of jobs in solving the sub-problems.
-
-    memory: instance of joblib.Memory or string
-        Used to cache the masking process.
-        By default, no caching is done. If a string is given, it is the
-        path to the caching directory.
-
-    memory_level: integer, optional (default 1)
-        Rough estimator of the amount of memory used by caching. Higher value
-        means more memory for caching.
-
+    %(verbose)s
+        Default=1.
+    %(n_jobs)s
+        Default=1.
+    %(memory)s
+    %(memory_level)s
     cv : int, a cv generator instance, or None (default 8)
         The input specifying which cross-validation generator to use.
         It can be an integer, in which case it is the number of folds in a
@@ -1160,6 +1110,11 @@ class SpaceNetClassifier(BaseSpaceNet):
 
     `Xstd_` : array, shape (n_features,)
         Standard deviation of X across samples
+
+    See Also
+    --------
+    nilearn.decoding.SpaceNetRegressor: Graph-Net and TV-L1 priors/penalties
+
     """
 
     def __init__(self, penalty="graph-net", loss="logistic",
@@ -1213,6 +1168,7 @@ class SpaceNetClassifier(BaseSpaceNet):
         return accuracy_score(y, self.predict(X))
 
 
+@fill_doc
 class SpaceNetRegressor(BaseSpaceNet):
     """Regression learners with sparsity and spatial priors.
 
@@ -1251,27 +1207,11 @@ class SpaceNetRegressor(BaseSpaceNet):
         Mask to be used on data. If an instance of masker is passed,
         then its mask will be used. If no mask is it will be computed
         automatically by a MultiNiftiMasker with default parameters.
-
-    target_affine : 3x3 or 4x4 matrix, optional (default None)
-        This parameter is passed to image.resample_img. Please see the
-        related documentation for details.
-
-    target_shape : 3-tuple of integers, optional (default None)
-        This parameter is passed to image.resample_img. Please see the
-        related documentation for details.
-
-    low_pass: None or float, optional
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
-    high_pass: None or float, optional
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
-    t_r : float, optional (default None)
-        This parameter is passed to signal.clean. Please see the related
-        documentation for details
-
+    %(target_affine)s
+    %(target_shape)s
+    %(low_pass)s
+    %(high_pass)s
+    %(t_r)s
     screening_percentile : float in the interval [0, 100]; Optional (default 20)
         Percentile value for ANOVA univariate feature selection. A value of
         100 means 'keep all features'. This percentile is is expressed
@@ -1292,22 +1232,12 @@ class SpaceNetRegressor(BaseSpaceNet):
 
     tol : float
         Defines the tolerance for convergence. Defaults to 1e-4.
-
-    verbose : int, optional (default 1)
-        Verbosity level.
-
-    n_jobs : int, optional (default 1)
-        Number of jobs in solving the sub-problems.
-
-    memory: instance of joblib.Memory or string
-        Used to cache the masking process.
-        By default, no caching is done. If a string is given, it is the
-        path to the caching directory.
-
-    memory_level: integer, optional (default 1)
-        Rough estimator of the amount of memory used by caching. Higher value
-        means more memory for caching.
-
+    %(verbose)s
+        Default=1.
+    %(n_jobs)s
+        Default=1.
+    %(memory)s
+    %(memory_level)s
     cv : int, a cv generator instance, or None (default 8)
         The input specifying which cross-validation generator to use.
         It can be an integer, in which case it is the number of folds in a
@@ -1374,6 +1304,11 @@ class SpaceNetRegressor(BaseSpaceNet):
 
     `Xstd_` : array, shape (n_features,)
         Standard deviation of X across samples
+
+    See Also
+    --------
+    nilearn.decoding.SpaceNetClassifier: Graph-Net and TV-L1 priors/penalties
+
     """
 
     def __init__(self, penalty="graph-net", l1_ratios=.5, alphas=None,

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -352,7 +352,6 @@ def path_scores(solver, X, y, mask, alphas, l1_ratios, train, test,
         are used, regardless of the number of voxels.
         Default=20.
     %(verbose)s
-        Default=1.
 
     """
     if l1_ratios is None:
@@ -555,11 +554,9 @@ class BaseSpaceNet(LinearRegression, CacheMixin):
     tol : float, optional (default 5e-4)
         Defines the tolerance for convergence for the backend FISTA solver.
     %(verbose)s
-        Default=1.
     %(n_jobs)s
-        Default=1.
     %(memory)s
-    %(memory_level)s
+    %(memory_level1)s
     cv : int, a cv generator instance, or None (default 8)
         The input specifying which cross-validation generator to use.
         It can be an integer, in which case it is the number of folds in a
@@ -1026,11 +1023,9 @@ class SpaceNetClassifier(BaseSpaceNet):
     tol : float
         Defines the tolerance for convergence. Defaults to 1e-4.
     %(verbose)s
-        Default=1.
     %(n_jobs)s
-        Default=1.
     %(memory)s
-    %(memory_level)s
+    %(memory_level1)s
     cv : int, a cv generator instance, or None (default 8)
         The input specifying which cross-validation generator to use.
         It can be an integer, in which case it is the number of folds in a
@@ -1233,11 +1228,9 @@ class SpaceNetRegressor(BaseSpaceNet):
     tol : float
         Defines the tolerance for convergence. Defaults to 1e-4.
     %(verbose)s
-        Default=1.
     %(n_jobs)s
-        Default=1.
     %(memory)s
-    %(memory_level)s
+    %(memory_level1)s
     cv : int, a cv generator instance, or None (default 8)
         The input specifying which cross-validation generator to use.
         It can be an integer, in which case it is the number of folds in a

--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -6,6 +6,7 @@ import matplotlib as mpl
 from matplotlib import cm as mpl_cm
 
 from nilearn._utils.niimg_conversions import check_niimg_3d
+from nilearn._utils import fill_doc
 from nilearn import surface
 from nilearn import datasets
 from nilearn.plotting.html_document import HTMLDocument
@@ -125,6 +126,7 @@ def _fill_html_template(info, embed_js=True):
     return SurfaceView(as_html)
 
 
+@fill_doc
 def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
                      threshold=None, cmap=cm.cold_hot,
                      black_bg=False, vmax=None, vmin=None, symmetric_cmap=True,
@@ -138,20 +140,21 @@ def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
         See http://nilearn.github.io/manipulating_images/input_output.html
 
     surf_mesh : str or dict, optional.
-        if 'fsaverage5', use fsaverage5 mesh from nilearn.datasets
-        if 'fsaverage', use fsaverage mesh from nilearn.datasets
-        if a dictionary, it should have the same structure as those returned by
+        If a string, it should be one of the following values:
+        %(fsaverage_options)s
+        If a dictionary, it should have the same structure as those returned by
         nilearn.datasets.fetch_surf_fsaverage, i.e. keys should be 'infl_left',
         'pial_left', 'sulc_left', 'infl_right', 'pial_right', and 'sulc_right',
         containing inflated and pial meshes, and sulcal depth values for left
-        and right hemispheres. Default='fsaverage5'.
+        and right hemispheres.
+        Default='fsaverage5'.
 
     threshold : str, number or None, optional
         If None, no thresholding.
         If it is a number only values of amplitude greater
         than threshold will be shown.
         If it is a string it must finish with a percent sign,
-        e.g. "25.3%", and only values of amplitude above the
+        e.g. "25.3%%", and only values of amplitude above the
         given percentile will be shown.
 
     cmap : str or matplotlib colormap, optional


### PR DESCRIPTION
This PR proposes to add a `fill_doc` decorator to automatically fill parts of docstrings. 

An example on the `datasets`  and `decoding` modules is also provided with the parameters `verbose`, `resume`, `data_dir`, `url`, `smoothing_fwhm`, `standardize`, `target_affine`, `target_shape`, `low_pass`, `high_pass`, `t_r`, `memory`, `memory_level`, and `n_jobs`.

Note: The code for the decorator comes from MNE (link at the top of `nilearn/_utils/docs.py`).

This has the following benefits:

- Standard documentation entries are all in one place
- Simplifies the maintenance of docstrings/documentation
- Reduces the length of files (several hundreds of lines were removed from the `datasets` module with this simple example although the rendering is exactly the same as before).

If we decide to adopt this, there are quite a few arguments that could be handled in this way across Nilearn.