### PR TITLE
[ENH] Allow custom HRF models

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -17,12 +17,19 @@ Enhancements
   and negative values in the map, as was done previously.
   When `two_sided` is `False`, only values greater than or equal to the threshold
   are retained.
-
 - :func:`nilearn.signal.clean` raises a warning when the user sets 
   parameters `detrend` and `standardize_confound` to False.
   The user is suggested to set one of
   those options to `True`, or standardize/demean the confounds before using the 
   function.
+- It is now possible to provide custom :term:`HRF` models to
+  :class:`nilearn.glm.first_level.FirstLevelModel`. The custom model should be
+  defined as a function, or a list of functions, implementing the same API as
+  Nilearn's usual models (see :func:`nilearn.glm.first_level.spm_hrf` for
+  example). The example
+  :ref:`sphx_glr_auto_examples_04_glm_first_level_plot_hrf.py` was
+  also modified to demo how to define custom :term:`HRF` models.
+  (See issue `#2940 <https://github.com/nilearn/nilearn/issues/2940>`_). 
 
 Changes
 -------

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -444,6 +444,54 @@ linewidths : :obj:`float`, optional
     Set the boundary thickness of the contours.
     Only reflects when ``view_type=contours``."""
 
+# hrf_model
+docdict['hrf_model'] = """
+hrf_model : :obj:`str`, function, list of functions, or None
+    This parameter defines the :term:`HRF` model to be used.
+    It can be a string if you are passing the name of a model
+    implemented in Nilearn.
+    Valid names are:
+
+        - 'spm': This is the :term:`HRF` model used in :term:`SPM`.
+          See :func:`nilearn.glm.first_level.spm_hrf`.
+        - 'spm + derivative': SPM model plus its time derivative.
+          This gives 2 regressors.
+          See :func:`nilearn.glm.first_level.spm_hrf`, and
+          :func:`nilearn.glm.first_level.spm_time_derivative`.
+        - 'spm + derivative + dispersion': Idem, plus dispersion
+          derivative. This gives 3 regressors.
+          See :func:`nilearn.glm.first_level.spm_hrf`,
+          :func:`nilearn.glm.first_level.spm_time_derivative`,
+          and :func:`nilearn.glm.first_level.spm_dispersion_derivative`.
+        - 'glover': This corresponds to the Glover :term:`HRF`.
+          See :func:`nilearn.glm.first_level.glover_hrf`.
+        - 'glover + derivative': The Glover :term:`HRF` + time
+          derivative. This gives 2 regressors.
+          See :func:`nilearn.glm.first_level.glover_hrf`, and
+          :func:`nilearn.glm.first_level.glover_time_derivative`.
+        - 'glover + derivative + dispersion': Idem, plus dispersion
+          derivative. This gives 3 regressors.
+          See :func:`nilearn.glm.first_level.glover_hrf`,
+          :func:`nilearn.glm.first_level.glover_time_derivative`, and
+          :func:`nilearn.glm.first_level.glover_dispersion_derivative`.
+        - 'fir': Finite impulse response basis. This is a set of
+          delayed dirac models.
+
+    It can also be a custom model. In this case, a function should
+    be provided for each regressor. Each function should behave as the
+    other models implemented within Nilearn. That is, it should take
+    both `t_r` and `oversampling` as inputs and return a sample numpy
+    array of appropriate shape.
+
+    .. note::
+        It is expected that `spm` standard and `glover` models would
+        not yield large differences in most cases.
+
+    .. note::
+        In case of `glover` and `spm` models, the derived regressors
+        are orthogonalized wrt the main one.
+
+"""
 # fsaverage options
 docdict['fsaverage_options'] = """
 

--- a/nilearn/glm/first_level/design_matrix.py
+++ b/nilearn/glm/first_level/design_matrix.py
@@ -39,6 +39,7 @@ from warnings import warn
 import numpy as np
 import pandas as pd
 
