### PR TITLE
[FIX] locals() → globals()

### DIFF
--- a/nilearn/plotting/cm.py
+++ b/nilearn/plotting/cm.py
@@ -219,7 +219,7 @@ _cmap_d['videen_style'] = _colors.LinearSegmentedColormap.from_list(
     'videen_style', videen_style)
 
 # Save colormaps in the scope of the module
-locals().update(_cmap_d)
+globals().update(_cmap_d)
 # Register cmaps in matplotlib too
 for k, v in _cmap_d.items():
     try:  # "bwr" is in latest matplotlib


### PR DESCRIPTION
In general, you cannot modify the local symbol table returned by `locals()`.
However, in the scope of the module, `locals()` is identical to `globals()`.

To make the intent clear, use `globals()` instead of `locals()`.

Closes #2957.