### PR TITLE
Scipy deprecation warning in RegionExtractor

### DIFF
--- a/nilearn/_utils/segmentation.py
+++ b/nilearn/_utils/segmentation.py
@@ -340,7 +340,7 @@ def _solve_cg(lap_sparse, B, tol):
     lap_sparse = lap_sparse.tocsc()
     X = []
     for i in range(len(B)):
-        x0 = cg(lap_sparse, -B[i].todense(), tol=tol)[0]
+        x0 = cg(lap_sparse, -B[i].todense(), tol=tol, atol='legacy')[0]
         X.append(x0)
 
     X = np.array(X)


### PR DESCRIPTION
Closes #3129 
Add `atol='legacy'` option in `scipy.sparse.linalg.cg` to avoid deprecation warning.
