### PR TITLE
[DOC] Advertise for office hours in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Important links
 Office Hours
 ============
 
-The nilearn team organizes regular online office hours to answer questions, discuss feature requests, or have any Nilearn-related discusssions. We try to maintain a frequency of *one hour every two weeks*, usually on Mondays, and make sure that at least one member of the core-developer team is available. These events are fully open, anyone is welcome to join!
+The nilearn team organizes regular online office hours to answer questions, discuss feature requests, or have any Nilearn-related discussions. We try to maintain a frequency of *one hour every two weeks*, usually on Mondays, and make sure that at least one member of the core-developer team is available. These events are fully open, anyone is welcome to join!
 
 The next office hours will be held on **Monday July 12th from 4pm to 5pm UTC** on `Discord <https://discord.gg/bMBhb7w>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,13 @@ Important links
 - Official source code repo: https://github.com/nilearn/nilearn/
 - HTML documentation (stable release): http://nilearn.github.io/
 
+Office Hours
+============
+
+The nilearn team organizes regular online office hours to answer questions, discuss feature requests, or have any Nilearn-related discusssions. We try to maintain a frequency of *one hour every two weeks*, usually on Mondays, and make sure that at least one member of the core-developer team is available. These events are fully open, anyone is welcome to join!
+
+The next office hours will be held on **Monday July 12th from 4pm to 5pm UTC** on `Discord <https://discord.gg/bMBhb7w>`_.
+
 Dependencies
 ============
 

--- a/README.rst
+++ b/README.rst
@@ -36,9 +36,9 @@ Important links
 Office Hours
 ============
 
-The nilearn team organizes regular online office hours to answer questions, discuss feature requests, or have any Nilearn-related discussions. We try to maintain a frequency of *one hour every two weeks*, usually on Mondays, and make sure that at least one member of the core-developer team is available. These events are fully open, anyone is welcome to join!
+The nilearn team organizes regular online office hours to answer questions, discuss feature requests, or have any Nilearn-related discussions. We try to maintain a frequency of *one hour every two weeks*, usually on Mondays, and make sure that at least one member of the core-developer team is available. These events are held on our on `Discord server <https://discord.gg/bMBhb7w>`_ and are fully open, anyone is welcome to join!
 
-The next office hours will be held on **Monday July 12th from 4pm to 5pm UTC** on `Discord <https://discord.gg/bMBhb7w>`_.
+You can check when the next office hours will be held on the Nilearn's website `landing page <https://nilearn.github.io/>`_.
 
 Dependencies
 ============


### PR DESCRIPTION
This PR proposes to add a few lines in the README to advertise for the Nilearn office hours with the next date and discord link, as suggested by @RaphaelMeudec as a way to increase the visibility of these events.