### PR TITLE
[MAINT] Remove `compute_gray_matter_mask`

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -124,6 +124,8 @@ Changes
   (See PR `#3081 <https://github.com/nilearn/nilearn/pull/3081>`_).
 - Deprecated function ``nilearn.plotting.plot_connectome_strength`` has been removed.
   (See PR `#3082 <https://github.com/nilearn/nilearn/pull/3082>`_).
+- Deprecated function ``nilearn.masking.compute_gray_matter_mask`` has been removed.
+  (See PR `#3090 <https://github.com/nilearn/nilearn/pull/3090>`_).
 - :func:`nilearn.glm.first_level.compute_regressor` will now raise an exception if
   parameter `cond_id` is not a string which could be used to name a python variable.
   For instance, number strings (ex: "1") will no longer be accepted as valid condition names.

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -512,45 +512,6 @@ def compute_multi_background_mask(data_imgs, border_size=2, upper_cutoff=0.85,
     return mask
 
 
-@deprecated("Function 'compute_gray_matter_mask' has been renamed to "
-            "'compute_brain_mask' and 'compute_gray_matter_mask' will be "
-            "removed in release 0.9.0.")
-@_utils.fill_doc
-def compute_gray_matter_mask(target_img, threshold=.5,
-                             connected=True, opening=2, memory=None,
-                             verbose=0):
-    """Compute a mask corresponding to the gray matter part of the brain.
-    The gray matter part is calculated through the resampling of MNI152
-    template gray matter mask onto the target image.
-
-    Parameters
-    ----------
-    target_img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
-        Images used to compute the mask. 3D and 4D images are accepted.
-        Only the shape and affine of ``target_img`` will be used here.
-
-    threshold : :obj:`float`, optional
-        The value under which the MNI template is cut off.
-        Default=0.5.
-    %(connected)s
-        Default is True
-    %(opening)s
-        Default=2.
-    %(memory)s
-    %(verbose0)s
-
-    Returns
-    -------
-    mask : :class:`nibabel.nifti1.Nifti1Image`
-        The brain mask (3D image).
-    """
-    return compute_brain_mask(target_img=target_img, threshold=threshold,
-                              connected=connected, opening=opening,
-                              memory=memory, verbose=verbose,
-                              mask_type='whole-brain')
-
-
 @_utils.fill_doc
 def compute_brain_mask(target_img, threshold=.5, connected=True, opening=2,
                        memory=None, verbose=0, mask_type='whole-brain'):

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -222,17 +222,6 @@ def test_compute_brain_mask():
         compute_brain_mask(img, verbose=1, mask_type='foo')
 
 
-def test_deprecation_warning_compute_gray_matter_mask():
-    img = Nifti1Image(np.ones((9, 9, 9)), np.eye(4))
-    if distutils.version.LooseVersion(sklearn.__version__) < '0.22':
-        with pytest.deprecated_call():
-            masking.compute_gray_matter_mask(img)
-    else:
-        with pytest.warns(FutureWarning,
-                          match="renamed to 'compute_brain_mask'"):
-            masking.compute_gray_matter_mask(img)
-
-
 def test_apply_mask():
     """ Test smoothing of timeseries extraction
     """


### PR DESCRIPTION
Remove function `compute_gray_matter_mask` (`compute_brain_mask` should be used instead) as its deprecation cycle has reached its end. 