### PR TITLE
[FIX] Fix binder links

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -331,7 +331,7 @@ sphinx_gallery_conf = {
         'org': 'nilearn',
         'repo': 'nilearn.github.io',
         'binderhub_url': 'https://mybinder.org',
-        'branch': 'main',
+        'branch': 'master',
         'dependencies': ['../requirements-build-docs.txt',
                          'binder/requirements.txt'],
         'notebooks_dir': 'examples'


### PR DESCRIPTION
Binder links seem to be broken due to the recent branch name change from "master" to "main" (see #2861 ).
See also #2898 