### PR TITLE
[FIX] LGTM warning: Missing variable declaration

### DIFF
--- a/nilearn/plotting/data/html/connectome_plot_template.html
+++ b/nilearn/plotting/data/html/connectome_plot_template.html
@@ -17,7 +17,7 @@
         function makePlot(surface, hemisphere, divId) {
 
             decodeHemisphere(connectomeInfo, surface, hemisphere);
-            info = connectomeInfo[surface + "_" + hemisphere];
+            var info = connectomeInfo[surface + "_" + hemisphere];
             info["type"] = "mesh3d";
             info["color"] = "#aaaaaa";
             info["opacity"] = getOpacity();


### PR DESCRIPTION
This is a JavaScript issue, in an HTML page:

Variable info is used like a local variable, but is missing a declaration.