### PR TITLE
[DOC] Request absolute imports in coding style guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -179,12 +179,12 @@ with the tools we use for development and deployment.
 |                    |               | - Link issue through mention :"Closes #XXXX"        |
 |  `PR Structure`_   |    Any        | - Clearly outline goals and changes proposed        |
 |                    |               | - Doesn't include "unrelated" code change           |
-|                    |               | - Add entry in "doc/whats_new.rst"                  |
+|                    |               | - Add entry in "doc/changes/latest.rst"             |
 +--------------------+---------------+-----------------------------------------------------+
 |                    |               | - Variables, functions, arguments have clear names  |
 |                    |               | - Easy to read, PEP8_ compliant                     |
-|   `Coding Style`_  |    Any        | - Public functions have docstring (numpydoc_ format)|
-|                    |               | - Low redundancy                                    |
+|                    |               | - Public functions have docstring (numpydoc_ format)|
+|   `Coding Style`_  |    Any        | - Low redundancy                                    |
 |                    |               | - No new dependency                                 |
 |                    |               | - Backward compatibility                            |
 |                    |               | - All internal imports are absolute, not relative   |

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -63,7 +63,7 @@ If you want to contribute code:
     * For new features, please be sure to create a `new issue`_ first, to discuss whether it can be included and its specifications.
     * To help with known `issues`_, please check `good first issues <https://github.com/nilearn/nilearn/labels/Good%20first%20issue>`_ to get started, `known bugs <https://github.com/nilearn/nilearn/labels/Bug>`_, or `proposed enhancements <https://github.com/nilearn/nilearn/labels/Enhancement>`_.
 
-Please see the :ref:`contributing_code` section for more detailed information, including 
+Please see the :ref:`contributing_code` section for more detailed information, including
 instructions for  `Setting up your environment`_ and a description of the `Contribution Guidelines`_.
 
 How do we decide what code goes in?
@@ -182,11 +182,12 @@ with the tools we use for development and deployment.
 |                    |               | - Add entry in "doc/whats_new.rst"                  |
 +--------------------+---------------+-----------------------------------------------------+
 |                    |               | - Variables, functions, arguments have clear names  |
-|                    |               | - Easy to read, PEP8_                               |
+|                    |               | - Easy to read, PEP8_ compliant                     |
 |   `Coding Style`_  |    Any        | - Public functions have docstring (numpydoc_ format)|
 |                    |               | - Low redundancy                                    |
 |                    |               | - No new dependency                                 |
 |                    |               | - Backward compatibility                            |
+|                    |               | - All internal imports are absolute, not relative   |
 +--------------------+---------------+-----------------------------------------------------+
 |                    |               | - Test type is adapted to function behavior         |
 |                    |               | - Tests pass continuous integration                 |


### PR DESCRIPTION
Closes #1919. Per discussion in #1919, large-scale changes to nilearn's coding style should be avoided, so we should just try to ensure that any affected code in new PRs follows this guideline. I think mentioning it in the contributing documentation should be sufficient.

I didn't think this required a whatsnew entry, but I can add one if necessary.

Changes proposed in this pull request:

- Specifically mention absolute imports are recommended within the coding style guidelines in the contributing documentation.

- Fix path to whatsnew in contributing guidelines. I think this was missed in #3049.
