### PR TITLE
Add pathlib.Path support for nilearn.datasets

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -54,6 +54,8 @@ Enhancements
   parameters or common lists of options for example. The standard parts are defined
   in a single location (`nilearn._utils.docs.py`) which makes them easier to
   maintain and update. (See `#2875 <https://github.com/nilearn/nilearn/pull/2875>`_)
+- The `data_dir` argument can now be either a `pathlib.Path` or a string. This
+  extension affects datasets and atlas fetchers.
 
 Changes
 -------

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -38,7 +38,7 @@ resume : :obj:`bool`, optional
 
 # Data_dir
 docdict['data_dir'] = """
-data_dir : :obj:`str`, optional
+data_dir : :obj:`pathlib.Path` or :obj:`str`, optional
     Path where data should be downloaded. By default,
     files are downloaded in home directory."""
 

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -406,8 +406,10 @@ def test_fetch_atlas_difumo(tmp_path, request_mocker):
             assert dataset.description != ''
 
     with pytest.raises(ValueError):
-        atlas.fetch_atlas_difumo(data_dir=tmp_path, dimension=42, resolution_mm=3)
-        atlas.fetch_atlas_difumo(data_dir=tmp_path, dimension=128, resolution_mm=3.14)
+        atlas.fetch_atlas_difumo(data_dir=tmp_path,
+                                 dimension=42, resolution_mm=3)
+        atlas.fetch_atlas_difumo(data_dir=tmp_path,
+                                 dimension=128, resolution_mm=3.14)
 
 
 def test_fetch_atlas_aal(tmp_path, request_mocker):

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -137,7 +137,7 @@ def test_downloader(tmp_path, request_mocker):
     # Now, we use the regular downloading feature. This will override the dummy
     # file created before.
 
-    atlas.fetch_atlas_craddock_2012(data_dir=str(tmp_path))
+    atlas.fetch_atlas_craddock_2012(data_dir=tmp_path)
     with dummy_file.open() as f:
         stuff = f.read()
     assert stuff == ''
@@ -187,7 +187,7 @@ def test_fail_fetch_atlas_harvard_oxford(tmp_path, request_mocker):
     # have maps as string and n_labels=4 with background. Since, we relay on xml
     # file to retrieve labels.
     ho_wo_symm = atlas.fetch_atlas_harvard_oxford(target_atlas,
-                                                  data_dir=str(tmp_path))
+                                                  data_dir=tmp_path)
     assert isinstance(ho_wo_symm.maps, str)
     assert isinstance(ho_wo_symm.labels, list)
     assert ho_wo_symm.labels[0] == "Background"
@@ -228,7 +228,7 @@ def test_fail_fetch_atlas_harvard_oxford(tmp_path, request_mocker):
     nibabel.Nifti1Image(atlas_data, np.eye(4) * 3).to_filename(
         nifti_target_split)
     ho = atlas.fetch_atlas_harvard_oxford(target_atlas,
-                                          data_dir=str(tmp_path),
+                                          data_dir=tmp_path,
                                           symmetric_split=True)
 
     assert isinstance(ho.maps, nibabel.Nifti1Image)
@@ -247,7 +247,7 @@ def test_fetch_atlas_craddock_2012(tmp_path, request_mocker):
     local_archive = Path(
         __file__).parent / "data" / "craddock_2011_parcellations.tar.gz"
     request_mocker.url_mapping["*craddock*"] = local_archive
