### PR TITLE
[ENH] NiftiMapsMasker Reporting

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -33,6 +33,12 @@ NEW
   similar interface to the :class:`~matplotlib.figure.Figure` returned with the
   `matplotlib` engine.
   (See PR `#3036 <https://github.com/nilearn/nilearn/pull/3036>`_).
+- :class:`~nilearn.input_data.NiftiMapsMasker` can now generate HTML reports in the same
+  way as :class:`~nilearn.input_data.NiftiMasker` and
+  :class:`~nilearn.input_data.NiftiLabelsMasker`. The report enables the users to browse
+  through the spatial maps with a previous and next button. The users can filter the maps
+  they wish to display by passing an integer, or a list of integers to
+  :meth:`~nilearn.input_data.NiftiMapsMasker.generate_report`.
 
 Fixes
 -----

--- a/examples/03_connectivity/plot_probabilistic_atlas_extraction.py
+++ b/examples/03_connectivity/plot_probabilistic_atlas_extraction.py
@@ -51,7 +51,8 @@ time_series = masker.transform(data.func[0],
 # You can pass the indices of the spatial maps you want to include in the
 # report in the order you want them to appear.
 # Here, we only include maps 2, 6, 7, 16, and 21 in the report:
-masker.generate_report(displayed_maps=[2, 6, 7, 16, 21])
+report = masker.generate_report(displayed_maps=[2, 6, 7, 16, 21])
+report
 
 ############################################################################
 # `time_series` is now a 2D matrix, of shape (number of time points x

--- a/examples/03_connectivity/plot_probabilistic_atlas_extraction.py
+++ b/examples/03_connectivity/plot_probabilistic_atlas_extraction.py
@@ -41,9 +41,17 @@ print('First subject resting-state nifti image (4D) is located at: %s' %
 from nilearn.input_data import NiftiMapsMasker
 masker = NiftiMapsMasker(maps_img=atlas_filename, standardize=True,
                          memory='nilearn_cache', verbose=5)
+masker.fit(data.func[0])
+time_series = masker.transform(data.func[0],
+                               confounds=data.confounds)
 
-time_series = masker.fit_transform(data.func[0],
-                                   confounds=data.confounds)
+############################################################################
+# We can generate an HTML report and visualize the components of the
+# :class:`~nilearn.input_data.NiftiMapsMasker`.
+# You can pass the indices of the spatial maps you want to include in the
+# report in the order you want them to appear.
+# Here, we only include maps 2, 6, 7, 16, and 21 in the report:
+masker.generate_report(displayed_maps=[2, 6, 7, 16, 21])
 
 ############################################################################
 # `time_series` is now a 2D matrix, of shape (number of time points x

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -236,7 +236,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
 
         Returns
         -------
-        report : :class:`~nilearn.reporting.html_report.HTMLReport`
+        report : `nilearn.reporting.html_report.HTMLReport`
             HTML report for the masker.
         """
         from nilearn.reporting.html_report import generate_report

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -229,29 +229,27 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
                     img = image.index_img(img, dim[-1] // 2)
                 # Find the cut coordinates
                 cut_coords = [plotting.find_xyz_cut_coords(
-                                image.index_img(maps_image, i))
-                                for i in range(n_maps)]
+                    image.index_img(
+                        maps_image, i)) for i in range(n_maps)]
                 displays = [plotting.plot_img(img,
-                                                   cut_coords=cut_coords[component],
-                                                   black_bg=False,
-                                                   cmap='CMRmap_r') 
-                                    for component in range(n_maps)]
-                for i,d in enumerate(displays):
+                                              cut_coords=cut_coords[component],
+                                              black_bg=False,
+                                              cmap='CMRmap_r')
+                            for component in range(n_maps)]
+                for i, d in enumerate(displays):
                     d.add_overlay(image.index_img(maps_image, i),
-                                    cmap=plotting.cm.black_blue)
+                                  cmap=plotting.cm.black_blue)
                 return displays
             else:
                 msg = ("No image provided to fit in NiftiMapsMasker. "
                        "Plotting only spatial maps for reporting.")
                 warnings.warn(msg)
                 self._report_content['warning_message'] = msg
-                displays = [plotting.plot_stat_map(
-                                image.index_img(maps_image, component)) 
-                                    for component in range(n_maps)]
+                displays = [plotting.plot_stat_map(image.index_img(
+                    maps_image, component)) for component in range(n_maps)]
                 return displays
         else:
             return [None]
-
 
     def fit(self, imgs=None, y=None):
         """Prepare signal extraction from regions.

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -272,10 +272,10 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
                     image.index_img(
                         maps_image, i)) for i in maps_to_be_displayed]
                 displays = [plotting.plot_img(img,
-                                              cut_coords=cut_coords[component],
+                                              cut_coords=cut_coords[idx],
                                               black_bg=False,
                                               cmap='CMRmap_r')
-                            for component in maps_to_be_displayed]
+                            for idx, component in enumerate(maps_to_be_displayed)]
                 for i, d in enumerate(displays):
                     d.add_overlay(image.index_img(maps_image, i),
                                   cmap=plotting.cm.black_blue)

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -220,7 +220,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
            and not isinstance(displayed_maps, (list, np.ndarray))):
             raise TypeError("Parameter ``displayed_maps`` of "
                             "``generate_report()`` should be a "
-                            "list or array. You provded a "
+                            "list or array. You provided a "
                             f"{type(displayed_maps)}")
         self.displayed_maps = displayed_maps
         return generate_report(self)
