### PR TITLE
[INFRA] Add dev docs deployment job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,12 +308,61 @@ jobs:
           fi
       - save_data_cache
 
+  deploy:
+    docker:
+      - image: circleci/python:3.9
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+              - "53:9f:4a:b1:56:9d:76:33:7a:e8:2e:a1:fe:41:81:34"
+      - attach_workspace:
+          at: /tmp/_build
+      - run:
+          name: Fetch docs
+          command: |
+              set -e
+              mkdir -p ~/.ssh
+              ssh-keyscan github.com >> ~/.ssh/known_hosts;
+              if [ ! -d ~/nilearn.github.io ]; then
+                git clone git@github.com:nilearn/nilearn.github.io.git ~/nilearn.github.io --depth=1
+              fi
+      - run:
+          name: Deploy dev docs
+          command: |
+              set -e;
+              if [ "${CIRCLE_BRANCH}" == "main" ]; then
+                git config --global user.email "circle@nilearn.com";
+                git config --global user.name "CircleCI";
+                cd ~/nilearn.github.io;
+                git checkout main
+                git remote -v
+                git fetch origin
+                git reset --hard origin/main
+                git clean -xdf
+                echo "Deploying dev docs for ${CIRCLE_BRANCH}.";
+                rm -Rf dev;
+                cp -a /tmp/_build/html dev;
+                git add -A;
+                git commit -m "CircleCI update of dev docs (build: ${CIRCLE_BUILD_NUM}).";
+                git push origin main;
+              else
+                echo "No deployment (build: ${CIRCLE_BRANCH}).";
+              fi
+
 workflows:
   version: 2
 
-  default:
+  build_and_deploy_doc:
     jobs:
       - build_docs
+
+      - deploy:
+          requires:
+              -build_docs
+          filters:
+            branches:
+              only:
+                - main
 
   nightly:
     triggers:


### PR DESCRIPTION
This PR is a corrected part of #2605 which only deals with enabling CircleCI to deploy the development docs. 
This PR only adds a job to the circleCI workflow which pushes the docs to `nilearn.github.io` in a subfolder `dev`.
If this work as expected, each commit on main should update the content of `nilearn.github.io/dev`.