### PR TITLE
[ENH] `NiftiLabelsMasker` reports use appropriate cut coordinates

### DIFF
--- a/nilearn/input_data/nifti_labels_masker.py
+++ b/nilearn/input_data/nifti_labels_masker.py
@@ -282,6 +282,11 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             self._report_content['summary'] = regions_summary
 
             img = self._reporting_data['img']
+            # compute the cut coordinates on the label image in case
+            # we have a functional image
+            cut_coords = plotting.find_xyz_cut_coords(
+                labels_image, activation_threshold=.5
+            )
             # If we have a func image to show in the report, use it
             if img is not None:
                 dim = image.load_img(img).shape
@@ -289,6 +294,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                     # compute middle image from 4D series for plotting
                     img = image.index_img(img, dim[-1] // 2)
                 display = plotting.plot_img(img,
+                                            cut_coords=cut_coords,
                                             black_bg=False,
                                             cmap='CMRmap_r')
                 plt.close()

--- a/nilearn/reporting/tests/test_html_report.py
+++ b/nilearn/reporting/tests/test_html_report.py
@@ -23,7 +23,7 @@ def _check_html(html_view):
 @pytest.fixture
 def data_img_3d():
     """Dummy 3D data for testing."""
-    data = np.zeros((9, 9, 9))
+    data = np.zeros((29, 29, 29))
     data[3:-3, 3:-3, 3:-3] = 10
     return Nifti1Image(data, np.eye(4))
 
@@ -31,8 +31,8 @@ def data_img_3d():
 @pytest.fixture
 def mask():
     """Dummy mask for testing."""
-    data = np.zeros((10, 10, 10), dtype=int)
-    data[3:7, 3:7, 3:7] = 1
+    data = np.zeros((30, 30, 30), dtype=int)
+    data[3:27, 3:27, 3:27] = 1
     return Nifti1Image(data, np.eye(4))
 
 


### PR DESCRIPTION
Closes #3110 

This PR makes sure the NiftiLabelsMasker's reports display the functional image with appropriate cut coordinates. @walkerped could you see if this works as you expected?

Example:

```python
from nilearn.input_data import NiftiLabelsMasker
from nilearn.image import load_img
from nilearn.datasets import fetch_development_fmri

atlasI = load_img('/home/nicolas/Downloads/MNI152_T1_1mm-RBNST.nii.gz', dtype=int)
labelL = ['Background','RBNST']
data = fetch_development_fmri(n_subjects=1)
masker = NiftiLabelsMasker(
    atlasI, labels=labelL, standardize=False,
    verbose=0, detrend=False
)
masker.fit(data.func[0])
report = masker.generate_report()
report
```
![cut_report](https://user-images.githubusercontent.com/2639645/148212024-5f2b9d1a-e15f-4a41-aaf6-30f63dfa0bbc.png)

