### PR TITLE
[DOC] Converts references in nilearn/regions to use footcite

### DIFF
--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1102,3 +1102,17 @@ The dominant view that perceptual learning is accompanied by changes in early se
 	keywords = {Test–retest reliability, Intrinsic connectivity network, ICA, Dual regression, Resting state},
 	abstract = {Functional connectivity analyses of resting-state fMRI data are rapidly emerging as highly efficient and powerful tools for in vivo mapping of functional networks in the brain, referred to as intrinsic connectivity networks (ICNs). Despite a burgeoning literature, researchers continue to struggle with the challenge of defining computationally efficient and reliable approaches for identifying and characterizing ICNs. Independent component analysis (ICA) has emerged as a powerful tool for exploring ICNs in both healthy and clinical populations. In particular, temporal concatenation group ICA (TC-GICA) coupled with a back-reconstruction step produces participant-level resting state functional connectivity maps for each group-level component. The present work systematically evaluated the test–retest reliability of TC-GICA derived RSFC measures over the short-term (<45 min) and long-term (5–16 months). Additionally, to investigate the degree to which the components revealed by TC-GICA are detectable via single-session ICA, we investigated the reproducibility of TC-GICA findings. First, we found moderate-to-high short- and long-term test–retest reliability for ICNs derived by combining TC-GICA and dual regression. Exceptions to this finding were limited to physiological- and imaging-related artifacts. Second, our reproducibility analyses revealed notable limitations for template matching procedures to accurately detect TC-GICA based components at the individual scan level. Third, we found that TC-GICA component's reliability and reproducibility ranks are highly consistent. In summary, TC-GICA combined with dual regression is an effective and reliable approach to exploratory analyses of resting state fMRI data.}
 }
+
+@misc{abraham:hal-01093944,
+  TITLE = {{Region segmentation for sparse decompositions: better brain parcellations from rest fMRI}},
+  AUTHOR = {Abraham, Alexandre and Dohmatob, Elvis and Thirion, Bertrand and Samaras, Dimitris and Varoquaux, Gael},
+  URL = {https://hal.inria.fr/hal-01093944},
+  HOWPUBLISHED = {{Sparsity Techniques in Medical Imaging}},
+  PAGES = {8},
+  YEAR = {2014},
+  MONTH = Sep,
+  KEYWORDS = {resting state fMRI ; region extraction ; brain networks ; clustering},
+  PDF = {https://hal.inria.fr/hal-01093944/file/paper16.pdf},
+  HAL_ID = {hal-01093944},
+  HAL_VERSION = {v1},
+}

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -321,6 +321,7 @@ Fixes
   gridspec (https://github.com/nilearn/nilearn/pull/2798).
 - Fix inconsistency in prediction values of Dummy Classifier for Decoder
   object (https://github.com/nilearn/nilearn/issues/2767).
+- Convert reference in regions/region_extractor.py to use footcite / footbibliography.
 
 Enhancements
 ------------

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -253,7 +253,7 @@ class RegionExtractor(NiftiMapsMasker):
     Particularly, to show that each decomposed brain maps can be
     used to focus on a target specific Regions of Interest analysis.
 
-    See [1]_.
+    See :footcite:`abraham:hal-01093944`.
 
     .. versionadded:: 0.2
 
@@ -353,9 +353,7 @@ class RegionExtractor(NiftiMapsMasker):
 
     References
     ----------
-    .. [1] Abraham et al. "Region segmentation for sparse decompositions:
-       better brain parcellations from rest fMRI", Sparsity Techniques in
-       Medical Imaging, Sep 2014, Boston, United States. pp.8
+    .. footbibliography::
 
     See Also
     --------


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #2787 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Change reference in `nilearn/regions/region_extractor.py` to use footcite / footbibliography.
