### PR TITLE
MAINT: Deal with mpl deprecation

### DIFF
--- a/nilearn/plotting/cm.py
+++ b/nilearn/plotting/cm.py
@@ -7,6 +7,7 @@ import numpy as _np
 
 from matplotlib import cm as _cm
 from matplotlib import colors as _colors
+from matplotlib import rcParams as _rcParams
 
 ################################################################################
 # Custom colormaps for two-tailed symmetric statistics
@@ -113,7 +114,7 @@ def alpha_cmap(color, name='', alpha_min=0.5, alpha_max=1.):
                 (red, green, blue, 1.),
                ]
     cmap = _colors.LinearSegmentedColormap.from_list(
-                                '%s_transparent' % name, cmapspec, _cm.LUTSIZE)
+        '%s_transparent' % name, cmapspec, _rcParams['image.lut'])
     cmap._init()
     cmap._lut[:, -1] = _np.linspace(alpha_min, alpha_max, cmap._lut.shape[0])
     cmap._lut[-1, -1] = 0

--- a/nilearn/plotting/cm.py
+++ b/nilearn/plotting/cm.py
@@ -179,9 +179,9 @@ for _cmapname in list(_cmaps_data.keys()):  # needed as dict changes within loop
     _cmapspec = _cmaps_data[_cmapname]
     _cmaps_data[_cmapname_r] = _revcmap(_cmapspec)
     _cmap_d[_cmapname] = _colors.LinearSegmentedColormap(
-        _cmapname, _cmapspec, _cm.LUTSIZE)
+        _cmapname, _cmapspec, _rcParams['image.lut'])
     _cmap_d[_cmapname_r] = _colors.LinearSegmentedColormap(
-        _cmapname_r, _cmaps_data[_cmapname_r], _cm.LUTSIZE)
+        _cmapname_r, _cmaps_data[_cmapname_r], _rcParams['image.lut'])
 
 ################################################################################
 # A few transparent colormaps
@@ -252,7 +252,7 @@ def dim_cmap(cmap, factor=.3, to_white=True):
         cdict[color] = color_lst
 
     return _colors.LinearSegmentedColormap(
-        '%s_dimmed' % cmap.name, cdict, _cm.LUTSIZE)
+        '%s_dimmed' % cmap.name, cdict, _rcParams['image.lut'])
 
 
 def replace_inside(outer_cmap, inner_cmap, vmin, vmax):
@@ -312,4 +312,4 @@ def replace_inside(outer_cmap, inner_cmap, vmin, vmax):
 
     return _colors.LinearSegmentedColormap(
         '%s_inside_%s' % (inner_cmap.name, outer_cmap.name),
-        cdict, _cm.LUTSIZE)
+        cdict, _rcParams['image.lut'])

--- a/nilearn/plotting/displays.py
+++ b/nilearn/plotting/displays.py
@@ -976,7 +976,7 @@ class BaseSlicer(object):
             self._colorbar_ax, ticks=ticks, norm=norm,
             orientation='vertical', cmap=our_cmap, boundaries=bounds,
             spacing='proportional', format='%.2g')
-        self._cbar.patch.set_facecolor(self._brain_color)
+        self._cbar.ax.set_facecolor(self._brain_color)
 
         self._colorbar_ax.yaxis.tick_left()
         tick_color = 'w' if self._black_bg else 'k'

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -261,7 +261,8 @@ def _crop_colorbar(cbar, cbar_vmin, cbar_vmax):
         outline[6:, 1] += cbar.norm(cbar_vmin)
         cbar.outline.set_xy(outline)
 
-    cbar.set_ticks(new_tick_locs, update_ticks=True)
+    cbar.set_ticks(new_tick_locs)
+    cbar.update_ticks()
 
 
 @fill_doc

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -242,7 +242,7 @@ def _crop_colorbar(cbar, cbar_vmin, cbar_vmax):
     # so we use the code from there
     if LooseVersion(matplotlib.__version__) >= LooseVersion("3.2.0"):
         cbar.ax.set_ylim(cbar_vmin, cbar_vmax)
-        X, _ = cbar._mesh()
+        X = cbar._mesh()[0]
         X = np.array([X[0], X[-1]])
         Y = np.array([[cbar_vmin, cbar_vmin], [cbar_vmax, cbar_vmax]])
         N = X.shape[0]


### PR DESCRIPTION
Should fix on latest `matplotlib` dev:
```
matplotlib._api.deprecation.MatplotlibDeprecationWarning: LUTSIZE was deprecated in Matplotlib 3.5 and will be removed two minor releases later. Use rcParams['image.lut'] instead.
```