### PR TITLE
[FIX] LGTM.com warning: Variable defined multiple times

### DIFF
--- a/examples/07_advanced/plot_advanced_decoding_scikit.py
+++ b/examples/07_advanced/plot_advanced_decoding_scikit.py
@@ -85,9 +85,10 @@ fmri_masked = masker.fit_transform(fmri_niimgs)
 # the function :func:`sklearn.model_selection.cross_val_score` that computes
 # for you the score for the different folds of cross-validation.
 from sklearn.model_selection import cross_val_score
-cv_scores = cross_val_score(svc, fmri_masked, conditions, cv=5)
-
 # Here `cv=5` stipulates a 5-fold cross-validation
+cv_scores = cross_val_score(svc, fmri_masked, conditions, cv=5)
+print("SVC accuracy: {:.3f}".format(cv_scores.mean()))
+
 
 ###########################################################################
 # Tuning cross-validation parameters
@@ -105,7 +106,8 @@ from sklearn.model_selection import LeaveOneGroupOut
 cv = LeaveOneGroupOut()
 cv_scores = cross_val_score(svc, fmri_masked, conditions, cv=cv,
                             scoring='roc_auc', groups=session_label, n_jobs=-1)
-print("SVC accuracy: {:.3f}".format(cv_scores.mean()))
+print("SVC accuracy (tuned parameters): {:.3f}".format(cv_scores.mean()))
+
 ###########################################################################
 # Measuring the chance level
 # ------------------------------------
@@ -130,7 +132,6 @@ from sklearn.model_selection import permutation_test_score
 null_cv_scores = permutation_test_score(
     svc, fmri_masked, conditions, cv=cv, groups=session_label)[1]
 print("Permutation test score: {:.3f}".format(null_cv_scores.mean()))
-
 
 ###########################################################################
 # Decoding without a mask: Anova-SVM in scikit-lean


### PR DESCRIPTION
This assignment to '`cv_scores`' is unnecessary as it is redefined [`here`](https://lgtm.com/projects/g/nilearn/nilearn/snapshot/3af46e7cd3a9362bb815e3deb17d8c3d95485758/files/examples/03_connectivity/plot_extract_regions_dictlearning_maps.py?sort=name&dir=ASC&mode=heatmap#x673dd6739f275dd8:1) before this value is used.

https://lgtm.com/projects/g/nilearn/nilearn/snapshot/3af46e7cd3a9362bb815e3deb17d8c3d95485758/files/examples/07_advanced/plot_advanced_decoding_scikit.py#x5b739e019ffb38d3:1