### PR TITLE
[ENH] Add more options for `mask_strategy`

### DIFF
--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -165,7 +165,7 @@ The `mask_strategy` argument controls how the mask is computed:
 
 * `background`: detects a continuous background
 * `epi`: suitable for EPI images
-* `wb-template`: uses an MNI whole-brain template
+* `whole-brain-template`: uses an MNI whole-brain template
 * `gm-template`: uses an MNI grey-matter template
 * `wm-template`: uses an MNI white-matter template
 

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -165,7 +165,9 @@ The `mask_strategy` argument controls how the mask is computed:
 
 * `background`: detects a continuous background
 * `epi`: suitable for EPI images
-* `template`: uses an MNI grey-matter template
+* `wb-template`: uses an MNI whole-brain template
+* `gm-template`: uses an MNI grey-matter template
+* `wm-template`: uses an MNI white-matter template
 
 Extra mask parameters: opening, cutoff...
 ..........................................

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -17,7 +17,7 @@ NEW
 - :func:`nilearn.image.binarize_img` binarizes images into 0 and 1.
 - :class:`nilearn.input_data.NiftiMasker`,
   :class:`nilearn.input_data.MultiNiftiMasker`, and objects relying on such maskers
-  (:class:`nilearn.decoding.Decoder` or :class:`nilearn.decomposition.MultiPCA`
+  (:class:`nilearn.decoding.Decoder` or :class:`nilearn.decomposition.CanICA`
   for example) can now use new options for the argument `mask_strategy`:
   `wb-template` for whole-brain template (same as previous option `template`),
   `gm-template` for grey-matter template, and `wm-template` for white-matter

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,9 +19,9 @@ NEW
   :class:`nilearn.input_data.MultiNiftiMasker`, and objects relying on such maskers
   (:class:`nilearn.decoding.Decoder` or :class:`nilearn.decomposition.CanICA`
   for example) can now use new options for the argument `mask_strategy`:
-  `wb-template` for whole-brain template (same as previous option `template`),
-  `gm-template` for grey-matter template, and `wm-template` for white-matter
-  template.
+  `whole-brain-template` for whole-brain template (same as previous option
+  `template`), `gm-template` for grey-matter template, and `wm-template`
+  for white-matter template.
 
 Fixes
 -----

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,7 +15,13 @@ NEW
 - :func:`nilearn.datasets.load_mni152_wm_mask` loads mask from the white-matter
   MNI152 template.
 - :func:`nilearn.image.binarize_img` binarizes images into 0 and 1.
-
+- :class:`nilearn.input_data.NiftiMasker`,
+  :class:`nilearn.input_data.MultiNiftiMasker`, and objects relying on such maskers
+  (:class:`nilearn.decoding.Decoder` or :class:`nilearn.decomposition.MultiPCA`
+  for example) can now use new options for the argument `mask_strategy`:
+  `wb-template` for whole-brain template (same as previous option `template`),
+  `gm-template` for grey-matter template, and `wm-template` for white-matter
+  template.
 
 Fixes
 -----

--- a/examples/03_connectivity/plot_compare_decomposition.py
+++ b/examples/03_connectivity/plot_compare_decomposition.py
@@ -39,7 +39,7 @@ print('First functional nifti image (4D) is at: %s' %
 ####################################################################
 # Apply CanICA on the data
 # ---------------------------------
-# We use as "template" as a strategy to compute the mask, as this leads
+# We use "wb-template" as a strategy to compute the mask, as this leads
 # to slightly faster and more reproducible results. However, the images
 # need to be in :term:`MNI` template space.
 
@@ -48,7 +48,7 @@ from nilearn.decomposition import CanICA
 canica = CanICA(n_components=20,
                 memory="nilearn_cache", memory_level=2,
                 verbose=10,
-                mask_strategy='template',
+                mask_strategy='wb-template',
                 random_state=0)
 canica.fit(func_filenames)
 
@@ -101,7 +101,7 @@ dict_learning = DictLearning(n_components=20,
                              verbose=1,
                              random_state=0,
                              n_epochs=1,
-                             mask_strategy='template')
+                             mask_strategy='wb-template')
 
 print('[Example] Fitting dicitonary learning model')
 dict_learning.fit(func_filenames)

--- a/examples/03_connectivity/plot_compare_decomposition.py
+++ b/examples/03_connectivity/plot_compare_decomposition.py
@@ -39,16 +39,16 @@ print('First functional nifti image (4D) is at: %s' %
 ####################################################################
 # Apply CanICA on the data
 # ---------------------------------
-# We use "wb-template" as a strategy to compute the mask, as this leads
-# to slightly faster and more reproducible results. However, the images
-# need to be in :term:`MNI` template space.
+# We use "whole-brain-template" as a strategy to compute the mask,
+# as this leads to slightly faster and more reproducible results.
+# However, the images need to be in :term:`MNI` template space.
 
 from nilearn.decomposition import CanICA
 
 canica = CanICA(n_components=20,
                 memory="nilearn_cache", memory_level=2,
                 verbose=10,
-                mask_strategy='wb-template',
+                mask_strategy='whole-brain-template',
                 random_state=0)
 canica.fit(func_filenames)
 
@@ -101,7 +101,7 @@ dict_learning = DictLearning(n_components=20,
                              verbose=1,
                              random_state=0,
                              n_epochs=1,
-                             mask_strategy='wb-template')
+                             mask_strategy='whole-brain-template')
 
 print('[Example] Fitting dicitonary learning model')
 dict_learning.fit(func_filenames)

--- a/examples/06_manipulating_images/plot_mask_computation.py
+++ b/examples/06_manipulating_images/plot_mask_computation.py
@@ -120,10 +120,12 @@ report
 # Computing the mask from the MNI template
 ###############################################################################
 #
-# A mask can also be computed from the MNI gray matter template. In this
-# case, it is resampled to the target image
+# A mask can also be computed from the MNI template. In this case, it is
+# resampled to the target image. Three options are available: 'wb-template',
+# 'gm-template', and 'wm-template' depending on whether the whole-brain, gray
+# matter, or white matter template should be used.
 
-masker = NiftiMasker(mask_strategy='template')
+masker = NiftiMasker(mask_strategy='wb-template')
 masker.fit(epi_img)
 report = masker.generate_report()
 report

--- a/examples/06_manipulating_images/plot_mask_computation.py
+++ b/examples/06_manipulating_images/plot_mask_computation.py
@@ -121,11 +121,11 @@ report
 ###############################################################################
 #
 # A mask can also be computed from the MNI template. In this case, it is
-# resampled to the target image. Three options are available: 'wb-template',
-# 'gm-template', and 'wm-template' depending on whether the whole-brain, gray
-# matter, or white matter template should be used.
+# resampled to the target image. Three options are available:
+# 'whole-brain-template', 'gm-template', and 'wm-template' depending on whether
+# the whole-brain, gray matter, or white matter template should be used.
 
-masker = NiftiMasker(mask_strategy='wb-template')
+masker = NiftiMasker(mask_strategy='whole-brain-template')
 masker.fit(epi_img)
 report = masker.generate_report()
 report

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -496,6 +496,37 @@ docdict['regressor_options'] = """
 
 """ % SKLEARN_LINKS
 
+# mask_strategy
+docdict["mask_strategy"] = """
+mask_strategy : {'background', 'epi', 'wb-template', 'gm-template',\
+'wm-template'}, optional
+    The strategy used to compute the mask:
+
+        - 'background': Use this option if your images present
+          a clear homogeneous background.
+        - 'epi': Use this option if your images are raw EPI images
+        - 'wb-template': This will extract the whole-brain part of your
+          data by resampling the MNI152 brain mask for your data's field
+          of view.
+
+            .. note::
+                This option is equivalent to the previous 'template' option
+                which is now deprecated.
+
+        - 'gm-template': This will extract the gray matter part of your
+          data by resampling the corresponding MNI152 template for your
+          data's field of view.
+
+            .. versionadded:: 0.8.1
+
+        - 'wm-template': This will extract the white matter part of your
+          data by resampling the corresponding MNI152 template for your
+          data's field of view.
+
+            .. versionadded:: 0.8.1
+
+"""
+
 docdict_indented = {}
 
 

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -498,16 +498,16 @@ docdict['regressor_options'] = """
 
 # mask_strategy
 docdict["mask_strategy"] = """
-mask_strategy : {'background', 'epi', 'wb-template', 'gm-template',\
-'wm-template'}, optional
+mask_strategy : {'background', 'epi', 'whole-brain-template',\
+'gm-template', 'wm-template'}, optional
     The strategy used to compute the mask:
 
         - 'background': Use this option if your images present
           a clear homogeneous background.
         - 'epi': Use this option if your images are raw EPI images
-        - 'wb-template': This will extract the whole-brain part of your
-          data by resampling the MNI152 brain mask for your data's field
-          of view.
+        - 'whole-brain-template': This will extract the whole-brain
+          part of your data by resampling the MNI152 brain mask for
+          your data's field of view.
 
             .. note::
                 This option is equivalent to the previous 'template' option

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -298,16 +298,18 @@ class _BaseDecoder(LinearRegression, CacheMixin):
     %(low_pass)s
     %(high_pass)s
     %(t_r)s
-    mask_strategy: {'background' or 'epi'}, optional. Default: 'background'
-        The strategy used to compute the mask: use 'background' if your
-        images present a clear homogeneous background, and 'epi' if they
-        are raw EPI images. Depending on this value, the mask will be
-        computed from masking.compute_background_mask or
-        masking.compute_epi_mask.
+    %(mask_strategy)s
 
         .. note::
             This parameter will be ignored if a mask image is provided.
 
+        .. note::
+            Depending on this value, the mask will be computed from
+            :func:`nilearn.masking.compute_background_mask`,
+            :func:`nilearn.masking.compute_epi_mask`, or
+            :func:`nilearn.masking.compute_brain_mask`.
+
+        Default is 'background'.
     %(memory)s
     %(memory_level)s
     %(n_jobs)s
@@ -837,16 +839,18 @@ class Decoder(_BaseDecoder):
     %(low_pass)s
     %(high_pass)s
     %(t_r)s
-    mask_strategy: {'background' or 'epi'}, optional. Default: 'background'
-        The strategy used to compute the mask: use 'background' if your
-        images present a clear homogeneous background, and 'epi' if they
-        are raw EPI images. Depending on this value, the mask will be
-        computed from masking.compute_background_mask or
-        masking.compute_epi_mask.
+    %(mask_strategy)s
 
         .. note::
             This parameter will be ignored if a mask image is provided.
 
+        .. note::
+            Depending on this value, the mask will be computed from
+            :func:`nilearn.masking.compute_background_mask`,
+            :func:`nilearn.masking.compute_epi_mask`, or
+            :func:`nilearn.masking.compute_brain_mask`.
+
+        Default is 'background'.
     %(memory)s
     %(memory_level)s
     %(n_jobs)s
@@ -943,16 +947,18 @@ class DecoderRegressor(_BaseDecoder):
     %(low_pass)s
     %(high_pass)s
     %(t_r)s
-    mask_strategy: {'background' or 'epi'}, optional. Default: 'background'
-        The strategy used to compute the mask: use 'background' if your
-        images present a clear homogeneous background, and 'epi' if they
-        are raw EPI images. Depending on this value, the mask will be
-        computed from masking.compute_background_mask or
-        masking.compute_epi_mask.
+    %(mask_strategy)s
 
         .. note::
             This parameter will be ignored if a mask image is provided.
 
+        .. note::
+            Depending on this value, the mask will be computed from
+            :func:`nilearn.masking.compute_background_mask`,
+            :func:`nilearn.masking.compute_epi_mask`, or
+            :func:`nilearn.masking.compute_brain_mask`.
+
+        Default is 'background'.
     %(memory)s
     %(memory_level)s
     %(n_jobs)s
@@ -1056,16 +1062,18 @@ class FREMRegressor(_BaseDecoder):
     %(low_pass)s
     %(high_pass)s
     %(t_r)s
-    mask_strategy : {'background' or 'epi'}, optional. Default: 'background'
-        The strategy used to compute the mask: use 'background' if your
-        images present a clear homogeneous background, and 'epi' if they
-        are raw EPI images. Depending on this value, the mask will be
-        computed from masking.compute_background_mask or
-        masking.compute_epi_mask.
+    %(mask_strategy)s
 
         .. note::
             This parameter will be ignored if a mask image is provided.
 
+        .. note::
+            Depending on this value, the mask will be computed from
+            :func:`nilearn.masking.compute_background_mask`,
+            :func:`nilearn.masking.compute_epi_mask`, or
+            :func:`nilearn.masking.compute_brain_mask`.
+
+        Default is 'background'.
     %(memory)s
     %(memory_level)s
     %(n_jobs)s
@@ -1177,16 +1185,18 @@ class FREMClassifier(_BaseDecoder):
     %(low_pass)s
     %(high_pass)s
     %(t_r)s
-    mask_strategy : {'background' or 'epi'}, optional. Default: 'background'
-        The strategy used to compute the mask: use 'background' if your
-        images present a clear homogeneous background, and 'epi' if they
-        are raw EPI images. Depending on this value, the mask will be
-        computed from masking.compute_background_mask or
-        masking.compute_epi_mask.
+    %(mask_strategy)s
 
         .. note::
             This parameter will be ignored if a mask image is provided.
 
+        .. note::
+            Depending on this value, the mask will be computed from
+            :func:`nilearn.masking.compute_background_mask`,
+            :func:`nilearn.masking.compute_epi_mask`, or
+            :func:`nilearn.masking.compute_brain_mask`.
+
+        Default is 'background'.
     %(memory)s
     %(memory_level)s
     %(n_jobs)s

--- a/nilearn/decomposition/base.py
+++ b/nilearn/decomposition/base.py
@@ -16,6 +16,7 @@ from joblib import Memory, Parallel, delayed
 from sklearn.linear_model import LinearRegression
 from sklearn.utils import check_random_state
 from sklearn.utils.extmath import randomized_svd, svd_flip
+from .._utils import fill_doc
 from .._utils.cache_mixin import CacheMixin, cache
 from .._utils.niimg import _safe_get_data
 from .._utils.niimg_conversions import _resolve_globbing
@@ -230,6 +231,7 @@ def _mask_and_reduce_single(masker,
     return U
 
 
+@fill_doc
 class BaseDecomposition(BaseEstimator, CacheMixin, TransformerMixin):
     """Base class for matrix factorization based decomposition estimators.
 
@@ -289,15 +291,15 @@ class BaseDecomposition(BaseEstimator, CacheMixin, TransformerMixin):
         This parameter is passed to image.resample_img. Please see the
         related documentation for details.
 
-    mask_strategy : {'epi', 'background', or 'template'}, optional
-        The strategy used to compute the mask: use 'background' if your
-        images present a clear homogeneous background, 'epi' if they
-        are raw EPI images, or you could use 'template' which will
-        extract the gray matter part of your data by resampling the MNI152
-        brain mask for your data's field of view.
-        Depending on this value, the mask will be computed from
-        masking.compute_background_mask, masking.compute_epi_mask or
-        masking.compute_brain_mask. Default='epi'.
+    %(mask_strategy)s
+
+        .. note::
+             Depending on this value, the mask will be computed from
+             :func:`nilearn.masking.compute_background_mask`,
+             :func:`nilearn.masking.compute_epi_mask`, or
+             :func:`nilearn.masking.compute_brain_mask`.
+
+        Default='epi'.
 
     mask_args : dict, optional
         If mask is None, these are additional parameters passed to

--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -16,8 +16,10 @@ from joblib import Memory, delayed, Parallel
 from sklearn.utils import check_random_state
 
 from .multi_pca import MultiPCA
+from nilearn._utils import fill_doc
 
 
+@fill_doc
 class CanICA(MultiPCA):
     """Perform Canonical Independent Component Analysis [1]_ [2]_.
 
@@ -91,15 +93,15 @@ class CanICA(MultiPCA):
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    mask_strategy : {'epi', 'background', or 'template'}, optional
-        The strategy used to compute the mask: use 'background' if your
-        images present a clear homogeneous background, 'epi' if they
-        are raw EPI images, or you could use 'template' which will
-        extract the gray matter part of your data by resampling the MNI152
-        brain mask for your data's field of view.
-        Depending on this value, the mask will be computed from
-        masking.compute_background_mask, masking.compute_epi_mask or
-        masking.compute_brain_mask. Default='epi'.
+    %(mask_strategy)s
+
+        .. note::
+             Depending on this value, the mask will be computed from
+             :func:`nilearn.masking.compute_background_mask`,
+             :func:`nilearn.masking.compute_epi_mask`, or
+             :func:`nilearn.masking.compute_brain_mask`.
+
+        Default='epi'.
 
     mask_args : dict, optional
         If mask is None, these are additional parameters passed to

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -18,6 +18,7 @@ from sklearn.linear_model import Ridge
 
 from .base import BaseDecomposition
 from .canica import CanICA
+from nilearn._utils import fill_doc
 
 # check_input=False is an optimization available in sklearn.
 sparse_encode_args = {'check_input': False}
@@ -34,6 +35,7 @@ def _compute_loadings(components, data):
     return loadings
 
 
+@fill_doc
 class DictLearning(BaseDecomposition):
     """Perform a map learning algorithm based on spatial component sparsity,
     over a CanICA initialization [1]_.  This yields more stable maps than CanICA.
@@ -114,15 +116,15 @@ class DictLearning(BaseDecomposition):
         This parameter is passed to signal.clean. Please see the related
         documentation for details.
 
-    mask_strategy : {'epi', 'background', or 'template'}, optional
-        The strategy used to compute the mask: use 'background' if your
-        images present a clear homogeneous background, 'epi' if they
-        are raw EPI images, or you could use 'template' which will
-        extract the gray matter part of your data by resampling the MNI152
-        brain mask for your data's field of view.
-        Depending on this value, the mask will be computed from
-        masking.compute_background_mask, masking.compute_epi_mask or
-        masking.compute_brain_mask. Default='epi'.
+    %(mask_strategy)s
+
+        .. note::
+             Depending on this value, the mask will be computed from
+             :func:`nilearn.masking.compute_background_mask`,
+             :func:`nilearn.masking.compute_epi_mask`, or
+             :func:`nilearn.masking.compute_brain_mask`.
+
+        Default='epi'.
 
     mask_args : dict, optional
         If mask is None, these are additional parameters passed to

--- a/nilearn/decomposition/multi_pca.py
+++ b/nilearn/decomposition/multi_pca.py
@@ -7,8 +7,10 @@ from joblib import Memory
 from sklearn.utils.extmath import randomized_svd
 
 from .base import BaseDecomposition
+from nilearn._utils import fill_doc
 
 
+@fill_doc
 class MultiPCA(BaseDecomposition):
     """Perform Multi Subject Principal Component Analysis.
 
@@ -37,16 +39,15 @@ class MultiPCA(BaseDecomposition):
         then its mask will be used. If no mask is given,
         it will be computed automatically by a MultiNiftiMasker with default
         parameters.
+    %(mask_strategy)s
 
-    mask_strategy : {'epi', 'background', or 'template'}, optional
-        The strategy used to compute the mask: use 'background' if your
-        images present a clear homogeneous background, 'epi' if they
-        are raw EPI images, or you could use 'template' which will
-        extract the gray matter part of your data by resampling the MNI152
-        brain mask for your data's field of view.
-        Depending on this value, the mask will be computed from
-        masking.compute_background_mask, masking.compute_epi_mask or
-        masking.compute_brain_mask. Default='epi'.
+        .. note::
+             Depending on this value, the mask will be computed from
+             :func:`nilearn.masking.compute_background_mask`,
+             :func:`nilearn.masking.compute_epi_mask`, or
+             :func:`nilearn.masking.compute_brain_mask`.
+
+        Default='epi'.
 
     mask_args : dict, optional
         If mask is None, these are additional parameters passed to

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -29,7 +29,7 @@ def _get_mask_strategy(strategy):
         return masking.compute_multi_background_mask
     elif strategy == 'epi':
         return masking.compute_multi_epi_mask
-    elif strategy == 'wb-template':
+    elif strategy == 'whole-brain-template':
         return partial(masking.compute_multi_brain_mask,
                        mask_type='whole-brain')
     elif strategy == 'gm-template':
@@ -40,14 +40,15 @@ def _get_mask_strategy(strategy):
                        mask_type='wm')
     elif strategy == 'template':
         warnings.warn("Masking strategy 'template' is deprecated."
-                      "Please use 'wb-template' instead.")
+                      "Please use 'whole-brain-template' instead.")
         return partial(masking.compute_multi_brain_mask,
                        mask_type='whole-brain')
     else:
         raise ValueError("Unknown value of mask_strategy '%s'. "
                          "Acceptable values are 'background', "
-                         "'epi', 'wb-template', 'gm-template', "
-                         "and 'wm-template'." % strategy)
+                         "'epi', 'whole-brain-template', "
+                         "'gm-template', and "
+                         "'wm-template'." % strategy)
 
 
 @fill_doc

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -22,28 +22,32 @@ from nilearn.image import get_data
 
 
 def _get_mask_strategy(strategy):
