### PR TITLE
[FIX] Fix labels HarvardOxford fetcher

### DIFF
--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -380,7 +380,7 @@ def fetch_atlas_harvard_oxford(atlas_name, data_dir=None,
         resume=resume,
         verbose=verbose)
     atlas_niimg = check_niimg(atlas_img)
-    label_idx_to_names = {k:v for k,v in enumerate(names)}
+    label_idx_to_names = {k: v for k, v in enumerate(names)}
     if not symmetric_split or is_lateralized:
         if not is_probabilistic and clean_labels:
             valid_idx = np.unique(get_data(atlas_niimg))
@@ -392,7 +392,7 @@ def fetch_atlas_harvard_oxford(atlas_name, data_dir=None,
     new_atlas_niimg = new_img_like(atlas_niimg,
                                    new_atlas_data,
                                    atlas_niimg.affine)
-    label_idx_to_names = {k:v for k,v in enumerate(new_names)}
+    label_idx_to_names = {k: v for k, v in enumerate(new_names)}
     if not is_probabilistic and clean_labels:
         valid_idx = np.unique(get_data(new_atlas_niimg))
         new_names = [label_idx_to_names[i] for i in valid_idx]

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -274,8 +274,10 @@ def test_atlas_harvard_oxford(atlas_data, tmp_path, request_mocker):
     nibabel.Nifti1Image(atlas_data, np.eye(4) * 3).to_filename(
         target_atlas_nii)
     bunch = atlas.fetch_atlas_harvard_oxford(
-        "cortl-maxprob-thr50-1mm", data_dir=str(tmp_path)
+        "cortl-maxprob-thr50-1mm", data_dir=str(tmp_path),
+        clean_labels=True
     )
+    assert len(bunch.labels) == len(np.unique(get_data(bunch.maps)))
     assert set(range(len(bunch.labels))) == set(np.unique(get_data(bunch.maps)))
 
 

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -278,7 +278,9 @@ def test_atlas_harvard_oxford(atlas_data, tmp_path, request_mocker):
         clean_labels=True
     )
     assert len(bunch.labels) == len(np.unique(get_data(bunch.maps)))
-    assert set(range(len(bunch.labels))) == set(np.unique(get_data(bunch.maps)))
+    assert(
+        set(range(len(bunch.labels))) == set(np.unique(get_data(bunch.maps)))
+    )
 
 
 def test_fetch_atlas_craddock_2012(tmp_path, request_mocker):

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -255,6 +255,30 @@ def test_fetch_atlas_fsl(name, label_fname, fname, is_symm, split,
     _test_result_xml(ho_wo, is_symm=is_symm or split)
 
 
+def test_atlas_harvard_oxford(atlas_data, tmp_path, request_mocker):
+    ho_dir = str(tmp_path / 'fsl' / 'data' / 'atlases')
+    os.makedirs(ho_dir)
+    nifti_dir = os.path.join(ho_dir, 'HarvardOxford')
+    os.makedirs(nifti_dir)
+    filename = "HarvardOxford-Cortical-Lateralized.xml"
+    with open(os.path.join(ho_dir, filename), 'w') as dm:
+        dm.write("<?xml version='1.0' encoding='us-ascii'?>\n"
+                 "<data>\n"
+                 '<label index="0" x="48" y="94" z="35">R1</label>\n'
+                 '<label index="1" x="25" y="70" z="32">R2</label>\n'
+                 '<label index="2" x="33" y="73" z="63">R3</label>\n'
+                 '<label index="3" x="47" y="75" z="66">R4</label>\n'
+                 "</data>")
+    target_atlas_fname = "HarvardOxford-cortl-maxprob-thr50-1mm.nii.gz"
+    target_atlas_nii = os.path.join(nifti_dir, target_atlas_fname)
+    nibabel.Nifti1Image(atlas_data, np.eye(4) * 3).to_filename(
+        target_atlas_nii)
+    bunch = atlas.fetch_atlas_harvard_oxford(
+        "cortl-maxprob-thr50-1mm", data_dir=str(tmp_path)
+    )
+    assert set(range(len(bunch.labels))) == set(np.unique(get_data(bunch.maps)))
+
+
 def test_fetch_atlas_craddock_2012(tmp_path, request_mocker):
     local_archive = Path(
         __file__).parent / "data" / "craddock_2011_parcellations.tar.gz"


### PR DESCRIPTION
Fixes #2036 

For some atlases, `fetch_atlas_harvard_oxford` does not return the same number of labels as different integer values in the maps:

```python
from nilearn.datasets import fetch_atlas_harvard_oxford

# Do not include probabiltic atlases in the list
atlases = ["cort-maxprob-thr0-1mm", "cort-maxprob-thr0-2mm",
           "cort-maxprob-thr25-1mm", "cort-maxprob-thr25-2mm",
           "cort-maxprob-thr50-1mm", "cort-maxprob-thr50-2mm",
           "cortl-maxprob-thr0-1mm", "cortl-maxprob-thr0-2mm",
           "cortl-maxprob-thr25-1mm", "cortl-maxprob-thr25-2mm",
           "cortl-maxprob-thr50-1mm", "cortl-maxprob-thr50-2mm",
           "sub-maxprob-thr0-1mm", "sub-maxprob-thr0-2mm",
           "sub-maxprob-thr25-1mm", "sub-maxprob-thr25-2mm",
           "sub-maxprob-thr50-1mm", "sub-maxprob-thr50-2mm"]

for name in atlases:
    b = fetch_atlas_harvard_oxford(name, clean_labels=False)
    data_maps = get_data(b.maps)
    try:
        # Same number of labels in list and in image
        assert len(b.labels) == len(np.unique(data_maps))
        # Labels in image are consecutive integers from 0 to Nlabel - 1
        assert np.all(np.unique(data_maps) == np.arange(len(b.labels)))
        # Sets of labels are equal
        assert set(np.unique(data_maps)) == set(range(len(b.labels)))
    except:
        print(name)
        print(set(range(len(b.labels))) - set(np.unique(data_maps)))
```
```
cort-maxprob-thr50-1mm
{10}
cortl-maxprob-thr50-1mm
{19, 20, 93}
cortl-maxprob-thr50-2mm
{93, 94}
```

For now, this PR implements a simple fix which consists in removing labels which corresponding integer value does not appear in the image. For example, the 11th label of `cort-maxprob-thr50-1mm` ('Superior Temporal Gyrus, posterior division') is removed because 10 does not appear in the image:

```python
b = fetch_atlas_harvard_oxford("cort-maxprob-thr50-1mm", clean_labels=True)
data_maps = get_data(b.maps)
assert len(b.labels) == len(np.unique(data_maps))
assert "Superior Temporal Gyrus, posterior division" not in b.labels
```

However, the image will still have non consecutive integer values which means that the following is not verified:

```python
assert set(np.unique(data_maps)) == set(range(len(b.labels)))
```

If this is an issue, I think we will have to re-label the image. WDYT?