### PR TITLE
[FIX] LGTM.com warning: Variable defined multiple times

### DIFF
--- a/examples/02_decoding/plot_oasis_vbm.py
+++ b/examples/02_decoding/plot_oasis_vbm.py
@@ -85,7 +85,6 @@ gm_maps_masked = nifti_masker.fit_transform(gm_imgs_train)
 from sklearn.feature_selection import VarianceThreshold
 variance_threshold = VarianceThreshold(threshold=.01)
 gm_maps_thresholded = variance_threshold.fit_transform(gm_maps_masked)
-gm_maps_masked = variance_threshold.inverse_transform(gm_maps_thresholded)
 
 # Then we convert the data back to the mask image in order to use it for
 # decoding process


### PR DESCRIPTION
[This assignment to '`gm_maps_masked`'](https://github.com/nilearn/nilearn/blob/4979af2/examples/02_decoding/plot_oasis_vbm.py#L88) is unnecessary as it is redefined [here](https://github.com/nilearn/nilearn/blob/4979af2/examples/02_decoding/plot_oasis_vbm.py#L163) before this value is used.