-    bunch = atlas.fetch_atlas_craddock_2012(data_dir=str(tmp_path),
+    bunch = atlas.fetch_atlas_craddock_2012(data_dir=tmp_path,
                                             verbose=0)
 
     keys = ("scorr_mean", "tcorr_mean",
@@ -267,7 +267,7 @@ def test_fetch_atlas_craddock_2012(tmp_path, request_mocker):
 
 
 def test_fetch_atlas_smith_2009(tmp_path, request_mocker):
-    bunch = atlas.fetch_atlas_smith_2009(data_dir=str(tmp_path), verbose=0)
+    bunch = atlas.fetch_atlas_smith_2009(data_dir=tmp_path, verbose=0)
 
     keys = ("rsn20", "rsn10", "rsn70",
             "bm20", "bm10", "bm70")
@@ -322,7 +322,7 @@ def _destrieux_data():
 
 def test_fetch_atlas_destrieux_2009(tmp_path, request_mocker):
     request_mocker.url_mapping["*destrieux2009.tgz"] = _destrieux_data()
-    bunch = atlas.fetch_atlas_destrieux_2009(data_dir=str(tmp_path),
+    bunch = atlas.fetch_atlas_destrieux_2009(data_dir=tmp_path,
                                              verbose=0)
 
     assert request_mocker.url_count == 1
@@ -330,7 +330,7 @@ def test_fetch_atlas_destrieux_2009(tmp_path, request_mocker):
                                 / 'destrieux2009_rois_lateralized.nii.gz')
 
     bunch = atlas.fetch_atlas_destrieux_2009(
-        lateralized=False, data_dir=str(tmp_path), verbose=0)
+        lateralized=False, data_dir=tmp_path, verbose=0)
 
     assert request_mocker.url_count == 1
     assert bunch['maps'] == str(tmp_path / 'destrieux_2009'
@@ -347,7 +347,7 @@ def test_fetch_atlas_msdl(tmp_path, request_mocker):
                root / "README.txt": ""}
     request_mocker.url_mapping["*MSDL_rois.zip"] = dict_to_archive(
         archive, "zip")
-    dataset = atlas.fetch_atlas_msdl(data_dir=str(tmp_path), verbose=0)
+    dataset = atlas.fetch_atlas_msdl(data_dir=tmp_path, verbose=0)
     assert isinstance(dataset.labels, list)
     assert isinstance(dataset.region_coords, list)
     assert isinstance(dataset.networks, list)
@@ -357,7 +357,7 @@ def test_fetch_atlas_msdl(tmp_path, request_mocker):
 
 
 def test_fetch_atlas_yeo_2011(tmp_path, request_mocker):
-    dataset = atlas.fetch_atlas_yeo_2011(data_dir=str(tmp_path), verbose=0)
+    dataset = atlas.fetch_atlas_yeo_2011(data_dir=tmp_path, verbose=0)
     assert isinstance(dataset.anat, str)
     assert isinstance(dataset.colors_17, str)
     assert isinstance(dataset.colors_7, str)
@@ -395,7 +395,7 @@ def test_fetch_atlas_difumo(tmp_path, request_mocker):
         request_mocker.url_mapping[url] = dict_to_archive(archive, "zip")
 
         for res in resolutions:
-            dataset = atlas.fetch_atlas_difumo(data_dir=str(tmp_path),
+            dataset = atlas.fetch_atlas_difumo(data_dir=tmp_path,
                                                dimension=dim,
                                                resolution_mm=res,
                                                verbose=0)
@@ -406,8 +406,8 @@ def test_fetch_atlas_difumo(tmp_path, request_mocker):
             assert dataset.description != ''
 
     with pytest.raises(ValueError):
-        atlas.fetch_atlas_difumo(data_dir=str(tmp_path), dimension=42, resolution_mm=3)
-        atlas.fetch_atlas_difumo(data_dir=str(tmp_path), dimension=128, resolution_mm=3.14)
+        atlas.fetch_atlas_difumo(data_dir=tmp_path, dimension=42, resolution_mm=3)
+        atlas.fetch_atlas_difumo(data_dir=tmp_path, dimension=128, resolution_mm=3.14)
 
 
 def test_fetch_atlas_aal(tmp_path, request_mocker):
@@ -418,7 +418,7 @@ def test_fetch_atlas_aal(tmp_path, request_mocker):
         {archive_root / "AAL.xml": metadata, archive_root / "AAL.nii": ""})
 
     request_mocker.url_mapping["*AAL_files*"] = aal_data
-    dataset = atlas.fetch_atlas_aal(data_dir=str(tmp_path), verbose=0)
+    dataset = atlas.fetch_atlas_aal(data_dir=tmp_path, verbose=0)
     assert isinstance(dataset.maps, str)
     assert isinstance(dataset.labels, list)
     assert isinstance(dataset.indices, list)
@@ -428,7 +428,7 @@ def test_fetch_atlas_aal(tmp_path, request_mocker):
                        match='The version of AAL requested "FLS33"'
                        ):
         atlas.fetch_atlas_aal(version="FLS33",
-                              data_dir=str(tmp_path),
+                              data_dir=tmp_path,
                               verbose=0)
 
     assert dataset.description != ''
@@ -436,12 +436,12 @@ def test_fetch_atlas_aal(tmp_path, request_mocker):
 
 def test_fetch_atlas_basc_multiscale_2015(tmp_path, request_mocker):
     # default version='sym',
