### PR TITLE
[DOC][MAINT] Standardize docstrings of `plotting` module

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -51,7 +51,7 @@ Enhancements
   the decorator `nilearn._utils.fill_doc`. This can be applied to common function
   parameters or common lists of options for example. The standard parts are defined
   in a single location (`nilearn._utils.docs.py`) which makes them easier to
-  maintain and update. (See `#2875 <https://github.com/nilearn/nilearn/pull/2875>`_).
+  maintain and update. (See `#2875 <https://github.com/nilearn/nilearn/pull/2875>`_)
 
 Changes
 -------

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -15,8 +15,10 @@ import sys
 #
 docdict = dict()
 
-NILEARN_REF_DOC = "http://nilearn.github.io"
-NIIMG_LINK = f"{NILEARN_REF_DOC}/manipulating_images/input_output.html"
+NILEARN_LINKS = {"landing_page": "http://nilearn.github.io"}
+NILEARN_LINKS["input_output"] = "{}/manipulating_images/input_output.html".format(
+    NILEARN_LINKS["landing_page"]
+)
 
 # Verbose
 verbose = """
@@ -126,8 +128,8 @@ docdict['n_jobs_all'] = n_jobs.format("-1")
 # img
 docdict['img'] = """
 img : Niimg-like object
-    See `input-output <{}>`_.
-""".format(NIIMG_LINK)
+    See `input-output <%(input_output)s>`_.
+""" % NILEARN_LINKS
 
 # cut_coords
 docdict['cut_coords'] = """
@@ -253,9 +255,9 @@ cbar_tick_format : :obj:`str`, optional
 # bg_img
 docdict['bg_img'] = """
 bg_img : Niimg-like object, optional
-    See `input_output <{}>`_.
+    See `input_output <%(input_output)s>`_.
     The background image to plot on top of.
-""".format(NIIMG_LINK)
+""" % NILEARN_LINKS
 
 # vmin
 docdict['vmin'] = """

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -10,14 +10,16 @@ https://github.com/mne-tools/mne-python/blob/main/mne/utils/docs.py
 
 import sys
 
+
 ###################################
 # Standard documentation entries
 #
 docdict = dict()
 
 NILEARN_LINKS = {"landing_page": "http://nilearn.github.io"}
-NILEARN_LINKS["input_output"] = "{}/manipulating_images/input_output.html".format(
-    NILEARN_LINKS["landing_page"]
+NILEARN_LINKS["input_output"] = (
+    "{}/manipulating_images/input_output.html".format(
+        NILEARN_LINKS["landing_page"])
 )
 
 # Verbose
@@ -31,7 +33,7 @@ docdict['verbose0'] = verbose.format(0)
 # Resume
 docdict['resume'] = """
 resume : :obj:`bool`, optional
-    Whether to resumed download of a partly-downloaded file.
+    Whether to resume download of a partly-downloaded file.
     Default=True."""
 
 # Data_dir
@@ -51,14 +53,14 @@ url : :obj:`str`, optional
 # Smoothing_fwhm
 docdict['smoothing_fwhm'] = """
 smoothing_fwhm : :obj:`float`, optional.
-    If `smoothing_fwhm` is not None, it gives the size in millimeters of the
-    spatial smoothing to apply to the signal.
-    Default=None."""
+    If ``smoothing_fwhm`` is not ``None``, it gives
+    the size in millimeters of the spatial smoothing
+    to apply to the signal. Default=None."""
 
 # Standardize
 standardize = """
 standardize : :obj:`bool`, optional.
-    If `standardize` is True, the data are centered and normed:
+    If ``standardize`` is True, the data are centered and normed:
     their variance is put to 1 in the time dimension.
     Default={}."""
 docdict['standardize'] = standardize.format('True')
@@ -68,18 +70,18 @@ docdict['standardize_false'] = standardize.format('False')
 docdict['target_affine'] = """
 target_affine: numpy.ndarray, optional.
     If specified, the image is resampled corresponding to this new affine.
-    `target_affine` can be a 3x3 or a 4x4 matrix.
+    ``target_affine`` can be a 3x3 or a 4x4 matrix.
     Default=None."""
 
 # Target_shape
 docdict['target_shape'] = """
 target_shape: tuple or list, optional.
     If specified, the image will be resized to match this new shape.
-    len(target_shape) must be equal to 3.
+    ``len(target_shape)`` must be equal to 3.
 
     .. note::
-        If `target_shape` is specified, a `target_affine` of shape
-        (4, 4) must also be given.
+        If ``target_shape`` is specified, a ``target_affine`` of shape
+        ``(4, 4)`` must also be given.
 
     Default=None."""
 
@@ -98,14 +100,14 @@ high_pass: :obj:`float`, optional
 # t_r
 docdict['t_r'] = """
 t_r: :obj:`float`, optional
-    Repetition time, in second (sampling period). Set to None if not.
+    Repetition time, in second (sampling period). Set to ``None`` if not.
     Default=None."""
 
 # Memory
 docdict['memory'] = """
 memory : instance of joblib.Memory or :obj:`str`
     Used to cache the masking process.
-    By default, no caching is done. If a str is given, it is the
+    By default, no caching is done. If a ``str`` is given, it is the
     path to the caching directory."""
 
 # Memory_level
@@ -136,19 +138,19 @@ docdict['cut_coords'] = """
 cut_coords : None, a tuple of :obj:`float`, or :obj:`int`, optional
     The MNI coordinates of the point where the cut is performed.
 
-        - If `display_mode` is 'ortho' or 'tiled', this should
-          be a 3-tuple: (x, y, z)
-        - For `display_mode` == 'x', 'y', or 'z', then these are
+        - If ``display_mode`` is 'ortho' or 'tiled', this should
+          be a 3-tuple: ``(x, y, z)``
+        - For ``display_mode == 'x'``, 'y', or 'z', then these are
           the coordinates of each cut in the corresponding direction.
-        - If None is given, the cuts are calculated automaticaly.
-        - If `display_mode` is 'mosaic', and the number of cuts is the same
-          for all directions, `cut_coords` can be specified as an integer.
+        - If ``None`` is given, the cuts are calculated automaticaly.
+        - If ``display_mode`` is 'mosaic', and the number of cuts is the same
+          for all directions, ``cut_coords`` can be specified as an integer.
           It can also be a length 3 tuple specifying the number of cuts for
           every direction if these are different.
 
         .. note::
 
-            If display_mode is 'x', 'y' or 'z', `cut_coords` can be
+            If ``display_mode`` is 'x', 'y' or 'z', ``cut_coords`` can be
             an integer, in which case it specifies the number of
             cuts to perform.
 
@@ -158,13 +160,14 @@ cut_coords : None, a tuple of :obj:`float`, or :obj:`int`, optional
 docdict['output_file'] = """
 output_file : :obj:`str`, or None, optional
     The name of an image file to export the plot to. Valid extensions
-    are .png, .pdf, .svg. If `output_file` is not None, the plot
+    are .png, .pdf, .svg. If ``output_file`` is not None, the plot
     is saved to a file, and the display is closed."""
 
 
 # display_mode
 docdict['display_mode'] = """
