### PR TITLE
[MAINT] Remove deprecated `sessions` and `sample_mask` attributes of `NiftiMasker`

### DIFF
--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -198,8 +198,8 @@ preparation::
          high_variance_confounds=False, low_pass=None, mask_args=None,
          mask_img=None, mask_strategy='background',
          memory=Memory(location=None), memory_level=1, reports=True,
-         runs=None, sample_mask=None, smoothing_fwhm=None,
-         standardize=False, standardize_confounds=True, t_r=None,
+         runs=None, smoothing_fwhm=None, standardize=False,
+         standardize_confounds=True, t_r=None,
          target_affine=None, target_shape=None, verbose=0)
 
 The meaning of each parameter is described in the documentation of

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -140,6 +140,11 @@ Changes
 - Deprecated parameter ``sessions`` of function :func:`~nilearn.signal.clean`
   has been removed. Use ``runs`` instead.
   (See PR `#3093 <https://github.com/nilearn/nilearn/pull/3093>`_).
+- Deprecated parameters ``sessions`` and ``sample_mask`` of
+  :class:`~nilearn.maskers.NiftiMasker` have been removed. Please use ``runs`` instead of
+  ``sessions``, and provide a ``sample_mask`` through
+  :meth:`~nilearn.maskers.NiftiMasker.transform`.
+  (See PR `#3133 <https://github.com/nilearn/nilearn/pull/3133>`_).
 - :func:`nilearn.glm.first_level.compute_regressor` will now raise an exception if
   parameter `cond_id` is not a string which could be used to name a python variable.
   For instance, number strings (ex: "1") will no longer be accepted as valid condition names.

--- a/examples/02_decoding/plot_haxby_multiclass.py
+++ b/examples/02_decoding/plot_haxby_multiclass.py
@@ -43,7 +43,7 @@ unique_conditions = unique_conditions[np.argsort(order)]
 from nilearn.maskers import NiftiMasker
 # For decoding, standardizing is often very important
 nifti_masker = NiftiMasker(mask_img=mask_filename, standardize=True,
-                           sessions=session, smoothing_fwhm=4,
+                           runs=session, smoothing_fwhm=4,
                            memory="nilearn_cache", memory_level=1)
 X = nifti_masker.fit_transform(func_filename)
 

--- a/examples/02_decoding/plot_haxby_searchlight.py
+++ b/examples/02_decoding/plot_haxby_searchlight.py
@@ -87,7 +87,7 @@ searchlight.fit(fmri_img, y)
 from nilearn.maskers import NiftiMasker
 
 # For decoding, standardizing is often very important
-nifti_masker = NiftiMasker(mask_img=mask_img, sessions=session,
+nifti_masker = NiftiMasker(mask_img=mask_img, runs=session,
                            standardize=True, memory='nilearn_cache',
                            memory_level=1)
 fmri_masked = nifti_masker.fit_transform(fmri_img)

--- a/examples/07_advanced/plot_advanced_decoding_scikit.py
+++ b/examples/07_advanced/plot_advanced_decoding_scikit.py
@@ -73,7 +73,7 @@ svc = SVC()
 # voxels inside the mask of interest, and transform 4D input fMRI data to
 # 2D arrays(`shape=(n_timepoints, n_voxels)`) that estimators can work on.
 from nilearn.maskers import NiftiMasker
-masker = NiftiMasker(mask_img=mask_filename, sessions=session_label,
+masker = NiftiMasker(mask_img=mask_filename, runs=session_label,
                      smoothing_fwhm=4, standardize=True,
                      memory="nilearn_cache", memory_level=1)
 fmri_masked = masker.fit_transform(fmri_niimgs)

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -174,26 +174,17 @@ def test_mask_4d():
     data_trans2 = masker.transform(data_img_4d, sample_mask=sample_mask)
     assert_array_equal(data_trans2, data_trans_direct)
 
-    # check deprecation warning, and the old API should still work
-    with pytest.warns(DeprecationWarning) as record:
-        masker = NiftiMasker(mask_img=mask_img, sample_mask=sample_mask)
-        masker.fit()
-        data_trans_depr = masker.transform(data_img_4d)
-    assert "sample_mask will be removed" in record[0].message.args[0]
-    assert_array_equal(data_trans_depr, data_trans_direct)
-
-    # show warning when supplying both, use the sample_mask from transform
     diff_sample_mask = np.array([2, 4])
     data_trans_img_diff = index_img(data_img_4d, diff_sample_mask)
     data_trans_direct_diff = get_data(data_trans_img_diff)[mask_bool, :]
     data_trans_direct_diff = np.swapaxes(data_trans_direct_diff, 0, 1)
-    masker = NiftiMasker(mask_img=mask_img, sample_mask=sample_mask)
+    masker = NiftiMasker(mask_img=mask_img)
     masker.fit()
-    with pytest.warns(UserWarning, match=r'^Overwriting') as record:
-        data_trans3 = masker.transform(data_img_4d,
-                                       sample_mask=diff_sample_mask)
+    data_trans3 = masker.transform(
+        data_img_4d, sample_mask=diff_sample_mask
+    )
     assert_array_equal(data_trans3, data_trans_direct_diff)
-    assert "Overwriting deprecated attribute " in record[0].message.args[0]
+
 
 def test_4d_single_scan():
     mask = np.zeros((10, 10, 10))
@@ -251,13 +242,8 @@ def test_sessions():
     data[..., 0] = 0
     data[20, 20, 20] = 1
     data_img = Nifti1Image(data, np.eye(4))
-    masker = NiftiMasker(sessions=np.ones(3, dtype=np.int))
+    masker = NiftiMasker(runs=np.ones(3, dtype=np.int))
     pytest.raises(ValueError, masker.fit_transform, data_img)
-
-    # check deprecation warning of attribute sessions
-    with pytest.warns(DeprecationWarning) as record:
-        masker.sessions
-    assert "`sessions` attribute is deprecated" in record[0].message.args[0]
 
 
 def test_joblib_cache():


### PR DESCRIPTION
`sessions` has been replaced by `runs`, and `sample_mask` is now provided through `transform`.
Both are deprecated and scheduled to be removed with release 0.9.