### PR TITLE
BUG: Import from collections.abc for 3.10

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -63,7 +63,7 @@ jobs:
         fail-fast: false
         matrix:
             os: ["ubuntu-latest", "macos-latest"]
-            python-version: ["3.7", "3.8", "3.9"]
+            python-version: ["3.7", "3.8", "3.9", "3.10"]
     name: ${{ matrix.os }} with Python ${{ matrix.python-version }} and latest package versions
     defaults:
       run:

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -4,7 +4,8 @@ Functions for surface manipulation.
 import os
 import warnings
 import gzip
-from collections import (namedtuple, Mapping)
+from collections import namedtuple
+from collections.abc import Mapping
 
 import numpy as np
 from scipy import sparse, interpolate


### PR DESCRIPTION
I recently moved to Python 3.10 and found that `collections.Mapping` no longer exists in that namespace, but rather `collections.abc.Mapping`. This existed all the way back to 3.6 so should be okay.

Closes #3095