-display_mode : {'ortho', 'tiled', 'mosaic','x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
+display_mode : {'ortho', 'tiled', 'mosaic','x',\
+'y', 'z', 'yx', 'xz', 'yz'}, optional
     Choose the direction of the cuts:
 
         - 'x': sagittal
@@ -182,15 +185,16 @@ display_mode : {'ortho', 'tiled', 'mosaic','x', 'y', 'z', 'yx', 'xz', 'yz'}, opt
 # figure
 docdict['figure'] = """
 figure : :obj:`int`, or :class:`matplotlib.figure.Figure`, or None,  optional
-    Matplotlib figure used or its number. If None is given, a
+    Matplotlib figure used or its number. If ``None`` is given, a
     new figure is created."""
 
 # axes
 docdict['axes'] = """
-axes : :class:`matplotlib.axes.Axes`, or 4 tuple of :obj:`float`: (xmin, ymin, width, height), optional
+axes : :class:`matplotlib.axes.Axes`, or 4 tuple\
+of :obj:`float`: (xmin, ymin, width, height), optional
     The axes, or the coordinates, in matplotlib figure
     space, of the axes used to display the plot.
-    If None, the complete figure is used."""
+    If ``None``, the complete figure is used."""
 
 # title
 docdict['title'] = """
@@ -201,29 +205,29 @@ title : :obj:`str`, or None, optional
 # threshold
 docdict['threshold'] = """
 threshold : a number, None, or 'auto', optional
-    If None is given, the image is not thresholded.
+    If ``None`` is given, the image is not thresholded.
     If a number is given, it is used to threshold the image:
     values below the threshold (in absolute value) are plotted
-    as transparent. If auto is given, the threshold is determined
+    as transparent. If 'auto' is given, the threshold is determined
     magically by analysis of the image.
 """
 
 # annotate
 docdict['annotate'] = """
 annotate : :obj:`bool`, optional
-    If `annotate` is True, positions and left/right annotation
+    If ``annotate`` is ``True``, positions and left/right annotation
     are added to the plot. Default=True."""
 
 # draw_cross
 docdict['draw_cross'] = """
 draw_cross : :obj:`bool`, optional
-    If `draw_cross` is True, a cross is drawn on the plot to indicate
+    If ``draw_cross`` is ``True``, a cross is drawn on the plot to indicate
     the cut position. Default=True."""
 
 # black_bg
 docdict['black_bg'] = """
 black_bg : :obj:`bool`, or 'auto', optional
-    If True, the background of the image is set to be black.
+    If ``True``, the background of the image is set to be black.
     If you wish to save figures with a black background, you
     will need to pass facecolor='k', edgecolor='k'
     to :func:`matplotlib.pyplot.savefig`."""
@@ -231,18 +235,18 @@ black_bg : :obj:`bool`, or 'auto', optional
 # colorbar
 docdict['colorbar'] = """
 colorbar : :obj:`bool`, optional
-    If True, display a colorbar on the right of the plots."""
+    If ``True``, display a colorbar on the right of the plots."""
 
 # symmetric_cbar
 docdict['symmetric_cbar'] = """
 symmetric_cbar : :obj:`bool`, or 'auto', optional
-    Specifies whether the colorbar should range from `-vmax` to `vmax`
-    or from `vmin` to `vmax`. Setting to 'auto' will select the latter
+    Specifies whether the colorbar should range from ``-vmax`` to ``vmax``
+    or from ``vmin`` to ``vmax``. Setting to 'auto' will select the latter
     if the range of the whole image is either positive or negative.
 
     .. note::
 
-        The colormap will always range from `-vmax` to `vmax`.
+        The colormap will always range from ``-vmax`` to ``vmax``.
 
 """
 
@@ -262,26 +266,26 @@ bg_img : Niimg-like object, optional
 # vmin
 docdict['vmin'] = """
 vmin : :obj:`float`, optional
-    Lower bound of the colormap. If `None`, the min of the image is used.
+    Lower bound of the colormap. If ``None``, the min of the image is used.
     Passed to :func:`matplotlib.pyplot.imshow`.
 """
 
 # vmax
 docdict['vmax'] = """
 vmax : :obj:`float`, optional
-    Upper bound of the colormap. If `None`, the max of the image is used.
+    Upper bound of the colormap. If ``None``, the max of the image is used.
     Passed to :func:`matplotlib.pyplot.imshow`.
 """
 
 # bg_vmin
 docdict['bg_vmin'] = """
 bg_vmin : :obj:`float`, optional
-    vmin for `bg_img`."""
+    vmin for ``bg_img``."""
 
 # bg_vmax
 docdict['bg_vmax'] = """
 bg_vmin : :obj:`float`, optional
-    vmax for `bg_img`."""
+    vmax for ``bg_img``."""
 
 # resampling_interpolation
 docdict['resampling_interpolation'] = """
@@ -318,10 +322,10 @@ docdict['avg_method'] = """
 avg_method : {'mean', 'median', 'min', 'max', custom function}, optional
     How to average vertex values to derive the face value:
 
-        - `mean`: results in smooth boundaries
-        - `median`: results in sharp boundaries
-        - `min` or `max`: for sparse matrices
-        - `custom function`: You can also pass a custom function
+        - ``mean``: results in smooth boundaries
+        - ``median``: results in sharp boundaries
+        - ``min`` or ``max``: for sparse matrices
+        - ``custom function``: You can also pass a custom function
           which will be executed though :func:`numpy.apply_along_axis`.
           Here is an example of a custom function:
 
@@ -344,15 +348,19 @@ hemispheres : list of :obj:`str`, optional
 
 # view
 docdict['view'] = """
-view : {'lateral', 'medial', 'dorsal', 'ventral', 'anterior', 'posterior'}, optional
-    View of the surface that is rendered. Default='lateral'."""
+view : {'lateral', 'medial', 'dorsal', 'ventral',\
+        'anterior', 'posterior'}, optional
+    View of the surface that is rendered.
+    Default='lateral'.
+"""
 
 # bg_on_data
 docdict['bg_on_data'] = """
 bg_on_data : :obj:`bool`, optional
-    If True, and a `bg_map` is specified, the `surf_data` data is multiplied
-    by the background image, so that e.g. sulcal depth is visible beneath
-    the `surf_data`.
+    If ``True``, and a ``bg_map`` is specified,
+    the ``surf_data`` data is multiplied by the background
+    image, so that e.g. sulcal depth is visible beneath
+    the ``surf_data``.
 
         .. note::
             This non-uniformly changes the surf_data values according
@@ -375,7 +383,7 @@ darkness : :obj:`float` between 0 and 1, optional
 docdict['linewidths'] = """
 linewidths : :obj:`float`, optional
     Set the boundary thickness of the contours.
-    Only reflects when `view_type`='contours'."""
+    Only reflects when ``view_type=contours``."""
 
 # fsaverage options
 docdict['fsaverage_options'] = """

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -15,6 +15,9 @@ import sys
 #
 docdict = dict()
 
+NILEARN_REF_DOC = "http://nilearn.github.io"
+NIIMG_LINK = f"{NILEARN_REF_DOC}/manipulating_images/input_output.html"
+
 # Verbose
 verbose = """
 verbose : :obj:`int`, optional
@@ -123,8 +126,8 @@ docdict['n_jobs_all'] = n_jobs.format("-1")
 # img
 docdict['img'] = """
 img : Niimg-like object
-    See `input-output <http://nilearn.github.io/manipulating_images/input_output.html>`_.
-"""
+    See `input-output <{}>`_.
+""".format(NIIMG_LINK)
 
 # cut_coords
 docdict['cut_coords'] = """
@@ -158,29 +161,36 @@ output_file : :obj:`str`, or None, optional
 
 # display_mode
 docdict['display_mode'] = """
-display_mode : {'ortho', 'tiled', 'mosaic','x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
+display_mode : {'ortho', 'tiled', 'mosaic','x', 'y', 'z',\
+'yx', 'xz', 'yz'}, optional
     Choose the direction of the cuts:
 
         - 'x': sagittal
         - 'y': coronal
         - 'z': axial
-        - 'ortho': three cuts are performed in orthogonal directions
-        - 'tiled': three cuts are performed and arranged in a 2x2 grid
-        - 'mosaic': three cuts are performed along multiple rows and columns
+        - 'ortho': three cuts are performed in orthogonal
+          directions
+        - 'tiled': three cuts are performed and arranged
+          in a 2x2 grid
+        - 'mosaic': three cuts are performed along
+          multiple rows and columns
 
     Default='ortho'."""
 
 # figure
 docdict['figure'] = """
-figure : :obj:`int`, or :class:`matplotlib.figure.Figure`, or None,  optional
+figure : :obj:`int`, or :class:`matplotlib.figure.Figure`,\
+or None,  optional
     Matplotlib figure used or its number. If None is given, a
     new figure is created."""
 
 # axes
 docdict['axes'] = """
-axes : :class:`matplotlib.axes.Axes`, or 4 tuple of :obj:`float`: (xmin, ymin, width, height), optional
-    The axes, or the coordinates, in matplotlib figure space, of the axes
-    used to display the plot. If None, the complete figure is used."""
+axes : :class:`matplotlib.axes.Axes`, or 4 tuple \
+of :obj:`float`: (xmin, ymin, width, height), optional
+    The axes, or the coordinates, in matplotlib figure
+    space, of the axes used to display the plot.
+    If None, the complete figure is used."""
 
 # title
 docdict['title'] = """
@@ -193,15 +203,16 @@ docdict['threshold'] = """
 threshold : a number, None, or 'auto', optional
     If None is given, the image is not thresholded.
     If a number is given, it is used to threshold the image:
-    values below the threshold (in absolute value) are plotted as transparent.
-    If auto is given, the threshold is determined magically by analysis of the image.
+    values below the threshold (in absolute value) are plotted
+    as transparent. If auto is given, the threshold is determined
+    magically by analysis of the image.
 """
 
 # annotate
 docdict['annotate'] = """
 annotate : :obj:`bool`, optional
-    If `annotate` is True, positions and left/right annotation are added to the plot.
-    Default=True."""
+    If `annotate` is True, positions and left/right annotation
+    are added to the plot. Default=True."""
 
 # draw_cross
 docdict['draw_cross'] = """
@@ -222,12 +233,24 @@ docdict['colorbar'] = """
 colorbar : :obj:`bool`, optional
     If True, display a colorbar on the right of the plots."""
 
+# symmetric_cbar
+docdict['symmetric_cbar'] = """
+symmetric_cbar : :obj:`bool`, or 'auto', optional
+    Specifies whether the colorbar should range from `-vmax` to `vmax`
+    or from `vmin` to `vmax`. Setting to 'auto' will select the latter
+    if the range of the whole image is either positive or negative.
+
+    .. note::
+        The colormap will always range from `-vmax` to `vmax`.
+
+"""
+
 # bg_img
 docdict['bg_img'] = """
 bg_img : Niimg-like object, optional
-    See `input_output <http://nilearn.github.io/manipulating_images/input_output.html>`_.
+    See `input_output <{}>`_.
     The background image to plot on top of.
-"""
+""".format(NIIMG_LINK)
 
 # vmin
 docdict['vmin'] = """
@@ -256,8 +279,8 @@ bg_vmin : :obj:`float`, optional
 # resampling_interpolation
 docdict['resampling_interpolation'] = """
 resampling_interpolation : :obj:`str`, optional
-    Interpolation to use when resampling the image to the destination space.
-    Can be:
+    Interpolation to use when resampling the image to
+    the destination space. Can be:
 
         - "continuous": use 3rd-order spline interpolation
         - "nearest": use nearest-neighbor mapping.
@@ -269,8 +292,9 @@ resampling_interpolation : :obj:`str`, optional
 
 # cmap
 docdict['cmap'] = """
-cmap : :class:`matplotlib.colors.Colormap`, optional
-    The colormap to use."""
+cmap : :class:`matplotlib.colors.Colormap`, or :obj:`str`, optional
+    The colormap to use. Either a string which is a name of
+    a matplotlib colormap, or a matplotlib colormap object."""
 
 # Dimming factor
 docdict['dim'] = """
@@ -280,6 +304,65 @@ dim : :obj:`float`, or 'auto', optional
     Accepted float values, where a typical span is between -2 and 2
     (-2 = increase contrast; 2 = decrease contrast), but larger values
     can be used for a more pronounced effect. 0 means no dimming."""
+
+# avg_method
+docdict['avg_method'] = """
+avg_method : {'mean', 'median', 'min', 'max', custom function}, optional
+    How to average vertex values to derive the face value:
+
+        - `mean`: results in smooth boundaries
+        - `median`: results in sharp boundaries
+        - `min` or `max`: for sparse matrices
+        - `custom function`: You can also pass a custom function
+          which will be executed though :func:`numpy.apply_along_axis`.
+          Here is an example of a custom function:
+
+            .. code-block:: python
+
+                def custom_function(vertices):
+                    return vertices[0] * vertices[1] * vertices[2]
+
+"""
+
+# hemi
+docdict['hemi'] = """
+hemi : {'left', 'right'}, optional
+    Hemisphere to display. Default='left'."""
+
+# hemispheres
+docdict['hemispheres'] = """
+hemispheres : list of :obj:`str`, optional
+    Hemispheres to display. Default=['left', 'right']."""
+
+# view
+docdict['view'] = """
+view : {'lateral', 'medial', 'dorsal', 'ventral',\
+'anterior', 'posterior'}, optional
+    View of the surface that is rendered. Default='lateral'."""
+
+# bg_on_data
+docdict['bg_on_data'] = """
+bg_on_data : :obj:`bool`, optional
+    If True, and a `bg_map` is specified, the `surf_data` data is multiplied
+    by the background image, so that e.g. sulcal depth is visible beneath
+    the `surf_data`.
+
+        .. note::
+            This non-uniformly changes the surf_data values according
+            to e.g the sulcal depth.
+
+"""
+
+# darkness
+docdict['darkness'] = """
+darkness : :obj:`float` between 0 and 1, optional
+    Specifying the darkness of the background image:
+
+        - 1 indicates that the original values of the background are used
+        - .5 indicates that the background values are reduced by half
+          before being applied.
+
+"""
 
 # fsaverage options
 docdict['fsaverage_options'] = """

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -138,13 +138,14 @@ cut_coords : None, a tuple of :obj:`float`, or :obj:`int`, optional
           be a 3-tuple: (x, y, z)
         - For `display_mode` == 'x', 'y', or 'z', then these are
           the coordinates of each cut in the corresponding direction.
-        - If None is given, the cuts is calculated automaticaly.
+        - If None is given, the cuts are calculated automaticaly.
         - If `display_mode` is 'mosaic', and the number of cuts is the same
           for all directions, `cut_coords` can be specified as an integer.
           It can also be a length 3 tuple specifying the number of cuts for
           every direction if these are different.
 
         .. note::
+
             If display_mode is 'x', 'y' or 'z', `cut_coords` can be
             an integer, in which case it specifies the number of
             cuts to perform.
@@ -222,7 +223,7 @@ docdict['black_bg'] = """
 black_bg : :obj:`bool`, or 'auto', optional
     If True, the background of the image is set to be black.
     If you wish to save figures with a black background, you
-    will need to pass "facecolor='k', edgecolor='k'"
+    will need to pass facecolor='k', edgecolor='k'
     to :func:`matplotlib.pyplot.savefig`."""
 
 # colorbar
@@ -238,6 +239,7 @@ symmetric_cbar : :obj:`bool`, or 'auto', optional
     if the range of the whole image is either positive or negative.
 
     .. note::
+
         The colormap will always range from `-vmax` to `vmax`.
 
 """
@@ -289,6 +291,7 @@ resampling_interpolation : :obj:`str`, optional
         - "nearest": use nearest-neighbor mapping.
 
             .. note::
+
                 "nearest" is faster but can be noisier in some cases.
 
 """
@@ -360,8 +363,8 @@ docdict['darkness'] = """
 darkness : :obj:`float` between 0 and 1, optional
     Specifying the darkness of the background image:
 
-        - 1 indicates that the original values of the background are used
-        - .5 indicates that the background values are reduced by half
+        - '1' indicates that the original values of the background are used
+        - '.5' indicates that the background values are reduced by half
           before being applied.
 
 """

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -161,8 +161,7 @@ output_file : :obj:`str`, or None, optional
 
 # display_mode
 docdict['display_mode'] = """
-display_mode : {'ortho', 'tiled', 'mosaic','x', 'y', 'z',\
-'yx', 'xz', 'yz'}, optional
+display_mode : {'ortho', 'tiled', 'mosaic','x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
     Choose the direction of the cuts:
 
         - 'x': sagittal
@@ -179,15 +178,13 @@ display_mode : {'ortho', 'tiled', 'mosaic','x', 'y', 'z',\
 
 # figure
 docdict['figure'] = """
-figure : :obj:`int`, or :class:`matplotlib.figure.Figure`,\
-or None,  optional
+figure : :obj:`int`, or :class:`matplotlib.figure.Figure`, or None,  optional
     Matplotlib figure used or its number. If None is given, a
     new figure is created."""
 
 # axes
 docdict['axes'] = """
-axes : :class:`matplotlib.axes.Axes`, or 4 tuple \
-of :obj:`float`: (xmin, ymin, width, height), optional
+axes : :class:`matplotlib.axes.Axes`, or 4 tuple of :obj:`float`: (xmin, ymin, width, height), optional
     The axes, or the coordinates, in matplotlib figure
     space, of the axes used to display the plot.
     If None, the complete figure is used."""
@@ -244,6 +241,12 @@ symmetric_cbar : :obj:`bool`, or 'auto', optional
         The colormap will always range from `-vmax` to `vmax`.
 
 """
+
+# cbar_tick_format
+docdict['cbar_tick_format'] = """
+cbar_tick_format : :obj:`str`, optional
+    Controls how to format the tick labels of the colorbar.
+    Ex: use "%%.2g" to display using scientific notation."""
 
 # bg_img
 docdict['bg_img'] = """
@@ -336,8 +339,7 @@ hemispheres : list of :obj:`str`, optional
 
 # view
 docdict['view'] = """
-view : {'lateral', 'medial', 'dorsal', 'ventral',\
-'anterior', 'posterior'}, optional
+view : {'lateral', 'medial', 'dorsal', 'ventral', 'anterior', 'posterior'}, optional
     View of the surface that is rendered. Default='lateral'."""
 
 # bg_on_data
@@ -363,6 +365,12 @@ darkness : :obj:`float` between 0 and 1, optional
           before being applied.
 
 """
+
+# linewidth
+docdict['linewidths'] = """
+linewidths : :obj:`float`, optional
+    Set the boundary thickness of the contours.
+    Only reflects when `view_type`='contours'."""
 
 # fsaverage options
 docdict['fsaverage_options'] = """

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -17,7 +17,7 @@ docdict = dict()
 
 # Verbose
 verbose = """
-verbose : int, optional
+verbose : :obj:`int`, optional
     Verbosity level (0 means no message).
     Default={}."""
 docdict['verbose'] = verbose.format(1)
@@ -25,19 +25,19 @@ docdict['verbose0'] = verbose.format(0)
 
 # Resume
 docdict['resume'] = """
-resume : bool, optional
+resume : :obj:`bool`, optional
     Whether to resumed download of a partly-downloaded file.
     Default=True."""
 
 # Data_dir
 docdict['data_dir'] = """
-data_dir : string, optional
+data_dir : :obj:`str`, optional
     Path where data should be downloaded. By default,
     files are downloaded in home directory."""
 
 # URL
 docdict['url'] = """
-url : string, optional
+url : :obj:`str`, optional
     URL of file to download.
     Override download URL. Used for test only (or if you
     setup a mirror of the data).
@@ -45,15 +45,15 @@ url : string, optional
 
 # Smoothing_fwhm
 docdict['smoothing_fwhm'] = """
-smoothing_fwhm : float, optional.
-    If smoothing_fwhm is not None, it gives the size in millimeters of the
+smoothing_fwhm : :obj:`float`, optional.
+    If `smoothing_fwhm` is not None, it gives the size in millimeters of the
     spatial smoothing to apply to the signal.
     Default=None."""
 
 # Standardize
 standardize = """
-standardize : bool, optional.
-    If standardize is True, the data are centered and normed:
+standardize : :obj:`bool`, optional.
+    If `standardize` is True, the data are centered and normed:
     their variance is put to 1 in the time dimension.
     Default={}."""
 docdict['standardize'] = standardize.format('True')
@@ -63,7 +63,7 @@ docdict['standardize_false'] = standardize.format('False')
 docdict['target_affine'] = """
 target_affine: numpy.ndarray, optional.
     If specified, the image is resampled corresponding to this new affine.
-    target_affine can be a 3x3 or a 4x4 matrix.
+    `target_affine` can be a 3x3 or a 4x4 matrix.
     Default=None."""
 
 # Target_shape
@@ -80,32 +80,32 @@ target_shape: tuple or list, optional.
 
 # Low_pass
 docdict['low_pass'] = """
-low_pass: float, optional
+low_pass: :obj:`float`, optional
     Low cutoff frequency in Hertz.
     Default=None."""
 
 # High pass
 docdict['high_pass'] = """
-high_pass: float, optional
+high_pass: :obj:`float`, optional
     High cutoff frequency in Hertz.
     Default=None."""
 
 # t_r
 docdict['t_r'] = """
-t_r: float, optional
+t_r: :obj:`float`, optional
     Repetition time, in second (sampling period). Set to None if not.
     Default=None."""
 
 # Memory
 docdict['memory'] = """
-memory : instance of joblib.Memory or str
+memory : instance of joblib.Memory or :obj:`str`
     Used to cache the masking process.
     By default, no caching is done. If a str is given, it is the
     path to the caching directory."""
 
 # Memory_level
 memory_level = """
-memory_level: int, optional.
+memory_level: :obj:`int`, optional.
     Rough estimator of the amount of memory used by caching. Higher value
     means more memory for caching.
     Default={}."""
@@ -114,11 +114,172 @@ docdict['memory_level1'] = memory_level.format(1)
 
 # n_jobs
 n_jobs = """
-n_jobs : int, optional.
+n_jobs : :obj:`int`, optional.
     The number of CPUs to use to do the computation. -1 means 'all CPUs'.
     Default={}."""
 docdict['n_jobs'] = n_jobs.format("1")
 docdict['n_jobs_all'] = n_jobs.format("-1")
+
+# img
+docdict['img'] = """
+img : Niimg-like object
+    See `input-output <http://nilearn.github.io/manipulating_images/input_output.html>`_.
+"""
+
+# cut_coords
+docdict['cut_coords'] = """
+cut_coords : None, a tuple of :obj:`float`, or :obj:`int`, optional
+    The MNI coordinates of the point where the cut is performed.
+
+        - If `display_mode` is 'ortho' or 'tiled', this should
+          be a 3-tuple: (x, y, z)
+        - For `display_mode` == 'x', 'y', or 'z', then these are
+          the coordinates of each cut in the corresponding direction.
+        - If None is given, the cuts is calculated automaticaly.
+        - If `display_mode` is 'mosaic', and the number of cuts is the same
+          for all directions, `cut_coords` can be specified as an integer.
+          It can also be a length 3 tuple specifying the number of cuts for
+          every direction if these are different.
+
+        .. note::
+            If display_mode is 'x', 'y' or 'z', `cut_coords` can be
+            an integer, in which case it specifies the number of
+            cuts to perform.
+
+"""
+
+# output_file
+docdict['output_file'] = """
+output_file : :obj:`str`, or None, optional
+    The name of an image file to export the plot to. Valid extensions
+    are .png, .pdf, .svg. If `output_file` is not None, the plot
+    is saved to a file, and the display is closed."""
+
+
+# display_mode
+docdict['display_mode'] = """
+display_mode : {'ortho', 'tiled', 'mosaic','x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
+    Choose the direction of the cuts:
+
+        - 'x': sagittal
+        - 'y': coronal
+        - 'z': axial
+        - 'ortho': three cuts are performed in orthogonal directions
+        - 'tiled': three cuts are performed and arranged in a 2x2 grid
+        - 'mosaic': three cuts are performed along multiple rows and columns
+
+    Default='ortho'."""
+
+# figure
+docdict['figure'] = """
+figure : :obj:`int`, or :class:`matplotlib.figure.Figure`, or None,  optional
+    Matplotlib figure used or its number. If None is given, a
+    new figure is created."""
+
+# axes
+docdict['axes'] = """
+axes : :class:`matplotlib.axes.Axes`, or 4 tuple of :obj:`float`: (xmin, ymin, width, height), optional
+    The axes, or the coordinates, in matplotlib figure space, of the axes
+    used to display the plot. If None, the complete figure is used."""
+
+# title
+docdict['title'] = """
+title : :obj:`str`, or None, optional
+    The title displayed on the figure.
+    Default=None."""
+
+# threshold
+docdict['threshold'] = """
+threshold : a number, None, or 'auto', optional
+    If None is given, the image is not thresholded.
+    If a number is given, it is used to threshold the image:
+    values below the threshold (in absolute value) are plotted as transparent.
+    If auto is given, the threshold is determined magically by analysis of the image.
+"""
+
+# annotate
+docdict['annotate'] = """
+annotate : :obj:`bool`, optional
+    If `annotate` is True, positions and left/right annotation are added to the plot.
+    Default=True."""
+
+# draw_cross
+docdict['draw_cross'] = """
+draw_cross : :obj:`bool`, optional
+    If `draw_cross` is True, a cross is drawn on the plot to indicate
+    the cut position. Default=True."""
+
+# black_bg
+docdict['black_bg'] = """
+black_bg : :obj:`bool`, or 'auto', optional
+    If True, the background of the image is set to be black.
+    If you wish to save figures with a black background, you
+    will need to pass "facecolor='k', edgecolor='k'"
+    to :func:`matplotlib.pyplot.savefig`."""
+
+# colorbar
+docdict['colorbar'] = """
+colorbar : :obj:`bool`, optional
+    If True, display a colorbar on the right of the plots."""
+
+# bg_img
+docdict['bg_img'] = """
+bg_img : Niimg-like object, optional
+    See `input_output <http://nilearn.github.io/manipulating_images/input_output.html>`_.
+    The background image to plot on top of.
+"""
+
+# vmin
+docdict['vmin'] = """
+vmin : :obj:`float`, optional
+    Lower bound of the colormap. If `None`, the min of the image is used.
+    Passed to :func:`matplotlib.pyplot.imshow`.
+"""
+
+# vmax
+docdict['vmax'] = """
+vmax : :obj:`float`, optional
+    Upper bound of the colormap. If `None`, the max of the image is used.
+    Passed to :func:`matplotlib.pyplot.imshow`.
+"""
+
+# bg_vmin
+docdict['bg_vmin'] = """
+bg_vmin : :obj:`float`, optional
+    vmin for `bg_img`."""
+
+# bg_vmax
+docdict['bg_vmax'] = """
+bg_vmin : :obj:`float`, optional
+    vmax for `bg_img`."""
+
+# resampling_interpolation
+docdict['resampling_interpolation'] = """
+resampling_interpolation : :obj:`str`, optional
+    Interpolation to use when resampling the image to the destination space.
+    Can be:
+
+        - "continuous": use 3rd-order spline interpolation
+        - "nearest": use nearest-neighbor mapping.
+
+            .. note::
+                "nearest" is faster but can be noisier in some cases.
+
+"""
+
+# cmap
+docdict['cmap'] = """
+cmap : :class:`matplotlib.colors.Colormap`, optional
+    The colormap to use."""
+
+# Dimming factor
+docdict['dim'] = """
+dim : :obj:`float`, or 'auto', optional
+    Dimming factor applied to background image. By default, automatic
+    heuristics are applied based upon the background image intensity.
+    Accepted float values, where a typical span is between -2 and 2
+    (-2 = increase contrast; 2 = decrease contrast), but larger values
+    can be used for a more pronounced effect. 0 means no dimming."""
 
 # fsaverage options
 docdict['fsaverage_options'] = """

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -20,6 +20,7 @@ from ..plotting import cm
 from ..plotting.find_cuts import find_xyz_cut_coords
 from ..plotting.img_plotting import _load_anat
 from nilearn.plotting.html_document import HTMLDocument
+from .._utils import fill_doc
 from .._utils.niimg_conversions import check_niimg_3d
 from .._utils.param_validation import check_threshold
 from .._utils.extmath import fast_abs_percentile
@@ -414,6 +415,7 @@ def _get_cut_slices(stat_map_img, cut_coords=None, threshold=None):
     return cut_slices
 
 
+@fill_doc
 def view_img(stat_map_img, bg_img='MNI152',
              cut_coords=None,
              colorbar=True,
@@ -439,10 +441,7 @@ def view_img(stat_map_img, bg_img='MNI152',
         See http://nilearn.github.io/manipulating_images/input_output.html
         The statistical map image. Can be either a 3D volume or a 4D volume
         with exactly one time point.
-
-    bg_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_images/input_output.html
-        The background image that the stat map will be plotted on top of.
+    %(bg_img)s
         If nothing is specified, the MNI152 template will be used.
         To turn off background image, just pass "bg_img=False".
         Default='MNI152'.
@@ -454,13 +453,10 @@ def view_img(stat_map_img, bg_img='MNI152',
 
     colorbar : boolean, optional
         If True, display a colorbar on top of the plots. Default=True.
-
-    title : string or None, optional
-        The title displayed on the figure (or None: no title).
-
+    %(title)s
     threshold : string, number or None, optional
         If None is given, the image is not thresholded.
-        If a string of the form "90%" is given, use the 90-th percentile of
+        If a string of the form "90%%" is given, use the 90-th percentile of
         the absolute value in the image.
         If a number is given, it is used to threshold the image:
         values below the threshold (in absolute value) are plotted
@@ -470,35 +466,22 @@ def view_img(stat_map_img, bg_img='MNI152',
     annotate : boolean, optional
         If annotate is True, current cuts are added to the viewer.
         Default=True.
-
-    draw_cross : boolean, optional
-        If draw_cross is True, a cross is drawn on the plot to
-        indicate the cuts. Default=True.
-
+    %(draw_cross)s
     black_bg : boolean or 'auto', optional
         If True, the background of the image is set to be black.
         Otherwise, a white background is used.
         If set to auto, an educated guess is made to find if the background
         is white or black.
         Default='auto'.
-
-    cmap : matplotlib colormap, optional
-        The colormap for specified image. Default=cm.cold_hot.
-
+    %(cmap)s
+        Default=`plt.cm.cold_hot`.
     symmetric_cmap : bool, optional
         True: make colormap symmetric (ranging from -vmax to vmax).
         False: the colormap will go from the minimum of the volume to vmax.
         Set it to False if you are plotting a positive volume, e.g. an atlas
         or an anatomical image. Default=True.
-
-    dim : float, 'auto', optional
-        Dimming factor applied to background image. By default, automatic
-        heuristics are applied based upon the background image intensity.
-        Accepted float values, where a typical scan is between -2 and 2
-        (-2 = increase constrast; 2 = decrease contrast), but larger values
-        can be used for a more pronounced effect. 0 means no dimming.
+    %(dim)s
         Default='auto'.
-
     vmax : float, or None, optional
         max value for mapping colors.
         If vmax is None and symmetric_cmap is True, vmax is the max
@@ -512,13 +495,8 @@ def view_img(stat_map_img, bg_img='MNI152',
         cannot be chosen.
         If `symmetric_cmap` is `False`, `vmin` defaults to the min of the
         image, or 0 when a threshold is used.
-
-    resampling_interpolation : string, optional
-        The interpolation method for resampling.
-        Can be 'continuous', 'linear', or 'nearest'.
-        See nilearn.image.resample_img
+    %(resampling_interpolation)s
         Default='continuous'.
-
     opacity : float in [0,1], optional
         The level of opacity of the overlay (0: transparent, 1: opaque).
         Default=1.

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -916,12 +916,7 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
             The ccolormap *must* be symmetrical.
 
         Default=`plt.cm.cold_hot`.
-
-    symmetric_cbar : boolean or 'auto', optional
-        Specifies whether the colorbar should range from -vmax to vmax
-        or from vmin to vmax. Setting to 'auto' will select the latter if
-        the range of the whole image is either positive or negative.
-        Note: The colormap will always be set to range from -vmax to vmax.
+    %(symmetric_cbar)s
         Default='auto'.
     %(dim)s
         Default='auto'.
@@ -1026,12 +1021,7 @@ def plot_glass_brain(stat_map_img,
         maximum intensity will be represented with different colors.
         See http://nilearn.github.io/auto_examples/01_plotting/plot_demo_glass_brain_extensive.html
         for examples. Default=True.
-
-    symmetric_cbar : boolean or 'auto', optional
-        Specifies whether the colorbar should range from -vmax to vmax
-        or from vmin to vmax. Setting to 'auto' will select the latter if
-        the range of the whole image is either positive or negative.
-        Note: The colormap will always be set to range from -vmax to vmax.
+    %(symmetric_cbar)s
         Default='auto'.
     %(resampling_interpolation)s
         Default='continuous'.
@@ -1496,6 +1486,7 @@ def plot_carpet(img, mask_img=None, mask_labels=None,
     %(vmax)s
     %(title)s
     %(cmap)s
+
         .. note::
             This argumeent is used only if an atlas is used.
 

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -907,6 +907,7 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
     %(black_bg)s
         Default='auto'.
     %(cmap)s
+
         .. note::
             The ccolormap *must* be symmetrical.
 

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -693,7 +693,7 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
     return display
 
 
-#@fill_doc
+@fill_doc
 def plot_prob_atlas(maps_img, bg_img=MNI152TEMPLATE, view_type='auto',
                     threshold='auto', linewidths=2.5, cut_coords=None,
                     output_file=None, display_mode='ortho',

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -693,7 +693,7 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
     return display
 
 
-@fill_doc
+#@fill_doc
 def plot_prob_atlas(maps_img, bg_img=MNI152TEMPLATE, view_type='auto',
                     threshold='auto', linewidths=2.5, cut_coords=None,
                     output_file=None, display_mode='ortho',

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -294,8 +294,8 @@ def plot_img(img, cut_coords=None, output_file=None, display_mode='ortho',
     %(resampling_interpolation)s
         Default='continuous'.
     %(bg_img)s
-         If nothing is specified, no background image is plotted.
-         Default=None.
+        If nothing is specified, no background image is plotted.
+        Default=None.
     %(vmin)s
     %(vmax)s
     kwargs : extra keyword arguments, optional
@@ -647,10 +647,7 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         If view_type == 'contours', maps are shown as contours. For this type, label
         denoted as 0 is considered as background and not shown.
         Default='continuous'.
-
-    linewidths : float, optional
-        This option can be used to set the boundary thickness of the
-        contours. Only reflects when view_type='contours'.
+    %(linewidths)s
         Default=2.5.
 
     Notes
@@ -749,9 +746,7 @@ def plot_prob_atlas(maps_img, bg_img=MNI152TEMPLATE, view_type='auto',
         directly to threshold the maps without any percentile calculation.
         If None, a very small threshold is applied to remove numerical
         noise from the maps background.
-
-    linewidths : float, optional
-        This option can be used to set the boundary thickness of the contours.
+    %(linewidths)s
         Default=2.5.
     %(cut_coords)s
     %(output_file)s

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -33,6 +33,7 @@ import matplotlib.pyplot as plt
 from matplotlib import gridspec as mgs
 
 from .. import _utils
+from .._utils import fill_doc
 from .._utils.extmath import fast_abs_percentile
 from .._utils.param_validation import check_threshold
 from .._utils.ndimage import get_border_data
@@ -114,6 +115,7 @@ def _get_colorbar_and_data_ranges(stat_map_data, vmax, symmetric_cbar, kwargs,
     return cbar_vmin, cbar_vmax, vmin, vmax
 
 
+@fill_doc
 def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
                       output_file=None, display_mode='ortho',
                       colorbar=False, figure=None, axes=None, title=None,
@@ -131,15 +133,10 @@ def _plot_img_with_bg(img, bg_img=None, cut_coords=None,
 
     Parameters
     ----------
-    img : Niimg like object
+    %(img)s
         Image to plot.
-
-    bg_vmin : float, optional
-        vmin for bg_img.
-
-    bg_vmax : float, optional
-        vmax for bg_img.
-
+    %(bg_vmin)s
+    %(bg_vmax)s
     interpolation : string, optional
         Passed to the add_overlay calls.
         Default='nearest'.
@@ -267,6 +264,7 @@ def _crop_colorbar(cbar, cbar_vmin, cbar_vmax):
     cbar.set_ticks(new_tick_locs, update_ticks=True)
 
 
+@fill_doc
 def plot_img(img, cut_coords=None, output_file=None, display_mode='ortho',
              figure=None, axes=None, title=None, threshold=None,
              annotate=True, draw_cross=True, black_bg=False, colorbar=False,
@@ -276,89 +274,30 @@ def plot_img(img, cut_coords=None, output_file=None, display_mode='ortho',
 
     Parameters
     ----------
-    img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
-
-    cut_coords : None, a tuple of floats, or an integer, optional
-        The MNI coordinates of the point where the cut is performed
-        If display_mode is 'ortho' or 'tiled',
-        this should be a 3-tuple: (x, y, z)
-        For display_mode == 'x', 'y', or 'z', then these are the
-        coordinates of each cut in the corresponding direction.
-        If None is given, the cuts is calculated automaticaly.
-        If display_mode is 'x', 'y' or 'z', cut_coords can be an integer,
-        in which case it specifies the number of cuts to perform
-
-    output_file : string, or None, optional
-        The name of an image file to export the plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
-
-    display_mode : {'ortho', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}
-        Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
-        'z' - axial, 'ortho' - three cuts are performed in orthogonal
-        directions, 'tiled' - three cuts are performed
-        and arranged in a 2x2 grid.
-        Default='ortho'.
-
-    figure : integer or matplotlib figure, optional
-        Matplotlib figure used or its number. If None is given, a
-        new figure is created.
-
-    axes : matplotlib axes or 4 tuple of float: (xmin, ymin, width, height), optional
-        The axes, or the coordinates, in matplotlib figure space,
-        of the axes used to display the plot. If None, the complete
-        figure is used.
-
-    title : string, optional
-        The title displayed on the figure.
-
-    threshold : a number, None, or 'auto', optional
-        If None is given, the image is not thresholded.
-        If a number is given, it is used to threshold the image:
-        values below the threshold (in absolute value) are plotted
-        as transparent. If auto is given, the threshold is determined
-        magically by analysis of the image.
-
-    annotate : boolean, optional
-        If annotate is True, positions and left/right annotation
-        are added to the plot. Default=True.
-
+    %(img)s
+    %(cut_coords)s
+    %(output_file)s
+    %(display_mode)s
+    %(figure)s
+    %(axes)s
+    %(title)s
+    %(threshold)s
+    %(annotate)s
     decimals : integer, optional
         Number of decimal places on slice position annotation. If False (default),
         the slice position is integer without decimal point.
-
-    draw_cross : boolean, optional
-        If draw_cross is True, a cross is drawn on the plot to
-        indicate the cut plosition. Default=True.
-
-    black_bg : boolean, optional
-        If True, the background of the image is set to be black. If
-        you wish to save figures with a black background, you
-        will need to pass "facecolor='k', edgecolor='k'"
-        to matplotlib.pyplot.savefig. Default=False.
-
-    colorbar : boolean, optional
-        If True, display a colorbar on the right of the plots.
+    %(draw_cross)s
+    %(black_bg)s
         Default=False.
-
-    resampling_interpolation : str, optional
-        Interpolation to use when resampling the image to the destination
-        space. Can be "continuous" to use 3rd-order spline interpolation,
-        or "nearest" to use nearest-neighbor mapping. "nearest" is faster
-        but can be noisier in some cases. Default='continuous'.
-
-    bg_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_images/input_output.html
-        The background image that the ROI/mask will be plotted on top of.
-        If nothing is specified, no background image is plotted.
-
-    vmin : float, optional
-        Lower bound of the colormap. If `None`, the min of the image is used.
-
-    vmax : float, optional
-        Upper bound of the colormap. If `None`, the max of the image is used.
-
+    %(colorbar)s
+        Default=False.
+    %(resampling_interpolation)s
+        Default='continuous'.
+    %(bg_img)s
+         If nothing is specified, no background image is plotted.
+         Default=None.
+    %(vmin)s
+    %(vmax)s
     kwargs : extra keyword arguments, optional
         Extra keyword arguments passed to matplotlib.pyplot.imshow.
 
@@ -512,6 +451,7 @@ def _load_anat(anat_img=MNI152TEMPLATE, dim='auto', black_bg='auto'):
 # Usage-specific functions
 
 
+@fill_doc
 def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
               output_file=None, display_mode='ortho', figure=None,
               axes=None, title=None, annotate=True, threshold=None,
@@ -527,81 +467,23 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
         The anatomical image to be used as a background. If None is
         given, nilearn tries to find a T1 template.
         Default=MNI152TEMPLATE.
-
-    cut_coords : None, a tuple of floats, or an integer, optional
-        The MNI coordinates of the point where the cut is performed
-        If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
-        For display_mode == 'x', 'y', or 'z', then these are the
-        coordinates of each cut in the corresponding direction.
-        If None is given, the cuts is calculated automaticaly.
-        If display_mode is 'x', 'y' or 'z', cut_coords can be an integer,
-        in which case it specifies the number of cuts to perform.
-        If display_mode is 'mosaic', and the number of cuts is the same
-        for all directions, cut_coords can be specified as an integer.
-        It can also be a length 3 tuple specifying the number of cuts for
-        every direction if these are different.
-
-    output_file : string, or None, optional
-        The name of an image file to export the plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
-
-    display_mode : {'ortho', 'tiled', 'mosaic', 'x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
-        Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
-        'z' - axial, 'ortho' - three cuts are performed in orthogonal
-        directions, 'tiled' - three cuts are performed
-        and arranged in a 2x2 grid, 'mosaic' - three cuts
-        are performed along multiple rows and columns, Default='ortho'.
-
-    figure : integer or matplotlib figure, optional
-        Matplotlib figure used or its number. If None is given, a
-        new figure is created.
-
-    axes : matplotlib axes or 4 tuple of float: (xmin, ymin, width, height), optional
-        The axes, or the coordinates, in matplotlib figure space,
-        of the axes used to display the plot. If None, the complete figure is used.
-
-    title : string, optional
-        The title displayed on the figure.
-
-    annotate : boolean, optional
-        If annotate is True, positions and left/right annotation
-        are added to the plot. Default=True.
-
-    threshold : a number, None, or 'auto', optional
-        If None is given, the image is not thresholded.
-        If a number is given, it is used to threshold the image:
-        values below the threshold (in absolute value) are plotted
-        as transparent. If auto is given, the threshold is determined
-        magically by analysis of the image.
-
-    draw_cross : boolean, optional
-        If draw_cross is True, a cross is drawn on the plot to
-        indicate the cut plosition. Default=True.
-
-    black_bg : boolean or 'auto', optional
-        If True, the background of the image is set to be black. If
-        you wish to save figures with a black background, you
-        will need to pass "facecolor='k', edgecolor='k'"
-        to matplotlib.pyplot.savefig.
+    %(cut_coords)s
+    %(output_file)s
+    %(display_mode)s
+    %(figure)s
+    %(axes)s
+    %(title)s
+    %(annotate)s
+    %(threshold)s
+    %(draw_cross)s
+    %(black_bg)s
         Default='auto'.
-
-    dim : float or 'auto', optional
-        Dimming factor applied to background image. By default, automatic
-        heuristics are applied based upon the image intensity.
-        Accepted float values, where a typical span is between -2 and 2
-        (-2 = increase contrast; 2 = decrease contrast), but larger
-        values can be used for a more pronounced effect. 0 means no
-        dimming. Default='auto'.
-
-    cmap : matplotlib colormap, optional
-        The colormap for the anat. Default=plt.cm.gray.
-
-    vmin : float, optional
-        Lower bound for plotting, passed to matplotlib.pyplot.imshow.
-
-    vmax : float, optional
-        Upper bound for plotting, passed to matplotlib.pyplot.imshow.
+    %(dim)s
+        Default='auto'.
+    %(cmap)s
+        Default=`plt.cm.gray`.
+    %(vmin)s
+    %(vmax)s
 
     Notes
     -----
@@ -629,6 +511,7 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
     return display
 
 
+@fill_doc
 def plot_epi(epi_img=None, cut_coords=None, output_file=None,
              display_mode='ortho', figure=None, axes=None, title=None,
              annotate=True, draw_cross=True, black_bg=True,
@@ -640,67 +523,20 @@ def plot_epi(epi_img=None, cut_coords=None, output_file=None,
     ----------
     epi_img : a nifti-image like object or a filename, optional
         The EPI (T2*) image.
-
-    cut_coords : None, a tuple of floats, or an integer, optional
-        The MNI coordinates of the point where the cut is performed
-        If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
-        For display_mode == 'x', 'y', or 'z', then these are the
-        coordinates of each cut in the corresponding direction.
-        If None is given, the cuts is calculated automaticaly.
-        If display_mode is 'x', 'y' or 'z', cut_coords can be an integer,
-        in which case it specifies the number of cuts to perform.
-        If display_mode is 'mosaic', and the number of cuts is the same
-        for all directions, cut_coords can be specified as an integer.
-        It can also be a length 3 tuple specifying the number of cuts for
-        every direction if these are different.
-
-    output_file : string, or None, optional
-        The name of an image file to export the plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
-
-    display_mode : {'ortho', 'tiled', 'mosaic', 'x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
-        Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
-        'z' - axial, 'ortho' - three cuts are performed in orthogonal
-        directions, 'tiled' - three cuts are performed
-        and arranged in a 2x2 grid. 'mosaic' - three cuts are
-        performed along multiple rows and columns. Default='ortho'.
-
-    figure : integer or matplotlib figure, optional
-        Matplotlib figure used or its number. If None is given, a
-        new figure is created.
-
-    axes : matplotlib axes or 4 tuple of float: (xmin, ymin, width, height), optional
-        The axes, or the coordinates, in matplotlib figure space,
-        of the axes used to display the plot. If None, the complete figure is used.
-
-    title : string, optional
-        The title displayed on the figure.
-
-    annotate : boolean, optional
-        If annotate is True, positions and left/right annotation
-        are added to the plot. Default=True.
-
-    draw_cross : boolean, optional
-        If draw_cross is True, a cross is drawn on the plot to
-        indicate the cut plosition. Default=True.
-
-    black_bg : boolean, optional
-        If True, the background of the image is set to be black. If
-        you wish to save figures with a black background, you
-        will need to pass "facecolor='k', edgecolor='k'"
-        to matplotlib.pyplot.savefig.
+    %(cut_coords)s
+    %(output_file)s
+    %(display_mode)s
+    %(figure)s
+    %(axes)s
+    %(title)s
+    %(annotate)s
+    %(draw_cross)s
+    %(black_bg)s
         Default=True.
-
-    cmap : matplotlib colormap, optional
-        The colormap for specified image.
-        Default=plt.cm.nipy_spectral.
-
-    vmin : float, optional
-        Lower bound for plotting, passed to matplotlib.pyplot.imshow.
-
-    vmax : float, optional
-        Upper bound for plotting, passed to matplotlib.pyplot.imshow.
+    %(cmap)s
+        Default=`plt.cm.nipy_spectral`.
+    %(vmin)s
+    %(vmax)s
 
     Notes
     -----
@@ -763,6 +599,7 @@ def _plot_roi_contours(display, roi_img, cmap, alpha, linewidths):
     return display
 
 
+@fill_doc
 def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
              output_file=None, display_mode='ortho', figure=None, axes=None,
              title=None, annotate=True, draw_cross=True, black_bg='auto',
@@ -778,101 +615,33 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         See http://nilearn.github.io/manipulating_images/input_output.html
         The ROI/mask image, it could be binary mask or an atlas or ROIs
         with integer values.
-
-    bg_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_images/input_output.html
-        The background image that the ROI/mask will be plotted on top of.
+    %(bg_img)s
         If nothing is specified, the MNI152 template will be used.
         To turn off background image, just pass "bg_img=None".
         Default=MNI152TEMPLATE.
-
-    cut_coords : None, or a tuple of floats, optional
-        The MNI coordinates of the point where the cut is performed, in
-        MNI coordinates and order.
-        If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
-        For display_mode == 'x', 'y', or 'z', then these are the
-        coordinates of each cut in the corresponding direction.
-        If None is given, the cuts is calculated automaticaly.
-        If display_mode is 'mosaic', and the number of cuts is the same
-        for all directions, cut_coords can be specified as an integer.
-        It can also be a length 3 tuple specifying the number of cuts for
-        every direction if these are different.
-
-    output_file : string, or None, optional
-        The name of an image file to export the plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
-
-    display_mode : {'ortho', 'mosaic', 'tiled', 'x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
-        Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
-        'z' - axial, 'ortho' - three cuts are performed in orthogonal
-        directions, 'tiled' - three cuts are performed
-        and arranged in a 2x2 grid, 'mosaic' - three cuts
-        are performed along multiple rows and columns, Default='ortho'.
-
-    figure : integer or matplotlib figure, optional
-        Matplotlib figure used or its number. If None is given, a
-        new figure is created.
-
-    axes : matplotlib axes or 4 tuple of float: (xmin, ymin, width, height), optional
-        The axes, or the coordinates, in matplotlib figure space,
-        of the axes used to display the plot. If None, the complete
-        figure is used.
-
-    title : string, optional
-        The title displayed on the figure.
-
-    annotate : boolean, optional
-        If annotate is True, positions and left/right annotation
-        are added to the plot. Default=True.
-
-    draw_cross : boolean, optional
-        If draw_cross is True, a cross is drawn on the plot to
-        indicate the cut plosition.
-
-    black_bg : boolean or 'auto', optional
-        If True, the background of the image is set to be black. If
-        you wish to save figures with a black background, you
-        will need to pass "facecolor='k', edgecolor='k'"
-        to matplotlib.pyplot.savefig.
+    %(cut_coords)s
+    %(output_file)s
+    %(display_mode)s
+    %(figure)s
+    %(axes)s
+    %(title)s
+    %(annotate)s
+    %(draw_cross)s
+    %(black_bg)s
         Default='auto'.
-
-    threshold : None, 'auto', or a number, optional
-        If None is given, the image is not thresholded.
-        If a number is given, it is used to threshold the image:
-        values below the threshold (in absolute value) are plotted
-        as transparent. If auto is given, the threshold is determined
-        magically by analysis of the image.
+    %(threshold)s
         Default=0.5.
-
     alpha : float between 0 and 1, optional
         Alpha sets the transparency of the color inside the filled
         contours. Default=0.7.
-
-    cmap : matplotlib colormap, optional
-        The colormap for the atlas maps. Default=plt.cm.gist_ncar.
-
-    dim : float or 'auto', optional
-        Dimming factor applied to background image. By default, automatic
-        heuristics are applied based upon the background image intensity.
-        Accepted float values, where a typical span is between -2 and 2
-        (-2 = increase contrast; 2 = decrease contrast), but larger values
-        can be used for a more pronounced effect. 0 means no dimming.
+    %(cmap)s
+        Default=`plt.cm.gist_ncar`.
+    %(dim)s
         Default='auto'.
-
-    vmin : float, optional
-        Lower bound for plotting, passed to matplotlib.pyplot.imshow.
-
-    vmax : float, optional
-        Upper bound for plotting, passed to matplotlib.pyplot.imshow.
-
-    resampling_interpolation : str, optional
-        Interpolation to use when resampling the image to the destination
-        space. Can be "continuous" to use 3rd-order spline interpolation,
-        or "nearest" to use nearest-neighbor mapping.
-        "nearest" is faster but can be noisier in some cases.
+    %(vmin)s
+    %(vmax)s
+    %(resampling_interpolation)s
         Default='nearest'.
-
     view_type : {'continuous', 'contours'}, optional
         By default view_type == 'continuous', rois are shown as continuous colors.
         If view_type == 'contours', maps are shown as contours. For this type, label
@@ -927,6 +696,7 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
     return display
 
 
+@fill_doc
 def plot_prob_atlas(maps_img, bg_img=MNI152TEMPLATE, view_type='auto',
                     threshold='auto', linewidths=2.5, cut_coords=None,
                     output_file=None, display_mode='ortho',
@@ -942,10 +712,7 @@ def plot_prob_atlas(maps_img, bg_img=MNI152TEMPLATE, view_type='auto',
     ----------
     maps_img : Niimg-like object or the filename
         4D image of the probabilistic atlas maps.
-
-    bg_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_images/input_output.html
-        The anatomical image to be used as a background.
+    %(bg_img)s
         If nothing is specified, the MNI152 template will be used.
         To turn off background image, just pass "bg_img=False".
         Default=MNI152TEMPLATE.
@@ -972,7 +739,7 @@ def plot_prob_atlas(maps_img, bg_img=MNI152TEMPLATE, view_type='auto',
         maps for a better visualization.
         The threshold can also be expressed as a percentile over the values
         of the whole atlas. In that case, the value must be specified as
-        string finishing with a percent sign, e.g., "25.3%".
+        string finishing with a percent sign, e.g., "25.3%%".
         If a single string is provided, the same percentile will be applied
         over the whole atlas. Otherwise, if a list of percentiles is
         provided, each 3D map is thresholded with certain percentile
@@ -986,78 +753,24 @@ def plot_prob_atlas(maps_img, bg_img=MNI152TEMPLATE, view_type='auto',
     linewidths : float, optional
         This option can be used to set the boundary thickness of the contours.
         Default=2.5.
-
-    cut_coords : None, a tuple of floats, or an integer, optional
-        The MNI coordinates of the point where the cut is performed
-        If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
-        For display_mode == 'x', 'y', or 'z', then these are the
-        coordinates of each cut in the corresponding direction.
-        If None is given, the cuts is calculated automaticaly.
-        If display_mode is 'x', 'y' or 'z', cut_coords can be an integer,
-        in which case it specifies the number of cuts to perform.
-        If display_mode is 'mosaic', and the number of cuts is the same
-        for all directions, cut_coords can be specified as an integer.
-        It can also be a length 3 tuple specifying the number of cuts for
-        every direction if these are different.
-
-    output_file : string, or None, optional
-        The name of an image file to export the plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
-
-    display_mode : {'ortho', 'tiled', 'mosaic', 'x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
-        Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
-        'z' - axial, 'ortho' - three cuts are performed in orthogonal
-        directions, 'tiled' - three cuts are performed
-        and arranged in a 2x2 grid, 'mosaic' - three cuts are performed along
-        multiple rows and columns, Default='ortho'.
-
-    figure : integer or matplotlib figure, optional
-        Matplotlib figure used or its number. If None is given, a
-        new figure is created.
-
-    axes : matplotlib axes or 4 tuple of float: (xmin, ymin, width, height), optional
-        The axes, or the coordinates, in matplotlib figure space,
-        of the axes used to display the plot. If None, the complete figure is used.
-
-    title : string, optional
-        The title displayed on the figure.
-
-    annotate : boolean, optional
-        If annotate is True, positions and left/right annotation
-        are added to the plot. Default=True.
-
-    draw_cross : boolean, optional
-        If draw_cross is True, a cross is drawn on the plot to
-        indicate the cut plosition. Default=True.
-
-    black_bg : boolean or 'auto', optional
-        If True, the background of the image is set to be black. If
-        you wish to save figures with a black background, you
-        will need to pass "facecolor='k', edgecolor='k'" to pylab's
-        savefig. Default='auto'.
-
-    dim : float or 'auto', optional
-        Dimming factor applied to background image. By default, automatic
-        heuristics are applied based upon the background image intensity.
-        Accepted float values, where a typical span is between -2 and 2
-        (-2 = increase contrast; 2 = decrease contrast), but larger values
-        can be used for a more pronounced effect. 0 means no dimming.
+    %(cut_coords)s
+    %(output_file)s
+    %(display_mode)s
+    %(figure)s
+    %(axes)s
+    %(title)s
+    %(annotate)s
+    %(draw_cross)s
+    %(black_bg)s
         Default='auto'.
-
-    cmap : matplotlib colormap, optional
-        The colormap for the atlas maps. Default=plt.cm.gist_rainbow.
-
-    colorbar : boolean, optional
-        If True, display a colorbar on the right of the plots.
+    %(dim)s
+        Default='auto'.
+    %(cmap)s
+        Default=`plt.cm.gist_rainbow`.
+    %(colorbar)s
         Default=False.
-
-    vmin : float, optional
-        Lower bound for plotting, passed to matplotlib.pyplot.imshow.
-
-    vmax : float, optional
-        Upper bound for plotting, passed to matplotlib.pyplot.imshow.
-
+    %(vmin)s
+    %(vmax)s
     alpha : float between 0 and 1, optional
         Alpha sets the transparency of the color inside the filled contours.
         Default=0.7.
@@ -1164,6 +877,7 @@ def plot_prob_atlas(maps_img, bg_img=MNI152TEMPLATE, view_type='auto',
     return display
 
 
+@fill_doc
 def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
                   output_file=None, display_mode='ortho', colorbar=True,
                   figure=None, axes=None, title=None, threshold=1e-6,
@@ -1179,79 +893,29 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
     stat_map_img : Niimg-like object
         See http://nilearn.github.io/manipulating_images/input_output.html
         The statistical map image
-
-    bg_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_images/input_output.html
-        The background image that the ROI/mask will be plotted on top of.
+    %(bg_img)s
         If nothing is specified, the MNI152 template will be used.
         To turn off background image, just pass "bg_img=None".
         Default=MNI152TEMPLATE.
-
-    cut_coords : None, a tuple of floats, or an integer, optional
-        The MNI coordinates of the point where the cut is performed
-        If display_mode is 'ortho' or 'tiled', this should be a 3-tuple: (x, y, z)
-        For display_mode == 'x', 'y', or 'z', then these are the
-        coordinates of each cut in the corresponding direction.
-        If None is given, the cuts is calculated automaticaly.
-        If display_mode is 'x', 'y' or 'z', cut_coords can be an integer,
-        in which case it specifies the number of cuts to perform.
-        If display_mode is 'mosaic', and the number of cuts is the same
-        for all directions, cut_coords can be specified as an integer.
-        It can also be a length 3 tuple specifying the number of cuts for
-        every direction if these are different.
-
-    output_file : string, or None, optional
-        The name of an image file to export the plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
-
-    display_mode : {'ortho', 'tiled', 'mosaic', 'x', 'y', 'z', 'yx', 'xz', 'yz'}, optional
-        Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
-        'z' - axial, 'ortho' - three cuts are performed in orthogonal
-        directions, 'tiled' - three cuts are performed
-        and arranged in a 2x2 grid, 'mosaic' - three cuts
-        are performed along multiple rows and columns, Default='ortho'.
-
-    colorbar : boolean, optional
-        If True, display a colorbar on the right of the plots. Default=True.
-
-    figure : integer or matplotlib figure, optional
-        Matplotlib figure used or its number. If None is given, a
-        new figure is created.
-
-    axes : matplotlib axes or 4 tuple of float: (xmin, ymin, width, height), optional
-        The axes, or the coordinates, in matplotlib figure space,
-        of the axes used to display the plot. If None, the complete figure is used.
-
-    title : string, optional
-        The title displayed on the figure.
-
-    threshold : a number, None, or 'auto', optional
-        If None is given, the image is not thresholded.
-        If a number is given, it is used to threshold the image:
-        values below the threshold (in absolute value) are plotted
-        as transparent. If auto is given, the threshold is determined
-        magically by analysis of the image.
+    %(cut_coords)s
+    %(output_file)s
+    %(display_mode)s
+    %(colorbar)s
+        Default=True.
+    %(figure)s
+    %(axes)s
+    %(title)s
+    %(threshold)s
         Default=1e-6.
-
-    annotate : boolean, optional
-        If annotate is True, positions and left/right annotation
-        are added to the plot. Default=True.
-
-    draw_cross : boolean, optional
-        If draw_cross is True, a cross is drawn on the plot to
-        indicate the cut plosition. Default=True.
-
-    black_bg : boolean or 'auto', optional
-        If True, the background of the image is set to be black. If
-        you wish to save figures with a black background, you
-        will need to pass "facecolor='k', edgecolor='k'"
-        to matplotlib.pyplot.savefig.
+    %(annotate)s
+    %(draw_cross)s
+    %(black_bg)s
         Default='auto'.
+    %(cmap)s
+        .. note::
+            The ccolormap *must* be symmetrical.
 
-    cmap : matplotlib colormap, optional
-        The colormap for specified image. The ccolormap *must* be symmetrical.
-        Default=plt.cm.cold_hot.
+        Default=`plt.cm.cold_hot`.
 
     symmetric_cbar : boolean or 'auto', optional
         Specifies whether the colorbar should range from -vmax to vmax
@@ -1259,23 +923,10 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
         the range of the whole image is either positive or negative.
         Note: The colormap will always be set to range from -vmax to vmax.
         Default='auto'.
-
-    dim : float or 'auto', optional
-        Dimming factor applied to background image. By default, automatic
-        heuristics are applied based upon the background image intensity.
-        Accepted float values, where a typical scan is between -2 and 2
-        (-2 = increase constrast; 2 = decrease contrast), but larger values
-        can be used for a more pronounced effect. 0 means no dimming.
+    %(dim)s
         Default='auto'.
-
-    vmax : float, optional
-        Upper bound for plotting, passed to matplotlib.pyplot.imshow.
-
-    resampling_interpolation : str, optional
-        Interpolation to use when resampling the image to the destination
-        space. Can be "continuous" to use 3rd-order spline interpolation,
-        or "nearest" to use nearest-neighbor mapping.
-        "nearest" is faster but can be noisier in some cases.
+    %(vmax)s
+    %(resampling_interpolation)s
         Default='continuous'.
 
     Notes
@@ -1316,6 +967,7 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
     return display
 
 
+@fill_doc
 def plot_glass_brain(stat_map_img,
                      output_file=None, display_mode='ortho', colorbar=False,
                      figure=None, axes=None, title=None, threshold='auto',
@@ -1343,12 +995,7 @@ def plot_glass_brain(stat_map_img,
         See http://nilearn.github.io/manipulating_images/input_output.html
         The statistical map image. It needs to be in MNI space
         in order to align with the brain schematics.
-
-    output_file : string, or None, optional
-        The name of an image file to export the plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
-
+    %(output_file)s
     display_mode : string, optional
         Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
         'z' - axial, 'l' - sagittal left hemisphere only,
@@ -1356,52 +1003,22 @@ def plot_glass_brain(stat_map_img,
         performed in orthogonal directions. Possible values are: 'ortho',
         'x', 'y', 'z', 'xz', 'yx', 'yz', 'l', 'r', 'lr', 'lzr', 'lyr',
         'lzry', 'lyrz'. Default='ortho'.
-
-    colorbar : boolean, optional
-        If True, display a colorbar on the right of the plots.
+    %(colorbar)s
         Default=False.
-
-    figure : integer or matplotlib figure, optional
-        Matplotlib figure used or its number. If None is given, a
-        new figure is created.
-
-    axes : matplotlib axes or 4 tuple of float: (xmin, ymin, width, height), optional
-        The axes, or the coordinates, in matplotlib figure space,
-        of the axes used to display the plot. If None, the complete figure is used.
-
-    title : string, optional
-        The title displayed on the figure.
-
-    threshold : a number or 'auto', optional
-            If None is given, the image is not thresholded.
-            If a number is given, it is used to threshold the image:
-            values below the threshold (in absolute value) are plotted
-            as transparent. If auto is given, the threshold is determined
-            magically by analysis of the image.
-            Default='auto'.
-
-    annotate : boolean, optional
-        If annotate is True, positions and left/right annotation
-        are added to the plot. Default=True.
-
-    black_bg : boolean, optional
-        If True, the background of the image is set to be black. If
-        you wish to save figures with a black background, you
-        will need to pass "facecolor='k', edgecolor='k'"
-        to matplotlib.pyplot.savefig. Default=False.
-
-    cmap : matplotlib colormap, optional
-        The colormap for specified image
-
+    %(figure)s
+    %(axes)s
+    %(title)s
+    %(threshold)s
+        Default='auto'.
+    %(annotate)s
+    %(black_bg)s
+        Default=False.
+    %(cmap)s
+        Default=None.
     alpha : float between 0 and 1, optional
         Alpha transparency for the brain schematics. Default=0.7.
-
-    vmin : float, optional
-        Lower bound for plotting, passed to matplotlib.pyplot.imshow.
-
-    vmax : float, optional
-        Upper bound for plotting, passed to matplotlib.pyplot.imshow.
-
+    %(vmin)s
+    %(vmax)s
     plot_abs : boolean, optional
         If set to True (default) maximum intensity projection of the
         absolute value will be used (rendering positive and negative
@@ -1416,12 +1033,7 @@ def plot_glass_brain(stat_map_img,
         the range of the whole image is either positive or negative.
         Note: The colormap will always be set to range from -vmax to vmax.
         Default='auto'.
-
-    resampling_interpolation : str, optional
-        Interpolation to use when resampling the image to the destination
-        space. Can be "continuous" (default) to use 3rd-order spline
-        interpolation, or "nearest" to use nearest-neighbor mapping.
-        "nearest" is faster but can be noisier in some cases.
+    %(resampling_interpolation)s
         Default='continuous'.
 
     Notes
@@ -1468,6 +1080,7 @@ def plot_glass_brain(stat_map_img,
     return display
 
 
+@fill_doc
 def plot_connectome(adjacency_matrix, node_coords,
                     node_color='auto', node_size=50,
                     edge_cmap=cm.bwr,
@@ -1519,14 +1132,9 @@ def plot_connectome(adjacency_matrix, node_coords,
         If it is a number only the edges with a value greater than
         edge_threshold will be shown.
         If it is a string it must finish with a percent sign,
-        e.g. "25.3%", and only the edges with a abs(value) above
+        e.g. "25.3%%", and only the edges with a abs(value) above
         the given percentile will be shown.
-
-    output_file : string, or None, optional
-        The name of an image file to export the plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
-
+    %(output_file)s
     display_mode : string, optional
         Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
         'z' - axial, 'l' - sagittal left hemisphere only,
@@ -1534,28 +1142,12 @@ def plot_connectome(adjacency_matrix, node_coords,
         performed in orthogonal directions. Possible values are: 'ortho',
         'x', 'y', 'z', 'xz', 'yx', 'yz', 'l', 'r', 'lr', 'lzr', 'lyr',
         'lzry', 'lyrz'. Default='ortho'.
-
-    figure : integer or matplotlib figure, optional
-        Matplotlib figure used or its number.
-        If None is given, a new figure is created.
-
-    axes : matplotlib axes or 4 tuple of float: (xmin, ymin, width, height), optional
-        The axes, or the coordinates, in matplotlib figure space,
-        of the axes used to display the plot. If None, the complete figure is used.
-
-    title : string, optional
-        The title displayed on the figure.
-
-    annotate : boolean, optional
-        If annotate is True, positions and left/right annotation are
-        added to the plot. Default=True.
-
-    black_bg : boolean, optional
-        If True, the background of the image is set to be black. If
-        you wish to save figures with a black background, you
-        will need to pass "facecolor='k', edgecolor='k'"
-        to matplotlib.pyplot.savefig. Default=False.
-
+    %(figure)s
+    %(axes)s
+    %(title)s
+    %(annotate)s
+    %(black_bg)s
+        Default=False.
     alpha : float between 0 and 1, optional
         Alpha transparency for the brain schematics. Default=0.7.
 
@@ -1565,9 +1157,7 @@ def plot_connectome(adjacency_matrix, node_coords,
     node_kwargs : dict, optional
         Will be passed as kwargs to the plt.scatter call that plots all
         the nodes in one go.
-
-    colorbar : bool, optional
-        If True, display a colorbar on the right of the plots.
+    %(colorbar)s
         Default=False.
 
     See Also
@@ -1600,6 +1190,7 @@ def plot_connectome(adjacency_matrix, node_coords,
     return display
 
 
+@fill_doc
 def plot_connectome_strength(adjacency_matrix, node_coords, node_size="auto",
                              cmap=None, output_file=None, display_mode="ortho",
                              figure=None, axes=None, title=None):
@@ -1624,11 +1215,7 @@ def plot_connectome_strength(adjacency_matrix, node_coords, node_size="auto",
 
     cmap : str or colormap, optional
         Colormap used to represent the strength of a node.
-
-    output_file : string, or None, optional
-        The name of an image file to export the plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
+    %(output_file)s
 
     display_mode : string, optional
         Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
@@ -1637,19 +1224,9 @@ def plot_connectome_strength(adjacency_matrix, node_coords, node_size="auto",
         performed in orthogonal directions. Possible values are: 'ortho',
         'x', 'y', 'z', 'xz', 'yx', 'yz', 'l', 'r', 'lr', 'lzr', 'lyr',
         'lzry', 'lyrz'. Default='ortho'.
-
-    figure : integer or matplotlib figure, optional
-        Matplotlib figure used or its number. If None is given, a
-        new figure is created.
-
-    axes : matplotlib axes or 4 tuple of float: (xmin, ymin, width, height), \
-optional
-        The axes, or the coordinates, in matplotlib figure space,
-        of the axes used to display the plot. If None, the complete
-        figure is used.
-
-    title : string, optional
-        The title displayed on the figure.
+    %(figure)s
+    %(axes)s
+    %(title)s
 
     Notes
     -----
@@ -1751,6 +1328,7 @@ optional
     return display
 
 
+@fill_doc
 def plot_markers(node_values, node_coords, node_size='auto',
                  node_cmap=plt.cm.viridis_r, node_vmin=None, node_vmax=None,
                  node_threshold=None, alpha=0.7, output_file=None,
@@ -1792,11 +1370,7 @@ def plot_markers(node_values, node_coords, node_size='auto',
 
     alpha : float between 0 and 1, optional
         Alpha transparency for markers. Default=0.7.
-
-    output_file : string, or None, optional
-        The name of an image file to export the plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
+    %(output_file)s
 
     display_mode : string, optional
         Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
@@ -1805,35 +1379,16 @@ def plot_markers(node_values, node_coords, node_size='auto',
         performed in orthogonal directions. Possible values are: 'ortho',
         'x', 'y', 'z', 'xz', 'yx', 'yz', 'l', 'r', 'lr', 'lzr', 'lyr',
         'lzry', 'lyrz'. Default='ortho'.
-
-    figure : integer or matplotlib figure, optional
-        Matplotlib figure used or its number. If None is given, a
-        new figure is created.
-
-    axes : matplotlib axes or 4 tuple of float: (xmin, ymin, width, height), optional
-        The axes, or the coordinates, in matplotlib figure space,
-        of the axes used to display the plot. If None, the complete
-        figure is used.
-
-    title : string, optional
-        The title displayed on the figure.
-
-    annotate : boolean, optional
-        If annotate is True, positions and left/right annotation
-        are added to the plot. Default=True.
-
-    black_bg : boolean, optional
-        If True, the background of the image is set to be black. If
-        you wish to save figures with a black background, you
-        will need to pass "facecolor='k', edgecolor='k'"
-        to matplotlib.pyplot.savefig. Default=False.
-
+    %(figure)s
+    %(axes)s
+    %(title)s
+    %(annotate)s
+    %(black_bg)s
+        Default=False.
     node_kwargs : dict, optional
         will be passed as kwargs to the plt.scatter call that plots all
         the nodes in one go
-
-    colorbar : boolean, optional
-        If True, display a colorbar on the right of the plots.
+    %(colorbar)s
         Default=True.
 
     """
@@ -1905,6 +1460,7 @@ def plot_markers(node_values, node_coords, node_size='auto',
     return display
 
 
+@fill_doc
 def plot_carpet(img, mask_img=None, mask_labels=None,
                 detrend=True, output_file=None,
                 figure=None, axes=None, vmin=None, vmax=None, title=None,
@@ -1915,9 +1471,8 @@ def plot_carpet(img, mask_img=None, mask_labels=None,
 
     Parameters
     ----------
-    img : Niimg-like object
+    %(img)s
         4D image.
-        See http://nilearn.github.io/manipulating_images/input_output.html.
 
     mask_img : Niimg-like object or None, optional
         Limit plotted voxels to those inside the provided mask (default is
@@ -1934,37 +1489,17 @@ def plot_carpet(img, mask_img=None, mask_labels=None,
 
     detrend : :obj:`bool`, optional
         Detrend and z-score the data prior to plotting. Default=True.
+    %(output_file)s
+    %(figure)s
+    %(axes)s
+    %(vmin)s
+    %(vmax)s
+    %(title)s
+    %(cmap)s
+        .. note::
+            This argumeent is used only if an atlas is used.
 
-    output_file : :obj:`str` or None, optional
-        The name of an image file to which to export the plot (default is
-        None). Valid extensions are .png, .pdf, and .svg.
-        If `output_file` is not None, the plot is saved to a file, and the
-        display is closed.
-
-    figure : :class:`matplotlib.figure.Figure` or None, optional
-        Matplotlib figure used (default is None).
-        If None is given, a new figure is created.
-
-    axes : matplotlib axes or None, optional
-        The axes used to display the plot (default is None).
-        If None, the complete figure is used.
-
-    vmin : float or None, optional
-        Lower bound for plotting, passed to matplotlib.pyplot.imshow.
-        If None, vmin will be automatically determined based on the data.
-        Default=None.
-
-    vmax : float or None, optional
-        Upper bound for plotting, passed to matplotlib.pyplot.imshow.
-        If None, vmax will be automatically determined based on the data.
-        Default=None.
-
-    title : :obj:`str` or None, optional
-        The title displayed on the figure (default is None).
-
-    cmap : matplotlib colormap, optional
-        The colormap for the sidebar, if an atlas is used.
-        Default=plt.cm.gist_ncar.
+        Default=`plt.cm.gist_ncar`.
 
     Returns
     -------

--- a/nilearn/plotting/matrix_plotting.py
+++ b/nilearn/plotting/matrix_plotting.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 from matplotlib.tight_layout import get_renderer
 from matplotlib.colorbar import make_axes
+from .._utils import fill_doc
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", FutureWarning)
     from nilearn.glm.contrasts import expression_to_contrast_vector
@@ -36,6 +37,7 @@ def fit_axes(ax):
         ax.set_position(new_position)
 
 
+@fill_doc
 def plot_matrix(mat, title=None, labels=None, figure=None, axes=None,
                 colorbar=True, cmap=plt.cm.RdBu_r, tri='full',
                 auto_fit=True, grid=False, reorder=False, **kwargs):
@@ -45,10 +47,7 @@ def plot_matrix(mat, title=None, labels=None, figure=None, axes=None,
     ----------
     mat : 2-D numpy array
         Matrix to be plotted.
-
-    title : string or None, optional
-        A text to add in the upper left corner.
-
+    %(title)s
     labels : list, ndarray of strings, empty list, False, or None, optional
         The label of each row and column. Needs to be the same
         length as rows/columns of mat. If False, None, or an
@@ -63,13 +62,10 @@ def plot_matrix(mat, title=None, labels=None, figure=None, axes=None,
     axes : None or Axes, optional
         Axes instance to be plotted on. Creates a new one if None.
         Specifying both axes and figure is not allowed.
-
-    colorbar : boolean, optional
-        If True, an integrated colorbar is added. Default=True.
-
-    cmap : matplotlib colormap, optional
-        The colormap for the matrix. Default=plt.cm.RdBu_r.
-
+    %(colorbar)s
+        Default=True.
+    %(cmap)s
+        Default=`plt.cm.RdBu_r`.
     tri : {'full', 'lower', 'diag'}, optional
         Which triangular part of the matrix to plot:
         'lower' is the lower part, 'diag' is the lower including
@@ -239,6 +235,7 @@ def plot_matrix(mat, title=None, labels=None, figure=None, axes=None,
     return display
 
 
+@fill_doc
 def plot_contrast_matrix(contrast_def, design_matrix, colorbar=False, ax=None,
                          output_file=None):
     """Creates plot for contrast definition.
@@ -259,17 +256,11 @@ def plot_contrast_matrix(contrast_def, design_matrix, colorbar=False, ax=None,
 
     design_matrix : pandas DataFrame
         Design matrix to use.
-
-    colorbar : Boolean, optional
-        Include a colorbar in the contrast matrix plot. Default=False.
-
+    %(colorbar)s
+        Default=False.
     ax : matplotlib Axes object, optional
         Axis on which to plot the figure. If None, a new figure will be created.
-
-    output_file : string or None, optional
-        The name of an image file to export the plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
+    %(output_file)s
 
     Returns
     -------
@@ -313,6 +304,7 @@ def plot_contrast_matrix(contrast_def, design_matrix, colorbar=False, ax=None,
     return ax
 
 
+@fill_doc
 def plot_design_matrix(design_matrix, rescale=True, ax=None, output_file=None):
     """Plot a design matrix provided as a DataFrame
 
@@ -327,11 +319,7 @@ def plot_design_matrix(design_matrix, rescale=True, ax=None, output_file=None):
 
     ax : axis handle, optional
         Handle to axis onto which we will draw design matrix.
-
-    output_file : string or None, optional
-        The name of an image file to export the plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
+    %(output_file)s
 
     Returns
     -------
@@ -372,6 +360,7 @@ def plot_design_matrix(design_matrix, rescale=True, ax=None, output_file=None):
     return ax
 
 
+@fill_doc
 def plot_event(model_event, cmap=None, output_file=None, **fig_kwargs):
     """Creates plot for event visualization.
 
@@ -382,15 +371,8 @@ def plot_event(model_event, cmap=None, output_file=None, **fig_kwargs):
         ``event_type`` with event name, ``onset`` and ``duration``.
         The `pandas.DataFrame` can also be obtained from
         :func:`nilearn.glm.first_level.first_level_from_bids`.
-
-    cmap : str or matplotlib.cmap, optional
-        The colormap used to label different events.
-
-    output_file : string or None, optional
-        The name of an image file to export the plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
-
+    %(cmap)s
+    %(output_file)s
     **fig_kwargs : extra keyword arguments, optional
         Extra arguments passed to matplotlib.pyplot.subplots.
 

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -19,7 +19,7 @@ from nilearn.surface import (load_surf_data,
                              load_surf_mesh,
                              vol_to_surf)
 from nilearn.surface.surface import _check_mesh
-from nilearn._utils import check_niimg_3d
+from nilearn._utils import check_niimg_3d, fill_doc
 
 from matplotlib.colors import to_rgba
 from matplotlib.patches import Patch
@@ -29,6 +29,7 @@ VALID_VIEWS = "anterior", "posterior", "medial", "lateral", "dorsal", "ventral"
 VALID_HEMISPHERES = "left", "right"
 
 
+@fill_doc
 def plot_surf(surf_mesh, surf_map=None, bg_map=None,
               hemi='left', view='lateral', cmap=None, colorbar=False,
               avg_method='mean', threshold=None, alpha='auto',
@@ -60,34 +61,13 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
         Background image to be plotted on the mesh underneath the
         surf_data in greyscale, most likely a sulcal depth map for
         realistic shading.
-
-    hemi : {'left', 'right'}, optional
-        Hemisphere to display. Default='left'.
-
-    view : {'lateral', 'medial', 'dorsal', 'ventral', 'anterior', 'posterior'}, optional
-        View of the surface that is rendered. Default='lateral'.
-
-    cmap : matplotlib colormap, str or colormap object, optional
-        To use for plotting of the stat_map. Either a string
-        which is a name of a matplotlib colormap, or a matplotlib
-        colormap object. If None, matplotlib default will be chosen.
-
-    colorbar : bool, optional
-        If True, a colorbar of surf_map is displayed. Default=False.
-
-    avg_method : {'mean', 'median', 'min', 'max', custom function}, optional
-        How to average vertex values to derive the face value,
-        mean results in smooth, median in sharp boundaries,
-        min or max for sparse matrices.
-        You can also pass a custom function which will be
-        executed though `numpy.apply_along_axis`.
-        Here is an example of a custom function:
-
-        .. code-block:: python
-
-            def custom_function(vertices):
-                return vertices[0] * vertices[1] * vertices[2]
-
+    %(hemi)s
+    %(view)s
+    %(cmap)s
+        If None, matplotlib default will be chosen.
+    %(colorbar)s
+        Default=False.
+    %(avg_method)s
         Default='mean'.
 
     threshold : a number or None, default is None.
@@ -100,26 +80,12 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
         If 'auto' is chosen, alpha will default to .5 when no bg_map
         is passed and to 1 if a bg_map is passed.
         Default='auto'.
-
-    bg_on_data : bool, optional
-        If True, and a bg_map is specified, the surf_data data is multiplied
-        by the background image, so that e.g. sulcal depth is visible beneath
-        the surf_data.
-        NOTE: that this non-uniformly changes the surf_data values according
-        to e.g the sulcal depth.
+    %(bg_on_data)s
         Default=False.
-
-    darkness : float between 0 and 1, optional
-        Specifying the darkness of the background image.
-        1 indicates that the original values of the background are used.
-        .5 indicates the background values are reduced by half before being
-        applied. Default=1.
-
-    vmin, vmax : float, float, optional
-        Lower / upper bound to plot surf_data values.
-        If None, the values will be set to min/max of the data.
-        Default values are None.
-
+    %(darkness)s
+        Default=1.
+    %(vmin)s
+    %(vmax)s
     cbar_vmin, cbar_vmax : float, float, optional
         Lower / upper bounds for the colorbar.
         If None, the values will be set from the data.
@@ -127,25 +93,16 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
 
     cbar_tick_format : str, optional
         Controls how to format the tick labels of the colorbar.
-        Ex: use "%i" to display as integers.
-        Default='%.2g' for scientific notation.
-
-    title : str, optional
-        Figure title.
-
-    output_file : str, or None, optional
-        The name of an image file to export plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
-
+        Ex: use "%%i" to display as integers.
+        Default='%%.2g' for scientific notation.
+    %(title)s
+    %(output_file)s
     axes : instance of matplotlib axes, None, optional
         The axes instance to plot to. The projection must be '3d' (e.g.,
         `figure, axes = plt.subplots(subplot_kw={'projection': '3d'})`,
         where axes should be passed.).
         If None, a new axes is created.
-
-    figure : instance of matplotlib figure, None, optional
-        The figure instance to plot to. If None, a new figure is created.
+    %(figure)s
 
     See Also
     --------
@@ -422,6 +379,7 @@ def _get_faces_on_edge(faces, parc_idx):
     return np.logical_and(faces_outside_edge > 0, verts_per_face < 3)
 
 
+@fill_doc
 def plot_surf_contours(surf_mesh, roi_map, axes=None, figure=None, levels=None,
                        labels=None, colors=None, legend=False, cmap='tab20',
                        title=None, output_file=None, **kwargs):
@@ -450,11 +408,7 @@ def plot_surf_contours(surf_mesh, roi_map, axes=None, figure=None, levels=None,
         `figure, axes = plt.subplots(subplot_kw={'projection': '3d'})`,
         where axes should be passed.).
         If None, uses axes from figure if available, else creates new axes.
-
-    figure : instance of matplotlib figure, None, optional
-        The figure instance to plot to.
-        If None, uses figure of axes if available, else creates a new figure.
-
+    %(figure)s
     levels : list of integers, or None, optional
         A list of indices of the regions that are to be outlined.
         Every index needs to correspond to one index in roi_map.
@@ -470,19 +424,10 @@ def plot_surf_contours(surf_mesh, roi_map, axes=None, figure=None, levels=None,
 
     legend : boolean,  optional
         Whether to plot a legend of region's labels. Default=False.
-
-    cmap : matplotlib colormap, str or colormap object, optional
-        To use for plotting of the contours. Either a string
-        which is a name of a matplotlib colormap, or a matplotlib
-        colormap object. Default='tab20'.
-
-    title : str, optional
-        Figure title.
-
-    output_file : str, or None, optional
-        The name of an image file to export plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
+    %(cmap)s
+        Default='tab20'.
+    %(title)s
+    %(output_file)s
 
     See Also
     --------
@@ -558,6 +503,7 @@ def plot_surf_contours(surf_mesh, roi_map, axes=None, figure=None, levels=None,
         return figure
 
 
+@fill_doc
 def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
                        hemi='left', view='lateral', threshold=None,
                        alpha='auto', vmax=None, cmap='cold_hot',
@@ -590,26 +536,19 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
         Background image to be plotted on the mesh underneath the
         stat_map in greyscale, most likely a sulcal depth map for
         realistic shading.
-
-    hemi : {'left', 'right'}, optional
-        Hemispere to display. Default='left'.
-
-    view : {'lateral', 'medial', 'dorsal', 'ventral', 'anterior', 'posterior'}, optional
-        View of the surface that is rendered. Default='lateral'.
-
+    %(hemi)s
+    %(view)s
     threshold : a number or None, optional
         If None is given, the image is not thresholded.
         If a number is given, it is used to threshold the image,
         values below the threshold (in absolute value) are plotted
         as transparent.
+    %(cmap)s
+    %(colorbar)s
 
-    cmap : matplotlib colormap in str or colormap object, optional
-        To use for plotting of the stat_map. Either a string
-        which is a name of a matplotlib colormap, or a matplotlib
-        colormap object. Default='cold_hot'.
+        .. note::
+            This function uses a symmetric colorbar for the statistical map.
 
-    colorbar : bool, optional
-        If True, a symmetric colorbar of the statistical map is displayed.
         Default=True.
 
     alpha : float or 'auto', optional
@@ -617,47 +556,21 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
         If 'auto' is chosen, alpha will default to .5 when no bg_map is
         passed and to 1 if a bg_map is passed.
         Default='auto'.
-
-    vmax : float, optional
-        Upper bound for plotting of stat_map values.
-
-    symmetric_cbar : bool or 'auto', optional
-        Specifies whether the colorbar should range from -vmax to vmax
-        or from vmin to vmax. Setting to 'auto' will select the latter
-        if the range of the whole image is either positive or negative.
-        Note: The colormap will always range from -vmax to vmax.
+    %(vmax)s
+    %(symmetric_cbar)s
         Default='auto'.
-
-    bg_on_data : bool, optional
-        If True, and a bg_map is specified, the stat_map data is multiplied
-        by the background image, so that e.g. sulcal depth is visible beneath
-        the stat_map.
-        NOTE: that this non-uniformly changes the stat_map values according
-        to e.g the sulcal depth.
+    %(bg_on_data)s
         Default=False.
-
-    darkness : float between 0 and 1, optional
-        Specifying the darkness of the background image. 1 indicates that the
-        original values of the background are used. .5 indicates the
-        background values are reduced by half before being applied.
+    %(darkness)s
         Default=1.
-
-    title : str, optional
-        Figure title.
-
-    output_file : str, optional
-        The name of an image file to export plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
-
+    %(title)s
+    %(output_file)s
     axes : instance of matplotlib axes, None, optional
         The axes instance to plot to. The projection must be '3d' (e.g.,
         `figure, axes = plt.subplots(subplot_kw={'projection': '3d'})`,
         where axes should be passed.).
         If None, a new axes is created.
-
-    figure : instance of matplotlib figure, None, optional
-        The figure instance to plot to. If None, a new figure is created.
+    %(figure)s
 
     See Also
     --------
@@ -766,6 +679,7 @@ def _colorbar_from_array(array, vmax, threshold, kwargs,
     return sm
 
 
+@fill_doc
 def plot_img_on_surf(stat_map, surf_mesh='fsaverage5', mask_img=None,
                      hemispheres=['left', 'right'],
                      inflate=False,
@@ -811,35 +725,18 @@ def plot_img_on_surf(stat_map, surf_mesh='fsaverage5', mask_img=None,
         display mode. Order is preserved, and left and right hemispheres
         are shown on the left and right sides of the figure.
         Default=['lateral', 'medial'].
+    %(hemispheres)s
+    %(output_file)s
+    %(title)s
+    %(colorbar)s
+        .. note::
+            This function uses a symmetric colorbar for the statistical map.
 
-    hemispheres : list of strings, optional
-        Hemispheres to display. Default=['left', 'right'].
-
-    output_file : str, optional
-        The name of an image file to export plot to. Valid extensions
-        are: *.png*, *.pdf*, *.svg*. If output_file is not None,
-        the plot is saved to a file, and the display is closed. Return
-        value is None.
-
-    title : str, optional
-        Place a title on the upper center of the figure.
-
-    colorbar : bool, optional
-        If *True*, a symmetric colorbar of the statistical map is displayed.
         Default=True.
-
-    vmax : float, optional
-        Upper bound for plotting of stat_map values.
-
-    threshold : float, optional
-        If None is given, the image is not thresholded.
-        If a number is given, it is used to threshold the image,
-        values below the threshold (in absolute value) are plotted
-        as transparent.
-
-    cmap : str, optional
-        The name of a matplotlib or nilearn colormap. Default='cold_hot'.
-
+    %(vmax)s
+    %(threshold)s
+    %(cmap)s
+        Default='cold_hot'.
     kwargs : dict, optional
         keyword arguments passed to plot_surf_stat_map.
 
@@ -925,6 +822,7 @@ def plot_img_on_surf(stat_map, surf_mesh='fsaverage5', mask_img=None,
         return fig, axes
 
 
+@fill_doc
 def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
                   hemi='left', view='lateral', threshold=1e-14,
                   alpha='auto', vmin=None, vmax=None, cmap='gist_ncar',
@@ -952,67 +850,39 @@ def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
         a Numpy array with a value for each vertex of the surf_mesh.
         The value at each vertex one inside the ROI and zero inside ROI, or an
         integer giving the label number for atlases.
-
-    hemi : {'left', 'right'}, optional
-        Hemisphere to display. Default='left'.
-
+    %(hemi)s
     bg_map : Surface data object (to be defined), optional
         Background image to be plotted on the mesh underneath the
         stat_map in greyscale, most likely a sulcal depth map for
         realistic shading.
-
-    view : {'lateral', 'medial', 'dorsal', 'ventral', 'anterior', 'posterior'}, optional
-        View of the surface that is rendered. Default='lateral'.
-
+    %(view)s
     threshold : a number or None, optional
         Threshold regions that are labelled 0.
         If you want to use 0 as a label, set threshold to None.
         Default=1e-14.
-
-    cmap : matplotlib colormap str or colormap object, optional
-        To use for plotting of the rois. Either a string which is a name
-        of a matplotlib colormap, or a matplotlib colormap object.
+    %(cmap)s
         Default='gist_ncar'.
-
     cbar_tick_format : str, optional
         Controls how to format the tick labels of the colorbar.
-        Ex: use "%.2g" to display using scientific notation.
-        Default='%i' for integers.
+        Ex: use "%%.2g" to display using scientific notation.
+        Default='%%i' for integers.
 
     alpha : float or 'auto', optional
         Alpha level of the mesh (not the stat_map). If default,
         alpha will default to .5 when no bg_map is passed
         and to 1 if a bg_map is passed.
         Default='auto'.
-
-    bg_on_data : bool, optional
-        If True, and a bg_map is specified, the stat_map data is multiplied
-        by the background image, so that e.g. sulcal depth is visible beneath
-        the stat_map. Beware that this non-uniformly changes the stat_map
-        values according to e.g the sulcal depth.
+    %(bg_on_data)s
         Default=False.
-
-    darkness : float between 0 and 1, optional
-        Specifying the darkness of the background image. 1 indicates that the
-        original values of the background are used. .5 indicates the background
-        values are reduced by half before being applied.
+    %(darkness)s
         Default=1.
-
-    title : str, optional
-        Figure title.
-
-    output_file : str, or None, optional
-        The name of an image file to export plot to. Valid extensions
-        are .png, .pdf, .svg. If output_file is not None, the plot
-        is saved to a file, and the display is closed.
-
+    %(title)s
+    %(output_file)s
     axes : Axes instance or None, optional
         The axes instance to plot to. The projection must be '3d' (e.g.,
         `plt.subplots(subplot_kw={'projection': '3d'})`).
         If None, a new axes is created.
-
-    figure : Figure instance or None, optional
-        The figure to plot to. If None, a new figure is created.
+    %(figure)s
 
     See Also
     --------

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -90,10 +90,7 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
         Lower / upper bounds for the colorbar.
         If None, the values will be set from the data.
         Default values are None.
-
-    cbar_tick_format : str, optional
-        Controls how to format the tick labels of the colorbar.
-        Ex: use "%%i" to display as integers.
+    %(cbar_tick_format)s
         Default='%%.2g' for scientific notation.
     %(title)s
     %(output_file)s
@@ -729,6 +726,7 @@ def plot_img_on_surf(stat_map, surf_mesh='fsaverage5', mask_img=None,
     %(output_file)s
     %(title)s
     %(colorbar)s
+
         .. note::
             This function uses a symmetric colorbar for the statistical map.
 
@@ -862,11 +860,8 @@ def plot_surf_roi(surf_mesh, roi_map, bg_map=None,
         Default=1e-14.
     %(cmap)s
         Default='gist_ncar'.
-    cbar_tick_format : str, optional
-        Controls how to format the tick labels of the colorbar.
-        Ex: use "%%.2g" to display using scientific notation.
+    %(cbar_tick_format)s
         Default='%%i' for integers.
-
     alpha : float or 'auto', optional
         Alpha level of the mesh (not the stat_map). If default,
         alpha will default to .5 when no bg_map is passed


### PR DESCRIPTION
This PR proposes to extend recent work from #2875 to the `plotting` module where a lot of arguments are common to multiple functions. It also improves already standardized docstrings (add object references for example).