### PR TITLE
[FIX] LGTM error: Missing call to `__init__` during object initialization

### DIFF
--- a/nilearn/glm/regression.py
+++ b/nilearn/glm/regression.py
@@ -469,15 +469,9 @@ class SimpleRegressionResults(LikelihoodModelResults):
         The only difference is that the whitened Y and residual values
         are stored for a regression model.
         """
-        self.theta = results.theta
-        self.cov = results.cov
-        self.dispersion = results.dispersion
-        self.nuisance = results.nuisance
-
-        self.df_total = results.Y.shape[0]
-        self.df_model = results.model.df_model
-        # put this as a parameter of LikelihoodModel
-        self.df_residuals = self.df_total - self.df_model
+        LikelihoodModelResults.__init__(self, results.theta, results.Y,
+                                        results.model, results.cov,
+                                        results.dispersion, results.nuisance)
 
     def logL(self, Y):
         """


### PR DESCRIPTION
Class `SimpleRegressionResults` may not be initialized properly as method `LikelihoodModelResults.__init__` is not called from its `__init__` method.

The code is not exactly equivalent, so I need your input here. Method `LikelihoodModelResults.__init__` looks like this:
```python
        self.theta = theta
        self.Y = Y
        self.model = model
        if cov is None:
            self.cov = self.model.information(self.theta,
                                              nuisance=self.nuisance)
        else:
            self.cov = cov
        self.dispersion = dispersion
        self.nuisance = nuisance

        self.df_total = Y.shape[0]
        self.df_model = model.df_model
        # put this as a parameter of LikelihoodModel
        self.df_residuals = self.df_total - self.df_model
```
The old `SimpleRegressionResults.__init__` used to differ on the `cov` test: and `Y` and `model` were not set:
```python
        self.theta = results.theta
        self.cov = results.cov
        self.dispersion = results.dispersion
        self.nuisance = results.nuisance

        self.df_total = results.Y.shape[0]
        self.df_model = results.model.df_model
        # put this as a parameter of LikelihoodModel
        self.df_residuals = self.df_total - self.df_model
```
Was this on purpose.?