+from nilearn._utils import fill_doc
 from nilearn._utils.glm import full_rank
 from nilearn.glm.first_level.experimental_paradigm import check_events
 from nilearn.glm.first_level.hemodynamic_models import (_orthogonalize,
@@ -248,6 +249,7 @@ def _convolve_regressors(events, hrf_model, frame_times, fir_delays=[0],
 ######################################################################
 
 
+@fill_doc
 def make_first_level_design_matrix(
         frame_times, events=None, hrf_model='glover',
         drift_model='cosine', high_pass=.01, drift_order=1, fir_delays=[0],
@@ -280,13 +282,7 @@ def make_first_level_design_matrix(
         For the others keys a warning will be displayed.
         Particular attention should be given to the 'trial_type' key
         which defines the different conditions in the experimental paradigm.
-
-    hrf_model : {'glover', 'spm', 'spm + derivative', \
-            'spm + derivative + dispersion', 'glover + derivative', \
-            'glover + derivative + dispersion', \
-            'fir', None}, optional
-        Specifies the hemodynamic response function. Default='glover'.
-
+    %(hrf_model)s
     drift_model : {'cosine', 'polynomial', None}, optional
         Specifies the desired drift model. Default='cosine'.
 
@@ -309,7 +305,7 @@ def make_first_level_design_matrix(
 
     add_reg_names : list of (n_add_reg,) strings, optional
         If None, while add_regs was provided, these will be termed
-        'reg_%i', i = 0..n_add_reg - 1
+        'reg_i', i = 0..n_add_reg - 1
         If add_regs is a DataFrame, the corresponding column names are used
         and add_reg_names is ignored.
 

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -23,6 +23,7 @@ from nibabel.onetime import auto_attr
 from sklearn.base import clone
 from sklearn.cluster import KMeans
 
+from nilearn._utils import fill_doc
 from nilearn._utils.glm import (_check_events_file_uses_tab_separators,
                                 _check_run_tables, get_bids_files,
                                 parse_bids_filename)
@@ -216,6 +217,7 @@ def run_glm(Y, X, noise_model='ar1', bins=100, n_jobs=1, verbose=0):
     return labels, results
 
 
+@fill_doc
 class FirstLevelModel(BaseGLM):
     """ Implementation of the General Linear Model
     for single session fMRI data.
@@ -225,7 +227,7 @@ class FirstLevelModel(BaseGLM):
     t_r : float
         This parameter indicates repetition times of the experimental runs.
         In seconds. It is necessary to correctly consider times in the design
-        matrix. This parameter is also passed to nilearn.signal.clean.
+        matrix. This parameter is also passed to :func:`nilearn.signal.clean`.
         Please see the related documentation for details.
 
     slice_time_ref : float, optional
@@ -233,13 +235,8 @@ class FirstLevelModel(BaseGLM):
         slice timing preprocessing step of the experimental runs. It is
         expressed as a percentage of the t_r (time repetition), so it can have
         values between 0. and 1. Default=0.
-
-    hrf_model : {'glover', 'spm', 'spm + derivative', \
-            'spm + derivative + dispersion', 'glover + derivative', \
-            'glover + derivative + dispersion', 'fir', None}, optional
-        String that specifies the hemodynamic response function.
+    %(hrf_model)s
         Default='glover'.
-
     drift_model : string, optional
         This parameter specifies the desired drift model for the design
         matrices. It can be 'polynomial', 'cosine' or None.

--- a/nilearn/glm/first_level/hemodynamic_models.py
+++ b/nilearn/glm/first_level/hemodynamic_models.py
@@ -464,13 +464,13 @@ def _hrf_kernel(hrf_model, tr, oversampling=50, fir_delays=None):
     elif callable(hrf_model):
         try:
             hkernel = [hrf_model(tr, oversampling)]
-        except:
+        except TypeError:
             raise ValueError(error_msg)
     elif(isinstance(hrf_model, Iterable)
          and all([callable(_) for _ in hrf_model])):
         try:
             hkernel = [model(tr, oversampling) for model in hrf_model]
-        except:
+        except TypeError:
             raise ValueError(error_msg)
     elif hrf_model is None:
         hkernel = [np.hstack((1, np.zeros(oversampling - 1)))]

--- a/nilearn/glm/first_level/hemodynamic_models.py
+++ b/nilearn/glm/first_level/hemodynamic_models.py
@@ -12,6 +12,7 @@ import numpy as np
 from scipy.stats import gamma
 from collections.abc import Iterable
 
+from nilearn._utils import fill_doc
 
 def _gamma_difference_hrf(tr, oversampling=50, time_length=32., onset=0.,
                           delay=6, undershoot=16., dispersion=1.,
@@ -412,8 +413,8 @@ def _hrf_kernel(hrf_model, tr, oversampling=50, fir_delays=None):
 
     Parameters
     ----------
-    hrf_model : string or None,
-        identifier of the hrf model
+    hrf_model : string, function, list of functions, or None,
+        HRF model to be used.
 
     tr : float
         the repetition time in seconds
@@ -481,6 +482,7 @@ def _hrf_kernel(hrf_model, tr, oversampling=50, fir_delays=None):
     return hkernel
 
 
+@fill_doc
 def compute_regressor(exp_condition, hrf_model, frame_times, con_id='cond',
                       oversampling=50, fir_delays=None, min_onset=-24):
     """ This is the main function to convolve regressors with hrf model
@@ -490,11 +492,7 @@ def compute_regressor(exp_condition, hrf_model, frame_times, con_id='cond',
     exp_condition : array-like of shape (3, n_events)
         yields description of events for this condition as a
         (onsets, durations, amplitudes) triplet
-
-    hrf_model : {'spm', 'spm + derivative', 'spm + derivative + dispersion',
-        'glover', 'glover + derivative', 'fir', None}
-        Name of the hrf model to be used
-
+    %(hrf_model)s
     frame_times : array of shape (n_scans)
         the desired sampling times
 
@@ -519,26 +517,6 @@ def compute_regressor(exp_condition, hrf_model, frame_times, con_id='cond',
 
     reg_names : list of strings
         Corresponding regressor names.
-
-    Notes
-    -----
-    The different hemodynamic models can be understood as follows:
-     - 'spm': this is the hrf model used in SPM
-     - 'spm + derivative': SPM model plus its time derivative (2 regressors)
-     - 'spm + time + dispersion': idem, plus dispersion derivative
-                                (3 regressors)
-     - 'glover': this one corresponds to the Glover hrf
-     - 'glover + derivative': the Glover hrf + time derivative (2 regressors)
-     - 'glover + derivative + dispersion': idem + dispersion derivative
-                                        (3 regressors)
-    'fir': list or array,
-        finite impulse response basis, a set of delayed dirac models.
-
-    It is expected that spm standard and Glover model would not yield
-    large differences in most cases.
-
-    In case of glover and spm models, the derived regressors are
-    orthogonalized wrt the main one.
 
     """
     # fir_delays should be integers

--- a/nilearn/glm/tests/test_hemodynamic_models.py
+++ b/nilearn/glm/tests/test_hemodynamic_models.py
@@ -36,7 +36,8 @@ def expected_length(tr):
 
 @pytest.mark.parametrize('hrf_model', HRF_MODELS)
 @pytest.mark.parametrize('tr', [2, 3])
-def test_hrf_norm_and_length(hrf_model, tr, expected_integral, expected_length):
+def test_hrf_norm_and_length(hrf_model, tr, expected_integral,
+                             expected_length):
     """ test that the hrf models are correctly normalized and
     have correct lengths.
     """

--- a/nilearn/glm/tests/test_hemodynamic_models.py
+++ b/nilearn/glm/tests/test_hemodynamic_models.py
@@ -15,42 +15,34 @@ from nilearn.glm.first_level.hemodynamic_models import \
      glover_hrf, glover_time_derivative)
 
 
-def test_spm_hrf():
-    """ test that the spm_hrf is correctly normalized and has correct length
+HRF_MODEL_NAMES = ['spm', 'glover', 'spm + derivative',
+                   'glover + derivative',
+                   'spm + derivative + dispersion']
+
+
+HRF_MODELS = [spm_hrf, glover_hrf, spm_time_derivative,
+              glover_time_derivative, spm_dispersion_derivative]
+
+
+@pytest.fixture
+def expected_integral(hrf_model):
+    return 1 if hrf_model in [spm_hrf, glover_hrf] else 0
+
+
+@pytest.fixture
+def expected_length(tr):
+    return int(32 / tr * 50)
+
+
+@pytest.mark.parametrize('hrf_model', HRF_MODELS)
+@pytest.mark.parametrize('tr', [2, 3])
+def test_hrf_norm_and_length(hrf_model, tr, expected_integral, expected_length):
+    """ test that the hrf models are correctly normalized and
+    have correct lengths.
     """
-    h = spm_hrf(2.0)
-    assert_almost_equal(h.sum(), 1)
-    assert len(h) == 800
-
-
-def test_spm_hrf_derivative():
-    """ test that the spm_hrf is correctly normalized and has correct length
-    """
-    h = spm_time_derivative(2.0)
-    assert_almost_equal(h.sum(), 0)
-    assert len(h) == 800
-    h = spm_dispersion_derivative(2.0)
-    assert_almost_equal(h.sum(), 0)
-    assert len(h) == 800
-
-
-def test_glover_hrf():
-    """ test that the spm_hrf is correctly normalized and has correct length
-    """
-    h = glover_hrf(2.0)
-    assert_almost_equal(h.sum(), 1)
-    assert len(h) == 800
-    h = glover_dispersion_derivative(2.0)
-    assert_almost_equal(h.sum(), 0)
-    assert len(h) == 800
-
-
-def test_glover_time_derivative():
-    """ test that the spm_hrf is correctly normalized and has correct length
-    """
-    h = glover_time_derivative(2.0)
-    assert_almost_equal(h.sum(), 0)
-    assert len(h) == 800
+    h = hrf_model(tr)
+    assert_almost_equal(h.sum(), expected_integral)
+    assert len(h) == expected_length
 
 
 def test_resample_regressor():

--- a/nilearn/glm/tests/test_hemodynamic_models.py
+++ b/nilearn/glm/tests/test_hemodynamic_models.py
@@ -240,6 +240,7 @@ def test_hkernel():
     with pytest.raises(ValueError,
                        match="Could not process custom HRF model provided."):
         _hrf_kernel(lambda x: np.ones(int(x)), tr)
+        _hrf_kernel(lambda x, y, z: x + y + z, tr)
         _hrf_kernel([lambda x: np.ones(int(x))] * 2, tr)
     h = _hrf_kernel(lambda tr, ov: np.ones(int(tr * ov)), tr)
     assert len(h) == 1

--- a/nilearn/glm/tests/test_hemodynamic_models.py
+++ b/nilearn/glm/tests/test_hemodynamic_models.py
@@ -240,9 +240,12 @@ def test_hkernel():
     with pytest.raises(ValueError,
                        match="Could not process custom HRF model provided."):
         _hrf_kernel(lambda x: np.ones(int(x)), tr)
-        _hrf_kernel(lambda x, y, z: x + y + z, tr)
+        _hrf_kernel([lambda x, y, z: x + y + z], tr)
         _hrf_kernel([lambda x: np.ones(int(x))] * 2, tr)
     h = _hrf_kernel(lambda tr, ov: np.ones(int(tr * ov)), tr)
+    assert len(h) == 1
+    assert_almost_equal(h[0], np.ones(100))
+    h = _hrf_kernel([lambda tr, ov: np.ones(int(tr * ov))], tr)
     assert len(h) == 1
     assert_almost_equal(h[0], np.ones(100))
     with pytest.raises(ValueError,


### PR DESCRIPTION
See feature request #2940 

**Description**

This PR is still (very) WIP but proposes a draft of a possible API allowing users to provide a custom HRF model when running GLMs. The user basically has to write a function, or a list of functions computing the samples rather than providing the values directly.

Note: This PR is still lacking a lot of things but I wanted to discuss the possible API before going further.

**Example**

```python
import numpy as np
from nilearn.glm.first_level import FirstLevelModel

def custom_hrf(tr, oversampling=50, time_length=32, onset=0.):
    """This should be defined by the user and comply with the API of other
    HRF models implemented in Nilearn.
    """
    # Do something with inputs...
    # Stupid example here
    hrf = np.ones(time_length)
    hrf[0] = 0
    hrf[-1] = 0
    hrf /= hrf.sum()
    return hrf

fmri_glm = FirstLevelModel(
        t_r=2,
        hrf_model=custom_hrf,
    )
```

@dangom is this more or less what you had in mind?  
(Happy to talk about it next Monday during the office hours btw).