### PR TITLE
Matplotlib backend switch warning

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -110,6 +110,9 @@ Enhancements
   for :class:`~nilearn.glm.first_level.FirstLevelModel`.
   (See FR `#3027 <https://github.com/nilearn/nilearn/issues/3027>`_
   and PR `#3033 <https://github.com/nilearn/nilearn/pull/3033>`_)
+- Importing :mod:`nilearn.plotting` will now raise a warning if the matplotlib
+  backend has been changed from its original value, instead of silently modifying
+  it.
 
 Changes
 -------

--- a/nilearn/plotting/__init__.py
+++ b/nilearn/plotting/__init__.py
@@ -2,9 +2,8 @@
 Plotting code for nilearn
 """
 # Original Authors: Chris Filo Gorgolewski, Gael Varoquaux
-import os
-import sys
 import importlib
+import warnings
 
 
 ###############################################################################
@@ -29,13 +28,16 @@ def _set_mpl_backend():
                                           OPTIONAL_MATPLOTLIB_MIN_VERSION)
         current_backend = matplotlib.get_backend().lower()
 
-        if 'inline' in current_backend or 'nbagg' in current_backend:
-            return
-        # Set the backend to a non-interactive one for unices without X
-        # (see gh-2560)
-        if (sys.platform not in ('darwin', 'win32') and
-                'DISPLAY' not in os.environ):
+        try:
+            matplotlib.use(current_backend)
+        except:
+            # If matplotlib.use throws an error, it means the desired backend
+            # is not compatible with the machine. We set it to default `agg`
+            warnings.warn('Matplotlib backend has been set to `agg` by Nilearn'
+                          'due to incompatibility between current backend and'
+                          'the machine.')
             matplotlib.use('Agg')
+
 
 
 _set_mpl_backend()

--- a/nilearn/plotting/__init__.py
+++ b/nilearn/plotting/__init__.py
@@ -29,15 +29,16 @@ def _set_mpl_backend():
         current_backend = matplotlib.get_backend().lower()
 
         try:
+            # Making sure the current backend is usable by matplotlib
             matplotlib.use(current_backend)
         except:
-            # If matplotlib.use throws an error, it means the desired backend
-            # is not compatible with the machine. We set it to default `agg`
-            warnings.warn('Matplotlib backend has been set to `agg` by Nilearn'
-                          'due to incompatibility between current backend and'
-                          'the machine.')
-            matplotlib.use('Agg')
+            # If not, switching to default agg backend
+            matplotlib.use("Agg")
+        new_backend = matplotlib.get_backend().lower()
 
+        if new_backend != current_backend:
+            # Matplotlib backend has been changed, let's warn the user
+            warnings.warn(f"Backend changed to {new_backend}...")
 
 
 _set_mpl_backend()

--- a/nilearn/plotting/__init__.py
+++ b/nilearn/plotting/__init__.py
@@ -31,7 +31,7 @@ def _set_mpl_backend():
         try:
             # Making sure the current backend is usable by matplotlib
             matplotlib.use(current_backend)
-        except:
+        except Exception:
             # If not, switching to default agg backend
             matplotlib.use("Agg")
         new_backend = matplotlib.get_backend().lower()

--- a/nilearn/plotting/tests/test_matplotlib_backend.py
+++ b/nilearn/plotting/tests/test_matplotlib_backend.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+
+SKIP_REASON = "matplotlib missing; necessary for this test"
+try:
+    import matplotlib  # noqa: F401
+except ImportError:
+    MATPLOTLIB_INSTALLED = False
+else:
+    MATPLOTLIB_INSTALLED = True
+import pytest
+
+from nilearn.plotting import _set_mpl_backend
+
+
+@pytest.mark.skipif(not MATPLOTLIB_INSTALLED, reason=SKIP_REASON)
+@patch("matplotlib.use")
+@patch("matplotlib.get_backend", side_effect=["backend_1", "backend_2"])
+def test_should_raise_warning_if_backend_changes(*_):
+    # The backend values returned by matplotlib.get_backend are different.
+    # Warning should be raised to inform user of the backend switch.
+    with pytest.warns(UserWarning, match="Backend changed to backend_2..."):
+        _set_mpl_backend()
+
+
+@pytest.mark.skipif(not MATPLOTLIB_INSTALLED, reason=SKIP_REASON)
+@patch("matplotlib.use")
+@patch("matplotlib.get_backend", side_effect=["backend_1", "backend_1"])
+def test_should_not_raise_warning_if_backend_is_not_changed(*_):
+    # The backend values returned by matplotlib.get_backend are identical.
+    # Warning should not be raised.
+    with pytest.warns(None):
+        _set_mpl_backend()
+
+
+@pytest.mark.skipif(not MATPLOTLIB_INSTALLED, reason=SKIP_REASON)
+@patch("matplotlib.use", side_effect=[Exception("Failed to switch backend"), True])
+def test_should_switch_to_default_agg_backend_if_current_backend_fails(use_mock):
+    # First call to `matplotlib.use` raises an exception, hence the default Agg
+    # backend should be triggered
+    _set_mpl_backend()
+
+    assert use_mock.call_count == 2
+    # Check that the most recent call to `matplotlib.use` has arg `Agg`
+    use_mock.assert_called_with("Agg")

--- a/nilearn/plotting/tests/test_matplotlib_backend.py
+++ b/nilearn/plotting/tests/test_matplotlib_backend.py
@@ -24,7 +24,8 @@ def test_should_raise_warning_if_backend_changes(*_):
 
 @pytest.mark.skipif(not MATPLOTLIB_INSTALLED, reason=SKIP_REASON)
 @patch("matplotlib.use")
-@patch("matplotlib.get_backend", side_effect=["backend_1", "backend_1"])
+@patch("matplotlib.get_backend",
+       side_effect=["backend_1", "backend_1"])
 def test_should_not_raise_warning_if_backend_is_not_changed(*_):
     # The backend values returned by matplotlib.get_backend are identical.
     # Warning should not be raised.
@@ -33,8 +34,9 @@ def test_should_not_raise_warning_if_backend_is_not_changed(*_):
 
 
 @pytest.mark.skipif(not MATPLOTLIB_INSTALLED, reason=SKIP_REASON)
-@patch("matplotlib.use", side_effect=[Exception("Failed to switch backend"), True])
-def test_should_switch_to_default_agg_backend_if_current_backend_fails(use_mock):
+@patch("matplotlib.use",
+       side_effect=[Exception("Failed to switch backend"), True])
+def test_should_switch_to_agg_backend_if_current_backend_fails(use_mock):
     # First call to `matplotlib.use` raises an exception, hence the default Agg
     # backend should be triggered
     _set_mpl_backend()


### PR DESCRIPTION
PR that tackles elements said in #3063 

This PR contains:

- more robust backend switch using `matplotlib.use` instead of testing hard-coded backends
- warning if matplotlib backend is switched
- tests

Closes #3063 
