### PR TITLE
[ENH] Rename objects of `nilearn.decomposition` with leading "_"

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -54,3 +54,4 @@ Changes
 - Refactors fmriprep confound loading such that that the parsing of the 
   relevant image file and the loading of the confounds are done in 
   separate steps (:gh:`3274` by `David G Ellis`_).
+- Private submodules, functions, and classes from the :mod:`~nilearn.decomposition` module now start with a "_" character to make it clear that they are not part of the public API (:gh:`3141` by `Nicolas Gensollen`_).

--- a/nilearn/decomposition/__init__.py
+++ b/nilearn/decomposition/__init__.py
@@ -1,6 +1,6 @@
 """
 The :mod:`nilearn.decomposition` module includes a subject level
-variant of the ICA called Canonical ICA.
+variant of the :term:`ICA` called Canonical :term:`ICA`.
 """
 from .canica import CanICA
 from .dict_learning import DictLearning

--- a/nilearn/decomposition/_multi_pca.py
+++ b/nilearn/decomposition/_multi_pca.py
@@ -6,12 +6,12 @@ import numpy as np
 from joblib import Memory
 from sklearn.utils.extmath import randomized_svd
 
-from .base import BaseDecomposition
+from ._base import _BaseDecomposition
 from nilearn._utils import fill_doc
 
 
 @fill_doc
-class MultiPCA(BaseDecomposition):
+class _MultiPCA(_BaseDecomposition):
     """Perform Multi Subject Principal Component Analysis.
 
     Perform a PCA on each subject, stack the results, and reduce them
@@ -150,23 +150,23 @@ class MultiPCA(BaseDecomposition):
         self.n_components = n_components
         self.do_cca = do_cca
 
-        BaseDecomposition.__init__(self, n_components=n_components,
-                                   random_state=random_state,
-                                   mask=mask,
-                                   smoothing_fwhm=smoothing_fwhm,
-                                   standardize=standardize,
-                                   standardize_confounds=standardize_confounds,
-                                   detrend=detrend,
-                                   low_pass=low_pass,
-                                   high_pass=high_pass, t_r=t_r,
-                                   target_affine=target_affine,
-                                   target_shape=target_shape,
-                                   mask_strategy=mask_strategy,
-                                   mask_args=mask_args,
-                                   memory=memory,
-                                   memory_level=memory_level,
-                                   n_jobs=n_jobs,
-                                   verbose=verbose)
+        _BaseDecomposition.__init__(self, n_components=n_components,
+                                    random_state=random_state,
+                                    mask=mask,
+                                    smoothing_fwhm=smoothing_fwhm,
+                                    standardize=standardize,
+                                    standardize_confounds=standardize_confounds,
+                                    detrend=detrend,
+                                    low_pass=low_pass,
+                                    high_pass=high_pass, t_r=t_r,
+                                    target_affine=target_affine,
+                                    target_shape=target_shape,
+                                    mask_strategy=mask_strategy,
+                                    mask_args=mask_args,
+                                    memory=memory,
+                                    memory_level=memory_level,
+                                    n_jobs=n_jobs,
+                                    verbose=verbose)
 
     def _raw_fit(self, data):
         """Helper function that directly process unmasked data"""

--- a/nilearn/decomposition/_multi_pca.py
+++ b/nilearn/decomposition/_multi_pca.py
@@ -150,23 +150,20 @@ class _MultiPCA(_BaseDecomposition):
         self.n_components = n_components
         self.do_cca = do_cca
 
-        _BaseDecomposition.__init__(self, n_components=n_components,
-                                    random_state=random_state,
-                                    mask=mask,
-                                    smoothing_fwhm=smoothing_fwhm,
-                                    standardize=standardize,
-                                    standardize_confounds=standardize_confounds,
-                                    detrend=detrend,
-                                    low_pass=low_pass,
-                                    high_pass=high_pass, t_r=t_r,
-                                    target_affine=target_affine,
-                                    target_shape=target_shape,
-                                    mask_strategy=mask_strategy,
-                                    mask_args=mask_args,
-                                    memory=memory,
-                                    memory_level=memory_level,
-                                    n_jobs=n_jobs,
-                                    verbose=verbose)
+        _BaseDecomposition.__init__(
+            self, n_components=n_components,
+            random_state=random_state,
+            mask=mask, smoothing_fwhm=smoothing_fwhm,
+            standardize=standardize,
+            standardize_confounds=standardize_confounds,
+            detrend=detrend, low_pass=low_pass,
+            high_pass=high_pass, t_r=t_r,
+            target_affine=target_affine,
+            target_shape=target_shape,
+            mask_strategy=mask_strategy, mask_args=mask_args,
+            memory=memory, memory_level=memory_level,
+            n_jobs=n_jobs, verbose=verbose
+        )
 
     def _raw_fit(self, data):
         """Helper function that directly process unmasked data"""

--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -15,12 +15,12 @@ from sklearn.decomposition import fastica
 from joblib import Memory, delayed, Parallel
 from sklearn.utils import check_random_state
 
-from .multi_pca import MultiPCA
+from ._multi_pca import _MultiPCA
 from nilearn._utils import fill_doc
 
 
 @fill_doc
-class CanICA(MultiPCA):
+class CanICA(_MultiPCA):
     """Perform Canonical Independent Component Analysis [1]_ [2]_.
 
     Parameters
