### PR TITLE
[FIX] Fix sphinx config

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -88,7 +88,7 @@ source_suffix = '.rst'
 #source_encoding = 'utf-8'
 
 # Generate the plots for the gallery
-plot_gallery = 'True'
+plot_gallery = True
 
 # The master toctree document.
 master_doc = 'index'


### PR DESCRIPTION
Fix needed with latest version (`0.10.1`) of `sphinx-gallery`. `plot_gallery` should no longer be a string, but a boolean, otherwise a warning is raised which makes the CI fail in strict mode.
See https://github.com/sphinx-gallery/sphinx-gallery/pull/863