### PR TITLE
Flake fixes for GLM module

### DIFF
--- a/nilearn/glm/_base.py
+++ b/nilearn/glm/_base.py
@@ -19,8 +19,8 @@ class BaseGLM(BaseEstimator, TransformerMixin, CacheMixin):
         ----------
             A fitted first or second level model object.
 
-        contrasts : Dict[string, ndarray] or String or List[String] or ndarray or
-            List[ndarray]
+        contrasts : Dict[string, ndarray] or String or List[String] or
+            ndarray or List[ndarray]
 
             Contrasts information for a first or second level model.
 
@@ -33,7 +33,8 @@ class BaseGLM(BaseEstimator, TransformerMixin, CacheMixin):
                 or contrast coefficient
 
                 Each contrast name must be a string.
-                Each contrast coefficient must be a list or numpy array of ints.
+                Each contrast coefficient must be a list or
+                numpy array of ints.
 
             Contrasts are passed to ``contrast_def`` for FirstLevelModel
             (:func:`nilearn.glm.first_level.FirstLevelModel.compute_contrast`)
@@ -96,7 +97,8 @@ class BaseGLM(BaseEstimator, TransformerMixin, CacheMixin):
 
         report_dims : Sequence[int, int], optional
             Default is (1600, 800) pixels.
-            Specifies width, height (in pixels) of report window within a notebook.
+            Specifies width, height (in pixels) of report window
+            within a notebook.
             Only applicable when inserting the report into a Jupyter notebook.
             Can be set after report creation using report.width, report.height.
 

--- a/nilearn/glm/contrasts.py
+++ b/nilearn/glm/contrasts.py
@@ -86,7 +86,7 @@ def compute_contrast(labels, regression_result, con_val, contrast_type=None):
     if contrast_type not in acceptable_contrast_types:
         raise ValueError(
             '"{0}" is not a known contrast type. Allowed types are {1}'.
-                format(contrast_type, acceptable_contrast_types))
+            format(contrast_type, acceptable_contrast_types))
 
     if contrast_type == 't':
         effect_ = np.zeros((1, labels.size))
@@ -240,8 +240,8 @@ class Contrast(object):
 
         # Case: one-dimensional contrast ==> t or t**2
         if self.contrast_type == 'F':
