### PR TITLE
Fix documentation build

### DIFF
--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -593,13 +593,13 @@ def _get_atlas_data_and_labels(atlas_source, atlas_name, symmetric_split=False,
     atlas_file = os.path.join(root, atlas_source,
                               '{}-{}.nii.gz'.format(atlas_source,
                                                     atlas_name))
-    atlas_img, label_file = _fetch_files(
+    atlas_file, label_file = _fetch_files(
         data_dir,
         [(atlas_file, url, opts),
          (label_file, url, opts)],
         resume=resume, verbose=verbose)
     # Reorder image to have positive affine diagonal
-    atlas_img = reorder_img(atlas_img)
+    atlas_img = reorder_img(atlas_file)
     names = {}
     from xml.etree import ElementTree
     names[0] = 'Background'

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -173,7 +173,7 @@ def _write_sample_atlas_metadata(ho_dir, filename, is_symm):
 
 
 def _test_atlas_instance_should_match_data(atlas, is_symm):
-    assert isinstance(atlas.filename, str) or isinstance(atlas.filename, Path)
+    assert Path(atlas.filename).exists() and Path(atlas.filename).is_absolute()
     assert isinstance(atlas.maps, nibabel.Nifti1Image)
     assert isinstance(atlas.labels, list)
 


### PR DESCRIPTION
A bug has been introduced by myself in #3179 leading to the documentation not building anymore in the CI. This PR fixes it.

Reason for the bug:

- in #3179, I changed the behaviour of atlas fetching for Juelich and Oxford: before the `.filename` element contained the image element instead of the path, the purpose of my PR was to switch this image element to the appropriate element path
- doing so, I made the method return a relative path instead of the absolute path of the element, returning path like `data/atlases/Juelich/Juelich-maxprob-thr0-1mm.nii.gz`
- the problem is that during `fetch_files`, this relative path is added to the data_dir, which is generally `$HOME/nilearn_data/fsl`
- this lead the documentation build to look for the atlas image in the current directory instead of `$HOME/nilearn_data/fsl`, causing the bug

What's in the fix:

- I fixed it by returning the actual absolute path
- I improved the test to check whether the path did exist + was absolute

Sorry for the trouble!