### PR TITLE
[MAINT] LGTM.com recommendation: Unused local variable

### DIFF
--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -367,7 +367,8 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                 raise ValueError("Invalid value for resampling_target: " +
                                  str(self.resampling_target))
 
-            mask_data, mask_affine = masking._load_mask_img(self.mask_img_)
+            # Just check that the mask is valid
+            masking._load_mask_img(self.mask_img_)
 
         if not hasattr(self,
                        '_resampled_labels_img_'):

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -43,6 +43,9 @@ def _load_mask_img(mask_img, allow_empty=False):
     -------
     mask: numpy.ndarray
         boolean version of the mask
+
+    mask_affine: None or (4,4) array-like
+        affine of the mask
     """
     mask_img = _utils.check_niimg_3d(mask_img)
     mask = _safe_get_data(mask_img, ensure_finite=True)


### PR DESCRIPTION
The value assigned to local variable '`mask_data`' is never used.
The value assigned to local variable '`mask_affine`' is never used.

Closes #2993.