-            stat = np.sum((self.effect - baseline) ** 2, 0) / self.dim / \
-                   np.maximum(self.variance, self.tiny)
+            stat = np.sum((self.effect - baseline) ** 2, 0) / \
+                self.dim / np.maximum(self.variance, self.tiny)
         elif self.contrast_type == 't':
             # avoids division by zero
             stat = (self.effect - baseline) / np.sqrt(

--- a/nilearn/glm/first_level/design_matrix.py
+++ b/nilearn/glm/first_level/design_matrix.py
@@ -281,10 +281,10 @@ def make_first_level_design_matrix(
         Particular attention should be given to the 'trial_type' key
         which defines the different conditions in the experimental paradigm.
 
-    hrf_model : {'glover', 'spm', 'spm + derivative',
-        'spm + derivative + dispersion',
-        'glover + derivative', 'glover + derivative + dispersion',
-        'fir', None}, optional
+    hrf_model : {'glover', 'spm', 'spm + derivative', \
+            'spm + derivative + dispersion', 'glover + derivative', \
+            'glover + derivative + dispersion', \
+            'fir', None}, optional
         Specifies the hemodynamic response function. Default='glover'.
 
     drift_model : {'cosine', 'polynomial', None}, optional
@@ -302,8 +302,8 @@ def make_first_level_design_matrix(
         In case of FIR design, yields the array of delays used in the FIR
         model (in scans). Default=[0].
 
-    add_regs : array of shape(n_frames, n_add_reg) or
-               pandas DataFrame, optional
+    add_regs : array of shape(n_frames, n_add_reg) or \
+            pandas DataFrame, optional
         additional user-supplied regressors, e.g. data driven noise regressors
         or seed based regressors.
 

--- a/nilearn/glm/first_level/design_matrix.py
+++ b/nilearn/glm/first_level/design_matrix.py
@@ -281,7 +281,8 @@ def make_first_level_design_matrix(
         Particular attention should be given to the 'trial_type' key
         which defines the different conditions in the experimental paradigm.
 
-    hrf_model : {'glover', 'spm', 'spm + derivative', 'spm + derivative + dispersion',
+    hrf_model : {'glover', 'spm', 'spm + derivative',
+        'spm + derivative + dispersion',
         'glover + derivative', 'glover + derivative + dispersion',
         'fir', None}, optional
         Specifies the hemodynamic response function. Default='glover'.
@@ -301,7 +302,8 @@ def make_first_level_design_matrix(
         In case of FIR design, yields the array of delays used in the FIR
         model (in scans). Default=[0].
 
-    add_regs : array of shape(n_frames, n_add_reg) or pandas DataFrame, optional
+    add_regs : array of shape(n_frames, n_add_reg) or
+               pandas DataFrame, optional
         additional user-supplied regressors, e.g. data driven noise regressors
         or seed based regressors.
 

--- a/nilearn/glm/first_level/experimental_paradigm.py
+++ b/nilearn/glm/first_level/experimental_paradigm.py
@@ -25,6 +25,7 @@ VALID_FIELDS = set(["onset",
                     "modulation",
                     ])
 
+
 def check_events(events):
     """Test that the events data describes a valid experimental paradigm
 
@@ -86,14 +87,13 @@ def check_events(events):
     unexpected_columns = set(events_copy.columns).difference(VALID_FIELDS)
     for unexpected_column in unexpected_columns:
         warnings.warn(("Unexpected column `{}` in events "
-                       "data will be ignored.").format(
-                            unexpected_column))
+                       "data will be ignored.").format(unexpected_column))
 
     # Make sure we have a numeric type for duration
     if not is_numeric_dtype(events_copy['duration']):
         try:
             events_copy = events_copy.astype({'duration': float})
-        except:
+        except ValueError:
             raise ValueError("Could not cast duration to float "
                              "in events data.")
 
@@ -103,15 +103,14 @@ def check_events(events):
     #   - onset
     COLUMN_DEFINING_EVENT_IDENTITY = ['trial_type',
                                       'onset',
-                                      'duration',]
+                                      'duration']
 
     # Duplicate handling strategy
-    STRATEGY = {'modulation': np.sum, # Sum the modulation values of duplicate events
-                }
+    # Sum the modulation values of duplicate events
+    STRATEGY = {'modulation': np.sum}
 
     cleaned_events = events_copy.groupby(
-                        COLUMN_DEFINING_EVENT_IDENTITY,
-                        sort=False).agg(STRATEGY).reset_index()
+        COLUMN_DEFINING_EVENT_IDENTITY, sort=False).agg(STRATEGY).reset_index()
 
     # If there are duplicates, give a warning
     if len(cleaned_events) != len(events_copy):
@@ -124,4 +123,3 @@ def check_events(events):
     duration = cleaned_events['duration'].values
     modulation = cleaned_events['modulation'].values
     return trial_type, onset, duration, modulation
-

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -234,10 +234,9 @@ class FirstLevelModel(BaseGLM):
         expressed as a percentage of the t_r (time repetition), so it can have
         values between 0. and 1. Default=0.
 
-    hrf_model : {'glover', 'spm', 'spm + derivative',
-        'spm + derivative + dispersion',
-        'glover + derivative', 'glover + derivative + dispersion',
-        'fir', None}, optional
+    hrf_model : {'glover', 'spm', 'spm + derivative', \
+            'spm + derivative + dispersion', 'glover + derivative', \
+            'glover + derivative + dispersion', 'fir', None}, optional
         String that specifies the hemodynamic response function.
         Default='glover'.
 
@@ -409,7 +408,7 @@ class FirstLevelModel(BaseGLM):
             Data on which the GLM will be fitted. If this is a list,
             the affine is considered the same for all.
 
-        events : pandas Dataframe or string or list of pandas DataFrames
+        events : pandas Dataframe or string or list of pandas DataFrames \
                  or strings, optional
             fMRI events used to build design matrices. One events object
             expected per run_img. Ignored in case designs is not None.

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -441,8 +441,10 @@ class FirstLevelModel(BaseGLM):
         # Raise a warning if both design_matrices and confounds are provided
         if design_matrices is not None and \
                 (confounds is not None or events is not None):
-            warn('If design matrices are supplied,'
-                 'confounds and events will be ignored.')
+            warn(
+                'If design matrices are supplied, '
+                'confounds and events will be ignored.'
+            )
         # Local import to prevent circular imports
         from nilearn.input_data import NiftiMasker  # noqa
 

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -422,7 +422,7 @@ class FirstLevelModel(BaseGLM):
             respective run_img. Ignored in case designs is not None.
             If string, then a path to a csv file is expected.
 
-        design_matrices : pandas DataFrame or
+        design_matrices : pandas DataFrame or \
                           list of pandas DataFrames, optional
             Design matrices that will be used to fit the GLM. If given it
             takes precedence over events and confounds.

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -144,7 +144,7 @@ def run_glm(Y, X, noise_model='ar1', bins=100, n_jobs=1, verbose=0):
 
     """
     acceptable_noise_models = ['ols', 'arN']
-    if ((noise_model[:2] != 'ar') and (noise_model is not 'ols')):
+    if ((noise_model[:2] != 'ar') and (noise_model != 'ols')):
         raise ValueError(
             "Acceptable noise models are {0}. You provided "
             "'noise_model={1}'".format(acceptable_noise_models,
@@ -179,8 +179,7 @@ def run_glm(Y, X, noise_model='ar1', bins=100, n_jobs=1, verbose=0):
         # Either bin the AR1 coefs or cluster ARN coefs
         if ar_order == 1:
             for idx in range(len(ar_coef_)):
-                ar_coef_[idx] = (ar_coef_[idx] * bins).astype(int) \
-                                * 1. / bins
+                ar_coef_[idx] = (ar_coef_[idx] * bins).astype(int) * 1. / bins
             labels = np.array([str(val) for val in ar_coef_])
         else:  # AR(N>1) case
             n_clusters = np.min([bins, Y.shape[1]])
@@ -235,8 +234,10 @@ class FirstLevelModel(BaseGLM):
         expressed as a percentage of the t_r (time repetition), so it can have
         values between 0. and 1. Default=0.
 
-    hrf_model : {'glover', 'spm', 'spm + derivative', 'spm + derivative + dispersion',
-        'glover + derivative', 'glover + derivative + dispersion', 'fir', None}, optional
+    hrf_model : {'glover', 'spm', 'spm + derivative',
+        'spm + derivative + dispersion',
+        'glover + derivative', 'glover + derivative + dispersion',
+        'fir', None}, optional
         String that specifies the hemodynamic response function.
         Default='glover'.
 
@@ -408,7 +409,8 @@ class FirstLevelModel(BaseGLM):
             Data on which the GLM will be fitted. If this is a list,
             the affine is considered the same for all.
 
-        events : pandas Dataframe or string or list of pandas DataFrames or strings, optional
+        events : pandas Dataframe or string or list of pandas DataFrames
+                 or strings, optional
             fMRI events used to build design matrices. One events object
             expected per run_img. Ignored in case designs is not None.
             If string, then a path to a csv file is expected.
@@ -421,7 +423,8 @@ class FirstLevelModel(BaseGLM):
             respective run_img. Ignored in case designs is not None.
             If string, then a path to a csv file is expected.
 
-        design_matrices : pandas DataFrame or list of pandas DataFrames, optional
+        design_matrices : pandas DataFrame or
+                          list of pandas DataFrames, optional
             Design matrices that will be used to fit the GLM. If given it
             takes precedence over events and confounds.
 
@@ -437,8 +440,10 @@ class FirstLevelModel(BaseGLM):
         self.masker_ = None
 
         # Raise a warning if both design_matrices and confounds are provided
-        if design_matrices is not None and (confounds is not None or events is not None):
-            warn('If design matrices are supplied, confounds and events will be ignored.')
+        if design_matrices is not None and \
+                (confounds is not None or events is not None):
+            warn('If design matrices are supplied,'
+                 'confounds and events will be ignored.')
         # Local import to prevent circular imports
         from nilearn.input_data import NiftiMasker  # noqa
 

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -45,8 +45,7 @@ def _check_second_level_input(second_level_input, design_matrix,
             models_input = enumerate(second_level_input)
             for model_idx, first_level in models_input:
                 if (first_level.labels_ is None
-                    or first_level.results_ is None
-                    ):
+                        or first_level.results_ is None):
                     raise ValueError(
                         'Model %s at index %i has not been fit yet'
                         '' % (first_level.subject_label, model_idx))
@@ -82,7 +81,8 @@ def _check_second_level_input(second_level_input, design_matrix,
                                  ' columns subject_label, map_name and'
                                  ' effects_map_path')
         # Make sure subject_label contain strings
-        if not all([isinstance(_, str) for _ in second_level_input['subject_label'].tolist()]):
+        if not all([isinstance(_, str) for _ in
+                    second_level_input['subject_label'].tolist()]):
             raise ValueError('subject_label column must contain only strings')
     elif isinstance(second_level_input, (str, Nifti1Image)):
         if design_matrix is None:
@@ -115,7 +115,8 @@ def _check_confounds(confounds):
                              ' one called "subject_label" and the other'
                              ' with a given confound')
         # Make sure subject_label contain strings
-        if not all([isinstance(_, str) for _ in confounds['subject_label'].tolist()]):
+        if not all([isinstance(_, str) for _ in
+                    confounds['subject_label'].tolist()]):
             raise ValueError('subject_label column must contain only strings')
 
 

--- a/nilearn/glm/tests/test_check_events_file_uses_tab_separators.py
+++ b/nilearn/glm/tests/test_check_events_file_uses_tab_separators.py
@@ -113,7 +113,6 @@ if __name__ == '__main__':
         test_func()
         pprint('... complete')
 
-
     def run_test_suite():
         tests = [
             test_for_invalid_filepath,
@@ -126,6 +125,5 @@ if __name__ == '__main__':
         ]
         for test_ in tests:
             _run_tests_print_test_messages(test_func=test_)
-
 
     run_test_suite()

--- a/nilearn/glm/tests/test_dmtx.py
+++ b/nilearn/glm/tests/test_dmtx.py
@@ -12,15 +12,11 @@ import pytest
 
 from nibabel.tmpdirs import InTemporaryDirectory
 from numpy.testing import (
-    assert_almost_equal, assert_array_equal, assert_array_almost_equal,
-    assert_equal)
+    assert_almost_equal, assert_array_equal, assert_array_almost_equal)
 
-from nilearn.glm.first_level.design_matrix import (_convolve_regressors,
-                                                   _cosine_drift,
-                                                   check_design_matrix,
-                                                   make_first_level_design_matrix,
-                                                   make_second_level_design_matrix,
-                                                   )
+from nilearn.glm.first_level.design_matrix import \
+    (_convolve_regressors, _cosine_drift, check_design_matrix,
+     make_first_level_design_matrix, make_second_level_design_matrix)
 
 # load the spm file to test cosine basis
 my_path = osp.dirname(osp.abspath(__file__))
@@ -29,10 +25,9 @@ DESIGN_MATRIX = np.load(full_path_design_matrix_file)
 
 
 def design_matrix_light(
-    frame_times, events=None, hrf_model='glover',
-    drift_model='cosine', high_pass=.01, drift_order=1, fir_delays=None,
-    add_regs=None, add_reg_names=None, min_onset=-24, path=None
-    ):
+        frame_times, events=None, hrf_model='glover',
+        drift_model='cosine', high_pass=.01, drift_order=1, fir_delays=None,
+        add_regs=None, add_reg_names=None, min_onset=-24, path=None):
     """ Same as make_first_level_design_matrix,
     but only returns the computed matrix and associated name.
     """
@@ -143,7 +138,7 @@ def test_design_matrix0c():
         frame_times, drift_model='polynomial',
         drift_order=3, add_regs=axdf))
     assert_almost_equal(X1[:, 0], ax[:, 0])
-    assert_array_equal(names[:4],  np.arange(4))
+    assert_array_equal(names[:4], np.arange(4))
 
 
 def test_design_matrix0d():

--- a/nilearn/glm/tests/test_dmtx.py
+++ b/nilearn/glm/tests/test_dmtx.py
@@ -14,9 +14,13 @@ from nibabel.tmpdirs import InTemporaryDirectory
 from numpy.testing import (
     assert_almost_equal, assert_array_equal, assert_array_almost_equal)
 
-from nilearn.glm.first_level.design_matrix import \
-    (_convolve_regressors, _cosine_drift, check_design_matrix,
-     make_first_level_design_matrix, make_second_level_design_matrix)
+from nilearn.glm.first_level.design_matrix import (
+    _convolve_regressors,
+    _cosine_drift,
+    check_design_matrix,
+    make_first_level_design_matrix,
+    make_second_level_design_matrix
+)
 
 # load the spm file to test cosine basis
 my_path = osp.dirname(osp.abspath(__file__))

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -576,7 +576,7 @@ def test_first_level_contrast_computation():
         model = model.fit([func_img, func_img], [events, events])
         # Check that an error is raised for invalid contrast_def
         with pytest.raises(ValueError,
-                           match="contrast_def must be an"
+                           match="contrast_def must be an "
                                  "array or str or list"):
             model.compute_contrast(37)
         # smoke test for different contrasts in fixed effects

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -7,7 +7,6 @@ import shutil
 import numpy as np
 import pandas as pd
 import pytest
-import warnings
 from nibabel import Nifti1Image, load
 from nibabel.tmpdirs import InTemporaryDirectory
 from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
@@ -33,14 +32,15 @@ FUNCFILE = os.path.join(BASEDIR, 'functional.nii.gz')
 
 def test_high_level_glm_one_session():
     shapes, rk = [(7, 8, 9, 15)], 3
-    mask, fmri_data, design_matrices = generate_fake_fmri_data_and_design(shapes, rk)
+    mask, fmri_data, design_matrices =\
+        generate_fake_fmri_data_and_design(shapes, rk)
 
     # Give an unfitted NiftiMasker as mask_img and check that we get an error
     masker = NiftiMasker(mask)
     with pytest.raises(ValueError,
                        match="It seems that NiftiMasker has not been fitted."):
-        single_session_model = FirstLevelModel(mask_img=masker).fit(
-                fmri_data[0], design_matrices=design_matrices[0])
+        _ = FirstLevelModel(mask_img=masker).fit(
+            fmri_data[0], design_matrices=design_matrices[0])
 
     # Give a fitted NiftiMasker with a None mask_img_ attribute
     # and check that the masker parameters are overriden by the
@@ -49,14 +49,14 @@ def test_high_level_glm_one_session():
     masker.mask_img_ = None
     with pytest.warns(UserWarning,
                       match="Parameter memory of the masker overriden"):
-        single_session_model = FirstLevelModel(mask_img=masker).fit(
-                fmri_data[0], design_matrices=design_matrices[0])
+        _ = FirstLevelModel(mask_img=masker).fit(
+            fmri_data[0], design_matrices=design_matrices[0])
 
     # Give a fitted NiftiMasker
     masker = NiftiMasker(mask)
     masker.fit()
     single_session_model = FirstLevelModel(mask_img=masker).fit(
-                    fmri_data[0], design_matrices=design_matrices[0])
+        fmri_data[0], design_matrices=design_matrices[0])
     assert single_session_model.masker_ == masker
 
     # Call with verbose (improve coverage)
@@ -79,7 +79,8 @@ def test_explicit_fixed_effects():
     """ tests the fixed effects performed manually/explicitly"""
     with InTemporaryDirectory():
         shapes, rk = ((7, 8, 7, 15), (7, 8, 7, 16)), 3
-        mask, fmri_data, design_matrices = write_fake_fmri_data_and_design(shapes, rk)
+        mask, fmri_data, design_matrices =\
+            write_fake_fmri_data_and_design(shapes, rk)
         contrast = np.eye(rk)[1]
         # session 1
         multi_session_model = FirstLevelModel(mask_img=mask).fit(
@@ -142,7 +143,8 @@ def test_explicit_fixed_effects():
 def test_high_level_glm_with_data():
     with InTemporaryDirectory():
         shapes, rk = ((7, 8, 7, 15), (7, 8, 7, 16)), 3
-        mask, fmri_data, design_matrices = write_fake_fmri_data_and_design(shapes, rk)
+        mask, fmri_data, design_matrices =\
+            write_fake_fmri_data_and_design(shapes, rk)
         multi_session_model = FirstLevelModel(mask_img=None).fit(
             fmri_data, design_matrices=design_matrices)
         n_voxels = get_data(multi_session_model.masker_.mask_img_).sum()
@@ -194,7 +196,8 @@ def test_high_level_glm_with_data():
 def test_high_level_glm_with_paths():
     shapes, rk = ((7, 8, 7, 15), (7, 8, 7, 14)), 3
     with InTemporaryDirectory():
-        mask_file, fmri_files, design_files = write_fake_fmri_data_and_design(shapes, rk)
+        mask_file, fmri_files, design_files =\
+            write_fake_fmri_data_and_design(shapes, rk)
         multi_session_model = FirstLevelModel(mask_img=None).fit(
             fmri_files, design_matrices=design_files)
         z_image = multi_session_model.compute_contrast(np.eye(rk)[1])
@@ -208,7 +211,8 @@ def test_high_level_glm_with_paths():
 def test_high_level_glm_null_contrasts():
     # test that contrast computation is resilient to 0 values.
     shapes, rk = ((7, 8, 7, 15), (7, 8, 7, 19)), 3
-    mask, fmri_data, design_matrices = generate_fake_fmri_data_and_design(shapes, rk)
+    mask, fmri_data, design_matrices = \
+        generate_fake_fmri_data_and_design(shapes, rk)
 
     multi_session_model = FirstLevelModel(mask_img=None).fit(
         fmri_data, design_matrices=design_matrices)
@@ -225,7 +229,8 @@ def test_high_level_glm_null_contrasts():
 def test_high_level_glm_different_design_matrices():
     # test that one can estimate a contrast when design matrices are different
     shapes, rk = ((7, 8, 7, 15), (7, 8, 7, 19)), 3
-    mask, fmri_data, design_matrices = generate_fake_fmri_data_and_design(shapes, rk)
+    mask, fmri_data, design_matrices =\
+        generate_fake_fmri_data_and_design(shapes, rk)
 
     # add a column to the second design matrix
     design_matrices[1]['new'] = np.ones((19, 1))
@@ -252,7 +257,8 @@ def test_high_level_glm_different_design_matrices():
 def test_high_level_glm_different_design_matrices_formulas():
     # test that one can estimate a contrast when design matrices are different
     shapes, rk = ((7, 8, 7, 15), (7, 8, 7, 19)), 3
-    mask, fmri_data, design_matrices = generate_fake_fmri_data_and_design(shapes, rk)
+    mask, fmri_data, design_matrices =\
+        generate_fake_fmri_data_and_design(shapes, rk)
 
     # make column names identical
     design_matrices[1].columns = design_matrices[0].columns
@@ -266,15 +272,16 @@ def test_high_level_glm_different_design_matrices_formulas():
     # Compute contrast with formulas
     cols_formula = tuple(design_matrices[0].columns[:2])
     formula = "%s-%s" % cols_formula
-    with pytest.warns(UserWarning, match='One contrast given, assuming it for all 2 runs'):
-        z_joint_formula = multi_session_model.compute_contrast(
-            formula, output_type='effect_size')
+    with pytest.warns(UserWarning, match='One contrast given, '
+                                         'assuming it for all 2 runs'):
+        _ = multi_session_model.compute_contrast(formula,
+                                                 output_type='effect_size')
 
 
 def test_compute_contrast_num_contrasts():
-
     shapes, rk = ((7, 8, 7, 15), (7, 8, 7, 19), (7, 8, 7, 13)), 3
-    mask, fmri_data, design_matrices = generate_fake_fmri_data_and_design(shapes, rk)
+    mask, fmri_data, design_matrices =\
+        generate_fake_fmri_data_and_design(shapes, rk)
 
     # Fit a glm with 3 sessions and design matrices
     multi_session_model = FirstLevelModel(mask_img=mask).fit(
@@ -282,10 +289,11 @@ def test_compute_contrast_num_contrasts():
 
     # raise when n_contrast != n_runs | 1
     with pytest.raises(ValueError):
-        multi_session_model.compute_contrast([np.eye(rk)[1]]*2)
+        multi_session_model.compute_contrast([np.eye(rk)[1]] * 2)
 
-    multi_session_model.compute_contrast([np.eye(rk)[1]]*3)
-    with pytest.warns(UserWarning, match='One contrast given, assuming it for all 3 runs'):
+    multi_session_model.compute_contrast([np.eye(rk)[1]] * 3)
+    with pytest.warns(UserWarning, match='One contrast given, '
+                                         'assuming it for all 3 runs'):
         multi_session_model.compute_contrast([np.eye(rk)[1]])
 
 
@@ -410,10 +418,12 @@ def test_fmri_inputs():
                 FirstLevelModel(mask_img=None).fit([fi], design_matrices=d)
                 FirstLevelModel(mask_img=mask).fit(fi, design_matrices=[d])
                 FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d])
-                with pytest.warns(UserWarning, match="If design matrices are supplied"):
+                with pytest.warns(UserWarning, match="If design matrices "
+                                                     "are supplied"):
                     # test with confounds
-                    FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d],
-                                                    confounds=conf)
+                    FirstLevelModel(mask_img=mask).fit([fi],
+                                                       design_matrices=[d],
+                                                       confounds=conf)
 
                 # Provide t_r, confounds, and events but no design matrix
                 FirstLevelModel(mask_img=mask, t_r=2.0).fit(
@@ -426,7 +436,7 @@ def test_fmri_inputs():
                 with pytest.raises(ValueError,
                                    match="Rows in confounds does not match"):
                     FirstLevelModel(mask_img=mask, t_r=2.0).fit(
-                            fi, confounds=conf, events=events)
+                        fi, confounds=conf, events=events)
 
                 # test with confounds as numpy array
                 FirstLevelModel(mask_img=mask).fit([fi], design_matrices=[d],
@@ -566,7 +576,8 @@ def test_first_level_contrast_computation():
         model = model.fit([func_img, func_img], [events, events])
         # Check that an error is raised for invalid contrast_def
         with pytest.raises(ValueError,
-                           match="contrast_def must be an array or str or list"):
+                           match="contrast_def must be an"
+                                 "array or str or list"):
             model.compute_contrast(37)
         # smoke test for different contrasts in fixed effects
         model.compute_contrast([c1, c2])