-    data_sym = atlas.fetch_atlas_basc_multiscale_2015(data_dir=str(tmp_path),
+    data_sym = atlas.fetch_atlas_basc_multiscale_2015(data_dir=tmp_path,
                                                       verbose=0)
     # version='asym'
     data_asym = atlas.fetch_atlas_basc_multiscale_2015(version='asym',
                                                        verbose=0,
-                                                       data_dir=str(tmp_path))
+                                                       data_dir=tmp_path)
 
     keys = ['scale007', 'scale012', 'scale020', 'scale036', 'scale064',
             'scale122', 'scale197', 'scale325', 'scale444']
@@ -466,7 +466,7 @@ def test_fetch_atlas_basc_multiscale_2015(tmp_path, request_mocker):
             ValueError,
             match='The version of Brain parcellations requested "aym"'):
         atlas.fetch_atlas_basc_multiscale_2015(version="aym",
-                                               data_dir=str(tmp_path),
+                                               data_dir=tmp_path,
                                                verbose=0)
 
     assert request_mocker.url_count == 2
@@ -487,7 +487,7 @@ def test_fetch_coords_dosenbach_2010(request_mocker):
 
 
 def test_fetch_atlas_allen_2011(tmp_path, request_mocker):
-    bunch = atlas.fetch_atlas_allen_2011(data_dir=str(tmp_path), verbose=0)
+    bunch = atlas.fetch_atlas_allen_2011(data_dir=tmp_path, verbose=0)
     keys = ("maps",
             "rsn28",
             "comps")
@@ -515,7 +515,7 @@ def test_fetch_atlas_surf_destrieux(tmp_path, request_mocker, verbose=0):
                 np.arange(4), np.zeros((4, 5)), 5 * ['a'],
                 )
 
-    bunch = atlas.fetch_atlas_surf_destrieux(data_dir=str(tmp_path), verbose=0)
+    bunch = atlas.fetch_atlas_surf_destrieux(data_dir=tmp_path, verbose=0)
     # Our mock annots have 4 labels
     assert len(bunch.labels) == 4
     assert bunch.map_left.shape == (4, )
@@ -541,11 +541,11 @@ def test_fetch_atlas_talairach(tmp_path, request_mocker):
     request_mocker.url_mapping["*talairach.nii"] = _get_small_fake_talairach()
     level_values = np.ones((81, 3)) * [0, 1, 2]
     talairach = atlas.fetch_atlas_talairach('hemisphere',
-                                            data_dir=str(tmp_path))
+                                            data_dir=tmp_path)
     assert_array_equal(get_data(talairach.maps).ravel(),
                        level_values.T.ravel())
     assert_array_equal(talairach.labels, ['Background', 'b', 'a'])
-    talairach = atlas.fetch_atlas_talairach('ba', data_dir=str(tmp_path))
+    talairach = atlas.fetch_atlas_talairach('ba', data_dir=tmp_path)
     assert_array_equal(get_data(talairach.maps).ravel(),
                        level_values.ravel())
     pytest.raises(ValueError, atlas.fetch_atlas_talairach, 'bad_level')
@@ -614,7 +614,7 @@ def test_fetch_atlas_schaefer_2018(tmp_path, request_mocker):
         data = atlas.fetch_atlas_schaefer_2018(n_rois=n_rois,
                                                yeo_networks=yeo_networks,
                                                resolution_mm=resolution_mm,
-                                               data_dir=str(tmp_path),
+                                               data_dir=tmp_path,
                                                verbose=0)
         assert data.description != ''
         assert isinstance(data.maps, str)

--- a/nilearn/datasets/tests/test_func.py
+++ b/nilearn/datasets/tests/test_func.py
@@ -71,7 +71,7 @@ def test_fetch_haxby(tmp_path, request_mocker):
     request_mocker.url_mapping[
         re.compile(r".*(subj\d).*\.tar\.gz")] = _make_haxby_subject_data
     for i in range(1, 6):
