### PR TITLE
[FIX] LGTM warning: Variable defined multiple times

### DIFF
--- a/nilearn/_utils/numpy_conversions.py
+++ b/nilearn/_utils/numpy_conversions.py
@@ -104,7 +104,7 @@ def as_ndarray(arr, copy=False, dtype=None, order='K'):
                 # Changing order while reading through a memmap is incredibly
                 # inefficient.
                 ret = np.array(arr, copy=True)
-                ret = _asarray(arr, dtype=dtype, order=order)
+                ret = _asarray(ret, dtype=dtype, order=order)
 
     elif isinstance(arr, np.ndarray):
         ret = _asarray(arr, dtype=dtype, order=order)


### PR DESCRIPTION
This assignment to '`ret`' is unnecessary as it is redefined [`here`](https://lgtm.com/projects/g/nilearn/nilearn/snapshot/d520eb8468e57b591fe97798f038a56ab134679b/files/nilearn/_utils/numpy_conversions.py?sort=name&dir=ASC&mode=heatmap#x8ed7d7b85aaf0808:1) before this value is used.

Closes #2959.