@@ -619,7 +630,7 @@ def test_first_level_from_bids():
             first_level_from_bids(bids_path, 2, 'MNI')
         with pytest.raises(TypeError):
             first_level_from_bids(bids_path, 'main', 'MNI',
-                                         model_init=[])
+                                  model_init=[])
         with pytest.raises(TypeError,
                            match="space_label must be a string"):
             first_level_from_bids(bids_path, 'main',
@@ -716,7 +727,7 @@ def test_first_level_with_no_signal_scaling():
                         signal_scaling="foo")
 
     first_level = FirstLevelModel(mask_img=False, noise_model='ols',
-                                        signal_scaling=False)
+                                  signal_scaling=False)
     fmri_data.append(Nifti1Image(np.zeros((1, 1, 1, 2)) + 6, np.eye(4)))
 
     first_level.fit(fmri_data, design_matrices=design_matrices)
@@ -733,7 +744,8 @@ def test_first_level_with_no_signal_scaling():
 
 def test_first_level_residuals():
     shapes, rk = [(10, 10, 10, 100)], 3
-    mask, fmri_data, design_matrices = generate_fake_fmri_data_and_design(shapes, rk)
+    mask, fmri_data, design_matrices =\
+        generate_fake_fmri_data_and_design(shapes, rk)
 
     for i in range(len(design_matrices)):
         design_matrices[i].iloc[:, 0] = 1