-        haxby = func.fetch_haxby(data_dir=str(tmp_path), subjects=[i],
+        haxby = func.fetch_haxby(data_dir=tmp_path, subjects=[i],
                                  verbose=0)
         # subject_data + (md5 + mask if first subj)
         assert request_mocker.url_count == i + 2
@@ -88,7 +88,7 @@ def test_fetch_haxby(tmp_path, request_mocker):
 
     # subjects with list
     subjects = [1, 2, 6]
-    haxby = func.fetch_haxby(data_dir=str(tmp_path), subjects=subjects,
+    haxby = func.fetch_haxby(data_dir=tmp_path, subjects=subjects,
                              verbose=0)
     assert len(haxby.func) == len(subjects)
     assert len(haxby.mask_house_little) == len(subjects)
@@ -105,7 +105,7 @@ def test_fetch_haxby(tmp_path, request_mocker):
 
     for sub_id in subjects:
         with pytest.raises(ValueError, match=message.format(sub_id)):
-            func.fetch_haxby(data_dir=str(tmp_path), subjects=[sub_id])
+            func.fetch_haxby(data_dir=tmp_path, subjects=[sub_id])
 
 
 def _adhd_example_subject(match, request):
@@ -141,7 +141,7 @@ def test_fetch_adhd(tmp_path, request_mocker):
     request_mocker.url_mapping["*metadata.tgz"] = _adhd_metadata()
     request_mocker.url_mapping[
         re.compile(r".*adhd40_([0-9]+)\.tgz")] = _adhd_example_subject
-    adhd = func.fetch_adhd(data_dir=str(tmp_path), n_subjects=12, verbose=0)
+    adhd = func.fetch_adhd(data_dir=tmp_path, n_subjects=12, verbose=0)
     assert len(adhd.func) == 12
     assert len(adhd.confounds) == 12
     assert request_mocker.url_count == 13  # Subjects + phenotypic
@@ -149,7 +149,7 @@ def test_fetch_adhd(tmp_path, request_mocker):
 
 
 def test_miyawaki2008(tmp_path, request_mocker):
-    dataset = func.fetch_miyawaki2008(data_dir=str(tmp_path), verbose=0)
+    dataset = func.fetch_miyawaki2008(data_dir=tmp_path, verbose=0)
     assert len(dataset.func) == 32
     assert len(dataset.label) == 32
     assert isinstance(dataset.mask, str)
@@ -164,7 +164,7 @@ def test_fetch_localizer_contrasts(tmp_path, request_mocker, localizer_mocker):
     dataset = func.fetch_localizer_contrasts(
         ['checkerboard'],
         n_subjects=2,
-        data_dir=str(tmp_path),
+        data_dir=tmp_path,
         verbose=1)
     assert not hasattr(dataset, 'anats')
     assert not hasattr(dataset, 'tmaps')
@@ -178,7 +178,7 @@ def test_fetch_localizer_contrasts(tmp_path, request_mocker, localizer_mocker):
     dataset = func.fetch_localizer_contrasts(
         ['checkerboard', 'horizontal checkerboard'],
         n_subjects=2,
-        data_dir=str(tmp_path),
+        data_dir=tmp_path,
         verbose=1)
     assert isinstance(dataset.ext_vars, np.recarray)
     assert isinstance(dataset.cmaps[0], str)
@@ -189,7 +189,7 @@ def test_fetch_localizer_contrasts(tmp_path, request_mocker, localizer_mocker):
     dataset = func.fetch_localizer_contrasts(
         ['checkerboard'],
         n_subjects=1,
-        data_dir=str(tmp_path),
+        data_dir=tmp_path,
         get_anats=True,
         get_masks=True,
         get_tmaps=True,
@@ -210,7 +210,7 @@ def test_fetch_localizer_contrasts(tmp_path, request_mocker, localizer_mocker):
     dataset2 = func.fetch_localizer_contrasts(
         ['checkerboard'],
         n_subjects=[2, 3, 5],
-        data_dir=str(tmp_path),
+        data_dir=tmp_path,
         verbose=1)
     assert dataset2.ext_vars.size == 3
     assert len(dataset2.cmaps) == 3
@@ -223,7 +223,7 @@ def test_fetch_localizer_calculation_task(tmp_path, request_mocker,
     # 2 subjects
     dataset = func.fetch_localizer_calculation_task(
         n_subjects=2,
-        data_dir=str(tmp_path),
+        data_dir=tmp_path,
         verbose=1)
     assert isinstance(dataset.ext_vars, np.recarray)
     assert isinstance(dataset.cmaps[0], str)
@@ -236,7 +236,7 @@ def test_fetch_localizer_button_task(tmp_path, request_mocker,
                                      localizer_mocker):
     # Disabled: cannot be tested without actually fetching covariates CSV file
     # Only one subject
-    dataset = func.fetch_localizer_button_task(data_dir=str(tmp_path),
+    dataset = func.fetch_localizer_button_task(data_dir=tmp_path,
                                                verbose=1)
 
     assert isinstance(dataset.tmaps, list)
@@ -260,13 +260,13 @@ def test_fetch_abide_pcp(tmp_path, request_mocker):
     request_mocker.url_mapping["*rocessed1.csv"] = pheno.to_csv(index=False)
 
     # All subjects
-    dataset = func.fetch_abide_pcp(data_dir=str(tmp_path),
+    dataset = func.fetch_abide_pcp(data_dir=tmp_path,
                                    quality_checked=False, verbose=0)
     assert len(dataset.func_preproc) == 400
     assert dataset.description != ''
 
     # Smoke test using only a string, rather than a list of strings
-    dataset = func.fetch_abide_pcp(data_dir=str(tmp_path),
+    dataset = func.fetch_abide_pcp(data_dir=tmp_path,
                                    quality_checked=False, verbose=0,
                                    derivatives='func_preproc')
 
@@ -288,7 +288,7 @@ def test__load_mixed_gambles(request_mocker):
 def test_fetch_mixed_gambles(tmp_path, request_mocker):
     for n_subjects in [1, 5, 16]:
         mgambles = func.fetch_mixed_gambles(n_subjects=n_subjects,
-                                            data_dir=str(tmp_path),
+                                            data_dir=tmp_path,
                                             verbose=0, return_raw_data=True)
         datasetdir = tmp_path / "jimura_poldrack_2012_zmaps"
         assert mgambles["zmaps"][0] == str(
@@ -336,7 +336,7 @@ def test_fetch_megatrawls_netmats(tmp_path, request_mocker):
         net_file2.write("1")
 
     megatrawl_netmats_data = func.fetch_megatrawls_netmats(
-        data_dir=str(tmp_path))
+        data_dir=tmp_path)
 
     # expected number of returns in output name should be equal
     assert len(megatrawl_netmats_data) == 5
@@ -354,7 +354,7 @@ def test_fetch_megatrawls_netmats(tmp_path, request_mocker):
 
     # check if input provided for dimensions, timeseries, matrices to be same
     # to user settings
-    netmats_data = func.fetch_megatrawls_netmats(data_dir=str(tmp_path),
+    netmats_data = func.fetch_megatrawls_netmats(data_dir=tmp_path,
                                                  dimensionality=300,
                                                  timeseries='multiple_spatial_regression',
                                                  matrices='full_correlation')
@@ -441,7 +441,7 @@ def test_fetch_cobre(tmp_path, request_mocker):
     # All subjects
     cobre_data = check_deprecation(
         func.fetch_cobre, "'fetch_cobre' has been deprecated")(
-            n_subjects=None, data_dir=str(tmp_path))
+            n_subjects=None, data_dir=tmp_path)
 
     phenotypic_names = ['func', 'confounds', 'phenotypic', 'description',
                         'desc_con', 'desc_phenotypic']
@@ -462,13 +462,13 @@ def test_fetch_cobre(tmp_path, request_mocker):
 
     # Fetch only 30 subjects
     data_30_subjects = func.fetch_cobre(n_subjects=30,
-                                        data_dir=str(tmp_path))
+                                        data_dir=tmp_path)
     assert len(data_30_subjects.func) == 30
     assert len(data_30_subjects.confounds) == 30
 
     # Test more than maximum subjects
     test_150_subjects = func.fetch_cobre(n_subjects=150,
-                                         data_dir=str(tmp_path))
+                                         data_dir=tmp_path)
     assert len(test_150_subjects.func) == 146
 
 
@@ -485,7 +485,7 @@ def test_fetch_surf_nki_enhanced(tmp_path, request_mocker, verbose=0):
     )
     request_mocker.url_mapping[
         "*pheno_nki_nilearn.csv"] = pheno_data.to_csv(index=False)
-    nki_data = func.fetch_surf_nki_enhanced(data_dir=str(tmp_path))
+    nki_data = func.fetch_surf_nki_enhanced(data_dir=tmp_path)
 
     assert nki_data.description != ''
     assert len(nki_data.func_left) == 10
@@ -531,7 +531,7 @@ def test_fetch_development_fmri_participants(tmp_path, request_mocker):
         "https://osf.io/yr3av/download"] = mock_participants.to_csv(
         index=False, sep="\t")
     participants = func._fetch_development_fmri_participants(
-        data_dir=str(tmp_path), url=None, verbose=1)
+        data_dir=tmp_path, url=None, verbose=1)
     assert isinstance(participants, np.ndarray)
     assert participants.shape == (5,)
 
@@ -539,7 +539,7 @@ def test_fetch_development_fmri_participants(tmp_path, request_mocker):
 def test_fetch_development_fmri_functional(tmp_path, request_mocker):
     mock_participants = _mock_participants_data(n_ids=8)
     funcs, confounds = func._fetch_development_fmri_functional(
-        mock_participants, data_dir=str(tmp_path),
+        mock_participants, data_dir=tmp_path,
         url=None, resume=True, verbose=1)
     assert len(funcs) == 8
     assert len(confounds) == 8
@@ -554,7 +554,7 @@ def test_fetch_development_fmri(tmp_path, request_mocker):
         index=False, sep="\t")
 
     data = func.fetch_development_fmri(n_subjects=2,
-                                       data_dir=str(tmp_path), verbose=1)
+                                       data_dir=tmp_path, verbose=1)
     assert len(data.func) == 2
     assert len(data.confounds) == 2
     assert isinstance(data.phenotypic, np.ndarray)
