### PR TITLE
[FIX] LGTM warning: Missing variable declaration

### DIFF
--- a/nilearn/plotting/data/html/surface_plot_template.html
+++ b/nilearn/plotting/data/html/surface_plot_template.html
@@ -13,7 +13,7 @@
         function makePlot(surface, hemisphere, divId) {
 
             decodeHemisphere(surfaceMapInfo, surface, hemisphere);
-            info = surfaceMapInfo[surface + "_" + hemisphere];
+            var info = surfaceMapInfo[surface + "_" + hemisphere];
             info["type"] = "mesh3d";
             info["vertexcolor"] = surfaceMapInfo["vertexcolor_" + hemisphere];
 


### PR DESCRIPTION
Variable `info` is used like a local variable, but is missing a declaration.

https://lgtm.com/projects/g/nilearn/nilearn/snapshot/da6f4deac95baa887fe1bf810cc5f8fa3a737a25/files/nilearn/plotting/data/html/surface_plot_template.html#x2cf07f2b7245f9a9:1