@@ -256,8 +256,8 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
                 if max(self.displayed_maps) > n_maps:
                     raise ValueError("Report cannot display the "
                                      "following maps "
-                                    f"{self.displayed_maps} because "
-                                    f"masker only has {n_maps} maps.")
+                                     f"{self.displayed_maps} because "
+                                     f"masker only has {n_maps} maps.")
                 maps_to_be_displayed = self.displayed_maps
             self._report_content['number_of_maps'] = n_maps
             self._report_content['displayed_maps'] = maps_to_be_displayed
@@ -285,8 +285,10 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
                        "Plotting only spatial maps for reporting.")
                 warnings.warn(msg)
                 self._report_content['warning_message'] = msg
-                displays = [plotting.plot_stat_map(image.index_img(
-                    maps_image, component)) for component in maps_to_be_displayed]
+                displays = [
+                    plotting.plot_stat_map(
+                        image.index_img(maps_image, component)
+                    ) for component in maps_to_be_displayed]
                 return displays
         else:
             return [None]

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -264,7 +264,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         except ImportError:
             with warnings.catch_warnings():
                 mpl_unavail_msg = ('Matplotlib is not imported! '
-                                   'No reports will be generated.')
+                                   'No report will be generated.')
                 warnings.filterwarnings('always', message=mpl_unavail_msg)
                 warnings.warn(category=ImportWarning,
                               message=mpl_unavail_msg)