@@ -773,7 +785,8 @@ def test_first_level_residuals():
     [(10, 10, 10, 25), (10, 10, 10, 100)],
 ])
 def test_get_voxelwise_attributes_should_return_as_many_as_design_matrices(shapes):
-    mask, fmri_data, design_matrices = generate_fake_fmri_data_and_design(shapes)
+    mask, fmri_data, design_matrices =\
+        generate_fake_fmri_data_and_design(shapes)
 
     for i in range(len(design_matrices)):
         design_matrices[i].iloc[:, 0] = 1
@@ -783,12 +796,14 @@ def test_get_voxelwise_attributes_should_return_as_many_as_design_matrices(shape
     model.fit(fmri_data, design_matrices=design_matrices)
 
     # Check that length of outputs is the same as the number of design matrices
-    assert len(model._get_voxelwise_model_attribute("resid", True)) == len(shapes)
+    assert len(model._get_voxelwise_model_attribute("resid", True)) == \
+           len(shapes)
 
 
 def test_first_level_predictions_r_square():
     shapes, rk = [(10, 10, 10, 25)], 3
-    mask, fmri_data, design_matrices = generate_fake_fmri_data_and_design(shapes, rk)
+    mask, fmri_data, design_matrices =\
+        generate_fake_fmri_data_and_design(shapes, rk)
 
     for i in range(len(design_matrices)):
         design_matrices[i].iloc[:, 0] = 1

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -39,7 +39,7 @@ def test_high_level_glm_one_session():
     masker = NiftiMasker(mask)
     with pytest.raises(ValueError,
                        match="It seems that NiftiMasker has not been fitted."):
-        _ = FirstLevelModel(mask_img=masker).fit(
+        FirstLevelModel(mask_img=masker).fit(
             fmri_data[0], design_matrices=design_matrices[0])
 
     # Give a fitted NiftiMasker with a None mask_img_ attribute
@@ -49,7 +49,7 @@ def test_high_level_glm_one_session():
     masker.mask_img_ = None
     with pytest.warns(UserWarning,
                       match="Parameter memory of the masker overriden"):
-        _ = FirstLevelModel(mask_img=masker).fit(
+        FirstLevelModel(mask_img=masker).fit(
             fmri_data[0], design_matrices=design_matrices[0])
 
     # Give a fitted NiftiMasker
@@ -274,8 +274,8 @@ def test_high_level_glm_different_design_matrices_formulas():
     formula = "%s-%s" % cols_formula
     with pytest.warns(UserWarning, match='One contrast given, '
                                          'assuming it for all 2 runs'):
-        _ = multi_session_model.compute_contrast(formula,
-                                                 output_type='effect_size')
+        multi_session_model.compute_contrast(formula,
+                                             output_type='effect_size')
 
 
 def test_compute_contrast_num_contrasts():

--- a/nilearn/glm/tests/test_hemodynamic_models.py
+++ b/nilearn/glm/tests/test_hemodynamic_models.py
@@ -8,19 +8,11 @@ from numpy.testing import (assert_almost_equal,
                            assert_array_almost_equal,
                            )
 
-from nilearn.glm.first_level.hemodynamic_models import (_hrf_kernel,
-                                                        _orthogonalize,
-                                                        _regressor_names,
-                                                        _resample_regressor,
-                                                        _sample_condition,
-                                                        compute_regressor,
-                                                        spm_dispersion_derivative,
-                                                        spm_hrf,
-                                                        spm_time_derivative,
-                                                        glover_dispersion_derivative,
-                                                        glover_hrf,
-                                                        glover_time_derivative,
-                                                        )
+from nilearn.glm.first_level.hemodynamic_models import \
+    (_hrf_kernel, _orthogonalize, _regressor_names, _resample_regressor,
+     _sample_condition, compute_regressor, spm_dispersion_derivative,
+     spm_hrf, spm_time_derivative, glover_dispersion_derivative,
+     glover_hrf, glover_time_derivative)
 
 
 def test_spm_hrf():
@@ -173,7 +165,8 @@ def test_sample_condition_5():
 
 
 def test_sample_condition_6():
-    """ Test the experimental condition sampling -- overalapping onsets, different durations
+    """ Test the experimental condition sampling -- overalapping onsets,
+    different durations
     """
     condition = ([0, 0, 10], [1, 2, 1], [1., 1., 1.])
     frame_times = np.linspace(0, 49, 50)
@@ -185,7 +178,8 @@ def test_sample_condition_6():
 
 
 def test_sample_condition_7():
-    """ Test the experimental condition sampling -- different onsets, overlapping offsets
+    """ Test the experimental condition sampling -- different onsets,
+    overlapping offsets
     """
     condition = ([0, 10, 20], [11, 1, 1], [1., 1., 1.])
     frame_times = np.linspace(0, 49, 50)

--- a/nilearn/glm/tests/test_paradigm.py
+++ b/nilearn/glm/tests/test_paradigm.py
@@ -24,7 +24,7 @@ def basic_paradigm():
 
 
 def duplicate_events_paradigm():
-    conditions = ['c0', 'c0', 'c0', 'c0','c1', 'c1']
+    conditions = ['c0', 'c0', 'c0', 'c0', 'c1', 'c1']
     onsets = [10, 30, 70, 70, 10, 30]
     durations = [1., 1., 1., 1., 1., 1]
     events = pd.DataFrame({'trial_type': conditions,
@@ -97,7 +97,8 @@ def test_check_events():
     # Missing duration
     missing_duration = events.drop(columns=['duration'])
     with pytest.raises(ValueError,
-                       match='The provided events data has no duration column.'):
+                       match='The provided events data has '
+                             'no duration column.'):
         check_events(missing_duration)
 
     # Duration wrong type
@@ -156,7 +157,7 @@ def test_duplicate_events():
         ttype, onset, duration, modulation = check_events(events)
     assert_array_equal(ttype, ['c0', 'c0', 'c0', 'c1', 'c1'])
     assert_array_equal(onset, [10, 30, 70, 10, 30])
-    assert_array_equal(duration, [1. , 1. , 1., 1. , 1. ])
+    assert_array_equal(duration, [1., 1., 1., 1., 1.])
     # Modulation was updated
     assert_array_equal(modulation, [1, 1, 2, 1, 1])
 

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -22,12 +22,9 @@ from nilearn._utils.data_gen import (write_fake_fmri_data_and_design,
                                      generate_fake_fmri_data_and_design)
 from nilearn.image import concat_imgs, get_data
 from nilearn.input_data import NiftiMasker
-from nilearn.glm.first_level import (FirstLevelModel,
-                                             run_glm,
-                                             )
+from nilearn.glm.first_level import (FirstLevelModel, run_glm)
 from nilearn.glm.second_level import (SecondLevelModel,
-                                              non_parametric_inference,
-                                              )
+                                      non_parametric_inference)
 
 # This directory path
 BASEDIR = os.path.dirname(os.path.abspath(__file__))
@@ -42,13 +39,15 @@ def test_check_second_level_input():
         _check_second_level_input([FirstLevelModel()], pd.DataFrame())
     with pytest.raises(ValueError,
                        match="Model sub_1 at index 0 has not been fit yet"):
-        _check_second_level_input([FirstLevelModel(subject_label="sub_{}".format(i))
-                                   for i in range(1, 3)], pd.DataFrame())
+        _check_second_level_input([FirstLevelModel(
+            subject_label="sub_{}".format(i))
+            for i in range(1, 3)], pd.DataFrame())
     with InTemporaryDirectory():
         shapes, rk = [(7, 8, 9, 15)], 3
-        mask, fmri_data, design_matrices = generate_fake_fmri_data_and_design(shapes, rk)
-        input_models = [FirstLevelModel(mask_img=mask).fit(fmri_data[0],
-                                                           design_matrices=design_matrices[0])]
+        mask, fmri_data, design_matrices = \
+            generate_fake_fmri_data_and_design(shapes, rk)
+        input_models = [FirstLevelModel(mask_img=mask).fit(
+            fmri_data[0], design_matrices=design_matrices[0])]
         obj = lambda: None
         obj.results_ = "foo"
         obj.labels_ = "bar"
@@ -58,7 +57,8 @@ def test_check_second_level_input():
             _check_second_level_input(input_models + [obj], pd.DataFrame())
         with pytest.raises(ValueError,
                            match="In case confounds are provided, first level "
-                                 "objects need to provide the attribute subject_label"):
+                                 "objects need to provide the attribute "
+                                 "subject_label"):
             _check_second_level_input(input_models * 2, pd.DataFrame(),
                                       confounds=pd.DataFrame())
         with pytest.raises(ValueError,
@@ -72,12 +72,14 @@ def test_check_second_level_input():
     with pytest.raises(ValueError,
                        match="second_level_input DataFrame must have columns "
                              "subject_label, map_name and effects_map_path"):
-        _check_second_level_input(pd.DataFrame(columns=["foo", "bar"]), pd.DataFrame())
+        _check_second_level_input(pd.DataFrame(columns=["foo", "bar"]),
+                                  pd.DataFrame())
     with pytest.raises(ValueError,
                        match="subject_label column must contain only strings"):
         _check_second_level_input(pd.DataFrame({"subject_label": [1, 2],
                                                 "map_name": ["a", "b"],
-                                                "effects_map_path": ["c", "d"]}),
+                                                "effects_map_path":
+                                                    ["c", "d"]}),
                                   pd.DataFrame())
     with pytest.raises(ValueError,
                        match="List of niimgs as second_level_input "
@@ -101,7 +103,7 @@ def test_check_output_type():
 
 def test_check_design_matrix():
     from nilearn.glm.second_level.second_level import _check_design_matrix
-    _check_design_matrix(None) # Should not do anything
+    _check_design_matrix(None)  # Should not do anything
     with pytest.raises(ValueError,
                        match="design matrix must be a pandas DataFrame"):
         _check_design_matrix("foo")
@@ -110,7 +112,7 @@ def test_check_design_matrix():
 
 def test_check_confounds():
     from nilearn.glm.second_level.second_level import _check_confounds
-    _check_confounds(None) # Should not do anything
+    _check_confounds(None)  # Should not do anything
     with pytest.raises(ValueError,
                        match="confounds must be a pandas DataFrame"):
         _check_confounds("foo")
@@ -128,8 +130,9 @@ def test_check_confounds():
 
 
 def test_check_first_level_contrast():
-    from nilearn.glm.second_level.second_level import _check_first_level_contrast
-    _check_first_level_contrast(["foo"], None) # Should not do anything
+    from nilearn.glm.second_level.second_level import \
+        _check_first_level_contrast
+    _check_first_level_contrast(["foo"], None)  # Should not do anything
     with pytest.raises(ValueError,
                        match="If second_level_input was a list"):
         _check_first_level_contrast([FirstLevelModel()], None)
@@ -140,7 +143,8 @@ def test_check_effect_maps():
     from nilearn.glm.second_level.second_level import _check_effect_maps
     _check_effect_maps([1, 2, 3], np.array([[1, 2], [3, 4], [5, 6]]))
     with pytest.raises(ValueError,
-                       match="design_matrix does not match the number of maps considered"):
+                       match="design_matrix does not match "
+                             "the number of maps considered"):
         _check_effect_maps([1, 2], np.array([[1, 2], [3, 4], [5, 6]]))
 
 
@@ -157,7 +161,8 @@ def test_get_contrast():
                        match="No second-level contrast is specified."):
         _get_contrast(None, design_matrix)
     with pytest.raises(ValueError,
-                       match="second_level_contrast must be a list of 0s and 1s"):
+                       match="second_level_contrast must be "
+                             "a list of 0s and 1s"):
         _get_contrast([0, 0], design_matrix)
     assert _get_contrast([0, 1], design_matrix) == 'conf2'
     assert _get_contrast([1, 0], design_matrix) == 'conf1'