-     """Helper function returning the mask computing method based
-     on a provided strategy.
-     """
-     if strategy == 'background':
-         return masking.compute_multi_background_mask
-     elif strategy == 'epi':
-         return masking.compute_multi_epi_mask
-     elif strategy == 'wb-template':
-         return partial(masking.compute_multi_brain_mask, mask_type='whole-brain')
-     elif strategy == 'gm-template':
-         return partial(masking.compute_multi_brain_mask, mask_type='gm')
-     elif strategy == 'wm-template':
-         return partial(masking.compute_multi_brain_mask, mask_type='wm')
-     elif strategy == 'template':
-         warnings.warn("Masking strategy 'template' is deprecated."
-                       "Please use 'wb-template' instead.")
-         return partial(masking.compute_multi_brain_mask, mask_type='whole-brain')
-     else:
-         raise ValueError("Unknown value of mask_strategy '%s'. "
-                          "Acceptable values are 'background', "
-                          "'epi', 'wb-template', 'gm-template', "
-                          "and 'wm-template'." % strategy)
+    """Helper function returning the mask computing method based
+    on a provided strategy.
+    """
+    if strategy == 'background':
+        return masking.compute_multi_background_mask
+    elif strategy == 'epi':
+        return masking.compute_multi_epi_mask
+    elif strategy == 'wb-template':
+        return partial(masking.compute_multi_brain_mask,
+                       mask_type='whole-brain')
+    elif strategy == 'gm-template':
+        return partial(masking.compute_multi_brain_mask,
+                       mask_type='gm')
+    elif strategy == 'wm-template':
+        return partial(masking.compute_multi_brain_mask,
+                       mask_type='wm')
+    elif strategy == 'template':
+        warnings.warn("Masking strategy 'template' is deprecated."
+                      "Please use 'wb-template' instead.")
+        return partial(masking.compute_multi_brain_mask,
+                       mask_type='whole-brain')
+    else:
+        raise ValueError("Unknown value of mask_strategy '%s'. "
+                         "Acceptable values are 'background', "
+                         "'epi', 'wb-template', 'gm-template', "
+                         "and 'wm-template'." % strategy)
 
 
 @fill_doc
