### PR TITLE
[INFRA] Add missing documentation building requirements

### DIFF
--- a/requirements-build-docs.txt
+++ b/requirements-build-docs.txt
@@ -8,6 +8,8 @@ sphinx
 sphinx-gallery
 sphinxcontrib-bibtex
 sphinx-copybutton
+sphinxext-opengraph
+memory_profiler
 numpydoc
 coverage
 pillow


### PR DESCRIPTION
`sphinxext-opengraph` is required to build the docs but missing from `requirements-build-docs.txt`.
Also adds `memory_profiler`.
Linking related #2953 