### PR TITLE
Unify argument names in view_markers and view_connectome

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -48,6 +48,10 @@ Enhancements
 Changes
 -------
 
+- :func:`nilearn.plotting.view_markers` is renamed to :func:`nilearn.plotting.view_nodes`.
+  Additionally, all arguments with the pattern `markers_` are renamed to `nodes_` to
+  remove discrepancy with :func:`nilearn.plotting.view_connectome`.
+
 .. _v0.8.0:
 
 0.8.0

--- a/nilearn/plotting/__init__.py
+++ b/nilearn/plotting/__init__.py
@@ -52,7 +52,7 @@ from .matrix_plotting import (plot_matrix, plot_contrast_matrix,
                               plot_design_matrix, plot_event)
 from .html_surface import view_surf, view_img_on_surf
 from .html_stat_map import view_img
-from .html_connectome import view_connectome, view_markers
+from .html_connectome import view_connectome, view_nodes
 from .surf_plotting import (plot_surf, plot_surf_stat_map, plot_surf_roi,
                             plot_img_on_surf, plot_surf_contours)
 
@@ -64,7 +64,7 @@ __all__ = ['cm', 'plot_img', 'plot_anat', 'plot_epi',
            'show', 'plot_matrix',
            'plot_design_matrix', 'plot_contrast_matrix', 'plot_event',
            'view_surf', 'view_img_on_surf',
-           'view_img', 'view_connectome', 'view_markers',
+           'view_img', 'view_connectome', 'view_nodes',
            'find_parcellation_cut_coords',
            'find_probabilistic_atlas_cut_coords',
            'plot_surf', 'plot_surf_stat_map', 'plot_surf_roi',

--- a/nilearn/plotting/data/html/connectome_plot_template.html
+++ b/nilearn/plotting/data/html/connectome_plot_template.html
@@ -43,7 +43,7 @@
             for (let hemisphere of ["left", "right"]) {
                 makePlot("pial", hemisphere, "connectome-plot");
             }
-            if(connectomeInfo["connectome"]["markers_only"]){
+            if(connectomeInfo["connectome"]["nodes_only"]){
                 return;
             }
             if(connectomeInfo["connectome"]["colorbar"]){
@@ -76,7 +76,7 @@
         function addConnectome() {
             let info = connectomeInfo["connectome"];
 
-            for (let attribute of ["marker_x", "marker_y", "marker_z"]) {
+            for (let attribute of ["node_x", "node_y", "node_z"]) {
                 if (!(attribute in info)) {
                     info[attribute] = Array.from(decodeBase64(
                         info["_" + attribute], "float32"));
@@ -86,19 +86,19 @@
             let pyplot_elements = [{
                 type: 'scatter3d',
                 mode: 'markers+text',
-                x: info["marker_x"],
-                y: info["marker_y"],
-                z: info["marker_z"],
+                x: info["node_x"],
+                y: info["node_y"],
+                z: info["node_z"],
                 opacity: 1,
-                text: info["marker_labels"],
+                text: info["node_labels"],
                 marker: {
-                    size: info["marker_size"],
-                    color: info["marker_color"],
-                    colorscale: info["marker_colorscale"],
+                    size: info["node_size"],
+                    color: info["node_color"],
+                    colorscale: info["node_colorscale"],
                 }
             }]
 
-            if (!(info["markers_only"])) {
+            if (!(info["nodes_only"])) {
                 for (let attribute of ["con_x", "con_y", "con_z", "con_w"]) {
                   if (!(attribute in info)) {
                     info[attribute] = Array.from(decodeBase64(

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -166,9 +166,9 @@ def _prepare_lines_metadata(adjacency_matrix, coords, threshold,
 
 
 def _prepare_nodes_metadata(coords, node_size, node_color, node_only):
-    nodes_coordinates = _encode_coordinates(coords, prefix="_marker_")
+    nodes_coordinates = _encode_coordinates(coords, prefix="_node_")
     nodes_metadata = {
-        'markers_only': node_only,
+        'nodes_only': node_only,
         **nodes_coordinates
     }
 
@@ -176,8 +176,8 @@ def _prepare_nodes_metadata(coords, node_size, node_color, node_only):
         node_size = np.asarray(node_size)
     if hasattr(node_size, 'tolist'):
         node_size = node_size.tolist()
-    nodes_metadata['marker_size'] = node_size
-    nodes_metadata['marker_color'] = _prepare_colors_for_nodes(
+    nodes_metadata['node_size'] = node_size
+    nodes_metadata['node_color'] = _prepare_colors_for_nodes(
         node_color,
         len(coords),
     )
@@ -379,7 +379,7 @@ def view_nodes(node_coords, node_color='auto', node_size=5.,
     )
     if node_labels is None:
         node_labels = ['' for _ in range(node_coords.shape[0])]
-    connectome_info['marker_labels'] = node_labels
+    connectome_info['node_labels'] = node_labels
     connectome_info['title'] = title
     connectome_info['title_fontsize'] = title_fontsize
     return _make_connectome_html(connectome_info)

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -386,9 +386,10 @@ def view_nodes(node_coords, node_color='auto', node_size=5.,
     return _make_connectome_html(connectome_info)
 
 
-@deprecated("Function 'view_markers' has been renamed to "
-            "'view_nodes' and 'view_markers' will be removed in release 0.10.0")
+@deprecated("Function 'view_markers' has been renamed to 'view_nodes' "
+            "and 'view_markers' will be removed in release 0.10.0")
 def view_markers(marker_coords, marker_color='auto', marker_size=5.,
                  marker_labels=None, title=None, title_fontsize=25):
-    return view_nodes(marker_coords, node_color=marker_color, node_size=marker_size,
-                 node_labels=marker_labels, title=title, title_fontsize=title_fontsize)
+    return view_nodes(marker_coords, node_color=marker_color,
+                      node_size=marker_size, node_labels=marker_labels,
+                      title=title, title_fontsize=title_fontsize)

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -37,8 +37,8 @@ def _encode_coordinates(coords, prefix):
     coordinates = {}
 
     coords = np.asarray(coords, dtype='<f4')
-    marker_x, marker_y, marker_z = coords.T
-    for coord, cname in [(marker_x, "x"), (marker_y, "y"), (marker_z, "z")]:
+    node_x, node_y, node_z = coords.T
+    for coord, cname in [(node_x, "x"), (node_y, "y"), (node_z, "z")]:
         coordinates["{}{}".format(prefix, cname)] = encode(
             np.asarray(coord, dtype='<f4'))
 
@@ -77,13 +77,13 @@ def _prepare_line(edges, nodes):
     return path_edges, path_nodes
 
 
-def _prepare_colors_for_markers(marker_color, number_of_nodes):
+def _prepare_colors_for_markers(node_color, number_of_nodes):
     """
-    Generate "color" and "colorscale" attributes based on `marker_color` mode
+    Generate "color" and "colorscale" attributes based on `node_color` mode
 
     Parameters
     ----------
-    marker_color : color or sequence of colors, optional
+    node_color : color or sequence of colors, optional
         Color(s) of the nodes. Default='auto'.
 
     number_of_nodes : int
@@ -94,12 +94,12 @@ def _prepare_colors_for_markers(marker_color, number_of_nodes):
     markers_colors: list
         List of `number_of_nodes` colors as hexadecimal values
     """
-    if isinstance(marker_color, str) and marker_color == 'auto':
+    if isinstance(node_color, str) and node_color == 'auto':
         colors = mpl_cm.viridis(np.linspace(0, 1, number_of_nodes))
-    elif isinstance(marker_color, str):
-        colors = [marker_color] * number_of_nodes
+    elif isinstance(node_color, str):
+        colors = [node_color] * number_of_nodes
     else:
-        colors = marker_color
+        colors = node_color
 
     return to_color_strings(colors)
 
@@ -165,20 +165,20 @@ def _prepare_lines_metadata(adjacency_matrix, coords, threshold,
     return lines_metadata
 
 
-def _prepare_markers_metadata(coords, marker_size, marker_color, marker_only):
+def _prepare_markers_metadata(coords, node_size, node_color, node_only):
     markers_coordinates = _encode_coordinates(coords, prefix="_marker_")
     markers_metadata = {
-        'markers_only': marker_only,
+        'markers_only': node_only,
         **markers_coordinates
     }
 
-    if np.ndim(marker_size) > 0:
-        marker_size = np.asarray(marker_size)
-    if hasattr(marker_size, 'tolist'):
-        marker_size = marker_size.tolist()
-    markers_metadata['marker_size'] = marker_size
+    if np.ndim(node_size) > 0:
+        node_size = np.asarray(node_size)
+    if hasattr(node_size, 'tolist'):
+        node_size = node_size.tolist()
+    markers_metadata['marker_size'] = node_size
     markers_metadata['marker_color'] = _prepare_colors_for_markers(
-        marker_color,
+        node_color,
         len(coords),
     )
 
@@ -186,7 +186,7 @@ def _prepare_markers_metadata(coords, marker_size, marker_color, marker_only):
 
 
 def _get_connectome(adjacency_matrix, coords, threshold=None,
-                    marker_size=None, marker_color='auto', cmap=cm.cold_hot,
+                    node_size=None, node_color='auto', cmap=cm.cold_hot,
                     symmetric_cmap=True):
     lines_metadata = _prepare_lines_metadata(
         adjacency_matrix,
@@ -198,9 +198,9 @@ def _get_connectome(adjacency_matrix, coords, threshold=None,
 
     markers_metadata = _prepare_markers_metadata(
         coords,
-        marker_size,
-        marker_color,
-        marker_only=False,
+        node_size,
+        node_color,
+        node_only=False,
     )
 
     return {
@@ -308,8 +308,8 @@ def view_connectome(adjacency_matrix, node_coords, edge_threshold=None,
     connectome_info = _get_connectome(
         adjacency_matrix, node_coords,
         threshold=edge_threshold, cmap=edge_cmap,
-        symmetric_cmap=symmetric_cmap, marker_size=node_size,
-        marker_color=node_color)
+        symmetric_cmap=symmetric_cmap, node_size=node_size,
+        node_color=node_color)
     connectome_info['line_width'] = linewidth
     connectome_info['colorbar'] = colorbar
     connectome_info['cbar_height'] = colorbar_height
@@ -319,24 +319,24 @@ def view_connectome(adjacency_matrix, node_coords, edge_threshold=None,
     return _make_connectome_html(connectome_info)
 
 
-def view_markers(marker_coords, marker_color='auto', marker_size=5.,
-                 marker_labels=None, title=None, title_fontsize=25):
+def view_markers(node_coords, node_color='auto', node_size=5.,
+                 node_labels=None, title=None, title_fontsize=25):
     """Insert a 3d plot of markers in a brain into an HTML page.
 
     Parameters
     ----------
-    marker_coords : ndarray, shape=(n_nodes, 3)
+    node_coords : ndarray, shape=(n_nodes, 3)
         The coordinates of the nodes in MNI space.
 
-    marker_color : ndarray, shape=(n_nodes,), optional
+    node_color : ndarray, shape=(n_nodes,), optional
         colors of the markers: list of strings, hex rgb or rgba strings, rgb
         triplets, or rgba triplets (i.e. formats accepted by matplotlib, see
         https://matplotlib.org/users/colors.html#specifying-colors)
 
-    marker_size : float or array-like, optional
+    node_size : float or array-like, optional
         Size of the markers showing the seeds in pixels. Default=5.0.
 
-    marker_labels : list of str, shape=(n_nodes), optional
+    node_labels : list of str, shape=(n_nodes), optional
         Labels for the markers: list of strings
 
     title : str, optional
@@ -368,18 +368,18 @@ def view_markers(marker_coords, marker_color='auto', marker_size=5.,
         surface.
 
     """
-    marker_coords = np.asarray(marker_coords)
-    if marker_color is None:
-        marker_color = ['red' for _ in range(len(marker_coords))]
+    node_coords = np.asarray(node_coords)
+    if node_color is None:
+        node_color = ['red' for _ in range(len(node_coords))]
     connectome_info = _prepare_markers_metadata(
-        marker_coords,
-        marker_size,
-        marker_color,
-        marker_only=True,
+        node_coords,
+        node_size,
+        node_color,
+        node_only=True,
     )
-    if marker_labels is None:
-        marker_labels = ['' for _ in range(marker_coords.shape[0])]
-    connectome_info['marker_labels'] = marker_labels
+    if node_labels is None:
+        node_labels = ['' for _ in range(node_coords.shape[0])]
+    connectome_info['marker_labels'] = node_labels
     connectome_info['title'] = title
     connectome_info['title_fontsize'] = title_fontsize
     return _make_connectome_html(connectome_info)

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -77,7 +77,7 @@ def _prepare_line(edges, nodes):
     return path_edges, path_nodes
 
 
-def _prepare_colors_for_markers(node_color, number_of_nodes):
+def _prepare_colors_for_nodes(node_color, number_of_nodes):
     """
     Generate "color" and "colorscale" attributes based on `node_color` mode
 
@@ -91,7 +91,7 @@ def _prepare_colors_for_markers(node_color, number_of_nodes):
 
     Returns
     -------
-    markers_colors: list
+    node_colors: list
         List of `number_of_nodes` colors as hexadecimal values
     """
     if isinstance(node_color, str) and node_color == 'auto':
@@ -165,24 +165,24 @@ def _prepare_lines_metadata(adjacency_matrix, coords, threshold,
     return lines_metadata
 
 
-def _prepare_markers_metadata(coords, node_size, node_color, node_only):
-    markers_coordinates = _encode_coordinates(coords, prefix="_marker_")
-    markers_metadata = {
+def _prepare_nodes_metadata(coords, node_size, node_color, node_only):
+    nodes_coordinates = _encode_coordinates(coords, prefix="_marker_")
+    nodes_metadata = {
         'markers_only': node_only,
-        **markers_coordinates
+        **nodes_coordinates
     }
 
     if np.ndim(node_size) > 0:
         node_size = np.asarray(node_size)
     if hasattr(node_size, 'tolist'):
         node_size = node_size.tolist()
-    markers_metadata['marker_size'] = node_size
-    markers_metadata['marker_color'] = _prepare_colors_for_markers(
+    nodes_metadata['marker_size'] = node_size
+    nodes_metadata['marker_color'] = _prepare_colors_for_nodes(
         node_color,
         len(coords),
     )
 
-    return markers_metadata
+    return nodes_metadata
 
 
 def _get_connectome(adjacency_matrix, coords, threshold=None,
@@ -196,7 +196,7 @@ def _get_connectome(adjacency_matrix, coords, threshold=None,
         symmetric_cmap,
     )
 
-    markers_metadata = _prepare_markers_metadata(
+    nodes_metadata = _prepare_nodes_metadata(
         coords,
         node_size,
         node_color,
@@ -205,7 +205,7 @@ def _get_connectome(adjacency_matrix, coords, threshold=None,
 
     return {
         **lines_metadata,
-        **markers_metadata,
+        **nodes_metadata,
     }
 
 
@@ -261,7 +261,7 @@ def view_connectome(adjacency_matrix, node_coords, edge_threshold=None,
         Width of the lines that show connections. Default=6.0.
 
     node_size : float, optional
-        Size of the markers showing the seeds in pixels.
+        Size of the nodes showing the seeds in pixels.
         Default=3.0.
 
     colorbar : bool, optional
@@ -295,8 +295,8 @@ def view_connectome(adjacency_matrix, node_coords, edge_threshold=None,
     nilearn.plotting.plot_connectome:
         projected views of a connectome in a glass brain.
 
-    nilearn.plotting.view_markers:
-        interactive plot of colored markers
+    nilearn.plotting.view_nodes:
+        interactive plot of colored nodes
 
     nilearn.plotting.view_surf, nilearn.plotting.view_img_on_surf:
         interactive view of statistical maps or surface atlases on the cortical
@@ -319,9 +319,9 @@ def view_connectome(adjacency_matrix, node_coords, edge_threshold=None,
     return _make_connectome_html(connectome_info)
 
 
-def view_markers(node_coords, node_color='auto', node_size=5.,
+def view_nodes(node_coords, node_color='auto', node_size=5.,
                  node_labels=None, title=None, title_fontsize=25):
-    """Insert a 3d plot of markers in a brain into an HTML page.
+    """Insert a 3d plot of nodes in a brain into an HTML page.
 
     Parameters
     ----------
@@ -329,15 +329,15 @@ def view_markers(node_coords, node_color='auto', node_size=5.,
         The coordinates of the nodes in MNI space.
 
     node_color : ndarray, shape=(n_nodes,), optional
-        colors of the markers: list of strings, hex rgb or rgba strings, rgb
+        colors of the nodes: list of strings, hex rgb or rgba strings, rgb
         triplets, or rgba triplets (i.e. formats accepted by matplotlib, see
         https://matplotlib.org/users/colors.html#specifying-colors)
 
     node_size : float or array-like, optional
-        Size of the markers showing the seeds in pixels. Default=5.0.
+        Size of the nodes showing the seeds in pixels. Default=5.0.
 
     node_labels : list of str, shape=(n_nodes), optional
-        Labels for the markers: list of strings
+        Labels for the nodes: list of strings
 
     title : str, optional
         Title for the plot.
@@ -347,7 +347,7 @@ def view_markers(node_coords, node_color='auto', node_size=5.,
 
     Returns
     -------
-    ConnectomeView : plot of the markers.
+    ConnectomeView : plot of the nodes.
         It can be saved as an html page or rendered (transparently) by the
         Jupyter notebook. Useful methods are :
 
@@ -371,7 +371,7 @@ def view_markers(node_coords, node_color='auto', node_size=5.,
     node_coords = np.asarray(node_coords)
     if node_color is None:
         node_color = ['red' for _ in range(len(node_coords))]
-    connectome_info = _prepare_markers_metadata(
+    connectome_info = _prepare_nodes_metadata(
         node_coords,
         node_size,
         node_color,

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -3,6 +3,7 @@ import json
 import numpy as np
 from matplotlib import cm as mpl_cm
 from scipy import sparse
+from sklearn.utils import deprecated
 
 from .. import datasets
 from . import cm
@@ -320,7 +321,7 @@ def view_connectome(adjacency_matrix, node_coords, edge_threshold=None,
 
 
 def view_nodes(node_coords, node_color='auto', node_size=5.,
-                 node_labels=None, title=None, title_fontsize=25):
+               node_labels=None, title=None, title_fontsize=25):
     """Insert a 3d plot of nodes in a brain into an HTML page.
 
     Parameters
@@ -383,3 +384,11 @@ def view_nodes(node_coords, node_color='auto', node_size=5.,
     connectome_info['title'] = title
     connectome_info['title_fontsize'] = title_fontsize
     return _make_connectome_html(connectome_info)
+
+
+@deprecated("Function 'view_markers' has been renamed to "
+            "'view_nodes' and 'view_markers' will be removed in release 0.10.0")
+def view_markers(marker_coords, marker_color='auto', marker_size=5.,
+                 marker_labels=None, title=None, title_fontsize=25):
+    return view_nodes(marker_coords, node_color=marker_color, node_size=marker_size,
+                 node_labels=marker_labels, title=title, title_fontsize=title_fontsize)

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -519,7 +519,7 @@ def view_img(stat_map_img, bg_img='MNI152',
         static plot of brain volume, on a single or multiple planes.
     nilearn.plotting.view_connectome:
         interactive 3d view of a connectome.
-    nilearn.plotting.view_markers:
+    nilearn.plotting.view_nodes:
         interactive plot of colored markers.
     nilearn.plotting.view_surf, nilearn.plotting.view_img_on_surf:
         interactive view of statistical maps or surface atlases on the cortical

--- a/nilearn/plotting/tests/test_html_connectome.py
+++ b/nilearn/plotting/tests/test_html_connectome.py
@@ -105,6 +105,6 @@ def test_view_nodes():
                                       node_size=5.0,
                                       node_color=colors,
                                       node_labels=labels)
-    labels_dict = {"marker_labels": labels}
+    labels_dict = {"node_labels": labels}
     assert json.dumps(labels_dict)[1:-1] in html.html
 

--- a/nilearn/plotting/tests/test_html_connectome.py
+++ b/nilearn/plotting/tests/test_html_connectome.py
@@ -17,19 +17,19 @@ def test_prepare_line():
     assert(pe == [0, 0, 0, 1, 1, 0, 2, 2, 0, 3, 3, 0]).all()
 
 
-@pytest.mark.parametrize('node_color,expected_marker_colors', [
+@pytest.mark.parametrize('node_color,expected_node_colors', [
     ('cyan', ['#00ffff', '#00ffff', '#00ffff']),
     ('auto', ['#440154', '#20908c', '#fde724']),
     (['cyan', 'red', 'blue'], ['#00ffff', '#ff0000', '#0000ff'])
 ])
-def test_prepare_colors_for_markers(node_color, expected_marker_colors):
+def test_prepare_colors_for_nodes(node_color, expected_node_colors):
     number_of_nodes = 3
-    marker_colors = html_connectome._prepare_colors_for_markers(
+    node_colors = html_connectome._prepare_colors_for_nodes(
         node_color,
         number_of_nodes,
     )
 
-    assert marker_colors == expected_marker_colors
+    assert node_colors == expected_node_colors
 
 
 def _make_connectome():
@@ -84,27 +84,27 @@ def test_view_connectome():
     check_html(html, False, 'connectome-plot')
 
 
-def test_view_markers():
+def test_view_nodes():
     coords = np.arange(12).reshape((4, 3))
     colors = ['r', 'g', 'black', 'white']
-    labels = ["red marker", "green marker", 
-          "black marker", "white marker"]
-    html = html_connectome.view_markers(coords, colors)
+    labels = ["red node", "green node",
+              "black node", "white node"]
+    html = html_connectome.view_nodes(coords, colors)
     check_html(html, False, 'connectome-plot')
-    html = html_connectome.view_markers(coords)
+    html = html_connectome.view_nodes(coords)
     check_html(html, False, 'connectome-plot')
-    html = html_connectome.view_markers(coords, node_size=15)
+    html = html_connectome.view_nodes(coords, node_size=15)
     check_html(html, False, 'connectome-plot')
-    html = html_connectome.view_markers(
+    html = html_connectome.view_nodes(
         coords, node_size=np.arange(len(coords)))
     check_html(html, False, 'connectome-plot')
-    html = html_connectome.view_markers(
+    html = html_connectome.view_nodes(
         coords, node_size=list(range(len(coords))))
     check_html(html, False, 'connectome-plot')
-    html = html_connectome.view_markers(coords, 
-                                    node_size=5.0,
-                                    node_color=colors,
-                                    node_labels=labels)
+    html = html_connectome.view_nodes(coords,
+                                      node_size=5.0,
+                                      node_color=colors,
+                                      node_labels=labels)
     labels_dict = {"marker_labels": labels}
     assert json.dumps(labels_dict)[1:-1] in html.html
 

--- a/nilearn/plotting/tests/test_html_connectome.py
+++ b/nilearn/plotting/tests/test_html_connectome.py
@@ -93,18 +93,18 @@ def test_view_markers():
     check_html(html, False, 'connectome-plot')
     html = html_connectome.view_markers(coords)
     check_html(html, False, 'connectome-plot')
-    html = html_connectome.view_markers(coords, marker_size=15)
+    html = html_connectome.view_markers(coords, node_size=15)
     check_html(html, False, 'connectome-plot')
     html = html_connectome.view_markers(
-        coords, marker_size=np.arange(len(coords)))
+        coords, node_size=np.arange(len(coords)))
     check_html(html, False, 'connectome-plot')
     html = html_connectome.view_markers(
-        coords, marker_size=list(range(len(coords))))
+        coords, node_size=list(range(len(coords))))
     check_html(html, False, 'connectome-plot')
     html = html_connectome.view_markers(coords, 
-                                    marker_size=5.0,
-                                    marker_color=colors,
-                                    marker_labels=labels)
+                                    node_size=5.0,
+                                    node_color=colors,
+                                    node_labels=labels)
     labels_dict = {"marker_labels": labels}
     assert json.dumps(labels_dict)[1:-1] in html.html
 


### PR DESCRIPTION
This PR fixes #2852 by removing any references to `markers` in the connectome plots. This implies changes in:

- html_connectome argument names and methods
- connectome template arguments