@@ -251,7 +251,7 @@ class CanICA(MultiPCA):
             self.components_img_ = self.masker_.inverse_transform(
                 self.components_)
 
-    # Overriding MultiPCA._raw_fit overrides MultiPCA.fit behavior
+    # Overriding _MultiPCA._raw_fit overrides _MultiPCA.fit behavior
     def _raw_fit(self, data):
         """Helper function that directly process unmasked data.
 
@@ -264,6 +264,6 @@ class CanICA(MultiPCA):
             Unmasked data to process
 
         """
-        components = MultiPCA._raw_fit(self, data)
+        components = _MultiPCA._raw_fit(self, data)
         self._unmix_components(components)
         return self

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -14,7 +14,7 @@ from sklearn.decomposition import dict_learning_online
 from joblib import Memory
 from sklearn.linear_model import Ridge
 
-from .base import BaseDecomposition
+from ._base import _BaseDecomposition
 from .canica import CanICA
 from nilearn._utils import fill_doc
 
@@ -34,7 +34,7 @@ def _compute_loadings(components, data):
 
 
 @fill_doc
-class DictLearning(BaseDecomposition):
+class DictLearning(_BaseDecomposition):
     """Perform a map learning algorithm based on spatial component sparsity,
     over a :term:`CanICA` initialization [1]_.
     This yields more stable maps than :term:`CanICA`.
@@ -189,17 +189,17 @@ class DictLearning(BaseDecomposition):
                  target_shape=None, mask_strategy='epi', mask_args=None,
                  n_jobs=1, verbose=0, memory=Memory(location=None),
                  memory_level=0):
-        BaseDecomposition.__init__(self, n_components=n_components,
-                                   random_state=random_state, mask=mask,
-                                   smoothing_fwhm=smoothing_fwhm,
-                                   standardize=standardize, detrend=detrend,
-                                   low_pass=low_pass, high_pass=high_pass,
-                                   t_r=t_r, target_affine=target_affine,
-                                   target_shape=target_shape,
-                                   mask_strategy=mask_strategy,
-                                   mask_args=mask_args, memory=memory,
-                                   memory_level=memory_level, n_jobs=n_jobs,
-                                   verbose=verbose)
+        _BaseDecomposition.__init__(self, n_components=n_components,
+                                    random_state=random_state, mask=mask,
+                                    smoothing_fwhm=smoothing_fwhm,
+                                    standardize=standardize, detrend=detrend,
+                                    low_pass=low_pass, high_pass=high_pass,
+                                    t_r=t_r, target_affine=target_affine,
+                                    target_shape=target_shape,
+                                    mask_strategy=mask_strategy,
+                                    mask_args=mask_args, memory=memory,
+                                    memory_level=memory_level, n_jobs=n_jobs,
+                                    verbose=verbose)
         self.n_epochs = n_epochs
         self.batch_size = batch_size
         self.method = method

--- a/nilearn/decomposition/tests/test_base.py
+++ b/nilearn/decomposition/tests/test_base.py
@@ -3,8 +3,7 @@ from scipy import linalg
 import nibabel
 from numpy.testing import assert_array_almost_equal
 from nilearn.maskers import MultiNiftiMasker
-from nilearn.decomposition.base import BaseDecomposition, mask_and_reduce
-from nilearn.decomposition.base import fast_svd
+from nilearn.decomposition._base import _mask_and_reduce, _fast_svd
 
 
 def test_fast_svd():
@@ -25,7 +24,7 @@ def test_fast_svd():
         # compute the singular values of X using the slow exact method
         U_, s_, V_ = linalg.svd(X, full_matrices=False)
 
-        Ur, Sr, Vr = fast_svd(X, k, random_state=0)
+        Ur, Sr, Vr = _fast_svd(X, k, random_state=0)
         assert Vr.shape == (k, n_features)
         assert Ur.shape == (n_samples, k)
 
@@ -52,27 +51,27 @@ def test_mask_reducer():
     masker = MultiNiftiMasker(mask_img=mask_img).fit()
 
     # Test fit on multiple image
-    data = mask_and_reduce(masker, imgs)
+    data = _mask_and_reduce(masker, imgs)
     assert data.shape == (8 * 5, 6 * 8 * 10)
 
-    data = mask_and_reduce(masker, imgs, n_components=3)
+    data = _mask_and_reduce(masker, imgs, n_components=3)
     assert data.shape == (8 * 3, 6 * 8 * 10)
 
-    data = mask_and_reduce(masker, imgs, reduction_ratio=0.4)
+    data = _mask_and_reduce(masker, imgs, reduction_ratio=0.4)
     assert data.shape == (8 * 2, 6 * 8 * 10)
 
     # Test on single image
-    data_single = mask_and_reduce(masker, imgs[0], n_components=3)
+    data_single = _mask_and_reduce(masker, imgs[0], n_components=3)
     assert data_single.shape == (3, 6 * 8 * 10)
 
     # Test n_jobs > 1
-    data = mask_and_reduce(masker, imgs[0], n_components=3,
+    data = _mask_and_reduce(masker, imgs[0], n_components=3,
                            n_jobs=2, random_state=0)
     assert data.shape == (3, 6 * 8 * 10)
     assert_array_almost_equal(data_single, data)
 
     # Test that reduced data is orthogonal
-    data = mask_and_reduce(masker, imgs[0], n_components=3,
+    data = _mask_and_reduce(masker, imgs[0], n_components=3,
                            random_state=0)
     assert data.shape == (3, 6 * 8 * 10)
     cov = data.dot(data.T)
@@ -82,8 +81,8 @@ def test_mask_reducer():
     assert_array_almost_equal(cov, cov_diag)
 
     # Test reproducibility
-    data1 = mask_and_reduce(masker, imgs[0], n_components=3,
+    data1 = _mask_and_reduce(masker, imgs[0], n_components=3,
                                   random_state=0)
-    data2 = mask_and_reduce(masker, [imgs[0]] * 2, n_components=3,
+    data2 = _mask_and_reduce(masker, [imgs[0]] * 2, n_components=3,
                                   random_state=0)
     assert_array_almost_equal(np.tile(data1, (2, 1)), data2)

--- a/nilearn/decomposition/tests/test_multi_pca.py
+++ b/nilearn/decomposition/tests/test_multi_pca.py
@@ -9,7 +9,7 @@ import pytest
 import nibabel
 from numpy.testing import assert_almost_equal
 
-from nilearn.decomposition.multi_pca import MultiPCA
+from nilearn.decomposition._multi_pca import _MultiPCA
 from nilearn.maskers import MultiNiftiMasker, NiftiMasker
 from nilearn._utils.testing import write_tmp_imgs
 
@@ -22,7 +22,7 @@ def _tmp_dir():
 
 
 def test_multi_pca():
-    # Smoke test the MultiPCA
+    # Smoke test the _MultiPCA
     # XXX: this is mostly a smoke test
     shape = (6, 8, 10, 5)
     affine = np.eye(4)
@@ -37,8 +37,8 @@ def test_multi_pca():
         data.append(nibabel.Nifti1Image(this_data, affine))
 
     mask_img = nibabel.Nifti1Image(np.ones(shape[:3], dtype=np.int8), affine)
-    multi_pca = MultiPCA(mask=mask_img, n_components=3,
-                         random_state=0)
+    multi_pca = _MultiPCA(mask=mask_img, n_components=3,
+                          random_state=0)
     # fit to the data and test for masker attributes
     multi_pca.fit(data)
     assert multi_pca.mask_img_ == mask_img
@@ -60,18 +60,18 @@ def test_multi_pca():
     multi_pca.fit(data[0])
 
     # Check that asking for too little components raises a ValueError
-    multi_pca = MultiPCA()
+    multi_pca = _MultiPCA()
     pytest.raises(ValueError, multi_pca.fit, data[:2])
 
     # Test fit on data with the use of a masker
     masker = MultiNiftiMasker()
-    multi_pca = MultiPCA(mask=masker, n_components=3)
+    multi_pca = _MultiPCA(mask=masker, n_components=3)
     multi_pca.fit(data)
     assert multi_pca.mask_img_ == multi_pca.masker_.mask_img_
 
     # Smoke test the use of a masker and without CCA
-    multi_pca = MultiPCA(mask=MultiNiftiMasker(mask_args=dict(opening=0)),
-                         do_cca=False, n_components=3)
+    multi_pca = _MultiPCA(mask=MultiNiftiMasker(mask_args=dict(opening=0)),
+                          do_cca=False, n_components=3)
     multi_pca.fit(data[:2])
 
     # Smoke test the transform and inverse_transform
@@ -80,7 +80,7 @@ def test_multi_pca():
     # Smoke test to fit with no img
     pytest.raises(TypeError, multi_pca.fit)
 
-    multi_pca = MultiPCA(mask=mask_img, n_components=3)
+    multi_pca = _MultiPCA(mask=mask_img, n_components=3)
     with pytest.raises(ValueError,
                        match="Object has no components_ attribute. This is "
                              "probably because fit has not been called"):
@@ -91,10 +91,10 @@ def test_multi_pca():
                              'an empty list was given.'):
         multi_pca.fit([])
     # Test passing masker arguments to estimator
-    multi_pca = MultiPCA(target_affine=affine,
-                         target_shape=shape[:3],
-                         n_components=3,
-                         mask_strategy='background')
+    multi_pca = _MultiPCA(target_affine=affine,
+                          target_shape=shape[:3],
+                          n_components=3,
+                          mask_strategy='background')
     multi_pca.fit(data)
 
 
@@ -112,16 +112,16 @@ def test_multi_pca_score():
     mask_img = nibabel.Nifti1Image(np.ones(shape[:3], dtype=np.int8), affine)
 
     # Assert that score is between zero and one
-    multi_pca = MultiPCA(mask=mask_img, random_state=0, memory_level=0,
-                         n_components=3)
+    multi_pca = _MultiPCA(mask=mask_img, random_state=0, memory_level=0,
+                          n_components=3)
     multi_pca.fit(imgs)
     s = multi_pca.score(imgs)
     assert np.all(s <= 1)
     assert np.all(0 <= s)
 
     # Assert that score does not fail with single subject data
-    multi_pca = MultiPCA(mask=mask_img, random_state=0, memory_level=0,
-                         n_components=3)
+    multi_pca = _MultiPCA(mask=mask_img, random_state=0, memory_level=0,
+                          n_components=3)
     multi_pca.fit(imgs[0])
     s = multi_pca.score(imgs[0])
     assert isinstance(s, float)
@@ -129,15 +129,15 @@ def test_multi_pca_score():
 
     # Assert that score is one for n_components == n_sample
     # in single subject configuration
-    multi_pca = MultiPCA(mask=mask_img, random_state=0, memory_level=0,
-                         n_components=5)
+    multi_pca = _MultiPCA(mask=mask_img, random_state=0, memory_level=0,
+                          n_components=5)
     multi_pca.fit(imgs[0])
     s = multi_pca.score(imgs[0])
     assert_almost_equal(s, 1., 1)
 
     # Per component score
-    multi_pca = MultiPCA(mask=mask_img, random_state=0, memory_level=0,
-                         n_components=5)
+    multi_pca = _MultiPCA(mask=mask_img, random_state=0, memory_level=0,
+                          n_components=5)
     multi_pca.fit(imgs[0])
     masker = NiftiMasker(mask_img).fit()
     s = multi_pca._raw_score(masker.transform(imgs[0]), per_component=True)
@@ -161,8 +161,8 @@ def test_components_img():
 
     mask_img = nibabel.Nifti1Image(np.ones(shape[:3], dtype=np.int8), affine)
     n_components = 3
-    multi_pca = MultiPCA(mask=mask_img, n_components=n_components,
-                         random_state=0)
+    multi_pca = _MultiPCA(mask=mask_img, n_components=n_components,
+                          random_state=0)
     # fit to the data and test for components images
     multi_pca.fit(data)
     components_img = multi_pca.components_img_
@@ -177,7 +177,7 @@ def test_with_globbing_patterns_with_single_image():
     data_4d = np.zeros((40, 40, 40, 3))
     data_4d[20, 20, 20] = 1
     img_4d = nibabel.Nifti1Image(data_4d, affine=np.eye(4))
-    multi_pca = MultiPCA(n_components=3)
+    multi_pca = _MultiPCA(n_components=3)
 
     with write_tmp_imgs(img_4d, create_files=True, use_wildcards=True) as img:
         input_image = _tmp_dir() + img
@@ -195,7 +195,7 @@ def test_with_globbing_patterns_with_multiple_images():
     data_4d = np.zeros((40, 40, 40, 3))
     data_4d[20, 20, 20] = 1
     img_4d = nibabel.Nifti1Image(data_4d, affine=np.eye(4))
-    multi_pca = MultiPCA(n_components=3)
+    multi_pca = _MultiPCA(n_components=3)
 
     with write_tmp_imgs(img_4d, img_4d, create_files=True,
                         use_wildcards=True) as imgs:

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -10,7 +10,7 @@ from joblib import Memory, delayed, Parallel
 
 from .rena_clustering import ReNA
 from .hierarchical_kmeans_clustering import HierarchicalKMeans
-from ..decomposition.multi_pca import MultiPCA
+from ..decomposition._multi_pca import _MultiPCA
 from nilearn.maskers import NiftiLabelsMasker
 from .._utils.niimg import _safe_get_data
 from .._utils.niimg_conversions import _iter_check_niimg
@@ -116,7 +116,7 @@ def _labels_masker_extraction(img, masker, confound):
 
 
 @fill_doc
-class Parcellations(MultiPCA):
+class Parcellations(_MultiPCA):
     """Learn :term:`parcellations<parcellation>`
     on :term:`fMRI` images.
 
