### PR TITLE
[MAINT] LGTM.com warning: Variable defined multiple times

### DIFF
--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -375,7 +375,6 @@ def _compute_facecolors_matplotlib(bg_map, faces, n_vertices,
     # set alpha if in auto mode
     if alpha == 'auto':
         alpha = .5 if bg_map is None else 1
-    face_colors = np.ones((faces.shape[0], 4))
     if bg_map is None:
         bg_data = np.ones(n_vertices) * 0.5
     else:


### PR DESCRIPTION
This assignment to '`face_colors`' is unnecessary as it is redefined [here](https://github.com/nilearn/nilearn/blob/4280451/nilearn/plotting/surf_plotting.py#L392) before this value is used.

https://lgtm.com/projects/g/nilearn/nilearn/snapshot/0277ef6bc1aaa54a0419a4102beeb2e410a3a306/files/nilearn/plotting/surf_plotting.py?sort=name&dir=ASC&mode=heatmap#x841fc8fb537934bc:1