### PR TITLE
[TEST] check both old and new derivative suffix

### DIFF
--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
@@ -424,7 +424,7 @@ def test_load_non_nifti(tmp_path):
 def test_invalid_filetype(tmp_path):
     """Invalid file types/associated files for load method."""
     bad_nii, bad_conf = create_tmp_filepath(tmp_path, copy_confounds=True,
-                                            old_deriveative_suffix=False)
+                                            old_derivative_suffix=False)
     conf, _ = load_confounds(bad_nii)
 
     # more than one legal filename for confounds

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
@@ -423,11 +423,11 @@ def test_load_non_nifti(tmp_path):
 
 def test_invalid_filetype(tmp_path):
     """Invalid file types/associated files for load method."""
-    bad_nii, bad_conf = create_tmp_filepath(tmp_path, copy_confounds=True)
+    bad_nii, bad_conf = create_tmp_filepath(tmp_path, copy_confounds=True, old_deriveative_suffix=False)
     conf, _ = load_confounds(bad_nii)
 
     # more than one legal filename for confounds
-    add_conf = "test_desc-confounds_timeseries.tsv"
+    add_conf = "test_desc-confounds_regressors.tsv"
     leagal_confounds, _ = get_leagal_confound()
     leagal_confounds.to_csv(tmp_path / add_conf, sep="\t", index=False)
     with pytest.raises(ValueError) as info:

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
@@ -423,7 +423,8 @@ def test_load_non_nifti(tmp_path):
 
 def test_invalid_filetype(tmp_path):
     """Invalid file types/associated files for load method."""
-    bad_nii, bad_conf = create_tmp_filepath(tmp_path, copy_confounds=True, old_deriveative_suffix=False)
+    bad_nii, bad_conf = create_tmp_filepath(tmp_path, copy_confounds=True,
+                                            old_deriveative_suffix=False)
     conf, _ = load_confounds(bad_nii)
 
     # more than one legal filename for confounds

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
@@ -24,6 +24,7 @@ def test_sanitize_confounds(inputs, flag):
     _, singleflag = _sanitize_confounds(inputs)
     assert singleflag is flag
 
+
 @pytest.mark.parametrize("flag,suffix",
                          [(True, "_desc-confounds_regressors"),
                           (False, "_desc-confounds_timeseries")])

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
@@ -1,6 +1,9 @@
 import pytest
 from nilearn.interfaces.fmriprep.load_confounds_utils import (
-    _sanitize_confounds
+    _sanitize_confounds, _get_file_name
+)
+from nilearn.interfaces.fmriprep.tests.utils import (
+    create_tmp_filepath
 )
 
 
@@ -20,3 +23,11 @@ def test_sanitize_confounds(inputs, flag):
     """Should correctly catch inputs that are a single image."""
     _, singleflag = _sanitize_confounds(inputs)
     assert singleflag is flag
+
+@pytest.mark.parametrize("flag,suffix",
+                         [(True, "_desc-confounds_regressors"),
+                          (False, "_desc-confounds_timeseries")])
+def test_get_file_name(tmp_path, flag, suffix):
+    img, _ = create_tmp_filepath(tmp_path, old_deriveative_suffix=flag)
+    conf = _get_file_name(img)
+    assert suffix in conf

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
@@ -29,6 +29,6 @@ def test_sanitize_confounds(inputs, flag):
                          [(True, "_desc-confounds_regressors"),
                           (False, "_desc-confounds_timeseries")])
 def test_get_file_name(tmp_path, flag, suffix):
-    img, _ = create_tmp_filepath(tmp_path, old_deriveative_suffix=flag)
+    img, _ = create_tmp_filepath(tmp_path, old_derivative_suffix=flag)
     conf = _get_file_name(img)
     assert suffix in conf

--- a/nilearn/interfaces/fmriprep/tests/utils.py
+++ b/nilearn/interfaces/fmriprep/tests/utils.py
@@ -2,6 +2,7 @@
 import os
 import json
 import pandas as pd
+from scipy.misc import derivative
 from nilearn.interfaces.fmriprep import load_confounds_utils
 
 
