### PR TITLE
[DOC] Add dev/stable version banners

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -73,13 +73,13 @@ html-strict:	sym_links
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 html-modified-examples-only: 	sym_links
-	$(SPHINXBUILD) -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -D sphinx_gallery_conf.run_stale_examples=True -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	BUILD_DEV_HTML=1 $(SPHINXBUILD) -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -D sphinx_gallery_conf.run_stale_examples=True -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	touch $(BUILDDIR)/html/.nojekyll
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 html-noplot:
-	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	BUILD_DEV_HTML=1 $(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	touch $(BUILDDIR)/html/.nojekyll
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
@@ -162,7 +162,7 @@ pdf: latex
 check:
 	rm -rf _build/doctrees
 	rm -rf $(BUILDDIR)/html/_images
-	$(SPHINXBUILD) -W -T -n -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	BUILD_DEV_HTML=1 $(SPHINXBUILD) -W -T -n -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 
 install:
 	rm -rf _build/doctrees _build/nilearn.github.io

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -230,6 +230,11 @@ html_show_sourcelink = False
 # base URL from which the finished HTML is served.
 #html_use_opensearch = ''
 
+# variables to pass to HTML templating engine
+build_dev_html = bool(int(os.environ.get('BUILD_DEV_HTML', False)))
+
+html_context = {'build_dev_html': build_dev_html}
+
 # If nonempty, this is the file name suffix for HTML files (e.g. ".xhtml").
 #html_file_suffix = ''
 

--- a/doc/themes/nilearn/layout.html
+++ b/doc/themes/nilearn/layout.html
@@ -25,6 +25,17 @@
 <div class=related-wrapper>
     {{relbar()}}
 </div>
+{% if build_dev_html %}
+<div class="devel-alert-banner">
+This is documentation for the <em>unstable development version</em> of Nilearn,
+the current stable version is available <a href="https://nilearn.github.io/stable/index.html">here</a>.
+</div>
+{% else %}
+<div class="stable-banner">
+This is the <em>stable</em> documentation for the latest release of Nilearn,
+the current development version is available <a href="https://nilearn.github.io/dev/index.html">here</a>.
+</div>
+{% endif %}
 {% endblock %}
 
 {% block rootrellink %}

--- a/doc/themes/nilearn/static/nature.css_t
+++ b/doc/themes/nilearn/static/nature.css_t
@@ -64,7 +64,19 @@ div.content {
     padding-bottom: 10px;
 }
 
+.devel-alert-banner {
+    background-color: #e74c3c;
+    border-color: #e74c3c;
+    color: #ffffff;
+    padding: 0.2em;
+}
 
+.stable-banner {
+    background-color: #008000;
+    border-color: #e74c3c;
+    color: #ffffff;
+    padding: 0.2em;
+}
 
 div.topic {
     background-color: #eee;
@@ -529,6 +541,7 @@ div.bodywrapper h1 {
 
 div.sphinxsidebar {
     margin: 0;
+    margin-top: 50px;
     padding: 0 15px 15px 0;
     min-width: 226px;
     width: 17%;


### PR DESCRIPTION
This PR proposes to add a red banner at the top of the landing page for the development version of the docs, and a green banner for the stable version with a link to switch from one to the other.
This was originally part of PR #2605 which I decided to break into smaller contributions.