### PR TITLE
[INFRA] Add plotly and kaleido to dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,9 @@ The required dependencies to use the software are:
 If you are using nilearn plotting functionalities or running the
 examples, matplotlib >= 1.5.1 is required.
 
+Some plotting functions in Nilearn support both matplotlib and plotly as plotting engines.
+In order to use the plotly engine in these functions, you will need to install both plotly and kaleido, which can both be installed with pip and anaconda. 
+
 If you want to run the tests, you need pytest >= 3.9 and pytest-cov for coverage reporting.
 
 

--- a/build_tools/circle/dependencies.sh
+++ b/build_tools/circle/dependencies.sh
@@ -4,7 +4,8 @@ conda init bash
 echo "conda version = $(conda --version)"
 conda create -n testenv
 conda install -n testenv -yq python=3.8 numpy scipy scikit-learn matplotlib pandas lxml mkl sphinx==3.5.4 numpydoc pillow pandas
-conda install -n testenv -yq nibabel sphinx-gallery sphinxcontrib-bibtex sphinx-copybutton junit-xml -c conda-forge
+conda install -n testenv -yq nibabel python-kaleido sphinx-gallery sphinxcontrib-bibtex sphinx-copybutton junit-xml -c conda-forge
+conda install -c plotly plotly
 source activate testenv
 python -m pip install --user --upgrade --progress-bar off pip setuptools
 python -m pip install .

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -21,6 +21,8 @@ conda update --yes conda
 conda init bash
 conda create -n testenv -yq
 conda install -n testenv -yq python=3.8 numpy scipy scikit-learn matplotlib pandas pytest pytest-xdist joblib nibabel cython requests
+conda install -c conda-forge python-kaleido
+conda install -c plotly plotly
 source activate testenv
 python -m pip install --user --upgrade --progress-bar off pip setuptools
 python -m pip install .

--- a/requirements-build-docs.txt
+++ b/requirements-build-docs.txt
@@ -16,3 +16,5 @@ nibabel
 scikit-learn
 joblib
 matplotlib
+plotly
+kaleido

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,8 @@ scikit-learn
 joblib
 pandas
 matplotlib
+plotly
+kaleido
 nibabel
 numpy
 cython


### PR DESCRIPTION
This PR adds both plotly and kaleido to the optional dependencies.

See also #2902 