### PR TITLE
replace interpreter call

### DIFF
--- a/nilearn/plotting/html_document.py
+++ b/nilearn/plotting/html_document.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import weakref
 import warnings
 import tempfile
@@ -20,7 +21,7 @@ def set_max_img_views_before_warning(new_value):
 
 def _remove_after_n_seconds(file_name, n_seconds):
     script = os.path.join(os.path.dirname(__file__), 'rm_file.py')
-    subprocess.Popen(['python', script, file_name, str(n_seconds)])
+    subprocess.Popen([sys.executable, script, file_name, str(n_seconds)])
 
 
 class HTMLDocument(object):


### PR DESCRIPTION
The `python` command is not guaranteed to exist. On some systems it refers to old python 2.

See https://www.python.org/dev/peps/pep-0394/

Outside of a virtualenv, this test fails:

```
[  158s] ___________________________ test_temp_file_removing ____________________________
[  158s] [gw3] linux -- Python 3.9.9 /usr/bin/python3.9
[  158s] 
[  158s]     def test_temp_file_removing():
[  158s]         html = html_document.HTMLDocument('hello')
[  158s]         wb_open = webbrowser.open
[  158s]         webbrowser.open = _open_mock
[  158s]         fd, tmpfile = tempfile.mkstemp()
[  158s]         try:
[  158s]             os.close(fd)
[  158s]             with pytest.warns(None) as record:
[  158s]                 html.open_in_browser(file_name=tmpfile, temp_file_lifetime=None)
[  158s]             for warning in record:
[  158s]                 assert "Saved HTML in temporary file" not in str(warning.message)
[  158s] >           html.open_in_browser(temp_file_lifetime=0.5)
[  158s] 
[  158s] nilearn/plotting/tests/test_html_document.py:30: 
[  158s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[  158s] nilearn/plotting/html_document.py:138: in open_in_browser
[  158s]     _remove_after_n_seconds(self._temp_file, temp_file_lifetime)
[  158s] nilearn/plotting/html_document.py:23: in _remove_after_n_seconds
[  158s]     subprocess.Popen(['python', script, file_name, str(n_seconds)])
[  158s] /usr/lib64/python3.9/subprocess.py:951: in __init__
[  158s]     self._execute_child(args, executable, preexec_fn, close_fds,
[  158s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[  158s] 
[  158s] self = <Popen: returncode: 255 args: ['python', '/home/abuild/rpmbuild/BUILD/nilear...>
[  158s] args = ['python', '/home/abuild/rpmbuild/BUILD/nilearn-0.8.1/nilearn/plotting/rm_file.py', '/tmp/nilearn_plot_6x3xmarn.html', '0.5']
[  158s] executable = b'python', preexec_fn = None, close_fds = True, pass_fds = ()
[  158s] cwd = None, env = None, startupinfo = None, creationflags = 0, shell = False
[  158s] p2cread = -1, p2cwrite = -1, c2pread = -1, c2pwrite = -1, errread = -1
[  158s] errwrite = -1, restore_signals = True, gid = None, gids = None, uid = None
[  158s] umask = -1, start_new_session = False
...
[  158s] >               raise child_exception_type(errno_num, err_msg, err_filename)
[  158s] E               FileNotFoundError: [Errno 2] No such file or directory: 'python'
[  158s] 
[  158s] /usr/lib64/python3.9/subprocess.py:1821: FileNotFoundError
```