### PR TITLE
[FIX] Replace undefined RST substitution in example

### DIFF
--- a/examples/05_glm_second_level/plot_thresholding.py
+++ b/examples/05_glm_second_level/plot_thresholding.py
@@ -46,7 +46,7 @@ z_map = second_level_model.compute_contrast(output_type='z_score')
 
 #########################################################################
 # Threshold the resulting map without multiple comparisons correction,
-# |z| > 3.29 (equivalent to p < 0.001), cluster size > 10 voxels.
+# abs(z) > 3.29 (equivalent to p < 0.001), cluster size > 10 voxels.
 from nilearn.image import threshold_img
 thresholded_map = threshold_img(
     z_map,


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None, but fixes a bug I introduced into the `plot_thresholding` example in #2965.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Replace pipes in example with `abs()`. Apparently pipes indicate a substitution, which I was not aware of when I used them.
