### PR TITLE
[MAINT] Drop support for Nibabel 2.x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ The required dependencies to use the software are:
 * SciPy >= 1.2
 * Scikit-learn >= 0.21
 * Joblib >= 0.12
-* Nibabel >= 2.5
+* Nibabel >= 3.0
 * Pandas >= 0.24
 
 If you are using nilearn plotting functionalities or running the

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -117,6 +117,8 @@ Enhancements
 Changes
 -------
 
+- Nibabel 2.x is no longer supported. Please consider upgrading to Nibabel >= 3.0.
+  (See PR `#3106 <https://github.com/nilearn/nilearn/pull/3106>`_).
 - Deprecated function ``nilearn.datasets.fetch_cobre`` has been removed.
   (See PR `#3081 <https://github.com/nilearn/nilearn/pull/3081>`_).
 - Deprecated function ``nilearn.plotting.plot_connectome_strength`` has been removed.

--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -65,32 +65,8 @@ def _python_deprecation_warnings():
         _py36_deprecation_warning()
 
 
-def _nibabel2_deprecation_warning():
-    msg = ('Support for Nibabel 2.x is deprecated and will stop '
-           'in release 0.9.0. Please consider upgrading to '
-           'Nibabel 3.x.')
-    warnings.filterwarnings('once', message=msg)
-    warnings.warn(message=msg,
-                  category=FutureWarning,
-                  stacklevel=3)
-
-
-def _nibabel_deprecation_warnings():
-    """Give a deprecation warning is the version of
-    Nibabel is < 3.0.0.
-    """
-    # Nibabel should be installed or we would
-    # have had an error when calling
-    # _check_module_dependencies
-    dist = pkg_resources.get_distribution('nibabel')
-    nib_version = LooseVersion(dist.version)
-    if nib_version < '3.0':
-        _nibabel2_deprecation_warning()
-
-
 _check_module_dependencies()
 _python_deprecation_warnings()
-_nibabel_deprecation_warnings()
 
 
 # Temporary work around to address formatting issues in doc tests

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -3,7 +3,7 @@ scipy==1.2.0
 pandas==0.24.0
 scikit-learn==0.21.0
 joblib==0.12
-nibabel==2.5.0
+nibabel==3.0.0
 pytest
 pytest-cov
 lxml


### PR DESCRIPTION
Closes #2429

Support for Nibabel 2.x was deprecated since #2869 and scheduled to stop for release 0.9.