@@ -165,12 +170,14 @@ def test_get_contrast():
 
 def test_infer_effect_maps():
     from nilearn.glm.second_level.second_level import _infer_effect_maps
-    #with InTemporaryDirectory():
+    # with InTemporaryDirectory():
     shapes, rk = ((7, 8, 9, 1), (7, 8, 7, 16)), 3
-    mask, fmri_data, design_matrices = write_fake_fmri_data_and_design(shapes, rk)
+    mask, fmri_data, design_matrices = write_fake_fmri_data_and_design(shapes,
+                                                                       rk)
     func_img = load(fmri_data[0])
-    second_level_input = pd.DataFrame({'map_name': ["a", "b"] ,
-                                        'effects_map_path': [fmri_data[0], "bar"]})
+    second_level_input = pd.DataFrame({'map_name': ["a", "b"],
+                                       'effects_map_path': [fmri_data[0],
+                                                            "bar"]})
     assert _infer_effect_maps(second_level_input, "a") == [fmri_data[0]]
     with pytest.raises(ValueError,
                        match="File not found: 'bar'"):
@@ -223,7 +230,7 @@ def test_high_level_glm_with_paths():
         z_image = model.fit(Y, design_matrix=X).compute_contrast(c1)
         assert_array_equal(z_image.shape, target_shape)
         assert_array_equal(z_image.affine, target_affine)
