### PR TITLE
Add optional random_state kwarg to run_glm()

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -25,6 +25,7 @@ Enhancements
 ------------
 
 - Add `sample_masks` to :meth:`~glm.first_level.FirstLevelModel.fit` for censoring time points (:gh:`3193` by `Hao-Ting Wang`_).
+- Function :func:`~glm.first_level.first_level.run_glm` and class :class: `~glm.first_level.first_level.FirstLevelModel` now accept a ``random_state`` parameter, which allows users to seed the ``KMeans`` cluster model used to estimate AR coeficients. (:gh:`3185` by `Sami Jawhar`_).
 
 Changes
 -------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -25,7 +25,7 @@ Enhancements
 ------------
 
 - Add `sample_masks` to :meth:`~glm.first_level.FirstLevelModel.fit` for censoring time points (:gh:`3193` by `Hao-Ting Wang`_).
-- Function :func:`~glm.first_level.first_level.run_glm` and class :class: `~glm.first_level.first_level.FirstLevelModel` now accept a ``random_state`` parameter, which allows users to seed the ``KMeans`` cluster model used to estimate AR coeficients. (:gh:`3185` by `Sami Jawhar`_).
+- Function :func:`~glm.first_level.first_level.run_glm` and class :class: `~glm.first_level.first_level.FirstLevelModel` now accept a ``random_state`` parameter, which allows users to seed the ``KMeans`` cluster model used to estimate AR coefficients. (:gh:`3185` by `Sami Jawhar`_).
 
 Changes
 -------

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -176,6 +176,8 @@
 
 .. _Salma Bougacha: https://github.com/salma1601
 
+.. _Sami Jawhar: https://github.com/sjawhar
+
 .. _Simon Steinkamp: https://github.com/SRSteinkamp
 
 .. _Sourav Singh: https://github.com/souravsingh

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -101,7 +101,8 @@ def _yule_walker(x, order):
     return rho
 
 
-def run_glm(Y, X, noise_model='ar1', bins=100, n_jobs=1, verbose=0, random_state=None):
+def run_glm(Y, X, noise_model='ar1', bins=100,
+            n_jobs=1, verbose=0, random_state=None):
     """ GLM fit for an fMRI data matrix
 
     Parameters
@@ -132,7 +133,7 @@ def run_glm(Y, X, noise_model='ar1', bins=100, n_jobs=1, verbose=0, random_state
 
     verbose : int, optional
         The verbosity level. Default=0.
-        
+
     random_state : int or numpy.random.RandomState, optional
         Random state seed to sklearn.cluster.KMeans
 
@@ -186,7 +187,8 @@ def run_glm(Y, X, noise_model='ar1', bins=100, n_jobs=1, verbose=0, random_state
             labels = np.array([str(val) for val in ar_coef_])
         else:  # AR(N>1) case
             n_clusters = np.min([bins, Y.shape[1]])
-            kmeans = KMeans(n_clusters=n_clusters, random_state=random_state).fit(ar_coef_)
+            kmeans = KMeans(n_clusters=n_clusters,
+                            random_state=random_state).fit(ar_coef_)
             ar_coef_ = kmeans.cluster_centers_[kmeans.labels_]
 
             # Create a set of rounded values for the labels with _ between

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -136,7 +136,9 @@ def run_glm(Y, X, noise_model='ar1', bins=100,
 
     random_state : int or numpy.random.RandomState, optional
         Random state seed to sklearn.cluster.KMeans for autoregressive models
-        of order at least 2 ('ar(N)' with n >= 2).
+        of order at least 2 ('ar(N)' with n >= 2). Default=None.
+
+        .. versionadded:: 0.9.1
 
     Returns
     -------
@@ -330,7 +332,9 @@ class FirstLevelModel(BaseGLM):
 
     random_state : int or numpy.random.RandomState, optional
         Random state seed to sklearn.cluster.KMeans for autoregressive models
-        of order at least 2 ('ar(N)' with n >= 2).
+        of order at least 2 ('ar(N)' with n >= 2). Default=None.
+
+        .. versionadded:: 0.9.1
 
     Attributes
     ----------

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -101,7 +101,7 @@ def _yule_walker(x, order):
     return rho
 
 
-def run_glm(Y, X, noise_model='ar1', bins=100, n_jobs=1, verbose=0):
+def run_glm(Y, X, noise_model='ar1', bins=100, n_jobs=1, verbose=0, random_state=None):
     """ GLM fit for an fMRI data matrix
 
     Parameters
@@ -132,6 +132,9 @@ def run_glm(Y, X, noise_model='ar1', bins=100, n_jobs=1, verbose=0):
 
     verbose : int, optional
         The verbosity level. Default=0.
