### PR TITLE
Add bin_img to binarize images

### DIFF
--- a/doc/modules/reference.rst
+++ b/doc/modules/reference.rst
@@ -179,6 +179,7 @@ the :ref:`user guide <user_guide>` for more information and usage examples.
    :toctree: generated/
    :template: function.rst
 
+   binarize_img
    clean_img
    concat_imgs
    coord_transform

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -14,6 +14,8 @@ NEW
   MNI152 template.
 - :func:`nilearn.datasets.load_mni152_wm_mask` loads mask from the white-matter
   MNI152 template.
+- :func:`nilearn.image.binarize_img` binarizes images into 0 and 1.
+
 
 Fixes
 -----

--- a/nilearn/image/__init__.py
+++ b/nilearn/image/__init__.py
@@ -6,6 +6,7 @@ from .resampling import resample_img, resample_to_img, reorder_img, \
     coord_transform
 from .image import high_variance_confounds, smooth_img, crop_img, \
     mean_img, swap_img_hemispheres, index_img, iter_img, threshold_img, \
+    binarize_img, \
     math_img, load_img, clean_img, largest_connected_component_img, get_data
 from .image import new_img_like  # imported this way to avoid circular imports
 from .._utils.niimg_conversions import concat_niimgs as concat_imgs
@@ -15,5 +16,5 @@ __all__ = ['resample_img', 'resample_to_img', 'high_variance_confounds',
            'smooth_img', 'crop_img', 'mean_img', 'reorder_img',
            'swap_img_hemispheres', 'concat_imgs', 'copy_img',
            'index_img', 'iter_img', 'new_img_like', 'threshold_img',
-           'math_img', 'load_img', 'clean_img', 'get_data',
+           'math_img', 'binarize_img', 'load_img', 'clean_img', 'get_data',
            'largest_connected_component_img', 'coord_transform']

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -932,6 +932,59 @@ def math_img(formula, **imgs):
     return new_img_like(niimg, result, niimg.affine)
 
 
+def binarize_img(img, threshold=0, mask_img=None):
+    """Binarize an image such that its values are either 0 or 1.
+
+    .. versionadded:: 0.8.1
+
+    Parameters
+    ----------
+    img : a 3D/4D Niimg-like object
+        Image which should be binarized.
+
+    threshold : :obj:`float` or :obj:`str`
+        If float, we threshold the image based on image intensities meaning
+        voxels which have intensities greater than this value will be kept.
+        The given value should be within the range of minimum and
+        maximum intensity of the input image.
+        If string, it should finish with percent sign e.g. "80%" and we
+        threshold based on the score obtained using this percentile on
+        the image data. The voxels which have intensities greater than
+        this score will be kept. The given string should be
+        within the range of "0%" to "100%".
+
+    mask_img : Niimg-like object, default None, optional
+        Mask image applied to mask the input data.
+        If None, no masking will be applied.
+
+    Returns
+    -------
+    :class:`~nibabel.nifti1.Nifti1Image`
+        Binarized version of the given input image. Output dtype is int.
+
+    See Also
+    --------
+    nilearn.image.threshold_img : To simply threshold but not binarize images.
+
+    Examples
+    --------
+    Let's load an image using nilearn datasets module::
+
+     >>> from nilearn import datasets
+     >>> anatomical_image = datasets.load_mni152_template()
+
+    Now we binarize it, generating a pseudo brainmask::
+
+     >>> from nilearn.image import binarize_img
+     >>> img = binarize_img(anatomical_image)
+
+    """
+    return math_img(
+        "img.astype(bool).astype(int)",
+        img=threshold_img(img, threshold, mask_img=mask_img)
+    )
+
+
 def clean_img(imgs, sessions=None, detrend=True, standardize=True,
               confounds=None, low_pass=None, high_pass=None, t_r=None,
               ensure_finite=False, mask_img=None):

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -23,6 +23,7 @@ from nilearn.image import new_img_like
 from nilearn.image import threshold_img
 from nilearn.image import iter_img, index_img
 from nilearn.image import math_img
+from nilearn.image import binarize_img
 from nilearn.image import largest_connected_component_img
 from nilearn.image import get_data
 
@@ -606,6 +607,23 @@ def test_math_img():
                                get_data(expected_result))
             assert_array_equal(result.affine, expected_result.affine)
             assert result.shape == expected_result.shape
+
+
+def test_binarize_img():
+    img = Nifti1Image(np.random.rand(10, 10, 10, 10), np.eye(4))
+    # Test that all output values are 1.
+    img1 = binarize_img(img)
+    np.testing.assert_array_equal(np.unique(img1.dataobj),
+                                  np.array([1]))
+    # Test that it works with threshold
+    img2 = binarize_img(img, threshold=0.5)
+    np.testing.assert_array_equal(np.unique(img2.dataobj),
+                                  np.array([0, 1]))
+    # Test that manual binarization equals binarize_img results.
+    img3 = Nifti1Image(np.random.rand(10, 10, 10, 10), np.eye(4))
+    img3.dataobj[img.dataobj < 0.5] = 0
+    img3.dataobj[img.dataobj >= 0.5] = 1
+    np.testing.assert_array_equal(img2.dataobj, img3.dataobj)
 
 
 def test_clean_img():


### PR DESCRIPTION
If there is interest, this PR adds a function to the image package to binarize images. I see myself using it all the time, and thought I'd share it.
It is based off of threshold img and math img to reduce burden on maintainers. As long as those two functions work properly, bin img should as well.