-        
+
         # Delete objects attached to files to avoid WindowsError when deleting
         # temporary directory (in Windows)
         del Y, FUNCFILE, func_img, model
@@ -242,7 +249,7 @@ def test_high_level_non_parametric_inference_with_paths():
         neg_log_pvals_img = non_parametric_inference(Y, design_matrix=X,
                                                      second_level_contrast=c1,
                                                      mask=mask, n_perm=n_perm,
-                                                     verbose=1) # For coverage
+                                                     verbose=1)  # For coverage
         neg_log_pvals = get_data(neg_log_pvals_img)
 
         assert isinstance(neg_log_pvals_img, Nifti1Image)
@@ -252,7 +259,8 @@ def test_high_level_non_parametric_inference_with_paths():
         assert np.all(0 <= neg_log_pvals)
         masker = NiftiMasker(mask, smoothing_fwhm=2.0)
         with pytest.warns(UserWarning,
-                          match="Parameter smoothing_fwhm of the masker overriden"):
+                          match="Parameter smoothing_fwhm "
+                                "of the masker overriden"):
             non_parametric_inference(Y, design_matrix=X,
                                      second_level_contrast=c1,
                                      smoothing_fwhm=3.0,

--- a/nilearn/glm/tests/test_utils.py
+++ b/nilearn/glm/tests/test_utils.py
@@ -118,10 +118,10 @@ def test_z_score_opposite_contrast():
         c1 = np.array([1] + [0] * (design_matrix.shape[1] - 1))
         c2 = np.array([0] + [1] + [0] * (design_matrix.shape[1] - 2))
         contrasts = {'seed1 - seed2': c1 - c2, 'seed2 - seed1': c2 - c1}
-        fmri_glm = FirstLevelModel(t_r=2., 
-                                   noise_model='ar1', 
-                                   standardize=False, 
-                                   hrf_model='spm', 
+        fmri_glm = FirstLevelModel(t_r=2.,
+                                   noise_model='ar1',
+                                   standardize=False,
+                                   hrf_model='spm',
                                    drift_model='cosine')
         fmri_glm.fit(fmri, design_matrices=design_matrix)
         z_map_seed1_vs_seed2 = fmri_glm.compute_contrast(
@@ -222,7 +222,7 @@ def test_img_table_checks():
     with pytest.raises(ValueError):
         _check_and_load_tables(['.csv', '.csv'], "")
     with pytest.raises(TypeError):
-        _check_and_load_tables([[], pd.DataFrame()], "") # np.array([0]), 
+        _check_and_load_tables([[], pd.DataFrame()], "")  # np.array([0]),
     with pytest.raises(ValueError):
         _check_and_load_tables(['.csv', pd.DataFrame()], "")
     # check high level wrapper keeps behavior
@@ -271,18 +271,20 @@ def test_get_bids_files():
         assert len(selection) == 1
         # 80 counfonds (4 runs per ses & sub), testing `fmriprep` >= 20.2 path
         selection = get_bids_files(os.path.join(bids_path, 'derivatives'),
-                file_tag='desc-confounds_timeseries')
+                                   file_tag='desc-confounds_timeseries')
         assert len(selection) == 80
 
     with InTemporaryDirectory():
         bids_path = create_fake_bids_dataset(n_sub=10, n_ses=2,
                                              tasks=['localizer', 'main'],
                                              n_runs=[1, 3],
-                                             confounds_tag="desc-confounds_regressors")
+                                             confounds_tag="desc-confounds_"
+                                                           "regressors")
         # 80 counfonds (4 runs per ses & sub), testing `fmriprep` >= 20.2 path
         selection = get_bids_files(os.path.join(bids_path, 'derivatives'),
-                file_tag='desc-confounds_regressors')
+                                   file_tag='desc-confounds_regressors')
         assert len(selection) == 80
