### PR TITLE
[FIX] scrubbing parameter names in `nilearn.input_data.fmriprep_confounds` not matching docstring

### DIFF
--- a/nilearn/input_data/fmriprep_confounds.py
+++ b/nilearn/input_data/fmriprep_confounds.py
@@ -28,7 +28,7 @@ component_parameters = {
     "global": ["global_signal"],
     "compcor": ["meta_json", "compcor", "n_compcor"],
     "ica_aroma": ["ica_aroma"],
-    "scrub": ["scrub", "fd_thresh", "std_dvars_thresh"],
+    "scrub": ["scrub", "fd_threshold", "std_dvars_threshold"],
 }
 
 
@@ -63,7 +63,7 @@ def _check_error(missing):
 def fmriprep_confounds(img_files,
                        strategy=["motion", "high_pass", "wm_csf"],
                        motion="full",
-                       scrub=5, fd_thresh=0.2, std_dvars_thresh=3,
+                       scrub=5, fd_threshold=0.2, std_dvars_threshold=3,
                        wm_csf="basic",
                        global_signal="basic",
                        compcor="anat_combined", n_compcor="all",
@@ -247,8 +247,8 @@ def fmriprep_confounds(img_files,
                                          demean,
                                          motion=motion,
                                          scrub=scrub,
-                                         fd_thresh=fd_thresh,
-                                         std_dvars_thresh=std_dvars_thresh,
+                                         fd_threshold=fd_threshold,
+                                         std_dvars_threshold=std_dvars_threshold,
                                          wm_csf=wm_csf,
                                          global_signal=global_signal,
                                          compcor=compcor,

--- a/nilearn/input_data/fmriprep_confounds.py
+++ b/nilearn/input_data/fmriprep_confounds.py
@@ -242,18 +242,16 @@ def fmriprep_confounds(img_files,
     confounds_out = []
     sample_mask_out = []
     for file in img_files:
-        sample_mask, conf = _load_single(file,
-                                         strategy,
-                                         demean,
-                                         motion=motion,
-                                         scrub=scrub,
-                                         fd_threshold=fd_threshold,
-                                         std_dvars_threshold=std_dvars_threshold,
-                                         wm_csf=wm_csf,
-                                         global_signal=global_signal,
-                                         compcor=compcor,
-                                         n_compcor=n_compcor,
-                                         ica_aroma=ica_aroma)
+        sample_mask, conf = _load_single(
+            file, strategy, demean,
+            motion=motion,
+            scrub=scrub,
+            fd_threshold=fd_threshold,
+            std_dvars_threshold=std_dvars_threshold,
+            wm_csf=wm_csf,
+            global_signal=global_signal,
+            compcor=compcor, n_compcor=n_compcor,
+            ica_aroma=ica_aroma)
         confounds_out.append(conf)
         sample_mask_out.append(sample_mask)
 

--- a/nilearn/input_data/fmriprep_confounds_components.py
+++ b/nilearn/input_data/fmriprep_confounds_components.py
@@ -62,15 +62,15 @@ def _load_ica_aroma(confounds_raw, ica_aroma):
         )
 
 
-def _load_scrub(confounds_raw, scrub, fd_thresh, std_dvars_thresh):
+def _load_scrub(confounds_raw, scrub, fd_threshold, std_dvars_threshold):
     """Remove volumes if FD and/or DVARS exceeds threshold."""
     n_scans = len(confounds_raw)
     # Get indices of fd outliers
     fd_outliers_index = np.where(
-        confounds_raw["framewise_displacement"] > fd_thresh
+        confounds_raw["framewise_displacement"] > fd_threshold
     )[0]
     dvars_outliers_index = np.where(
-        confounds_raw["std_dvars"] > std_dvars_thresh
+        confounds_raw["std_dvars"] > std_dvars_threshold
     )[0]
     motion_outliers_index = np.sort(
         np.unique(np.concatenate((fd_outliers_index, dvars_outliers_index)))

--- a/nilearn/input_data/fmriprep_confounds_strategy.py
+++ b/nilearn/input_data/fmriprep_confounds_strategy.py
@@ -146,21 +146,21 @@ def fmriprep_confounds_strategy(img_files, denoise_strategy="simple",
        see :func:`nilearn.input_data.fmriprep_confounds`.
 
         ========= ========= ====== ====== ============= ===== ============ \
-        ==================== ============== ========= ========= ======
-        strategy  high_pass motion wm_csf global_signal scrub fd_threshold  \
+        =================== ============== ========= ========= ======
+        strategy  high_pass motion wm_csf global_signal scrub fd_threshold \
         std_dvars_threshold compcor        n_compcor ica_aroma demean
-        ========= ========= ====== ====== ============= ===== ============  \
+        ========= ========= ====== ====== ============= ===== ============ \
         =================== ============== ========= ========= ======
-        simple    True      full*  basic* None*         N/A   N/A           \
+        simple    True      full*  basic* None*         N/A   N/A          \
         N/A                 N/A            N/A       N/A       True*
-        scrubbing True      full*  full   None*         5*    0.2*          \
+        scrubbing True      full*  full   None*         5*    0.2*         \
         3*                  N/A            N/A       N/A       True*
-        compcor   True      full*  N/A    N/A           N/A   N/A           \
+        compcor   True      full*  N/A    N/A           N/A   N/A          \
         N/A                 anat_combined* all*      N/A       True*
-        ica_aroma True      N/A    basic* None*         N/A   N/A           \
+        ica_aroma True      N/A    basic* None*         N/A   N/A          \
         N/A                 N/A            N/A       full      True*
-        ========= ========= ====== ====== ============= ===== ============  \
-        =================== ============== ========= ========= ======
+        ========= ========= ====== ====== ============= ===== ============ \
+        ================== ============== ========= ========= ======
 
     2. ICA-AROMA is implemented in two steps in :footcite:`Pruim2015`:
 

--- a/nilearn/input_data/fmriprep_confounds_strategy.py
+++ b/nilearn/input_data/fmriprep_confounds_strategy.py
@@ -28,8 +28,8 @@ preset_strategies = {
         "motion": "full",
         "wm_csf": "full",
         "scrub": 5,
-        "fd_thresh": 0.2,
-        "std_dvars_thresh": 3,
+        "fd_threshold": 0.2,
+        "std_dvars_threshold": 3,
         "global_signal": None,
         "demean": True
     },
@@ -145,22 +145,22 @@ def fmriprep_confounds_strategy(img_files, denoise_strategy="simple",
        strategies. Parameters with `*` denote customisable parameters. Please
        see :func:`nilearn.input_data.fmriprep_confounds`.
 
-        ========= ========= ====== ====== ============= ===== ========= \
-        ================ ============== ========= ========= ======
-        strategy  high_pass motion wm_csf global_signal scrub fd_thresh \
-        std_dvars_thresh compcor        n_compcor ica_aroma demean
-        ========= ========= ====== ====== ============= ===== ========= \
-        ================ ============== ========= ========= ======
-        simple    True      full*  basic* None*         N/A   N/A       \
-        N/A              N/A            N/A       N/A       True*
-        scrubbing True      full*  full   None*         5*    0.2*      \
-        3*               N/A            N/A       N/A       True*
-        compcor   True      full*  N/A    N/A           N/A   N/A       \
-        N/A              anat_combined* all*      N/A       True*
-        ica_aroma True      N/A    basic* None*         N/A   N/A       \
-        N/A              N/A            N/A       full      True*
-        ========= ========= ====== ====== ============= ===== ========= \
-        ================ ============== ========= ========= ======
+        ========= ========= ====== ====== ============= ===== ============ \
+        ==================== ============== ========= ========= ======
+        strategy  high_pass motion wm_csf global_signal scrub fd_threshold  \
+        std_dvars_threshold compcor        n_compcor ica_aroma demean
+        ========= ========= ====== ====== ============= ===== ============  \
+        =================== ============== ========= ========= ======
+        simple    True      full*  basic* None*         N/A   N/A           \
+        N/A                 N/A            N/A       N/A       True*
+        scrubbing True      full*  full   None*         5*    0.2*          \
+        3*                  N/A            N/A       N/A       True*
+        compcor   True      full*  N/A    N/A           N/A   N/A           \
+        N/A                 anat_combined* all*      N/A       True*
+        ica_aroma True      N/A    basic* None*         N/A   N/A           \
+        N/A                 N/A            N/A       full      True*
+        ========= ========= ====== ====== ============= ===== ============  \
+        =================== ============== ========= ========= ======
 
     2. ICA-AROMA is implemented in two steps in :footcite:`Pruim2015`:
 

--- a/nilearn/input_data/fmriprep_confounds_strategy.py
+++ b/nilearn/input_data/fmriprep_confounds_strategy.py
@@ -160,7 +160,7 @@ def fmriprep_confounds_strategy(img_files, denoise_strategy="simple",
         ica_aroma True      N/A    basic* None*         N/A   N/A          \
         N/A                 N/A            N/A       full      True*
         ========= ========= ====== ====== ============= ===== ============ \
-        ================== ============== ========= ========= ======
+        =================== ============== ========= ========= ======
 
     2. ICA-AROMA is implemented in two steps in :footcite:`Pruim2015`:
 

--- a/nilearn/input_data/tests/test_fmriprep_confounds.py
+++ b/nilearn/input_data/tests/test_fmriprep_confounds.py
@@ -483,7 +483,7 @@ def test_sample_mask(tmp_path):
     )
 
     reg, mask = fmriprep_confounds(
-        regular_nii, strategy=["motion", "scrub"], scrub=5, fd_thresh=0.15
+        regular_nii, strategy=["motion", "scrub"], scrub=5, fd_threshold=0.15
     )
     # the current test data has 6 time points marked as motion outliers,
     # and one nonsteady state (overlap with the first motion outlier)
@@ -505,7 +505,7 @@ def test_sample_mask(tmp_path):
 
     # When no volumes needs removing (very liberal motion threshould)
     reg, mask = fmriprep_confounds(
-        regular_nii, strategy=["motion", "scrub"], scrub=0, fd_thresh=4
+        regular_nii, strategy=["motion", "scrub"], scrub=0, fd_threshold=4
     )
     assert mask is None
 

--- a/nilearn/input_data/tests/test_fmriprep_confounds_strategy.py
+++ b/nilearn/input_data/tests/test_fmriprep_confounds_strategy.py
@@ -73,7 +73,7 @@ def test_strategy_scrubbing(tmp_path):
     file_nii, _ = create_tmp_filepath(tmp_path, image_type="regular",
                                       copy_confounds=True, copy_json=True)
     confounds, sample_mask = fmriprep_confounds_strategy(
-        file_nii, denoise_strategy="scrubbing", fd_thresh=0.15)
+        file_nii, denoise_strategy="scrubbing", fd_threshold=0.15)
 
     # out of 30 vols, should have 6 motion outliers from scrubbing,
     # and 2 vol removed by srubbing strategy "full"
@@ -84,7 +84,7 @@ def test_strategy_scrubbing(tmp_path):
     # this should not produce an error
     confounds, sample_mask = fmriprep_confounds_strategy(
         file_nii, denoise_strategy="scrubbing",
-        fd_thresh=1, std_dvars_thresh=5)
+        fd_threshold=1, std_dvars_threshold=5)
     assert len(sample_mask) == 29  # only non-steady volumes removed
 
     # maker sure global signal works


### PR DESCRIPTION
In `nilearn.input_data.fmriprep_confounds`, two parameter names are not matching the docstrings.

`fd_thresh` -> `fd_threshold`
`std_dvars_thresh` -> `std_dvars_threshold`