@@ -229,7 +233,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
 
             mask_args = (self.mask_args if self.mask_args is not None
                          else {})
-            compute_mask =  _get_mask_strategy(self.mask_strategy)
+            compute_mask = _get_mask_strategy(self.mask_strategy)
             self.mask_img_ = self._cache(
                 compute_mask, ignore=['n_jobs', 'verbose', 'memory'])(
                     imgs,

--- a/nilearn/input_data/multi_nifti_masker.py
+++ b/nilearn/input_data/multi_nifti_masker.py
@@ -7,19 +7,46 @@ Transformer used to apply basic transformations on multi subject MRI data.
 import collections.abc
 import itertools
 import warnings
+from functools import partial
 
 from joblib import Memory, Parallel, delayed
 
 from .. import _utils
 from .. import image
 from .. import masking
-from .._utils import CacheMixin
+from .._utils import CacheMixin, fill_doc
 from .._utils.class_inspect import get_params
 from .._utils.niimg_conversions import _iter_check_niimg
 from .nifti_masker import NiftiMasker, filter_and_mask
 from nilearn.image import get_data
 
 
+def _get_mask_strategy(strategy):
+     """Helper function returning the mask computing method based
+     on a provided strategy.
+     """
+     if strategy == 'background':
+         return masking.compute_multi_background_mask
+     elif strategy == 'epi':
+         return masking.compute_multi_epi_mask
+     elif strategy == 'wb-template':
+         return partial(masking.compute_multi_brain_mask, mask_type='whole-brain')
+     elif strategy == 'gm-template':
+         return partial(masking.compute_multi_brain_mask, mask_type='gm')
+     elif strategy == 'wm-template':
+         return partial(masking.compute_multi_brain_mask, mask_type='wm')
+     elif strategy == 'template':
+         warnings.warn("Masking strategy 'template' is deprecated."
+                       "Please use 'wb-template' instead.")
+         return partial(masking.compute_multi_brain_mask, mask_type='whole-brain')
+     else:
+         raise ValueError("Unknown value of mask_strategy '%s'. "
+                          "Acceptable values are 'background', "
+                          "'epi', 'wb-template', 'gm-template', "
+                          "and 'wm-template'." % strategy)
+
+
+@fill_doc
 class MultiNiftiMasker(NiftiMasker, CacheMixin):
     """Class for masking of Niimg-like objects.
 
@@ -84,15 +111,15 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         This parameter is passed to image.resample_img. Please see the
         related documentation for details.
 
-    mask_strategy : {'background', 'epi' or 'template'}, optional
-        The strategy used to compute the mask: use 'background' if your
-        images present a clear homogeneous background, 'epi' if they
-        are raw EPI images, or you could use 'template' which will
-        extract the gray matter part of your data by resampling the MNI152
-        brain mask for your data's field of view.
-        Depending on this value, the mask will be computed from
-        masking.compute_background_mask, masking.compute_epi_mask or
-        masking.compute_brain_mask. Default is 'background'.
+    %(mask_strategy)s
+
+        .. note::
+            Depending on this value, the mask will be computed from
+            :func:`nilearn.masking.compute_multi_background_mask`,
+            :func:`nilearn.masking.compute_multi_epi_mask`, or
+            :func:`nilearn.masking.compute_multi_brain_mask`.
+
+        Default is 'background'.
 
     mask_args : dict, optional
         If mask is None, these are additional parameters passed to
@@ -202,17 +229,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
 
             mask_args = (self.mask_args if self.mask_args is not None
                          else {})
-            if self.mask_strategy == 'background':
-                compute_mask = masking.compute_multi_background_mask
-            elif self.mask_strategy == 'epi':
-                compute_mask = masking.compute_multi_epi_mask
-            elif self.mask_strategy == 'template':
-                compute_mask = masking.compute_multi_brain_mask
-            else:
-                raise ValueError("Unknown value of mask_strategy '%s'. "
-                                 "Acceptable values are 'background', 'epi' "
-                                 "and 'template'.")
-
+            compute_mask =  _get_mask_strategy(self.mask_strategy)
             self.mask_img_ = self._cache(
                 compute_mask, ignore=['n_jobs', 'verbose', 'memory'])(
                     imgs,

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -6,6 +6,7 @@ Transformer used to apply basic transformations on MRI data.
 
 import warnings
 from copy import copy as copy_object
+from functools import partial
 
 from joblib import Memory
 
@@ -13,7 +14,7 @@ from .base_masker import BaseMasker, filter_and_extract
 from .. import _utils
 from .. import image
 from .. import masking
-from .._utils import CacheMixin
+from .._utils import CacheMixin, fill_doc
 from .._utils.class_inspect import get_params
 from .._utils.helpers import remove_parameters, rename_parameters
 from .._utils.niimg import img_data_dtype
@@ -30,6 +31,31 @@ class _ExtractionFunctor(object):
     def __call__(self, imgs):
         return(masking.apply_mask(imgs, self.mask_img_,
                                   dtype=img_data_dtype(imgs)), imgs.affine)
+
+
+def _get_mask_strategy(strategy):
+    """Helper function returning the mask computing method based
+    on a provided strategy.
+    """
+    if strategy == 'background':
+        return masking.compute_background_mask
+    elif strategy == 'epi':
+        return masking.compute_epi_mask
+    elif strategy == 'wb-template':
+        return partial(masking.compute_brain_mask, mask_type='whole-brain')
+    elif strategy == 'gm-template':
+        return partial(masking.compute_brain_mask, mask_type='gm')
+    elif strategy == 'wm-template':
+        return partial(masking.compute_brain_mask, mask_type='wm')
+    elif strategy == 'template':
+        warnings.warn("Masking strategy 'template' is deprecated."
+                      "Please use 'wb-template' instead.")
+        return partial(masking.compute_brain_mask, mask_type='whole-brain')
+    else:
+        raise ValueError("Unknown value of mask_strategy '%s'. "
+                         "Acceptable values are 'background', "
+                         "'epi', 'wb-template', 'gm-template', "
+                         "and 'wm-template'." % strategy)
 
 
 def filter_and_mask(imgs, mask_img_, parameters,
@@ -85,6 +111,7 @@ def filter_and_mask(imgs, mask_img_, parameters,
     return data
 
 
+@fill_doc
 class NiftiMasker(BaseMasker, CacheMixin):
     """Applying a mask to extract time-series from Niimg-like objects.
 
@@ -158,16 +185,15 @@ class NiftiMasker(BaseMasker, CacheMixin):
     target_shape : 3-tuple of integers, optional
         This parameter is passed to image.resample_img. Please see the
         related documentation for details.
+    %(mask_strategy)s
 
-    mask_strategy : {'background', 'epi' or 'template'}, optional
-        The strategy used to compute the mask: use 'background' if your
-        images present a clear homogeneous background, 'epi' if they
-        are raw EPI images, or you could use 'template' which will
-        extract the gray matter part of your data by resampling the MNI152
-        brain mask for your data's field of view.
-        Depending on this value, the mask will be computed from
-        masking.compute_background_mask, masking.compute_epi_mask or
-        masking.compute_brain_mask. Default='background'.
+            .. note::
+                Depending on this value, the mask will be computed from
+                :func:`nilearn.masking.compute_background_mask`,
+                :func:`nilearn.masking.compute_epi_mask`, or
+                :func:`nilearn.masking.compute_brain_mask`.
+
+        Default is 'background'.
 
     mask_args : dict, optional
         If mask is None, these are additional parameters passed to
@@ -395,16 +421,7 @@ class NiftiMasker(BaseMasker, CacheMixin):
         if self.mask_img is None:
             mask_args = (self.mask_args if self.mask_args is not None
                          else {})
-            if self.mask_strategy == 'background':
-                compute_mask = masking.compute_background_mask
-            elif self.mask_strategy == 'epi':
-                compute_mask = masking.compute_epi_mask
-            elif self.mask_strategy == 'template':
-                compute_mask = masking.compute_brain_mask
-            else:
-                raise ValueError("Unknown value of mask_strategy '%s'. "
-                                 "Acceptable values are 'background', "
-                                 "'epi' and 'template'." % self.mask_strategy)
+            compute_mask = _get_mask_strategy(self.mask_strategy)
             if self.verbose > 0:
                 print("[%s.fit] Computing the mask" % self.__class__.__name__)
             self.mask_img_ = self._cache(compute_mask, ignore=['verbose'])(

--- a/nilearn/input_data/nifti_masker.py
+++ b/nilearn/input_data/nifti_masker.py
@@ -41,7 +41,7 @@ def _get_mask_strategy(strategy):
         return masking.compute_background_mask
     elif strategy == 'epi':
         return masking.compute_epi_mask
-    elif strategy == 'wb-template':
+    elif strategy == 'whole-brain-template':
         return partial(masking.compute_brain_mask, mask_type='whole-brain')
     elif strategy == 'gm-template':
         return partial(masking.compute_brain_mask, mask_type='gm')
@@ -49,13 +49,14 @@ def _get_mask_strategy(strategy):
         return partial(masking.compute_brain_mask, mask_type='wm')
     elif strategy == 'template':
         warnings.warn("Masking strategy 'template' is deprecated."
-                      "Please use 'wb-template' instead.")
+                      "Please use 'whole-brain-template' instead.")
         return partial(masking.compute_brain_mask, mask_type='whole-brain')
     else:
         raise ValueError("Unknown value of mask_strategy '%s'. "
                          "Acceptable values are 'background', "
-                         "'epi', 'wb-template', 'gm-template', "
-                         "and 'wm-template'." % strategy)
+                         "'epi', 'whole-brain-template', "
+                         "'gm-template', and "
+                         "'wm-template'." % strategy)
 
 
 def filter_and_mask(imgs, mask_img_, parameters,

--- a/nilearn/input_data/tests/test_multi_nifti_masker.py
+++ b/nilearn/input_data/tests/test_multi_nifti_masker.py
@@ -161,29 +161,41 @@ def test_shelving():
         shutil.rmtree(cachedir, ignore_errors=True)
 
 
-def test_compute_multi_gray_matter_mask():
+def _get_random_imgs(shape, length):
     rng = np.random.RandomState(42)
+    return [Nifti1Image(rng.uniform(size=shape), np.eye(4))] * length
 
-    # Check mask is correctly is correctly calculated
-    imgs = [Nifti1Image(rng.uniform(size=(9, 9, 5)), np.eye(4)),
-            Nifti1Image(rng.uniform(size=(9, 9, 5)), np.eye(4))]
 
-    masker = MultiNiftiMasker(mask_strategy='template',
+def test_mask_strategy_errors():
+    # Error with unknown mask_strategy
+    imgs = _get_random_imgs((9, 9, 5), 2)
+    mask = MultiNiftiMasker(mask_strategy='foo')
+    with pytest.raises(ValueError,
+                       match="Unknown value of mask_strategy 'foo'"):
+        mask.fit(imgs)
+    # Warning with deprecated 'template' strategy
+    mask = MultiNiftiMasker(mask_strategy='template')
+    with pytest.warns(UserWarning,
+                      match="Masking strategy 'template' is deprecated."):
+        mask.fit(imgs)
+
+
+@pytest.mark.parametrize('strategy',
+                         [f'{p}-template' for p in ['wb', 'gm', 'wm']])
+def test_compute_multi_gray_matter_mask(strategy):
+    imgs = _get_random_imgs((9, 9, 5), 2)
+    masker = MultiNiftiMasker(mask_strategy=strategy,
                               mask_args={'opening': 1})
     masker.fit(imgs)
-
     # Check that the order of the images does not change the output
-    masker2 = MultiNiftiMasker(mask_strategy='template',
+    masker2 = MultiNiftiMasker(mask_strategy=strategy,
                                mask_args={'opening': 1})
     masker2.fit(imgs[::-1])
-
-    mask = masker.mask_img_
-    mask2 = masker2.mask_img_
-
     mask_ref = np.zeros((9, 9, 5), dtype='int8')
-
-    np.testing.assert_array_equal(get_data(mask), mask_ref)
-    np.testing.assert_array_equal(get_data(mask2), mask_ref)
+    np.testing.assert_array_equal(get_data(masker.mask_img_),
+                                  mask_ref)
+    np.testing.assert_array_equal(get_data(masker2.mask_img_),
+                                  mask_ref)
 
 
 def test_dtype():

--- a/nilearn/input_data/tests/test_multi_nifti_masker.py
+++ b/nilearn/input_data/tests/test_multi_nifti_masker.py
@@ -181,7 +181,8 @@ def test_mask_strategy_errors():
 
 
 @pytest.mark.parametrize('strategy',
-                         [f'{p}-template' for p in ['wb', 'gm', 'wm']])
+                         [f'{p}-template' for p in
+                          ['whole-brain', 'gm', 'wm']])
 def test_compute_multi_gray_matter_mask(strategy):
     imgs = _get_random_imgs((9, 9, 5), 2)
     masker = MultiNiftiMasker(mask_strategy=strategy,

--- a/nilearn/input_data/tests/test_nifti_masker.py
+++ b/nilearn/input_data/tests/test_nifti_masker.py
@@ -289,13 +289,20 @@ def test_joblib_cache():
             shutil.rmtree(cachedir, ignore_errors=True)
 
 
-def test_mask_init_errors():
-    # Errors that are caught in init
+def test_mask_strategy_errors():
+    # Error with unknown mask_strategy
     mask = NiftiMasker(mask_strategy='oops')
     with pytest.raises(
             ValueError,
             match="Unknown value of mask_strategy 'oops'"):
         mask.fit()
+    # Warning with deprecated 'template' strategy
+    img = np.random.RandomState(42).uniform(size=(9, 9, 5))
+    img = Nifti1Image(img, np.eye(4))
+    mask = NiftiMasker(mask_strategy='template')
+    with pytest.warns(UserWarning,
+                      match="Masking strategy 'template' is deprecated."):
+        mask.fit(img)
 
 
 def test_compute_epi_mask():
@@ -341,28 +348,33 @@ def test_compute_epi_mask():
                              get_data(mask4)[3:12, 3:12])
 
 
-def test_compute_brain_mask():
+def _get_random_img(shape):
+    img = np.random.RandomState(42).uniform(size=shape)
+    return Nifti1Image(img, np.eye(4))
+
+
+@pytest.fixture
+def expected_mask(mask_args):
+    mask = np.zeros((9, 9, 5))
+    if mask_args == dict():
+        return mask
+    else:
+        mask[2:7, 2:7, 2] = 1
+        return mask
+
+
+@pytest.mark.parametrize('strategy',
+                         [f'{p}-template' for p in ['wb', 'gm', 'wm']])
+@pytest.mark.parametrize('mask_args',
+                         [dict(), dict(threshold=0.)])
+def test_compute_brain_mask(strategy, mask_args, expected_mask):
     # Check masker for template masking strategy
-
-    img = np.random.RandomState(42).uniform(size=(9, 9, 5))
-    img = Nifti1Image(img, np.eye(4))
-
-    masker = NiftiMasker(mask_strategy='template')
-
+    img = _get_random_img((9, 9, 5))
+    masker = NiftiMasker(mask_strategy=strategy,
+                         mask_args=mask_args)
     masker.fit(img)
-    mask1 = masker.mask_img_
-
-    masker2 = NiftiMasker(mask_strategy='template',
-                          mask_args=dict(threshold=0.))
-
-    masker2.fit(img)
-    mask2 = masker2.mask_img_
-
-    mask_ref = np.zeros((9, 9, 5))
-    np.testing.assert_array_equal(get_data(mask1), mask_ref)
-
-    mask_ref[2:7, 2:7, 2] = 1
-    np.testing.assert_array_equal(get_data(mask2), mask_ref)
+    np.testing.assert_array_equal(get_data(masker.mask_img_),
+                                  expected_mask)
 
 
 def test_filter_and_mask_error():

--- a/nilearn/input_data/tests/test_nifti_masker.py
+++ b/nilearn/input_data/tests/test_nifti_masker.py
@@ -364,7 +364,8 @@ def expected_mask(mask_args):
 
 
 @pytest.mark.parametrize('strategy',
-                         [f'{p}-template' for p in ['wb', 'gm', 'wm']])
+                         [f'{p}-template' for p in
+                          ['whole-brain', 'gm', 'wm']])
 @pytest.mark.parametrize('mask_args',
                          [dict(), dict(threshold=0.)])
 def test_compute_brain_mask(strategy, mask_args, expected_mask):

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -13,6 +13,7 @@ from ..decomposition.multi_pca import MultiPCA
 from ..input_data import NiftiLabelsMasker
 from .._utils.niimg import _safe_get_data
 from .._utils.niimg_conversions import _iter_check_niimg
+from .._utils import fill_doc
 
 
 def _estimator_fit(data, estimator, method=None):
@@ -110,6 +111,7 @@ def _labels_masker_extraction(img, masker, confound):
     return signals
 
 
+@fill_doc
 class Parcellations(MultiPCA):
     """Learn parcellations on fMRI images.
 
@@ -184,15 +186,15 @@ class Parcellations(MultiPCA):
         This parameter is passed to image.resample_img. Please see the
         related documentation for details.
 
-    mask_strategy: {'epi', 'background', or 'template'}, optional
-        The strategy used to compute the mask: use 'background' if your
-        images present a clear homogeneous background, 'epi' if they
-        are raw EPI images, or you could use 'template' which will
-        extract the gray matter part of your data by resampling the MNI152
-        brain mask for your data's field of view.
-        Depending on this value, the mask will be computed from
-        masking.compute_background_mask, masking.compute_epi_mask or
-        masking.compute_brain_mask. Default='epi'.
+    %(mask_strategy)s
+
+        .. note::
+             Depending on this value, the mask will be computed from
+             :func:`nilearn.masking.compute_background_mask`,
+             :func:`nilearn.masking.compute_epi_mask`, or
+             :func:`nilearn.masking.compute_brain_mask`.
+
+        Default='epi'.
 
     mask_args : dict, optional
         If mask is None, these are additional parameters passed to


### PR DESCRIPTION
Fixes #2890 

Following the work of #2738, this PR proposes to add more options for the argument `mask_strategy`. 
That is, the former option `template` is replaced by `wb-template`, and options `gm-template` and `wm-template` are added to rely on the grey and white matter templates.