@@ -626,7 +626,7 @@ def test_fetch_bids_langloc_dataset(request_mocker, tmp_path):
     main_folder = os.path.join(data_dir, 'bids_langloc_dataset')
     os.mkdir(main_folder)
 
-    datadir, dl_files = func.fetch_bids_langloc_dataset(str(tmp_path))
+    datadir, dl_files = func.fetch_bids_langloc_dataset(tmp_path)
 
     assert isinstance(datadir, str)
     assert isinstance(dl_files, list)
@@ -708,7 +708,7 @@ def test_fetch_openneuro_dataset(request_mocker, tmp_path):
     dataset_version = 'ds000030_R1.0.4'
     data_prefix = '{}/{}/uncompressed'.format(
         dataset_version.split('_')[0], dataset_version)
-    data_dir = _get_dataset_dir(data_prefix, data_dir=str(tmp_path),
+    data_dir = _get_dataset_dir(data_prefix, data_dir=tmp_path,
                                 verbose=1)
     url_file = os.path.join(data_dir, 'urls.json')
     # Prepare url files for subject and filter tests
@@ -727,14 +727,14 @@ def test_fetch_openneuro_dataset(request_mocker, tmp_path):
 
     # Only 1 subject and not subject specific files get downloaded
     datadir, dl_files = func.fetch_openneuro_dataset(
-        urls, str(tmp_path), dataset_version)
+        urls, tmp_path, dataset_version)
     assert isinstance(datadir, str)
     assert isinstance(dl_files, list)
     assert len(dl_files) == 9
 
 
 def test_fetch_localizer(request_mocker, tmp_path):
