### PR TITLE
[FIX] Make `fetch_atlas_aal` work with `SPM5` and `SPM8`

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -17,6 +17,7 @@ Fixes
 - Fix function :func:`~datasets.fetch_abide_pcp` which was returning empty phenotypes and ``func_preproc`` after release ``0.9.0`` due to supporting pandas dataframes in fetchers (:gh:`3174` by `Nicolas Gensollen`_).
 - Fix function :func:`~datasets.fetch_atlas_harvard_oxford` and :func:`~datasets.fetch_atlas_juelich` which were returning the image in the `filename` attribute instead of the path to the image (:gh:`3179` by `Raphael Meudec`_).
 - Fix colorbars in :func:`~plotting.plot_stat_map`, :func:`~plotting.plot_glass_brain` and :func:`~plotting.plot_surf_stat_map` which could extend beyond the figure for users with newest matplotlib version (>=3.5.1) (:gh:`3188` by `Raphael Meudec`_)
+- Function :func:`~datasets.fetch_atlas_aal` now works with all supported versions of ``SPM`` (5, 8, and 12). (:gh:`3098` by `Nicolas Gensollen`_).
 
 Enhancements
 ------------

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1103,7 +1103,7 @@ def fetch_atlas_aal(version='SPM12', data_dir=None, url=None, resume=True,
             filenames = [(os.path.join('aal', 'atlas', f), url, opts)
                          for f in basenames]
         else:
-            url = f"http://www.gin.cnrs.fr/wp-content/uploads/aal_for_{version}.zip"
+            url = f"http://www.gin.cnrs.fr/wp-content/uploads/aal_for_{version}.zip"  # noqa
             basenames = ("ROI_MNI_V4.nii", "ROI_MNI_V4.txt")
             filenames = [(os.path.join(f'aal_for_{version}', f), url, opts)
                          for f in basenames]

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1093,32 +1093,43 @@ def fetch_atlas_aal(version='SPM12', data_dir=None, url=None, resume=True,
                          'Please choose one among %s.' %
                          (version, str(versions)))
 
-    if url is None:
-        baseurl = "http://www.gin.cnrs.fr/AAL_files/aal_for_%s.tar.gz"
-        url = baseurl % version
+    dataset_name = "aal_" + version
     opts = {'uncompress': True}
 
-    dataset_name = "aal_" + version
-    # keys and basenames would need to be handled for each spm_version
-    # for now spm_version 12 is hardcoded.
-    basenames = ("AAL.nii", "AAL.xml")
-    filenames = [(os.path.join('aal', 'atlas', f), url, opts)
-                 for f in basenames]
+    if url is None:
+        if version == 'SPM12':
+            url = "http://www.gin.cnrs.fr/AAL_files/aal_for_SPM12.tar.gz"
+            basenames = ("AAL.nii", "AAL.xml")
+            filenames = [(os.path.join('aal', 'atlas', f), url, opts)
+                         for f in basenames]
+        else:
+            url = f"http://www.gin.cnrs.fr/wp-content/uploads/aal_for_{version}.zip"
+            basenames = ("ROI_MNI_V4.nii", "ROI_MNI_V4.txt")
+            filenames = [(os.path.join(f'aal_for_{version}', f), url, opts)
+                         for f in basenames]
 
-    data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir,
-                                verbose=verbose)
-    atlas_img, labels_file = _fetch_files(data_dir, filenames, resume=resume,
-                                          verbose=verbose)
-
-    fdescr = _get_dataset_descr(dataset_name)
-    # We return the labels contained in the xml file as a dictionary
-    xml_tree = xml.etree.ElementTree.parse(labels_file)
-    root = xml_tree.getroot()
+    data_dir = _get_dataset_dir(
+        dataset_name, data_dir=data_dir, verbose=verbose
+    )
+    atlas_img, labels_file = _fetch_files(
+        data_dir, filenames, resume=resume, verbose=verbose
+    )
+    fdescr = _get_dataset_descr("aal_SPM12").decode('utf-8')
     labels = []
     indices = []
-    for label in root.iter('label'):
-        indices.append(label.find('index').text)
-        labels.append(label.find('name').text)
+    if version == 'SPM12':
+        xml_tree = xml.etree.ElementTree.parse(labels_file)
+        root = xml_tree.getroot()
+        for label in root.iter('label'):
+            indices.append(label.find('index').text)
+            labels.append(label.find('name').text)
+    else:
+        with open(labels_file, "r") as fp:
+            for line in fp.readlines():
+                _, label, index = line.strip().split('\t')
+                indices.append(index)
+                labels.append(label)
+        fdescr = fdescr.replace("SPM 12", version)
 
     params = {'description': fdescr, 'maps': atlas_img,
               'labels': labels, 'indices': indices}

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1114,7 +1114,7 @@ def fetch_atlas_aal(version='SPM12', data_dir=None, url=None, resume=True,
     atlas_img, labels_file = _fetch_files(
         data_dir, filenames, resume=resume, verbose=verbose
     )
-    fdescr = _get_dataset_descr("aal_SPM12").decode('utf-8')
+    fdescr = _get_dataset_descr("aal_SPM12")
     labels = []
     indices = []
     if version == 'SPM12':

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -449,7 +449,7 @@ def aal_archive_root(version):
                           ('SPM12', 'gztar', 'AAL_files')])
 def test_fetch_atlas_aal(version, archive_format, url_key, aal_archive_root,
                          tmp_path, request_mocker):
