### PR TITLE
[DOC] fix typo in FirstLevelModel docstring

### DIFF
--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -621,12 +621,12 @@ class FirstLevelModel(BaseGLM):
             with operators +-`*`/.
 
         stat_type : {'t', 'F'}, optional
-            type of the contrast
+            Type of the contrast.
 
         output_type : str, optional
             Type of the output map. Can be 'z_score', 'stat', 'p_value',
             'effect_size', 'effect_variance' or 'all'.
-            Default='z-score'.
+            Default='z_score'.
 
         Returns
         -------


### PR DESCRIPTION
Changes proposed in this pull request:

- fixed a minor typo in docstring. No functional changes.

On that note, this is probably not the right place to ask, but how does one get the the parameter estimates from ``compute_contrast``? I know this should be super simple...

````
from nilearn.glm.first_level import FirstLevelModel
glm = FirstLevelModel()
glm = glm.fit(fmri_img, design_matrices=design_matrices)
glm.compute_contrast(contrast_val, output_type='z_score')
`````

If I understand correctly, the supported values for ``output_type`` provide only a p-value, the test statistics (t or F), or a z-value (i.e., df-free representation of the test statistic).

This [example](https://nilearn.github.io/auto_examples/04_glm_first_level/plot_spm_multimodal_faces.html#sphx-glr-auto-examples-04-glm-first-level-plot-spm-multimodal-faces-py) mentions "basic contrasts" to get beta maps, but it never shows how to get them.