--- a/nilearn/input_data/nifti_maps_masker.py
+++ b/nilearn/input_data/nifti_maps_masker.py
@@ -259,17 +259,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
 
         """
         from nilearn.reporting.html_report import _embed_img
-        try:
-            from nilearn import plotting
-        except ImportError:
-            with warnings.catch_warnings():
-                mpl_unavail_msg = ('Matplotlib is not imported! '
-                                   'No report will be generated.')
-                warnings.filterwarnings('always', message=mpl_unavail_msg)
-                warnings.warn(category=ImportWarning,
-                              message=mpl_unavail_msg)
-                return [None]
-
+        from nilearn import plotting
         if self._reporting_data is not None:
             maps_image = self._reporting_data['maps_image']
         else:

--- a/nilearn/reporting/data/html/report_body_template_niftimapsmasker.html
+++ b/nilearn/reporting/data/html/report_body_template_niftimapsmasker.html
@@ -1,0 +1,318 @@
+<!-- CSS for the report -->
+<link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/pure-min.css" integrity="sha384-nn4HPE8lTHyVtfCBi5yW9d20FjT8BJwUXyWZT9InLYax14RDjBj46LmSztkmNP9w" crossorigin="anonymous">
+<link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
+
+<style type="text/css">
+
+/* Add a gutter to Pure's Columns */
+.pure-g > div {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+.pure-g > div {
+  padding: 0 0.5em;
+}
+
+/*!
+Pure-button class copied from pure-min.css,
+in case reports are displayed offline.
+
+Pure v1.0.0
+Copyright 2013 Yahoo!
+Licensed under the BSD License.
+https://github.com/yahoo/pure/blob/master/LICENSE.md
+*/
+
+.pure-button {
+    /* Structure */
+    display: inline-block;
+    zoom: 1;
+    line-height: normal;
+    white-space: nowrap;
+    vertical-align: middle;
+    text-align: center;
+    cursor: pointer;
+    -webkit-user-drag: none;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+    box-sizing: border-box;
+}
+
+.pure-button {
+    /* Button styling */
+    font-family: inherit;
+    font-size: 100%;
+    padding: 0.5em 1em;
+    color: #444; /* rgba not supported (IE 8) */
+    color: rgba(0, 0, 0, 0.80); /* rgba supported */
+    border: 1px solid #999;  /*IE 6/7/8*/
+    border: none rgba(0, 0, 0, 0);  /*IE9 + everything else*/
+    background-color: #E6E6E6;
+    text-decoration: none;
+    border-radius: 2px;
+}
+
+/*!
+End pure-button class definition from pure-min.css
+*/
+
+div.nilearn_report {
+    padding-top: 0px;
+    border: solid rgb(150, 150, 150);
+    border-width: 1pt;
+    border-radius: 6pt;
+    overflow: hidden;  /* Needed to avoid scrolling in jupyter :( */
+    color: black;
+    background-color: white;
+}
+
+.terminal div.nilearn_report {
+    max-width: min(50ex, 100vw); /* Needed in vscode */
+}
+
+/* Isolate us a bit from the styles specified by other stylesheets */
+
+div.nilearn_report h1 {
+    text-align: left;
+    margin-left: 0pt;
+    margin-right: 0pt;
+    padding-top: 5pt;
+    font-size: 1.8em;
+    padding-left: 5pt;
+}
+
+div.nilearn_report h1:first-child {
+    margin-top: 0pt;
+    background-color: #f5f5f5;
+    border-radius: 6pt 6pt 0pt 0pt;
+    padding-left: 5pt;
+}
+
+div.nilearn_report summary::-webkit-details-marker {
+    margin-right: 2px;
+}
+
+div.nilearn_report summary:focus {
+    outline-style: none;
+}
+
+div.nilearn_report table {
+    max-width: 100%;
+    border-collapse: collapse;
+    margin:50px auto;
+    float: right;
+}
+
+div.nilearn_report thead th {
+  text-align: center;
+}
+
+div.nilearn_report tbody tr:nth-child(even) {
+   background-color: #ddd;
+}
+
+div.nilearn_report details {
+    overflow-x: visible;
+}
+
+div.nilearn_report div.raise {
+    z-index: 1;
+
+}
+
+/* Tooltip container */
+div.nilearn_report .withtooltip {
+  position: relative;
+  border-bottom: 1px dotted black; /* If you want dots under the hoverable text */
+}
+
+/* Tooltip text */
+div.nilearn_report .withtooltip .tooltiptext {
+  visibility: hidden;
+  max-width: 35em;
+  width: 90%;
+  background-color: rgba(24,24,24,0.9);
+  color: #fff;
+  text-align: left;
+  font-size: 12pt;
+  font-weight: 200;
+  border-radius: 6px;
+  padding: 5px;css=resource_path.joinpath('css'),
+
+  margin-left: 3pt;
+
+  /* Position the tooltip text - see examples below! */
+  position: absolute;
+  z-index: 2;
+
+  width: 99%;
+  left: 2pt;
+  top: 133%;
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+div.nilearn_report .withtooltip:hover .tooltiptext {
+  visibility: visible;
+}
+
+div.nilearn_report .image {
+  position: relative;
+  height: auto;
+  width: 100%;
+}
+
+div.nilearn_report .image .overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  transition: .5s ease;
+  height: auto;
+  width: 100%;
+  -webkit-transition: .5s ease;
+}
+
+div.nilearn_report .image:hover .overlay {
+  opacity: 1;
+}
+
+.elem-warn {
+    color: #FF0000;
+    font-weight: bold;
+}
+
+.btn {
+  background-color: #3498DB;
+  color: white;
+  padding: 6px;
+  font-size: 16px;
+  border: none;
+  cursor: pointer;
+}
+
+.btn:hover, .btn:focus {
+  background-color: #2980B9;
+}
+
+.show {
+    display: block;
+}
+
+.hide {
+    display: none;
+}
+
+.buttonContainer {
+   float: left;
+   width: 33%; 
+}
+
+.empty {
+    height: 60px;
+}
+
+</style>
+<div class="nilearn_report">
+    <h1 class="withtooltip">
+        {{title}}
+        <span class="tooltiptext">{{docstring}}</span>
+    </h1>
+    <div class="pure-g">
+        <div class="pure-u-1 pure-u-md-2-3">
+            <div class="image">
+                <script>
+                    current_map = 0;
+                    number_maps = {{number_of_maps}};
+                </script>
+
+                <div align="center" class="buttonContainer">
+                    <button onclick="displayPreviousMap()" class="btn">Previous Map</button>
+                </div>
+
+                <div align="center" class="buttonContainer">
+                    <h3 class="comp-title">Component <span id="comp"></span></h3>
+                </div>
+
+                <div align="center" class="buttonContainer">
+                    <button onclick="displayNextMap()" class="btn">Next Map</button>
+                </div>
+
+                <img id="map0" class="pure-img show" width="100%"    
+                    src="data:image/svg+xml;base64,{{content[0]}}" alt="image"/>
+
+                {{for map in range(1, number_of_maps)}}
+                    <img id="map{{map}}" class="pure-img hide" width="100%" 
+                        src="data:image/svg+xml;base64,{{content[map]}}" alt="image"/>
+                {{endfor}}
+            </div>
+        </div>
+        <div class="pure-u-1 pure-u-md-1-3 raise">
+            {{if warning_message}}
+                <p class="elem-warn">{{warning_message}}</p>
+            {{endif}}
+            {{if description}}
+                <p class="elem-desc">{{description}}</p>
+            {{endif}}
+            {{if number_of_maps}}
+                <p class="elem-desc">
+                    The masker has <b>{{number_of_maps}}</b> spatial maps.
+                </p>
+            {{endif}}
+            <p></p>
+            <p></p>
+            {{if not warning_message}}
+                <div class="empty"></div>
+            {{endif}}
+            {{if parameters}}   
+                <details> 
+                    <summary class="pure-button">Parameters</summary>
+                    <table class="pure-table">
+                        <thead>
+                            <tr>
+                                <th>Parameter</th>
+                                <th>Value</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {{py: params = parameters.items()}}
+                            {{for p, v in params}}
+                                <tr>
+                                    <td data-column="Parameter">{{p}}</td>
+                                    <td data-column="Value">{{v}}</td>
+                                </tr>
+                            {{endfor}}
+                        </tbody>
+                    </table>
+                </details>
+            {{endif}}
+        </div>
+    </div>
+</div>
+<script>
+    document.getElementById("comp").innerHTML=current_map;
+
+    function displayNextMap() {
+        document.getElementById('map' + current_map).classList.replace("show", "hide");
+        current_map = current_map + 1;
+        if (current_map >= number_maps - 1){
+            current_map = 0;
+        }
+        document.getElementById('map' + current_map).classList.replace("hide", "show");
+        document.getElementById("comp").innerHTML=current_map;
+    }
+
+    function displayPreviousMap() {
+        document.getElementById('map' + current_map).classList.replace("show", "hide");
+        current_map = current_map - 1;
+        if (current_map < 0){
+            current_map = number_maps - 1;
+        }
+        document.getElementById('map' + current_map).classList.replace("hide", "show");
+        document.getElementById("comp").innerHTML=current_map;
+    }
+</script>
+

--- a/nilearn/reporting/data/html/report_body_template_niftimapsmasker.html
+++ b/nilearn/reporting/data/html/report_body_template_niftimapsmasker.html
@@ -198,14 +198,6 @@ div.nilearn_report .image:hover .overlay {
   background-color: #2980B9;
 }
 
-.show {
-    display: block;
-}
-
-.hide {
-    display: none;
-}
-
 .buttonContainer {
    float: left;
    width: 33%; 
@@ -242,12 +234,14 @@ div.nilearn_report .image:hover .overlay {
                     <button onclick="displayNextMap()" class="btn">Next Map</button>
                 </div>
 
-                <img id="map0" class="pure-img show" width="100%"    
-                    src="data:image/svg+xml;base64,{{content[0]}}" alt="image"/>
+                <img id="map0" class="pure-img" width="100%"
+                    src="data:image/svg+xml;base64,{{content[0]}}"
+                    style="display:block;" alt="image"/>
 
                 {{for map in range(1, len(displayed_maps))}}
-                    <img id="map{{map}}" class="pure-img hide" width="100%" 
-                        src="data:image/svg+xml;base64,{{content[map]}}" alt="image"/>
+                    <img id="map{{map}}" class="pure-img" width="100%"
+                        src="data:image/svg+xml;base64,{{content[map]}}"
+                        style="display:none;" alt="image"/>
                 {{endfor}}
             </div>
         </div>
@@ -302,22 +296,22 @@ div.nilearn_report .image:hover .overlay {
     document.getElementById("comp").innerHTML=displayed_maps[current_map_idx];
 
     function displayNextMap() {
-        document.getElementById('map' + current_map_idx).classList.replace("show", "hide");
+        document.getElementById('map' + current_map_idx).style["display"] = "none";
         current_map_idx = current_map_idx + 1;
         if (current_map_idx >= number_maps){
             current_map_idx = 0;
         }
-        document.getElementById('map' + current_map_idx).classList.replace("hide", "show");
+        document.getElementById('map' + current_map_idx).style["display"] = "block";
         document.getElementById("comp").innerHTML=displayed_maps[current_map_idx];
     }
 
     function displayPreviousMap() {
-        document.getElementById('map' + current_map_idx).classList.replace("show", "hide");
+        document.getElementById('map' + current_map_idx).style["display"] = "none";
         current_map_idx = current_map_idx - 1;
         if (current_map_idx < 0){
             current_map_idx = number_maps - 1;
         }
-        document.getElementById('map' + current_map_idx).classList.replace("hide", "show");
+        document.getElementById('map' + current_map_idx).style["display"] = "block";
         document.getElementById("comp").innerHTML=displayed_maps[current_map_idx];
     }
 </script>

--- a/nilearn/reporting/data/html/report_body_template_niftimapsmasker.html
+++ b/nilearn/reporting/data/html/report_body_template_niftimapsmasker.html
@@ -225,8 +225,9 @@ div.nilearn_report .image:hover .overlay {
         <div class="pure-u-1 pure-u-md-2-3">
             <div class="image">
                 <script>
-                    current_map = 0;
-                    number_maps = {{number_of_maps}};
+                    current_map_idx = 0;
+                    displayed_maps = {{displayed_maps}};
+                    number_maps = {{len(displayed_maps)}};
                 </script>
 
                 <div align="center" class="buttonContainer">
@@ -244,7 +245,7 @@ div.nilearn_report .image:hover .overlay {
                 <img id="map0" class="pure-img show" width="100%"    
                     src="data:image/svg+xml;base64,{{content[0]}}" alt="image"/>
 
-                {{for map in range(1, number_of_maps)}}
+                {{for map in range(1, len(displayed_maps))}}
                     <img id="map{{map}}" class="pure-img hide" width="100%" 
                         src="data:image/svg+xml;base64,{{content[map]}}" alt="image"/>
                 {{endfor}}
@@ -259,8 +260,13 @@ div.nilearn_report .image:hover .overlay {
             {{endif}}
             {{if number_of_maps}}
                 <p class="elem-desc">
-                    The masker has <b>{{number_of_maps}}</b> spatial maps.
+                    The masker has <b>{{number_of_maps}}</b> spatial maps in total.
                 </p>
+                {{if len(displayed_maps) != number_of_maps}}
+                    <p>
+                        Only <b>{{len(displayed_maps)}}</b> spatial maps are shown in this report.
+                    </p>
+                {{endif}}
             {{endif}}
             <p></p>
             <p></p>
@@ -293,26 +299,26 @@ div.nilearn_report .image:hover .overlay {
     </div>
 </div>
 <script>
-    document.getElementById("comp").innerHTML=current_map;
+    document.getElementById("comp").innerHTML=displayed_maps[current_map_idx];
 
     function displayNextMap() {
-        document.getElementById('map' + current_map).classList.replace("show", "hide");
-        current_map = current_map + 1;
-        if (current_map >= number_maps){
-            current_map = 0;
+        document.getElementById('map' + current_map_idx).classList.replace("show", "hide");
+        current_map_idx = current_map_idx + 1;
+        if (current_map_idx >= number_maps){
+            current_map_idx = 0;
         }
-        document.getElementById('map' + current_map).classList.replace("hide", "show");
-        document.getElementById("comp").innerHTML=current_map;
+        document.getElementById('map' + current_map_idx).classList.replace("hide", "show");
+        document.getElementById("comp").innerHTML=displayed_maps[current_map_idx];
     }
 
     function displayPreviousMap() {
-        document.getElementById('map' + current_map).classList.replace("show", "hide");
-        current_map = current_map - 1;
-        if (current_map < 0){
-            current_map = number_maps - 1;
+        document.getElementById('map' + current_map_idx).classList.replace("show", "hide");
+        current_map_idx = current_map_idx - 1;
+        if (current_map_idx < 0){
+            current_map_idx = number_maps - 1;
         }
-        document.getElementById('map' + current_map).classList.replace("hide", "show");
-        document.getElementById("comp").innerHTML=current_map;
+        document.getElementById('map' + current_map_idx).classList.replace("hide", "show");
+        document.getElementById("comp").innerHTML=displayed_maps[current_map_idx];
     }
 </script>
 

--- a/nilearn/reporting/data/html/report_body_template_niftimapsmasker.html
+++ b/nilearn/reporting/data/html/report_body_template_niftimapsmasker.html
@@ -298,7 +298,7 @@ div.nilearn_report .image:hover .overlay {
     function displayNextMap() {
         document.getElementById('map' + current_map).classList.replace("show", "hide");
         current_map = current_map + 1;
-        if (current_map >= number_maps - 1){
+        if (current_map >= number_maps){
             current_map = 0;
         }
         document.getElementById('map' + current_map).classList.replace("hide", "show");

--- a/nilearn/reporting/html_report.py
+++ b/nilearn/reporting/html_report.py
@@ -51,7 +51,7 @@ def _embed_img(display):
     """
     if display is None:  # no image to display
         return None
