### PR TITLE
[FIX] Fix labels in `fetch_atlas_destrieux_2009`

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -59,6 +59,9 @@ Fixes
   :func:`nilearn.reporting.make_glm_report` was fixed accordingly.
   (See issue `#3034 <https://github.com/nilearn/nilearn/issues/3034>`_) and fix
   `#3035 <https://github.com/nilearn/nilearn/pull/3035>`_).
+- :func:`~nilearn.datasets.fetch_atlas_destrieux_2009` now returns only labels
+  present in the maps images.
+  (See PR `#3070 <https://github.com/nilearn/nilearn/pull/3070>`_).
 
 Enhancements
 ------------

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -197,7 +197,7 @@ def _clean_labels(image, labels):
 
 @fill_doc
 def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
-                               resume=True, verbose=1, clean_labels=False):
+                               resume=True, verbose=1, clean_labels=None):
     """Download and load the Destrieux cortical atlas (dated 2009).
 
     See :footcite:`Fischl2004Automatically`,
@@ -239,6 +239,11 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
     .. footbibliography::
 
     """
+    if clean_labels is None:
+        warnings.warn("Default value for parameter `clean_labels` will "
+                      "change from ``False`` to ``True`` in Nilearn 0.10.",
+                      category=FutureWarning)
+        clean_labels = False
     if url is None:
         url = "https://www.nitrc.org/frs/download.php/11942/"
 

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -197,25 +197,38 @@ def _clean_labels(image, labels):
 
 @fill_doc
 def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
-                               resume=True, verbose=1):
-    """Download and load the Destrieux cortical atlas (dated 2009)
+                               resume=True, verbose=1, clean_labels=False):
+    """Download and load the Destrieux cortical atlas (dated 2009).
 
-    see :footcite:`Fischl2004Automatically`,
+    See :footcite:`Fischl2004Automatically`,
     and :footcite:`Destrieux2009sulcal`.
+
+    .. note::
+
+        Some labels from the list of labels might not be present in the
+        atlas image, which can be an issue in some specific cases. In order
+        to clean the list of labels and keep only the ones present in the
+        image, use ``clean_labels=True``.
 
     Parameters
     ----------
-    lateralized : boolean, optional
+    lateralized : :obj:`bool`, optional
         If True, returns an atlas with distinct regions for right and left
         hemispheres. Default=True.
     %(data_dir)s
     %(url)s
     %(resume)s
     %(verbose)s
+    clean_labels : :obj:`bool`, optional
+        If set to ``True``, labels which do not appear in the image will
+        be removed from the list of labels.
+        Default=False.
+
+        .. versionadded:: 0.8.2
 
     Returns
     -------
-    data : sklearn.datasets.base.Bunch
+    data : :func:`sklearn.utils.Bunch`
         Dictionary-like object, contains:
 
         - Cortical ROIs, lateralized or not (maps)
@@ -250,7 +263,8 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
     with open(files_[2], 'r') as rst_file:
         params['description'] = rst_file.read()
 
-    params['labels'] = _clean_labels(params['maps'], params['labels'])
+    if clean_labels:
+        params['labels'] = _clean_labels(params['maps'], params['labels'])
     return Bunch(**params)
 
 

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -181,6 +181,20 @@ def fetch_atlas_craddock_2012(data_dir=None, url=None, resume=True, verbose=1):
     return Bunch(**params)
 
 
+def _clean_labels(image, labels):
+    """Helper function removing labels that do not appear in the image."""
+    labels_in_img = set(np.unique(get_data(image)))
+    labels_set = set([label.index for label in labels])
+    diff = labels_set.difference(labels_in_img)
+    if len(diff) == 0:
+        return labels
+    cleaned_labels = np.array(
+        [label for label in labels if label.index not in diff],
+        dtype=[('index', '<i8'), ('name', 'S27')]
+    )
+    return cleaned_labels.view(np.recarray)
+
+
 @fill_doc
 def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
                                resume=True, verbose=1):
@@ -236,6 +250,7 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
     with open(files_[2], 'r') as rst_file:
         params['description'] = rst_file.read()
 
