### PR TITLE
[DOC] Fix dead link for localizer dataset

### DIFF
--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -421,7 +421,7 @@ def fetch_localizer_contrasts(contrasts, n_subjects=None, get_tmaps=False,
     individual level. Individual functional maps are reliable and
     quite precise. The procedure is decribed in more detail on the
     Functional Localizer page."
-    (see http://brainomics.cea.fr/localizer/)
+    (see https://osf.io/vhtf6/)
 
     You may cite :footcite:`PAPADOPOULOSORFANOS2017309`
     when using this dataset.


### PR DESCRIPTION
Changes proposed in this pull request:
- This PR fixes a dead link: from http://brainomics.cea.fr/localizer/ to https://osf.io/vhtf6/