-    metadata = ""
+    metadata = "A\tB\tC\n"
     if version == 'SPM12':
         metadata = (b"<?xml version='1.0' encoding='us-ascii'?>"
                     b"<metadata></metadata>")

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -452,7 +452,8 @@ def test_fetch_atlas_aal(version, archive_format, url_key, aal_archive_root,
     metadata = "A\tB\tC\n"
     if version == 'SPM12':
         metadata = (b"<?xml version='1.0' encoding='us-ascii'?>"
-                    b"<metadata></metadata>")
+                    b"<metadata><label><index>1</index>"
+                    b"<name>A</name></label></metadata>")
     label_file = "AAL.xml" if version == 'SPM12' else "ROI_MNI_V4.txt"
     atlas_file = "AAL.nii" if version == 'SPM12' else "ROI_MNI_V4.nii"
     aal_data = dict_to_archive(

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -435,28 +435,48 @@ def test_fetch_atlas_difumo(tmp_path, request_mocker):
                                  dimension=128, resolution_mm=3.14)
 
 
-def test_fetch_atlas_aal(tmp_path, request_mocker):
-    metadata = (b"<?xml version='1.0' encoding='us-ascii'?>"
-                b"<metadata></metadata>")
-    archive_root = Path("aal", "atlas")
-    aal_data = dict_to_archive(
-        {archive_root / "AAL.xml": metadata, archive_root / "AAL.nii": ""})
+@pytest.fixture
+def aal_archive_root(version):
+    if version == 'SPM12':
+        return Path("aal", "atlas")
+    else:
+        return Path(f"aal_for_{version}")
 
-    request_mocker.url_mapping["*AAL_files*"] = aal_data
-    dataset = atlas.fetch_atlas_aal(data_dir=tmp_path, verbose=0)
+
+@pytest.mark.parametrize("version,archive_format,url_key",
+                         [('SPM5', 'zip', 'uploads'),
+                          ('SPM8', 'zip', 'uploads'),
+                          ('SPM12', 'gztar', 'AAL_files')])
+def test_fetch_atlas_aal(version, archive_format, url_key, aal_archive_root,
+                         tmp_path, request_mocker):
+    metadata = ""
+    if version == 'SPM12':
+        metadata = (b"<?xml version='1.0' encoding='us-ascii'?>"
+                    b"<metadata></metadata>")
+    label_file = "AAL.xml" if version == 'SPM12' else "ROI_MNI_V4.txt"
+    atlas_file = "AAL.nii" if version == 'SPM12' else "ROI_MNI_V4.nii"
+    aal_data = dict_to_archive(
+        {aal_archive_root / label_file: metadata,
+         aal_archive_root / atlas_file: ""},
+        archive_format=archive_format
+    )
+    request_mocker.url_mapping[f"*{url_key}*"] = aal_data
+    dataset = atlas.fetch_atlas_aal(
+        version=version, data_dir=tmp_path, verbose=0
+    )
     assert isinstance(dataset.maps, str)
     assert isinstance(dataset.labels, list)
     assert isinstance(dataset.indices, list)
     assert request_mocker.url_count == 1
-
-    with pytest.raises(ValueError,
-                       match='The version of AAL requested "FLS33"'
-                       ):
-        atlas.fetch_atlas_aal(version="FLS33",
-                              data_dir=tmp_path,
-                              verbose=0)
-
     assert dataset.description != ''
+
+
+def test_fetch_atlas_aal_version_error(tmp_path, request_mocker):
+    with pytest.raises(ValueError,
+                       match='The version of AAL requested "FLS33"'):
+        atlas.fetch_atlas_aal(
+            version="FLS33", data_dir=tmp_path, verbose=0
+        )
 
 
 def test_fetch_atlas_basc_multiscale_2015(tmp_path, request_mocker):


### PR DESCRIPTION
Closes #3087 

To try it out, remove `aal` folders from `nilearn_data` and you should get the following output:

```python
In [1]: from nilearn import datasets, image
/home/nicolas/GitRepos/nilearn-fork/nilearn/datasets/__init__.py:93: FutureWarning: Fetchers from the nilearn.datasets module will be updated in version 0.9 to return python strings instead of bytes and Pandas dataframes instead of Numpy arrays.
  warn("Fetchers from the nilearn.datasets module will be "

In [2]: for version in [5, 8, 12]:
   ...:     bunch = datasets.fetch_atlas_aal(version=f"SPM{version}")
   ...:     assert len(bunch.description) > 0
   ...:     assert len(bunch.labels) == 116
   ...:     assert len(bunch.indices) == 116
   ...:     assert image.load_img(bunch.maps).shape ==  (91, 109, 91)
   ...: 

Dataset created in /home/nicolas/nilearn_data/aal_SPM5

Downloading data from http://www.gin.cnrs.fr/wp-content/uploads/aal_for_SPM5.zip ...
 ...done. (0 seconds, 0 min)
Extracting data from /home/nicolas/nilearn_data/aal_SPM5/f158e2c2ef1b2be86d7939837f482c25/aal_for_SPM5.zip..... done.

Dataset created in /home/nicolas/nilearn_data/aal_SPM8

Downloading data from http://www.gin.cnrs.fr/wp-content/uploads/aal_for_SPM8.zip ...
 ...done. (0 seconds, 0 min)
Extracting data from /home/nicolas/nilearn_data/aal_SPM8/8207ad831ac9f41247d3aeed52ddddb8/aal_for_SPM8.zip..... done.

Dataset created in /home/nicolas/nilearn_data/aal_SPM12

Downloading data from http://www.gin.cnrs.fr/AAL_files/aal_for_SPM12.tar.gz ...
 ...done. (2 seconds, 0 min)
Extracting data from /home/nicolas/nilearn_data/aal_SPM12/9845813e2300e5b614a9dd2713e13445/aal_for_SPM12.tar.gz..... done.
```