-    dataset = func.fetch_localizer_first_level(data_dir=str(tmp_path))
+    dataset = func.fetch_localizer_first_level(data_dir=tmp_path)
     assert isinstance(dataset['events'], str)
     assert isinstance(dataset.epi_img, str)
 
@@ -764,7 +764,7 @@ def _mock_bids_compliant_spm_auditory_events_file():
 
 
 def test_fetch_language_localizer_demo_dataset(request_mocker, tmp_path):
-    data_dir = str(tmp_path)
+    data_dir = tmp_path
     expected_data_dir = tmp_path / 'fMRI-language-localizer-demo-dataset'
     contents_dir = Path(
         __file__).parent / "data" / "archive_contents"
@@ -825,7 +825,7 @@ def test_fetch_spm_auditory(request_mocker, tmp_path):
     for file_ in saf_:
         shutil.copy(path_hdr, os.path.join(subject_dir, file_))
 
-    dataset = func.fetch_spm_auditory(data_dir=str(tmp_path))
+    dataset = func.fetch_spm_auditory(data_dir=tmp_path)
     assert isinstance(dataset.anat, str)
     assert isinstance(dataset.func[0], str)
     assert len(dataset.func) == 96
@@ -848,7 +848,7 @@ def test_fetch_spm_multimodal(request_mocker, tmp_path):
             open(os.path.join(dir_, 'fMETHODS-000%i-%i-01.img' %
                               (session + 5, i)), 'a').close()
 
-    dataset = func.fetch_spm_multimodal_fmri(data_dir=str(tmp_path))
+    dataset = func.fetch_spm_multimodal_fmri(data_dir=tmp_path)
     assert isinstance(dataset.anat, str)
     assert isinstance(dataset.func1[0], str)
     assert len(dataset.func1) == 390
