### PR TITLE
MAINT: Work around SciPy deprecation

### DIFF
--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -18,9 +18,9 @@ import nibabel
 import pandas as pd
 from scipy.io import loadmat
 try:
+    from scipy.io.matlab import MatReadError
+except ImportError:  # SciPy < 1.8
     from scipy.io.matlab.miobase import MatReadError
-except ImportError:
-    from scipy.io._matlab.miobase import MatReadError
 from sklearn.utils import Bunch, deprecated
 
 from .utils import (_get_dataset_dir, _fetch_files, _get_dataset_descr,

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -17,7 +17,10 @@ from io import BytesIO
 import nibabel
 import pandas as pd
 from scipy.io import loadmat
-from scipy.io.matlab.miobase import MatReadError
+try:
+    from scipy.io.matlab.miobase import MatReadError
+except ImportError:
+    from scipy.io._matlab.miobase import MatReadError
 from sklearn.utils import Bunch, deprecated
 
 from .utils import (_get_dataset_dir, _fetch_files, _get_dataset_descr,


### PR DESCRIPTION
SciPy made the `scipy.io.matlab` namespace private. This is a temporary workaround PR until https://github.com/scipy/scipy/pull/15004 is in and these hopefully land in a public namespace, so don't merge yet.