-    # If already embeded, simply return as is
+    # If already embedded, simply return as is
     if isinstance(display, str):
         return display
     return figure_to_svg_base64(display.frame_axes.figure)

--- a/nilearn/reporting/html_report.py
+++ b/nilearn/reporting/html_report.py
@@ -10,6 +10,7 @@ from nilearn.reporting.utils import figure_to_svg_base64
 
 ESTIMATOR_TEMPLATES = {
     'NiftiLabelsMasker': 'report_body_template_niftilabelsmasker.html',
+    'NiftiMapsMasker': 'report_body_template_niftimapsmasker.html',
     'default': 'report_body_template.html'}
 
 
@@ -156,6 +157,9 @@ def _define_overlay(estimator):
     elif len(displays) == 2:
         overlay, image = displays[0], displays[1]
 
+    else:
+        overlay, image = None, displays
+
     return overlay, image
 
 
@@ -207,12 +211,16 @@ def generate_report(estimator):
     else:  # We can create a report
         html_template = _get_estimator_template(estimator)
         overlay, image = _define_overlay(estimator)
+        if isinstance(image, list):
+            embeded_images = [_embed_img(i) for i in image]
+        else:
+            embeded_images = _embed_img(image)
         parameters = _str_params(estimator.get_params())
         docstring = estimator.__doc__
         snippet = docstring.partition('Parameters\n    ----------\n')[0]
         report = _update_template(title=estimator.__class__.__name__,
                                   docstring=snippet,
-                                  content=_embed_img(image),
+                                  content=embeded_images,
                                   overlay=_embed_img(overlay),
                                   parameters=parameters,
                                   data=data,

--- a/nilearn/reporting/html_report.py
+++ b/nilearn/reporting/html_report.py
@@ -51,6 +51,9 @@ def _embed_img(display):
     """
     if display is None:  # no image to display
         return None
+    # If already embeded, simply return as is
+    if isinstance(display, str):
+        return display
     return figure_to_svg_base64(display.frame_axes.figure)
 
 

--- a/nilearn/reporting/tests/test_html_report.py
+++ b/nilearn/reporting/tests/test_html_report.py
@@ -136,7 +136,7 @@ def test_warning_in_report_after_empty_fit(masker_class, input_parameters):  # n
 
 @pytest.mark.parametrize("displayed_maps", ["foo", '1', {"foo": "bar"}])
 def test_nifti_maps_masker_report_displayed_maps_errors(
-    niftimapsmasker_inputs, displayed_maps):
+        niftimapsmasker_inputs, displayed_maps):
     """Tests that a TypeError is raised when the argument `displayed_maps`
     of `generate_report()` is not valid.
     """
@@ -149,7 +149,7 @@ def test_nifti_maps_masker_report_displayed_maps_errors(
 
 @pytest.mark.parametrize("displayed_maps", [[2, 5, 10], [0, 66, 1, 260]])
 def test_nifti_maps_masker_report_maps_number_errors(
-    niftimapsmasker_inputs, displayed_maps):
+        niftimapsmasker_inputs, displayed_maps):
     """Tests that a ValueError is raised when the argument `displayed_maps`
     contains invalid map numbers.
     """
@@ -162,7 +162,7 @@ def test_nifti_maps_masker_report_maps_number_errors(
 
 @pytest.mark.parametrize("displayed_maps", [1, 6, 9, 12, 'all'])
 def test_nifti_maps_masker_report_integer_and_all_displayed_maps(
-    niftimapsmasker_inputs, displayed_maps):
+        niftimapsmasker_inputs, displayed_maps):
     """Tests NiftiMapsMasker reporting with no image provided to fit
     and displayed_maps provided as an integer or as 'all'.
     """
@@ -178,8 +178,8 @@ def test_nifti_maps_masker_report_integer_and_all_displayed_maps(
     assert masker._report_content['report_id'] == 0
     assert masker._report_content['number_of_maps'] == 9
     assert(
-        masker._report_content['displayed_maps'] ==\
-        list(range(expected_n_maps))
+        masker._report_content['displayed_maps']
+        == list(range(expected_n_maps))
     )
     msg = ("No image provided to fit in NiftiMapsMasker. "
            "Plotting only spatial maps for reporting.")

--- a/nilearn/reporting/tests/test_html_report.py
+++ b/nilearn/reporting/tests/test_html_report.py
@@ -99,7 +99,8 @@ def test_reports_after_fit_3d_data_with_mask(masker_class, input_parameters, dat
     _check_html(html)
 
 
-@pytest.mark.parametrize("masker_class", [NiftiMasker, NiftiLabelsMasker, NiftiMapsMasker])
+@pytest.mark.parametrize("masker_class",
+                         [NiftiMasker, NiftiLabelsMasker, NiftiMapsMasker])
 def test_warning_in_report_after_empty_fit(masker_class, input_parameters):  # noqa
     """Tests that a warning is both given and written in the report if
     no images were provided to fit.

--- a/nilearn/reporting/tests/test_html_report.py
+++ b/nilearn/reporting/tests/test_html_report.py
@@ -160,6 +160,29 @@ def test_nifti_maps_masker_report_maps_number_errors(
         masker.generate_report(displayed_maps)
 
 
+@pytest.mark.parametrize("displayed_maps",
+                         [[2, 5, 6],
+                          np.array([0, 3, 4, 5])])
+def test_nifti_maps_masker_report_list_and_arrays_maps_number(
+        niftimapsmasker_inputs, displayed_maps):
+    """Tests report generation for NiftiMapsMasker with displayed_maps
+    passed as a list of a Numpy arrays.
+    """
+    masker = NiftiMapsMasker(**niftimapsmasker_inputs)
+    masker.fit()
+    html = masker.generate_report(displayed_maps)
+    assert masker._report_content['report_id'] == 0
+    assert masker._report_content['number_of_maps'] == 9
+    assert(
+        masker._report_content['displayed_maps']
+        == list(displayed_maps)
+    )
+    msg = ("No image provided to fit in NiftiMapsMasker. "
+           "Plotting only spatial maps for reporting.")
+    assert masker._report_content['warning_message'] == msg
+    assert html.body.count("<img") == len(displayed_maps)
+
+
 @pytest.mark.parametrize("displayed_maps", [1, 6, 9, 12, 'all'])
 def test_nifti_maps_masker_report_integer_and_all_displayed_maps(
         niftimapsmasker_inputs, displayed_maps):


### PR DESCRIPTION
See #2689 

Minimum code to experiment:

```python
from nilearn import datasets
from nilearn.input_data import NiftiMapsMasker

msdl = datasets.fetch_atlas_msdl()
masker = NiftiMapsMasker(maps_img=msdl.maps)
masker.fit()
# You can pass an optional list of maps indices to `generate_report`
# Maps will be displayed in the requested order
# If nothing is provided, all maps will be displayed
report = masker.generate_report(displayed_maps=[19, 22, 2, 4, 16, 6, 9])
report
```