### PR TITLE
[DOC] Add `fMRIPrep` to glossary

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -77,7 +77,7 @@ If you wish to add a missing term, please `create a new issue`_ or
         protocols with minimal user input. It performs basic processing
         steps (coregistration, normalization, unwarping, noise component
         extraction, segmentation, skullstripping etc.) providing outputs,
-        often called confounds or nuissance parameters, that can be easily
+        often called confounds or nuisance parameters, that can be easily
         submitted to a variety of group level analyses, including task-based
         or resting-state :term:`fMRI`, graph theory measures, surface or
         volume-based statistics, etc.

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -71,6 +71,16 @@ If you wish to add a missing term, please `create a new issue`_ or
         The signal picked up by the MRI scanner is sensitive to these
         modifications of the local magnetic field.
 
+    fMRIPrep
+        `fMRIPrep`_ is a :term:`fMRI` data preprocessing pipeline designed
+        to provide an interface robust to variations in scan acquisition
+        protocols with minimal user input. It performs basic processing
+        steps (coregistration, normalization, unwarping, noise component
+        extraction, segmentation, skullstripping etc.) providing outputs
+        that can be easily submitted to a variety of group level analyses,
+        including task-based or resting-state :term:`fMRI`, graph theory
+        measures, surface or volume-based statistics, etc.
+
     FPR correction
         False positive rate correction. This refers to the methods employed to
         correct false positive rates such as the Bonferroni correction which
@@ -256,6 +266,9 @@ If you wish to add a missing term, please `create a new issue`_ or
 
 .. _`Family-wise error rate`:
     https://en.wikipedia.org/wiki/Family-wise_error_rate
+
+.. _`fMRIPrep`:
+    https://fmriprep.org/en/stable/
 
 .. _`FREM`:
     https://www.sciencedirect.com/science/article/abs/pii/S1053811917308182

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -76,10 +76,11 @@ If you wish to add a missing term, please `create a new issue`_ or
         to provide an interface robust to variations in scan acquisition
         protocols with minimal user input. It performs basic processing
         steps (coregistration, normalization, unwarping, noise component
-        extraction, segmentation, skullstripping etc.) providing outputs
-        that can be easily submitted to a variety of group level analyses,
-        including task-based or resting-state :term:`fMRI`, graph theory
-        measures, surface or volume-based statistics, etc.
+        extraction, segmentation, skullstripping etc.) providing outputs,
+        often called confounds or nuissance parameters, that can be easily
+        submitted to a variety of group level analyses, including task-based
+        or resting-state :term:`fMRI`, graph theory measures, surface or
+        volume-based statistics, etc.
 
     FPR correction
         False positive rate correction. This refers to the methods employed to

--- a/examples/04_glm_first_level/plot_bids_features.py
+++ b/examples/04_glm_first_level/plot_bids_features.py
@@ -62,7 +62,7 @@ data_dir, _ = fetch_openneuro_dataset(urls=urls)
 # To get the first level models we have to specify the dataset directory,
 # the task_label and the space_label as specified in the file names.
 # We also have to provide the folder with the desired derivatives, that in this
-# case were produced by the fmriprep :term:`BIDS` app.
+# case were produced by the :term:`fMRIPrep` :term:`BIDS` app.
 from nilearn.glm.first_level import first_level_from_bids
 task_label = 'stopsignal'
 space_label = 'MNI152NLin2009cAsym'

--- a/nilearn/_utils/data_gen.py
+++ b/nilearn/_utils/data_gen.py
@@ -550,7 +550,7 @@ def create_fake_bids_dataset(base_dir='', n_sub=10, n_ses=2,
     with_derivatives : bool, optional
         In the case derivatives are included, they come with two spaces and
         descriptions. Spaces are 'MNI' and 'T1w'. Descriptions are 'preproc'
-        and 'fmriprep'. Only space 'T1w' include both descriptions.
+        and :term:`fMRIPrep`. Only space 'T1w' include both descriptions.
         Default=True.
 
     with_confounds : bool, optional
@@ -558,8 +558,8 @@ def create_fake_bids_dataset(base_dir='', n_sub=10, n_ses=2,
 
     confounds_tag : string (filename suffix), optional
         If generating confounds, what path should they have? Defaults to
-        `desc-confounds_timeseries` as in `fmriprep` >= 20.2 but can be other
-        values (e.g. "desc-confounds_regressors" as in `fmriprep` < 20.2)
+        `desc-confounds_timeseries` as in :term:`fMRIPrep` >= 20.2 but can be other
+        values (e.g. "desc-confounds_regressors" as in :term:`fMRIPrep` < 20.2)
         Default="desc-confounds_timeseries".
 
     no_session : bool, optional

--- a/nilearn/_utils/data_gen.py
+++ b/nilearn/_utils/data_gen.py
@@ -558,8 +558,9 @@ def create_fake_bids_dataset(base_dir='', n_sub=10, n_ses=2,
 
     confounds_tag : string (filename suffix), optional
         If generating confounds, what path should they have? Defaults to
-        `desc-confounds_timeseries` as in :term:`fMRIPrep` >= 20.2 but can be other
-        values (e.g. "desc-confounds_regressors" as in :term:`fMRIPrep` < 20.2)
+        `desc-confounds_timeseries` as in :term:`fMRIPrep` >= 20.2
+        but can be other values (e.g. "desc-confounds_regressors" as
+        in :term:`fMRIPrep` < 20.2).
         Default="desc-confounds_timeseries".
 
     no_session : bool, optional

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -1678,7 +1678,7 @@ def fetch_development_fmri(n_subjects=None, reduce_confounds=True,
         6 anatomical compcor parameters. This selection only serves the
         purpose of having realistic examples. Depending on your research
         question, other confounds might be more appropriate.
-        If False, returns all fmriprep confounds.
+        If False, returns all :term:`fMRIPrep` confounds.
         Default=True.
     %(data_dir)s
     %(resume)s


### PR DESCRIPTION
Small PR to add `fMRIPrep` to the glossary and try triggering the auto-comment action (See #2982).
Ping @thomasbazeille 