### PR TITLE
[FIX] LGTM.com warning: Variable defined multiple times

### DIFF
--- a/examples/03_connectivity/plot_data_driven_parcellations.py
+++ b/examples/03_connectivity/plot_data_driven_parcellations.py
@@ -174,6 +174,7 @@ kmeans = Parcellations(method='kmeans', n_parcels=50,
                        verbose=1)
 # Call fit on functional dataset: single subject (less samples)
 kmeans.fit(dataset.func)
+print("KMeans clusters: %.2fs" % (time.time() - start))
 
 ###########################################################################
 # Visualize: Brain parcellations (KMeans)


### PR DESCRIPTION
This assignment to '`start`' is unnecessary as it is redefined [`here`](https://lgtm.com/projects/g/nilearn/nilearn/snapshot/3af46e7cd3a9362bb815e3deb17d8c3d95485758/files/examples/03_connectivity/plot_data_driven_parcellations.py#x6c0c807496e38e62:1) before this value is used.

https://lgtm.com/projects/g/nilearn/nilearn/snapshot/3af46e7cd3a9362bb815e3deb17d8c3d95485758/files/examples/03_connectivity/plot_data_driven_parcellations.py#x17cc86b550caca14:1