+        
+    random_state : int or numpy.random.RandomState, optional
+        Random state seed to sklearn.cluster.KMeans
 
     Returns
     -------
@@ -183,7 +186,7 @@ def run_glm(Y, X, noise_model='ar1', bins=100, n_jobs=1, verbose=0):
             labels = np.array([str(val) for val in ar_coef_])
         else:  # AR(N>1) case
             n_clusters = np.min([bins, Y.shape[1]])
-            kmeans = KMeans(n_clusters=n_clusters).fit(ar_coef_)
+            kmeans = KMeans(n_clusters=n_clusters, random_state=random_state).fit(ar_coef_)
             ar_coef_ = kmeans.cluster_centers_[kmeans.labels_]
 
             # Create a set of rounded values for the labels with _ between

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -135,7 +135,8 @@ def run_glm(Y, X, noise_model='ar1', bins=100,
         The verbosity level. Default=0.
 
     random_state : int or numpy.random.RandomState, optional
-        Random state seed to sklearn.cluster.KMeans
+        Random state seed to sklearn.cluster.KMeans for autoregressive models
+        of order at least 2 ('ar(N)' with n >= 2).
 
     Returns
     -------
@@ -327,6 +328,10 @@ class FirstLevelModel(BaseGLM):
         This id will be used to identify a `FirstLevelModel` when passed to
         a `SecondLevelModel` object.
 
+    random_state : int or numpy.random.RandomState, optional
+        Random state seed to sklearn.cluster.KMeans for autoregressive models
+        of order at least 2 ('ar(N)' with n >= 2).
+
     Attributes
     ----------
     labels_ : array of shape (n_voxels,),
@@ -344,13 +349,14 @@ class FirstLevelModel(BaseGLM):
     It may change in any future release of Nilearn.
 
     """
+
     def __init__(self, t_r=None, slice_time_ref=0., hrf_model='glover',
                  drift_model='cosine', high_pass=.01, drift_order=1,
                  fir_delays=[0], min_onset=-24, mask_img=None,
                  target_affine=None, target_shape=None, smoothing_fwhm=None,
                  memory=Memory(None), memory_level=1, standardize=False,
                  signal_scaling=0, noise_model='ar1', verbose=0, n_jobs=1,
-                 minimize_memory=True, subject_label=None):
+                 minimize_memory=True, subject_label=None, random_state=None):
         # design matrix parameters
         self.t_r = t_r
         self.slice_time_ref = slice_time_ref
@@ -388,6 +394,7 @@ class FirstLevelModel(BaseGLM):
         self.labels_ = None
         self.results_ = None
         self.subject_label = subject_label
+        self.random_state = random_state
 
     @property
     def scaling_axis(self):
@@ -610,7 +617,8 @@ class FirstLevelModel(BaseGLM):
                 sys.stderr.write('Performing GLM computation\r')
             labels, results = mem_glm(Y, design.values,
                                       noise_model=self.noise_model,
-                                      bins=bins, n_jobs=self.n_jobs)
+                                      bins=bins, n_jobs=self.n_jobs,
+                                      random_state=self.random_state)
             if self.verbose > 1:
                 t_glm = time.time() - t_glm
                 sys.stderr.write('GLM took %d seconds         \n' % t_glm)

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -396,15 +396,15 @@ def test_glm_random_state(random_state):
     n, p, q = 33, 80, 10
     X, Y = rng.standard_normal(size=(p, q)), rng.standard_normal(size=(p, n))
 
-    init = KMeans.__init__
     with unittest.mock.patch.object(
         KMeans,
         "__init__",
         autospec=True,
-        side_effect=lambda *args, **kwargs: init(*args, **kwargs),
+        side_effect=KMeans.__init__,
     ) as spy_kmeans:
         run_glm(Y, X, 'ar3', random_state=random_state)
-        assert spy_kmeans.call_args.kwargs["random_state"] == random_state
+        spy_kmeans.assert_called_once_with(
+            unittest.mock.ANY, n_clusters=unittest.mock.ANY, random_state=random_state)
 
 
 def test_scaling():

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -404,7 +404,9 @@ def test_glm_random_state(random_state):
     ) as spy_kmeans:
         run_glm(Y, X, 'ar3', random_state=random_state)
         spy_kmeans.assert_called_once_with(
-            unittest.mock.ANY, n_clusters=unittest.mock.ANY, random_state=random_state)
+            unittest.mock.ANY,
+            n_clusters=unittest.mock.ANY,
+            random_state=random_state)
 
 
 def test_scaling():


### PR DESCRIPTION
Changes proposed in this pull request:
- Add an optional `random_state` kwarg to `nilearn.glm.first_level.first_level.run_glm()`. Because we like reproducibility!
