### PR TITLE
[DOC] Add missing `fill_doc` decorator

### DIFF
--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -573,6 +573,7 @@ def fetch_atlas_smith_2009(data_dir=None, mirror='origin', url=None,
     return Bunch(**params)
 
 
+@fill_doc
 def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
     """Download and return file names for the Yeo 2011 parcellation.
 


### PR DESCRIPTION
Missing `fill_doc` decorator was causing documentation bugs [here](https://7947-1235740-gh.circle-artifacts.com/0/dev/modules/generated/nilearn.datasets.fetch_atlas_yeo_2011.html#nilearn.datasets.fetch_atlas_yeo_2011)