### PR TITLE
[DOC] Canonical noqa syntax

### DIFF
--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -2173,7 +2173,7 @@ def _download_spm_auditory_data(data_dir, subject_dir, subject_id):
     _fetch_file(url, subject_dir)
     try:
         _uncompress_file(archive_path)
-    except:  # noqa:E722
+    except:  # noqa: E722
         print('Archive corrupted, trying to download it again.')
         return fetch_spm_auditory(data_dir=data_dir, data_name='',
                                   subject_id=subject_id)
@@ -2424,7 +2424,7 @@ def _download_data_spm_multimodal(data_dir, subject_dir, subject_id):
         _fetch_file(url, subject_dir)
         try:
             _uncompress_file(archive_path)
-        except:  # noqa:E722
+        except:  # noqa: E722
             print('Archive corrupted, trying to download it again.')
             return fetch_spm_multimodal_fmri(data_dir=data_dir,
                                              data_name='',
@@ -2559,7 +2559,7 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
     _fetch_file(url, data_dir)
     try:
         _uncompress_file(archive_path)
-    except:  # noqa:E722
+    except:  # noqa: E722
         print('Archive corrupted, trying to download it again.')
         return fetch_fiac_first_level(data_dir=data_dir)
 

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock
 from tempfile import mkdtemp, mkstemp
 
 try:
-    import boto3  # noqa:F401
+    import boto3  # noqa: F401
 
 except ImportError:
     BOTO_INSTALLED = False

--- a/nilearn/glm/tests/test_thresholding.py
+++ b/nilearn/glm/tests/test_thresholding.py
@@ -84,13 +84,13 @@ def test_threshold_stats_img():
         None, None, threshold=3.0, height_control=None,
         cluster_threshold=0)
     assert threshold == 3.0
-    assert th_map == None  # noqa:E711
+    assert th_map == None  # noqa: E711
 
     th_map, threshold = threshold_stats_img(
         None, None, alpha=0.05, height_control='fpr',
         cluster_threshold=0)
     assert (threshold > 1.64)
-    assert th_map == None  # noqa:E711
+    assert th_map == None  # noqa: E711
 
     with pytest.raises(ValueError):
         threshold_stats_img(None, None, alpha=0.05, height_control='fdr')


### PR DESCRIPTION
As in [flake8 documentation](https://flake8.pycqa.org/en/latest/user/violations.html#in-line-ignoring-errors) and according to usual English punctuation. Consistent with the rest of the code.