### PR TITLE
More explicit docstring regarding min_distance

### DIFF
--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -152,7 +152,9 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
         only. Default=False.
 
     min_distance : `float`, optional
-        Minimum distance between subpeaks in mm. Default=8mm.
+        Minimum intra-cluster distance between subpeaks in mm. Default=8mm. If
+        two different clusters are closer than `min_distance`, it can results
+        in peaks closer than `min_distance`.
 
     Returns
     -------

--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -155,8 +155,8 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
         Minimum distance between subpeaks in mm. Default=8mm.
 
         .. note::
-            If two different clusters are closer than `min_distance`, it can
-            result in peaks closer than `min_distance`.
+            If two different clusters are closer than ``min_distance``, it can
+            result in peaks closer than ``min_distance``.
 
     Returns
     -------

--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -152,9 +152,11 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
         only. Default=False.
 
     min_distance : `float`, optional
-        Minimum intra-cluster distance between subpeaks in mm. Default=8mm. If
-        two different clusters are closer than `min_distance`, it can results
-        in peaks closer than `min_distance`.
+        Minimum distance between subpeaks in mm. Default=8mm.
+
+        .. note::
+            If two different clusters are closer than `min_distance`, it can
+            result in peaks closer than `min_distance`.
 
     Returns
     -------


### PR DESCRIPTION
Closes #3199.

This PR changes the docstring for `min_distance` argument in the `reporting.get_clusters_table` method to explicitly note that the minimal distance applies intra-clusters and not between clusters.
