### PR TITLE
[ENH] Add warning when `NiftiLabelsMasker` removes labels at transform time

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -30,6 +30,9 @@ Enhancements
   :ref:`sphx_glr_auto_examples_04_glm_first_level_plot_hrf.py` was
   also modified to demo how to define custom :term:`HRF` models.
   (See issue `#2940 <https://github.com/nilearn/nilearn/issues/2940>`_). 
+- :class:`nilearn.input_data.NiftiLabelsMasker` now gives a warning when some
+  labels are removed from the label image at transform time due to resampling
+  of the label image to the data image.
 
 Changes
 -------

--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -8,6 +8,7 @@ import warnings
 from joblib import Memory
 
 from .. import _utils
+from .._utils.niimg import _safe_get_data
 from .._utils import logger, CacheMixin, _compose_err_msg
 from .._utils.class_inspect import get_params
 from .._utils.niimg_conversions import _check_same_fov
@@ -440,11 +441,25 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             if not _check_same_fov(imgs_, self._resampled_labels_img_):
                 if self.verbose > 0:
                     print("Resampling labels")
+                labels_before_resampling = set(
+                    np.unique(_safe_get_data(self._resampled_labels_img_))
+                )
                 self._resampled_labels_img_ = self._cache(
                     image.resample_img, func_memory_level=2)(
                         self.labels_img_, interpolation="nearest",
                         target_shape=imgs_.shape[:3],
                         target_affine=imgs_.affine)
+                labels_after_resampling = set(
+                    np.unique(_safe_get_data(self._resampled_labels_img_))
+                )
+                labels_diff = labels_before_resampling - labels_after_resampling
+                if len(labels_diff) > 0:
+                    warnings.warn("After resampling the label image to the "
+                                  "data image, the following labels were "
+                                  f"removed: {labels_diff}. "
+                                  "Label image only contains "
+                                  f"{len(labels_after_resampling)} labels "
+                                  "(including background).")
             if self.mask_img is not None and not _check_same_fov(
                     imgs_, self._resampled_mask_img):
                 if self.verbose > 0:

--- a/nilearn/input_data/tests/test_nifti_labels_masker.py
+++ b/nilearn/input_data/tests/test_nifti_labels_masker.py
@@ -368,7 +368,14 @@ def test_nifti_labels_masker_resampling():
     for resampling_target in ['data', 'labels']:
         masker = NiftiLabelsMasker(labels_img=labels_img,
                                    resampling_target=resampling_target)
-        transformed = masker.fit_transform(fmri_img)
+        if resampling_target == 'data':
+            with pytest.warns(UserWarning,
+                              match=("After resampling the label image "
+                                     "to the data image, the following "
+                                     "labels were removed")):
+                transformed = masker.fit_transform(fmri_img)
+        else:
+            transformed = masker.fit_transform(fmri_img)
         resampled_labels_img = masker._resampled_labels_img_
         n_resampled_labels = len(np.unique(get_data(resampled_labels_img)))
         assert n_resampled_labels - 1 == transformed.shape[1]


### PR DESCRIPTION
In some cases, the `NiftiLabelsMasker` can remove labels from the label image at transform time due to the resampling of the label image to the data image. This can be confusing since the output signal has a different shape from expected.
This PR proposes to give a warning to the user with a list of the labels that were removed during resampling.