### PR TITLE
[MAINT] Fix positional args deprecations (sklearn >= 1.0)

### DIFF
--- a/examples/02_decoding/plot_miyawaki_reconstruction.py
+++ b/examples/02_decoding/plot_miyawaki_reconstruction.py
@@ -149,7 +149,7 @@ clfs = []
 n_clfs = y_train.shape[1]
 for i in range(y_train.shape[1]):
     sys.stderr.write("Training classifiers %03d/%d... \r" % (i + 1, n_clfs))
-    clf = Pipeline([('selection', SelectKBest(f_classif, 500)),
+    clf = Pipeline([('selection', SelectKBest(f_classif, k=500)),
                     ('clf', OMP(n_nonzero_coefs=10))])
     clf.fit(X_train, y_train[:, i])
     clfs.append(clf)

--- a/examples/07_advanced/plot_advanced_decoding_scikit.py
+++ b/examples/07_advanced/plot_advanced_decoding_scikit.py
@@ -215,7 +215,7 @@ print("ANOVA + LDA classification accuracy: %.4f / Chance Level: %.4f" %
 # Import it and define your fancy objects
 from sklearn.feature_selection import RFE
 svc = SVC()
-rfe = RFE(SVC(kernel='linear', C=1.), 50, step=0.25)
+rfe = RFE(SVC(kernel='linear', C=1.), n_features_to_select=50, step=0.25)
 
 # Create a new pipeline, composing the two classifiers `rfe` and `svc`
 

--- a/examples/07_advanced/plot_age_group_prediction_cross_val.py
+++ b/examples/07_advanced/plot_age_group_prediction_cross_val.py
@@ -56,7 +56,7 @@ pipe = Pipeline(
      ('classifier', GridSearchCV(LinearSVC(), {'C': [.1, 1., 10.]}, cv=5))])
 
 param_grid = [
-    {'classifier': [DummyClassifier('most_frequent')]},
+    {'classifier': [DummyClassifier(strategy='most_frequent')]},
     {'connectivity__kind': kinds}
 ]
 


### PR DESCRIPTION
Scikit-learn has deprecated positional args in various parts of their API since 0.23 and removed them in 1.0 (See [this PR](https://github.com/scikit-learn/scikit-learn/pull/20002)).