### PR TITLE
[MAINT] Bump dependencies for release `0.9.0`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,12 +46,12 @@ The required dependencies to use the software are:
 
 * Python >= 3.6
 * setuptools
-* Numpy >= 1.16
-* SciPy >= 1.2
-* Scikit-learn >= 0.21
-* Joblib >= 0.12
+* Numpy >= 1.18
+* SciPy >= 1.5
+* Scikit-learn >= 0.22
+* Joblib >= 0.15
 * Nibabel >= 3.0
-* Pandas >= 0.24
+* Pandas >= 1.0
 
 If you are using nilearn plotting functionalities or running the
 examples, matplotlib >= 1.5.1 is required.

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -6,6 +6,21 @@
 0.8.2.dev
 =========
 
+.. warning::
+
+ | **Python 3.6 is deprecated and will be removed in release 0.10.**
+ | **We recommend upgrading to Python 3.9.**
+ |
+ | **Nibabel 2.x is no longer supported. Please consider upgrading to Nibabel >= 3.0.**
+ |
+ | **Minimum supported versions of packages have been bumped up:**
+ | - Numpy -- v1.18
+ | - SciPy -- v1.5
+ | - Scikit-learn -- v0.22
+ | - Pandas -- v1.0
+ | - Joblib -- v0.15
+
+
 NEW
 ---
 

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,8 +1,8 @@
-numpy==1.16
-scipy==1.2.0
-pandas==0.24.0
-scikit-learn==0.21.0
-joblib==0.12
+numpy==1.18
+scipy==1.5
+pandas==1.0
+scikit-learn==0.22
+joblib==0.15
 nibabel==3.0.0
 pytest
 pytest-cov


### PR DESCRIPTION
This PR proposes to bump our dependencies for the 0.9.0 release:

- Joblib: 0.12  -->  0.15
- Numpy: 1.16  -->  1.18
- Scipy: 1.2  -->  1.5
- Scikit-learn: 0.21  -->  0.22
- Pandas:  0.24  --> 1.0

I also realized that the README says that matplotlib >= 1.5.1 is required although we don't test this. The minimum requirements tests are without matplotlib:

https://github.com/nilearn/nilearn/blob/c549dc0a66327b05ab3a25ddff02abe99db02501/.github/workflows/testing.yml#L26-L31

I think we should add a CI job testing minimum requirements WITH matplotlib. In this case, we could also bump the minimum version for matplotlib (>= 3.0 ??). 

WDYT?