### PR TITLE
[FIX] Fix view_img colorbar

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,6 +23,9 @@ Fixes
   it accepts three types of masks---i.e. whole-brain, grey-matter and
   white-matter---following the enhancements made in the function
   :func:`nilearn.masking.compute_brain_mask` in this release.
+- Fix colorbar of :func:`nilearn.plotting.view_img` which was not visible for some
+  combinations of `black_bg` and `bg_img` parameters.
+  (See issue `#2874 <https://github.com/nilearn/nilearn/issues/2874>`_).
 
 Enhancements
 ------------

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -9,6 +9,7 @@ from io import BytesIO
 from base64 import b64encode
 
 import numpy as np
+import matplotlib
 from matplotlib.image import imsave
 
 from nibabel.affines import apply_affine
@@ -326,7 +327,7 @@ def _json_view_data(bg_img, stat_map_img, mask_img, bg_min, bg_max, black_bg,
                              ensure_finite=True)
     bg_mask = np.logical_not(bg_mask).astype(float)
     bg_mask[bg_mask == 1] = np.nan
-    bg_cmap = copy.copy(cmap)
+    bg_cmap = copy.copy(matplotlib.cm.get_cmap(cmap))
     if black_bg:
         bg_cmap.set_bad('black')
     else:

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -327,7 +327,7 @@ def _json_view_data(bg_img, stat_map_img, mask_img, bg_min, bg_max, black_bg,
                              ensure_finite=True)
     bg_mask = np.logical_not(bg_mask).astype(float)
     bg_mask[bg_mask == 1] = np.nan
-    bg_cmap = copy.copy(matplotlib.cm.get_cmap(cmap))
+    bg_cmap = copy.copy(matplotlib.cm.get_cmap('gray'))
     if black_bg:
         bg_cmap.set_bad('black')
     else:

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -307,8 +307,8 @@ def _json_view_size(params):
     return width_view, height_view
 
 
-def _json_view_data(bg_img, stat_map_img, mask_img, bg_min, bg_max, colors,
-                    cmap, colorbar):
+def _json_view_data(bg_img, stat_map_img, mask_img, bg_min, bg_max, black_bg,
+                    colors, cmap, colorbar):
     """Create a json-like viewer object, and populate with base64 data.
     Returns: json_view
 
@@ -320,7 +320,8 @@ def _json_view_data(bg_img, stat_map_img, mask_img, bg_min, bg_max, colors,
     # Create a base64 sprite for the background
     bg_sprite = BytesIO()
     bg_data = _safe_get_data(bg_img, ensure_finite=True)
-    _save_sprite(bg_data, bg_sprite, bg_max, bg_min, None, 'gray', 'png')
+    bg_cmap = 'gray' if black_bg else cmap
+    _save_sprite(bg_data, bg_sprite, bg_max, bg_min, None, bg_cmap, 'png')
     json_view['bg_base64'] = _bytesIO_to_base64(bg_sprite)
 
     # Create a base64 sprite for the stat map
@@ -542,7 +543,7 @@ def view_img(stat_map_img, bg_img='MNI152',
 
     # Now create a json-like object for the viewer, and converts in html
     json_view = _json_view_data(bg_img, stat_map_img, mask_img, bg_min, bg_max,
-                                colors, cmap, colorbar)
+                                black_bg, colors, cmap, colorbar)
 
     json_view['params'] = _json_view_params(
         stat_map_img.shape, stat_map_img.affine, colors['vmin'],

--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -259,8 +259,8 @@ def test_json_view_data():
 
     # Build a sprite
     json_view = html_stat_map._json_view_data(
-        bg_img, stat_map_img, mask_img, bg_min=0, bg_max=1, colors=colors,
-        cmap='cold_hot', colorbar=True)
+        bg_img, stat_map_img, mask_img, bg_min=0, bg_max=1, black_bg=False,
+        colors=colors, cmap='cold_hot', colorbar=True)
 
     # Check the presence of critical fields
     assert isinstance(json_view['bg_base64'], str)

--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -244,8 +244,7 @@ def test_json_view_size():
     assert height == height_exp, "html viewer does not have expected height"
 
 
-def test_json_view_data():
-
+def _get_data_and_json_view(black_bg, cbar):
     # simple simulated data for stat_img and background
     bg_img, data = _simulate_img()
     stat_map_img, data = _simulate_img()
@@ -259,21 +258,25 @@ def test_json_view_data():
 
     # Build a sprite
     json_view = html_stat_map._json_view_data(
-        bg_img, stat_map_img, mask_img, bg_min=0, bg_max=1, black_bg=False,
-        colors=colors, cmap='cold_hot', colorbar=True)
+        bg_img, stat_map_img, mask_img, bg_min=0, bg_max=1, black_bg=black_bg,
+        colors=colors, cmap='cold_hot', colorbar=cbar)
+    return data, json_view
 
+
+@pytest.mark.parametrize("black_bg", [True, False])
+@pytest.mark.parametrize("cbar", [True, False])
+def test_json_view_data(black_bg, cbar):
+    _, json_view = _get_data_and_json_view(black_bg, cbar)
     # Check the presence of critical fields
     assert isinstance(json_view['bg_base64'], str)
     assert isinstance(json_view['stat_map_base64'], str)
     assert isinstance(json_view['cm_base64'], str)
 
-    return json_view, data
 
-
-def test_json_view_to_html():
-
-    # Re use the data simulated in another test
-    json_view, data = test_json_view_data()
+@pytest.mark.parametrize("black_bg", [True, False])
+@pytest.mark.parametrize("cbar", [True, False])
+def test_json_view_to_html(black_bg, cbar):
+    data, json_view = _get_data_and_json_view(black_bg, cbar)
     json_view['params'] = html_stat_map._json_view_params(
         data.shape, np.eye(4), vmin=0, vmax=1, cut_slices=[1, 1, 1],
         black_bg=True, opacity=1, draw_cross=True, annotate=False,


### PR DESCRIPTION
Fixes #2874 

This PR proposes a possible fix for #2874. 
I'm slightly out of my comfort zone here so I'll take any advice... :sweat_smile: 

```python
from nilearn import plotting, datasets

plotting.view_img(datasets.load_mni152_template(), black_bg=False, bg_img=None)
```
![ticks2](https://user-images.githubusercontent.com/2639645/121936543-092ab580-cd4a-11eb-82b6-2b586dd3f885.png)