@@ -21,22 +22,23 @@ img_file_patterns = {
 
 def get_testdata_path(non_steady_state=True):
     """Get file path for the confound regressors."""
+    derivative = "regressors"
     path_data = os.path.join(os.path.dirname(
         load_confounds_utils.__file__), "data")
     if non_steady_state:
         return [
             os.path.join(path_data, filename)
             for filename in [
-                "test_desc-confounds_regressors.tsv",
-                "test_desc-confounds_regressors.json",
+                f"test_desc-confounds_{derivative}.tsv",
+                f"test_desc-confounds_{derivative}.json",
             ]
         ]
     else:
         return [
             os.path.join(path_data, filename)
             for filename in [
-                "no_nonsteady_desc-confounds_regressors.tsv",
-                "test_desc-confounds_regressors.json",
+                f"no_nonsteady_desc-confounds_{derivative}.tsv",
+                f"test_desc-confounds_{derivative}.json",
             ]
         ]
 
@@ -47,10 +49,13 @@ def create_tmp_filepath(
     suffix="test",
     copy_confounds=False,
     copy_json=False,
+    old_deriveative_suffix=False
 ):
     """Create test files in temporary directory."""
+    deriveative = "regressors" if old_deriveative_suffix else "timeseries"
+
     # confound files
-    confounds_root = "_desc-confounds_regressors.tsv"
+    confounds_root = f"_desc-confounds_{deriveative}.tsv"
     tmp_conf = base_path / (suffix + confounds_root)
 
     if copy_confounds:
@@ -60,7 +65,7 @@ def create_tmp_filepath(
         tmp_conf.touch()
 
     if copy_json:
-        meta_root = "_desc-confounds_regressors.json"
+        meta_root = f"_desc-confounds_{deriveative}.json"
         tmp_meta = base_path / (suffix + meta_root)
         conf, meta = get_leagal_confound()
         with open(tmp_meta, "w") as file:

--- a/nilearn/interfaces/fmriprep/tests/utils.py
+++ b/nilearn/interfaces/fmriprep/tests/utils.py
@@ -48,7 +48,7 @@ def create_tmp_filepath(
     suffix="test",
     copy_confounds=False,
     copy_json=False,
-    old_deriveative_suffix=False
+    old_derivative_suffix=False
 ):
     """Create test files in temporary directory."""
     deriveative = "regressors" if old_deriveative_suffix else "timeseries"

--- a/nilearn/interfaces/fmriprep/tests/utils.py
+++ b/nilearn/interfaces/fmriprep/tests/utils.py
@@ -51,10 +51,10 @@ def create_tmp_filepath(
     old_derivative_suffix=False
 ):
     """Create test files in temporary directory."""
-    deriveative = "regressors" if old_derivative_suffix else "timeseries"
+    derivative = "regressors" if old_derivative_suffix else "timeseries"
 
     # confound files
-    confounds_root = f"_desc-confounds_{deriveative}.tsv"
+    confounds_root = f"_desc-confounds_{derivative}.tsv"
     tmp_conf = base_path / (suffix + confounds_root)
 
     if copy_confounds:
@@ -64,7 +64,7 @@ def create_tmp_filepath(
         tmp_conf.touch()
 
     if copy_json:
-        meta_root = f"_desc-confounds_{deriveative}.json"
+        meta_root = f"_desc-confounds_{derivative}.json"
         tmp_meta = base_path / (suffix + meta_root)
         conf, meta = get_leagal_confound()
         with open(tmp_meta, "w") as file:

--- a/nilearn/interfaces/fmriprep/tests/utils.py
+++ b/nilearn/interfaces/fmriprep/tests/utils.py
@@ -51,7 +51,7 @@ def create_tmp_filepath(
     old_derivative_suffix=False
 ):
     """Create test files in temporary directory."""
-    deriveative = "regressors" if old_deriveative_suffix else "timeseries"
+    deriveative = "regressors" if old_derivative_suffix else "timeseries"
 
     # confound files
     confounds_root = f"_desc-confounds_{deriveative}.tsv"

--- a/nilearn/interfaces/fmriprep/tests/utils.py
+++ b/nilearn/interfaces/fmriprep/tests/utils.py
@@ -2,7 +2,6 @@
 import os
 import json
 import pandas as pd
-from scipy.misc import derivative
 from nilearn.interfaces.fmriprep import load_confounds_utils
 
 


### PR DESCRIPTION
Add test to verify this note in comments:
 
    fmriprep has changed the file suffix between v20.1.1 and v20.2.0 with
    respect to BEP 012.
    cf. https://neurostars.org/t/naming-change-confounds-regressors-to-confounds-timeseries/17637 # noqa
    Check file with new naming scheme exists or replace,
    for backward compatibility.

This test was lost while migrating the library.
Although it didn't break any existing code, it's still better to have this test.