@@ -874,7 +874,7 @@ def test_fiac(request_mocker, tmp_path):
     mask = os.path.join(fiac0_dir, 'mask.nii.gz')
     open(mask, 'a').close()
 
-    dataset = func.fetch_fiac_first_level(data_dir=str(tmp_path))
+    dataset = func.fetch_fiac_first_level(data_dir=tmp_path)
     assert isinstance(dataset.func1, str)
     assert isinstance(dataset.func2, str)
     assert isinstance(dataset.design_matrix1, str)

--- a/nilearn/datasets/tests/test_neurovault.py
+++ b/nilearn/datasets/tests/test_neurovault.py
@@ -779,8 +779,11 @@ def test_should_download_original_images_along_resampled_images_if_previously_do
     sample_collection_id = sample_collection["id"]
 
     # Fetch non-resampled images
-    data = neurovault.fetch_neurovault_ids(collection_ids=[sample_collection_id], data_dir=tmp_path,
-                                                resample=True)
+    data = neurovault.fetch_neurovault_ids(
+        collection_ids=[sample_collection_id],
+        data_dir=tmp_path,
+        resample=True,
+    )
 
     # Check that only the resampled version is here
     assert np.all([os.path.isfile(im_meta['resampled_absolute_path']) for im_meta in data['images_meta']])
@@ -790,7 +793,11 @@ def test_should_download_original_images_along_resampled_images_if_previously_do
     access_time_resampled = (os.path.getatime(data['images_meta'][0]['resampled_absolute_path']))
 
     # Download original data
-    data_orig = neurovault.fetch_neurovault_ids(collection_ids=[sample_collection_id], data_dir=tmp_path, resample=False)
+    data_orig = neurovault.fetch_neurovault_ids(
+        collection_ids=[sample_collection_id],
+        data_dir=tmp_path,
+        resample=False,
+    )
 
     # Get the time of the last access to one of the original files (which should be download time)
     access_time = (os.path.getatime(data_orig['images_meta'][0]['absolute_path']))
@@ -814,7 +821,11 @@ def test_should_download_resampled_images_along_original_images_if_previously_do
     sample_collection_id = sample_collection["id"]
 
     # Fetch non-resampled images
-    data_orig = neurovault.fetch_neurovault_ids(collection_ids=[sample_collection_id], data_dir=tmp_path, resample=False)
+    data_orig = neurovault.fetch_neurovault_ids(
+        collection_ids=[sample_collection_id],
+        data_dir=tmp_path,
+        resample=False,
+    )
 
     # Check that the original version is here
     assert np.all([os.path.isfile(im_meta['absolute_path']) for im_meta in data_orig['images_meta']])
@@ -828,7 +839,11 @@ def test_should_download_resampled_images_along_original_images_if_previously_do
     modif_time_original = (os.path.getmtime(data_orig['images_meta'][0]['absolute_path']))
 
     # Ask for resampled data, which should only trigger resample
-    data = neurovault.fetch_neurovault_ids(collection_ids=[sample_collection_id], data_dir=tmp_path, resample=True)
+    data = neurovault.fetch_neurovault_ids(
+        collection_ids=[sample_collection_id],
+        data_dir=tmp_path,
+        resample=True,
+    )
 
     # Get the time of the last modification to the original data, after fetch
     modif_time_original_after = (os.path.getmtime(data['images_meta'][0]['absolute_path']))

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -37,7 +37,8 @@ currdir = os.path.dirname(os.path.abspath(__file__))
 datadir = os.path.join(currdir, 'data')
 
 
-def test_get_dataset_dir(tmp_path):
+@pytest.mark.parametrize("should_cast_path_to_string", [False, True])
+def test_get_dataset_dir(should_cast_path_to_string, tmp_path):
     # testing folder creation under different environments, enforcing
     # a custom clean install
     os.environ.pop('NILEARN_DATA', None)
@@ -63,11 +64,13 @@ def test_get_dataset_dir(tmp_path):
     assert os.path.exists(data_dir)
     shutil.rmtree(data_dir)
 
-    expected_base_dir = str(tmp_path / 'env_data')
-    expected_dataset_dir = os.path.join(expected_base_dir, 'test')
+    expected_base_dir = tmp_path / 'env_data'
+    expected_dataset_dir = expected_base_dir / 'test'
+    if should_cast_path_to_string:
+        expected_dataset_dir = str(expected_dataset_dir)
     data_dir = datasets.utils._get_dataset_dir(
         'test', default_paths=[expected_dataset_dir], verbose=0)
