### PR TITLE
avoid unnecessary data loading if dtype casting not needed

### DIFF
--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -131,7 +131,7 @@ def load_niimg(niimg, dtype=None):
                         " not compatible with nibabel format:\n"
                         + _repr_niimgs(niimg, shorten=True))
 
-    dtype = _get_target_dtype(_get_data(niimg).dtype, dtype)
+    dtype = _get_target_dtype(niimg.dataobj.dtype, dtype)
 
     if dtype is not None:
         # Copyheader and set dtype in header if header exists


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3112 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

This makes image.load_img behave more like nibabel.load in the case
that no data type conversion is needed.
This improves the speed of image.load_img  and improves usability
used when users only want to access a header or affine from a file.