+    params['labels'] = _clean_labels(params['maps'], params['labels'])
     return Bunch(**params)
 
 

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -372,14 +372,14 @@ def test_fetch_atlas_destrieux_2009(tmp_path, request_mocker, n_labels,
 
 def test_fetch_atlas_destrieux_2009_warning_clean_labels(request_mocker):
     """Tests that ``fetch_atlas_destrieux_2009`` gives a FutureWarning
-    when ``clean_labels`` isn't specified explicitely.
+    when ``clean_labels`` isn't specified explicitly.
     """
     request_mocker.url_mapping["*destrieux2009.tgz"] = _destrieux_data()
     with pytest.warns(FutureWarning,
                       match=("Default value for parameter `clean_labels` "
                              "will change from ``False`` to ``True`` "
                              "in Nilearn 0.10.")):
-        bunch = atlas.fetch_atlas_destrieux_2009()
+        atlas.fetch_atlas_destrieux_2009()
     assert request_mocker.url_count == 1
 
 

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -327,7 +327,7 @@ def _destrieux_data():
     atlas_img = nibabel.Nifti1Image(atlas, np.eye(4))
     # Create 11 labels. The fetcher should be able to remove
     # the extra label ('10') not present in the atlas image
-    labels = "\n".join([f"{l},label {l}" for l in range(11)])
+    labels = "\n".join([f"{idx},label {idx}" for idx in range(11)])
     labels = "index,name\n" + labels
     for lat in ["_lateralized", ""]:
         lat_data = {
@@ -347,7 +347,7 @@ def test_fetch_atlas_destrieux_2009(tmp_path, request_mocker):
     assert bunch['maps'] == str(tmp_path / 'destrieux_2009'
                                 / 'destrieux2009_rois_lateralized.nii.gz')
     labels_img = set(np.unique(get_data(bunch.maps)))
-    labels = set([l.index for l in bunch.labels])
+    labels = set([label.index for label in bunch.labels])
     assert labels_img == labels
     bunch = atlas.fetch_atlas_destrieux_2009(
         lateralized=False, data_dir=tmp_path, verbose=0)
@@ -356,7 +356,7 @@ def test_fetch_atlas_destrieux_2009(tmp_path, request_mocker):
     assert bunch['maps'] == str(tmp_path / 'destrieux_2009'
                                 / 'destrieux2009_rois.nii.gz')
     labels_img = set(np.unique(get_data(bunch.maps)))
-    labels = set([l.index for l in bunch.labels])
+    labels = set([label.index for label in bunch.labels])
     assert labels_img == labels
 
 

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -370,6 +370,19 @@ def test_fetch_atlas_destrieux_2009(tmp_path, request_mocker, n_labels,
         assert labels_img.issubset(labels)
 
 
+def test_fetch_atlas_destrieux_2009_warning_clean_labels(request_mocker):
+    """Tests that ``fetch_atlas_destrieux_2009`` gives a FutureWarning
+    when ``clean_labels`` isn't specified explicitely.
+    """
+    request_mocker.url_mapping["*destrieux2009.tgz"] = _destrieux_data()
+    with pytest.warns(FutureWarning,
+                      match=("Default value for parameter `clean_labels` "
+                             "will change from ``False`` to ``True`` "
+                             "in Nilearn 0.10.")):
+        bunch = atlas.fetch_atlas_destrieux_2009()
+    assert request_mocker.url_count == 1
+
+
 def test_fetch_atlas_msdl(tmp_path, request_mocker):
     labels = pd.DataFrame(
         {"x": [1.5, 1.2], "y": [1.5, 1.3],

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -322,11 +322,13 @@ def test_fetch_coords_seitzman_2018(request_mocker):
 
 
 def _destrieux_data(n_labels=10):
+    """Function mocking the download of the destrieux atlas.
+    Parameter `n_labels` controls the number of labels in the
+    CSV file. The number of labels in the image is 10.
+    """
     data = {"destrieux2009.rst": "readme"}
     atlas = np.random.randint(0, 10, (10, 10, 10))
     atlas_img = nibabel.Nifti1Image(atlas, np.eye(4))
-    # Create 11 labels. The fetcher should be able to remove
-    # the extra label ('10') not present in the atlas image
     labels = "\n".join([f"{idx},label {idx}" for idx in range(n_labels)])
     labels = "index,name\n" + labels
     for lat in ["_lateralized", ""]:
@@ -341,6 +343,11 @@ def _destrieux_data(n_labels=10):
 @pytest.mark.parametrize("n_labels", [10, 11])
 @pytest.mark.parametrize("lateralized", [True, False])
 def test_fetch_atlas_destrieux_2009(tmp_path, request_mocker, n_labels, lateralized):  # noqa
+    """Tests for function `fetch_atlas_destrieux_2009`.
+    The atlas is fetched with different combinations of `lateralized`
+    and `n_labels`. In the case `n_labels=11`, the fetcher should be able
+    to remove the extra label ('10') not present in the atlas image.
+    """
     request_mocker.url_mapping["*destrieux2009.tgz"] = _destrieux_data(
         n_labels=n_labels
     )

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -342,7 +342,9 @@ def _destrieux_data(n_labels=10):
 
 @pytest.mark.parametrize("n_labels", [10, 11])
 @pytest.mark.parametrize("lateralized", [True, False])
-def test_fetch_atlas_destrieux_2009(tmp_path, request_mocker, n_labels, lateralized):  # noqa
+@pytest.mark.parametrize("clean_labels", [True, False])
+def test_fetch_atlas_destrieux_2009(tmp_path, request_mocker, n_labels,
+                                    lateralized, clean_labels):
     """Tests for function `fetch_atlas_destrieux_2009`.
     The atlas is fetched with different combinations of `lateralized`
     and `n_labels`. In the case `n_labels=11`, the fetcher should be able
@@ -352,7 +354,8 @@ def test_fetch_atlas_destrieux_2009(tmp_path, request_mocker, n_labels, laterali
         n_labels=n_labels
     )
     bunch = atlas.fetch_atlas_destrieux_2009(
-        lateralized=lateralized, data_dir=tmp_path, verbose=0
+        lateralized=lateralized, data_dir=tmp_path,
+        verbose=0, clean_labels=clean_labels
     )
     assert request_mocker.url_count == 1
     name = '_lateralized' if lateralized else ""
@@ -361,7 +364,10 @@ def test_fetch_atlas_destrieux_2009(tmp_path, request_mocker, n_labels, laterali
     )
     labels_img = set(np.unique(get_data(bunch.maps)))
     labels = set([label.index for label in bunch.labels])
-    assert labels_img == labels
+    if clean_labels:
+        assert labels_img == labels
+    else:
+        assert labels_img.issubset(labels)
 
 
 def test_fetch_atlas_msdl(tmp_path, request_mocker):


### PR DESCRIPTION
See #2036 

This PR adds a test failing with extra labels present in the csv file but not in the image, and adds a fix which removes these labels. This PR only targets `fetch_atlas_destrieux_2009`.