### PR TITLE
[FIX] Undo wrong fix `fetch_atlas_destrieux_ 2009`

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -59,9 +59,6 @@ Fixes
   :func:`nilearn.reporting.make_glm_report` was fixed accordingly.
   (See issue `#3034 <https://github.com/nilearn/nilearn/issues/3034>`_) and fix
   `#3035 <https://github.com/nilearn/nilearn/pull/3035>`_).
-- :func:`~nilearn.datasets.fetch_atlas_destrieux_2009` now returns only labels
-  present in the maps images.
-  (See PR `#3070 <https://github.com/nilearn/nilearn/pull/3070>`_).
 - Function :func:`~nilearn.plotting.find_parcellation_cut_coords` now returns
   coordinates and labels having the same order as the one of the input labels
   index (See PR `#3078 <https://github.com/nilearn/nilearn/issues/3078>`_).

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -181,23 +181,9 @@ def fetch_atlas_craddock_2012(data_dir=None, url=None, resume=True, verbose=1):
     return Bunch(**params)
 
 
-def _clean_labels(image, labels):
-    """Helper function removing labels that do not appear in the image."""
-    labels_in_img = set(np.unique(get_data(image)))
-    labels_set = set([label.index for label in labels])
-    diff = labels_set.difference(labels_in_img)
-    if len(diff) == 0:
-        return labels
-    cleaned_labels = np.array(
-        [label for label in labels if label.index not in diff],
-        dtype=[('index', '<i8'), ('name', 'S27')]
-    )
-    return cleaned_labels.view(np.recarray)
-
-
 @fill_doc
 def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
-                               resume=True, verbose=1, clean_labels=None):
+                               resume=True, verbose=1):
     """Download and load the Destrieux cortical atlas (dated 2009).
 
     See :footcite:`Fischl2004Automatically`,
@@ -206,9 +192,8 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
     .. note::
 
         Some labels from the list of labels might not be present in the
-        atlas image, which can be an issue in some specific cases. In order
-        to clean the list of labels and keep only the ones present in the
-        image, use ``clean_labels=True``.
+        atlas image, in which case the integer values in the image might
+        not be consecutive.
 
     Parameters
     ----------
@@ -219,12 +204,6 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
     %(url)s
     %(resume)s
     %(verbose)s
-    clean_labels : :obj:`bool`, optional
-        If set to ``True``, labels which do not appear in the image will
-        be removed from the list of labels.
-        Default=False.
-
-        .. versionadded:: 0.8.2
 
     Returns
     -------
@@ -239,11 +218,6 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
     .. footbibliography::
 
     """
-    if clean_labels is None:
-        warnings.warn("Default value for parameter `clean_labels` will "
-                      "change from ``False`` to ``True`` in Nilearn 0.10.",
-                      category=FutureWarning)
-        clean_labels = False
     if url is None:
         url = "https://www.nitrc.org/frs/download.php/11942/"
 
@@ -268,8 +242,6 @@ def fetch_atlas_destrieux_2009(lateralized=True, data_dir=None, url=None,
     with open(files_[2], 'r') as rst_file:
         params['description'] = rst_file.read()
 
-    if clean_labels:
-        params['labels'] = _clean_labels(params['maps'], params['labels'])
     return Bunch(**params)
 
 


### PR DESCRIPTION
This PR undoes most of the recently merged #3070 since the proposed fix was not correct (see discussion in #3080).
Once this is merged, I will close #3080 and #2036.
#3083 improves the documentation and makes the implicit relationship between labels and integer values in the atlas image more clear to users.
Finally, the next steps are explained in #3085.

(Ping @jeromedockes)