### PR TITLE
[FIX] Off-by-one error while setting up ticks

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -13,6 +13,7 @@ NEW
 Fixes
 -----
 
+- Fix off-by-one error when setting ticks in :func:`~plotting.plot_surf` (:gh:`3105` by `Dimitri Papadopoulos Orfanos`_).
 - Regressor names can now be invalid identifiers but will raise an error with :meth:`~glm.first_level.FirstLevelModel.compute_contrast` if combined to make an invalid expression (:gh:`3374` by `Yasmin Mzayek`_).
 - Fix :func:`~plotting.plot_connectome` which was raising a ``ValueError`` when ``vmax < 0`` (:gh:`3390` by `Paul Bogdan`_).
 

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -341,11 +341,11 @@ def _get_ticks_matplotlib(vmin, vmax, cbar_tick_format):
     n_ticks = 5
     # ...unless we are dealing with integers with a small range
     # in this case, we reduce the number of ticks
-    if cbar_tick_format == "%i" and vmax - vmin < n_ticks:
+    if cbar_tick_format == "%i" and vmax - vmin < n_ticks - 1:
         ticks = np.arange(vmin, vmax + 1)
-        n_ticks = len(ticks)
     else:
-        ticks = np.linspace(vmin, vmax, n_ticks)
+        # remove duplicate ticks when vmin == vmax, or almost
+        ticks = np.unique(np.linspace(vmin, vmax, n_ticks))
     return ticks
 
 


### PR DESCRIPTION
Also remove unused local variable `n_ticks`, reported by LGTM.com.

Closes #3104.