@@ -271,19 +271,19 @@ class Parcellations(MultiPCA):
         self.scaling = scaling
         self.n_iter = n_iter
 
-        MultiPCA.__init__(self, n_components=200,
-                          random_state=random_state,
-                          mask=mask, memory=memory,
-                          smoothing_fwhm=smoothing_fwhm,
-                          standardize=standardize, detrend=detrend,
-                          low_pass=low_pass, high_pass=high_pass,
-                          t_r=t_r, target_affine=target_affine,
-                          target_shape=target_shape,
-                          mask_strategy=mask_strategy,
-                          mask_args=mask_args,
-                          memory_level=memory_level,
-                          n_jobs=n_jobs,
-                          verbose=verbose)
+        _MultiPCA.__init__(self, n_components=200,
+                           random_state=random_state,
+                           mask=mask, memory=memory,
+                           smoothing_fwhm=smoothing_fwhm,
+                           standardize=standardize, detrend=detrend,
+                           low_pass=low_pass, high_pass=high_pass,
+                           t_r=t_r, target_affine=target_affine,
+                           target_shape=target_shape,
+                           mask_strategy=mask_strategy,
+                           mask_args=mask_args,
+                           memory_level=memory_level,
+                           n_jobs=n_jobs,
+                           verbose=verbose)
 
     def _raw_fit(self, data):
         """Fits the parcellation method on this reduced data.
@@ -330,7 +330,7 @@ class Parcellations(MultiPCA):
         except Exception:
             pass
 
-        components = MultiPCA._raw_fit(self, data)
+        components = _MultiPCA._raw_fit(self, data)
 
         mask_img_ = self.masker_.mask_img_
         if self.verbose:


### PR DESCRIPTION
Closes #3138 

This PR proposes to rename some objects and submodules of `nilearn.decomposition` with a leading "_" to make it clear that these objects are private.