### PR TITLE
[MAINT] Remove parameter `sessions` in `clean()`

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -123,6 +123,9 @@ Changes
   (See PR `#3082 <https://github.com/nilearn/nilearn/pull/3082>`_).
 - Deprecated function ``nilearn.masking.compute_gray_matter_mask`` has been removed.
   (See PR `#3090 <https://github.com/nilearn/nilearn/pull/3090>`_).
+- Deprecated parameter ``sessions`` of function :func:`~nilearn.signal.clean`
+  has been removed. Use ``runs`` instead.
+  (See PR `#3093 <https://github.com/nilearn/nilearn/pull/3093>`_).
 - :func:`nilearn.glm.first_level.compute_regressor` will now raise an exception if
   parameter `cond_id` is not a string which could be used to name a python variable.
   For instance, number strings (ex: "1") will no longer be accepted as valid condition names.

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -443,7 +443,6 @@ def _ensure_float(data):
     return data
 
 
-@rename_parameters({'sessions': 'runs'}, '0.9.0')
 @fill_doc
 def clean(signals, runs=None, detrend=True, standardize='zscore',
           sample_mask=None, confounds=None, standardize_confounds=True,
@@ -478,12 +477,6 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
     runs : :class:`numpy.ndarray`, optional
         Add a run level to the cleaning process. Each run will be
         cleaned independently. Must be a 1D array of n_samples elements.
-
-        .. warning::
-
-            'runs' replaces 'sessions' after release 0.9.0.
-            Using 'session' will result in an error after release 0.9.0.
-
         Default is None.
 
     confounds : :class:`numpy.ndarray`, :obj:`str`,\

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -642,18 +642,18 @@ def _process_runs(signals, runs, detrend, standardize, confounds,
     if len(runs) != len(signals):
         raise ValueError(
             (
-                'The length of the session vector (%i) '
+                'The length of the run vector (%i) '
                 'does not match the length of the signals (%i)'
             ) % (len(runs), len(signals))
         )
     for run in np.unique(runs):
-        session_confounds = None
+        run_confounds = None
         if confounds is not None:
-            session_confounds = confounds[runs == run]
+            run_confounds = confounds[runs == run]
         signals[runs == run, :] = \
             clean(signals[runs == run],
                   detrend=detrend, standardize=standardize,
-                  confounds=session_confounds, low_pass=low_pass,
+                  confounds=run_confounds, low_pass=low_pass,
                   high_pass=high_pass, t_r=t_r)
     return signals
 
@@ -762,7 +762,7 @@ def _sanitize_runs(n_time, runs):
     if runs is not None and len(runs) != n_time:
         raise ValueError(
             (
-                "The length of the session vector (%i) "
+                "The length of the run vector (%i) "
                 "does not match the length of the signals (%i)"
             )
             % (len(runs), n_time)


### PR DESCRIPTION
Parameter `sessions` is deprecated in favor of `runs` and deprecation cycle ends with release 0.9.