### PR TITLE
MAINT: Use non-deprecated method

### DIFF
--- a/nilearn/plotting/matrix_plotting.py
+++ b/nilearn/plotting/matrix_plotting.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
-from matplotlib.tight_layout import get_renderer
 from matplotlib.colorbar import make_axes
 from .._utils import fill_doc
 with warnings.catch_warnings():
@@ -22,7 +21,7 @@ def _fit_axes(ax):
     labels fitting.
     """
     fig = ax.get_figure()
-    renderer = get_renderer(fig)
+    renderer = fig.canvas.get_renderer()
     ylabel_width = ax.yaxis.get_tightbbox(renderer).transformed(
         ax.figure.transFigure.inverted()).width
     if ax.get_position().xmin < 1.1 * ylabel_width:


### PR DESCRIPTION
Avoid this by using `fig.canvas.get_renderer`:
```
  File "/home/larsoner/python/nilearn/nilearn/plotting/matrix_plotting.py", line 9, in <module>
    from matplotlib.tight_layout import get_renderer
  File "/home/larsoner/python/matplotlib/lib/matplotlib/tight_layout.py", line 3, in <module>
    _api.warn_deprecated(
  File "/home/larsoner/python/matplotlib/lib/matplotlib/_api/deprecation.py", line 101, in warn_deprecated
    warn_external(warning, category=MatplotlibDeprecationWarning)
  File "/home/larsoner/python/matplotlib/lib/matplotlib/_api/__init__.py", line 361, in warn_external
    warnings.warn(message, category, stacklevel)
matplotlib._api.deprecation.MatplotlibDeprecationWarning: The module matplotlib.tight_layout is deprecated since 3.6.
```