-    assert data_dir == os.path.join(expected_base_dir, 'test')
+    assert data_dir == str(expected_dataset_dir)
     assert os.path.exists(data_dir)
     shutil.rmtree(data_dir)
 
@@ -281,7 +284,12 @@ def test_uncompress():
             shutil.rmtree(dtemp)
 
 
-def test_fetch_file_overwrite(tmp_path, request_mocker):
+@pytest.mark.parametrize("should_cast_path_to_string", [False, True])
+def test_fetch_file_overwrite(should_cast_path_to_string,
+                              tmp_path, request_mocker):
+    if should_cast_path_to_string:
+        tmp_path = str(tmp_path)
+
     # overwrite non-exiting file.
     fil = datasets.utils._fetch_file(url='http://foo/', data_dir=str(tmp_path),
                                      verbose=0, overwrite=True)
@@ -313,7 +321,12 @@ def test_fetch_file_overwrite(tmp_path, request_mocker):
         assert fp.read() == ''
 
 
-def test_fetch_files_use_session(tmp_path, request_mocker):
+@pytest.mark.parametrize("should_cast_path_to_string", [False, True])
+def test_fetch_files_use_session(should_cast_path_to_string,
+                                 tmp_path, request_mocker):
+    if should_cast_path_to_string:
+        tmp_path = str(tmp_path)
+
     # regression test for https://github.com/nilearn/nilearn/issues/2863
     session = MagicMock()
     datasets.utils._fetch_files(
@@ -327,7 +340,12 @@ def test_fetch_files_use_session(tmp_path, request_mocker):
     assert session.send.call_count == 2
 
 
-def test_fetch_files_overwrite(tmp_path, request_mocker):
+@pytest.mark.parametrize("should_cast_path_to_string", [False, True])
+def test_fetch_files_overwrite(should_cast_path_to_string,
+                               tmp_path, request_mocker):
+    if should_cast_path_to_string:
+        tmp_path = str(tmp_path)
+
     # overwrite non-exiting file.
     files = ('1.txt', 'http://foo/1.txt')
     fil = datasets.utils._fetch_files(data_dir=str(tmp_path), verbose=0,

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -216,7 +216,7 @@ def get_data_dirs(data_dir=None):
 
     # Check data_dir which force storage in a specific location
     if data_dir is not None:
-        paths.extend(data_dir.split(os.pathsep))
+        paths.extend(str(data_dir).split(os.pathsep))
 
     # If data_dir has not been specified, then we crawl default locations
     if data_dir is None:
@@ -268,7 +268,7 @@ def _get_dataset_dir(dataset_name, data_dir=None, default_paths=None,
     # Search possible data-specific system paths
     if default_paths is not None:
         for default_path in default_paths:
-            paths.extend([(d, True) for d in default_path.split(os.pathsep)])
+            paths.extend([(d, True) for d in str(default_path).split(os.pathsep)])
 
     paths.extend([(d, False) for d in get_data_dirs(data_dir=data_dir)])
 

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -268,7 +268,10 @@ def _get_dataset_dir(dataset_name, data_dir=None, default_paths=None,
     # Search possible data-specific system paths
     if default_paths is not None:
         for default_path in default_paths:
-            paths.extend([(d, True) for d in str(default_path).split(os.pathsep)])
+            paths.extend([
+                (d, True)
+                for d in str(default_path).split(os.pathsep)]
+            )
 
     paths.extend([(d, False) for d in get_data_dirs(data_dir=data_dir)])
 


### PR DESCRIPTION
This PR adds support for `pathlib.Path` to `data_dir` argument in datasets fetchers. All the fetchers from `nilearn.datasets` now accepts `pathlib.Path` or a string (instead of string only).

I have modified the tests from all fetchers which had to cast the `tmp_path` fixture to a string. Now the fixture is used directly as `data_dir` argument. This means there is no more tests for `data_dir` as a string, and I wasn't sure if I needed to keep both case (through a parametrize for each test for example)

The PR can easily be read commit by commit:

1. Changes to `nilearn.datasets.utils` that add `pathlib.Path` support
2. Modifications of the tests to avoid casting `tmp_path` to string everytime
3. Update document variable `data_dir`
4. Whatnew entry

I'm open to your opinions on the "no more `data_dir` as string tests". Maybe I could add both cases (`pathlib.Path` or string) in the tests of the following methods (`nilearn.datasets.utils.get_dataset_dir` and `nilearn.datasets.utils.fetch_files`) and leave the pathlib everywhere else?