### PR TITLE
from __future__ import: not needed in Python >= 3.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Dependencies
 
 The required dependencies to use the software are:
 
-* Python >= 3.6,
+* Python >= 3.6
 * setuptools
 * Numpy >= 1.16
 * SciPy >= 1.2

--- a/nilearn/decomposition/base.py
+++ b/nilearn/decomposition/base.py
@@ -2,7 +2,6 @@
 Base class for decomposition estimators, utilities for masking and dimension
 reduction of group data
 """
-from __future__ import division
 from math import ceil
 import itertools
 import glob

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -7,8 +7,6 @@ constitutes output maps
 # Author: Arthur Mensch
 # License: BSD 3 clause
 
-from __future__ import division
-
 import warnings
 
 import numpy as np

--- a/nilearn/externals/tempita/__init__.py
+++ b/nilearn/externals/tempita/__init__.py
@@ -29,8 +29,6 @@ can use ``__name='tmpl.html'`` to set the name of the template.
 
 If there are syntax errors ``TemplateError`` will be raised.
 """
-from __future__ import absolute_import, division, print_function
-
 import re
 import sys
 try:

--- a/nilearn/externals/tempita/_looper.py
+++ b/nilearn/externals/tempita/_looper.py
@@ -17,8 +17,6 @@ looper you can get a better sense of the context.  Use like::
     3 c
 
 """
-from __future__ import absolute_import, division, print_function
-
 import sys
 from .compat3 import basestring_
 

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -1,8 +1,6 @@
 """
 Test the second level model.
 """
-from __future__ import with_statement
-
 import os
 
 import numpy as np


### PR DESCRIPTION
These `from __future__ import` seem to be leftovers from when Python 2 was supported.

[__future__ — Future statement definitions](https://docs.python.org/3/library/__future__.html)
