### PR TITLE
Unify colorbar draws between Matplotlib versions

### DIFF
--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -13,8 +13,7 @@ from matplotlib.colors import Normalize, LinearSegmentedColormap
 from mpl_toolkits.mplot3d import Axes3D  # noqa
 from nilearn import image
 from nilearn.plotting.cm import cold_hot
-from nilearn.plotting.img_plotting import (_get_colorbar_and_data_ranges,
-                                           _crop_colorbar)
+from nilearn.plotting.img_plotting import _get_colorbar_and_data_ranges
 from nilearn.surface import (load_surf_data,
                              load_surf_mesh,
                              vol_to_surf)
@@ -501,19 +500,20 @@ def _plot_surf_matplotlib(coords, faces, surf_map=None, bg_map=None,
             face_colors[kept_indices] = cmap(surf_map_faces[kept_indices])
 
         if colorbar:
-            ticks = _get_ticks_matplotlib(vmin, vmax, cbar_tick_format)
-            our_cmap, norm = _get_cmap_matplotlib(cmap, vmin, vmax, threshold)
-            bounds = np.linspace(vmin, vmax, our_cmap.N)
+            cbar_vmin = cbar_vmin if cbar_vmin is not None else vmin
+            cbar_vmax = cbar_vmax if cbar_vmax is not None else vmax
+            ticks = _get_ticks_matplotlib(cbar_vmin, cbar_vmax, cbar_tick_format)
+            our_cmap, norm = _get_cmap_matplotlib(cmap, cbar_vmin, cbar_vmax, threshold)
+            bounds = np.linspace(cbar_vmin, cbar_vmax, our_cmap.N)
             # we need to create a proxy mappable
             proxy_mappable = ScalarMappable(cmap=our_cmap, norm=norm)
             proxy_mappable.set_array(surf_map_faces)
             cax, kw = make_axes(axes, location='right', fraction=.15,
                                 shrink=.5, pad=.0, aspect=10.)
-            cbar = figure.colorbar(
+            figure.colorbar(
                 proxy_mappable, cax=cax, ticks=ticks,
                 boundaries=bounds, spacing='proportional',
                 format=cbar_tick_format, orientation='vertical')
-            _crop_colorbar(cbar, cbar_vmin, cbar_vmax)
 
         p3dcollec.set_facecolors(face_colors)
 


### PR DESCRIPTION
This PR fixes #3183.

This PR comes from an issue with the scale of the colorbar that goes off limit for recent matplotlib versions. As discussed in #3183, I fixed it by drawing the colorbar with the appropriate scale values right the first time, and avoid re-calling the draw of the colorbar.

I tried out several plotting methods that seemed impacted by the change. I mainly use `plot_stat_map` day to day, so I am open to suggestions of other methods I should check!

# Visualizations

## Before the fix (current `main`)

![Capture d’écran de 2022-03-23 16-43-22](https://user-images.githubusercontent.com/12402673/159742248-9d17fbe2-25a3-4b8c-962a-895ad47874b2.png)

![Capture d’écran de 2022-03-23 16-43-29](https://user-images.githubusercontent.com/12402673/159742256-84783b06-a2ac-4f1b-91e3-651cf8df91b4.png)

## After the fix

![Capture d’écran de 2022-03-23 16-44-23](https://user-images.githubusercontent.com/12402673/159742315-6de207d4-46de-4c06-88e5-fc31318718a2.png)

![Capture d’écran de 2022-03-23 16-44-30](https://user-images.githubusercontent.com/12402673/159742321-04b415c4-383d-4667-a90a-bdc7a9ed914d.png)