+
 
 def test_parse_bids_filename():
     fields = ['sub', 'ses', 'task', 'lolo']

--- a/nilearn/glm/thresholding.py
+++ b/nilearn/glm/thresholding.py
@@ -143,9 +143,10 @@ def cluster_level_inference(stat_img, mask_img=None,
 
     References
     ----------
-    .. [1] Rosenblatt JD, Finos L, Weeda WD, Solari A, Goeman JJ. All-Resolutions
-       Inference for brain imaging. Neuroimage. 2018 Nov 1;181:786-796. doi:
-       10.1016/j.neuroimage.2018.07.060
+    .. [1] Rosenblatt JD, Finos L, Weeda WD, Solari A, Goeman JJ.
+        All-Resolutions Inference for brain imaging.
+        Neuroimage. 2018 Nov 1;181:786-796.
+        doi: 10.1016/j.neuroimage.2018.07.060
 
     """
 


### PR DESCRIPTION
Following #2915 and #2916 I noticed that flake is only run on changes to code (I think?). So I manually ran a flake check locally on the GLM module and then manually fixed most errors. I didn't use an automated approach, I can if you prefer.

No hard feeling if you want to reject this PR, I didn't ask in advance, and it touches a lot of code, so is probably risky.

TODO:

- [x] Check the doc strings render correctly for the long multiline type specifications 