### PR TITLE
[INFRA] Update docs `install` target

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -169,16 +169,17 @@ install:
 	# first clone the nilearn.github.io repo because it may ask
 	# for password and we don't want to delay this long build in
 	# the middle of it
-	# --no-checkout just fetches the root folder without content
 	# --depth 1 is a speed optimization since we don't need the
 	# history prior to the last commit
-	git clone --no-checkout --depth 1 git@github.com:nilearn/nilearn.github.io.git _build/nilearn.github.io
+	git clone --depth 1 git@github.com:nilearn/nilearn.github.io.git _build/nilearn.github.io
 	touch _build/nilearn.github.io/.nojekyll
+	rm -Rf _build/nilearn.github.io/stable;
+	mkdir _build/nilearn.github.io/stable;
 	make html
 	cd _build/ && \
-	cp -r html/* nilearn.github.io && \
+	cp -r html/* nilearn.github.io/stable/ && \
 	cd nilearn.github.io && \
-	git add * && \
+	git add -A && \
 	git add .nojekyll && \
 	git commit -a -m 'Make install' && \
 	git push


### PR DESCRIPTION
This PR updates the steps for the `install` target of the documentation Makefile.
This is necessary since we now deploy the development version of the documentation every time a PR is merged in main.