### PR TITLE
[DOC] Separate dataset functions by type of data returned

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -25,6 +25,7 @@ Enhancements
   to demonstrate how to implement common beta series models with nilearn (:gh:`3127` by `Taylor Salo`_).
 - Function :func:`~plotting.plot_carpet` now accepts a ``t_r`` parameter, which allows users to provide the TR of the image when the image's header may not be accurate. (:gh:`3165` by `Taylor Salo`_).
 - Terms :term:`Probabilistic atlas` and :term:`Deterministic atlas` were added to the glossary and references were added to atlas fetchers (:gh:`3152` by `Nicolas Gensollen`_).
+- Functions in :mod:`~datasets` have been organized by the type of data in the references page and :func:`~datasets.fetch_mixed_gambles` has been added to the documentation (:gh:`3207` by `Taylor Salo`_).
 
 Changes
 -------

--- a/doc/modules/reference.rst
+++ b/doc/modules/reference.rst
@@ -126,6 +126,7 @@ Preprocessed datasets
    fetch_language_localizer_demo_dataset
    fetch_localizer_first_level
    fetch_miyawaki2008
+   fetch_openneuro_dataset_index
    fetch_spm_auditory
    fetch_spm_multimodal_fmri
    fetch_surf_nki_enhanced
@@ -163,7 +164,6 @@ General functions
    fetch_neurovault
    fetch_neurovault_ids
    fetch_openneuro_dataset
-   fetch_openneuro_dataset_index
    get_data_dirs
    patch_openneuro_dataset
    select_from_index

--- a/doc/modules/reference.rst
+++ b/doc/modules/reference.rst
@@ -146,6 +146,7 @@ Statistical maps/derivatives
    fetch_localizer_calculation_task
    fetch_localizer_contrasts
    fetch_megatrawls_netmats
+   fetch_mixed_gambles
    fetch_oasis_vbm
    fetch_neurovault_auditory_computation_task
    fetch_neurovault_motor_task

--- a/doc/modules/reference.rst
+++ b/doc/modules/reference.rst
@@ -55,6 +55,9 @@ the :ref:`user guide <user_guide>` for more information and usage examples.
 
 **User guide:** See the :ref:`datasets` section for further details.
 
+Templates
+---------
+
 **Functions**:
 
 .. currentmodule:: nilearn.datasets
@@ -63,59 +66,107 @@ the :ref:`user guide <user_guide>` for more information and usage examples.
    :toctree: generated/
    :template: function.rst
 
+   fetch_icbm152_2009
+   fetch_icbm152_brain_gm_mask
+   fetch_surf_fsaverage
+   load_mni152_brain_mask
+   load_mni152_gm_mask
+   load_mni152_gm_template
+   load_mni152_template
+   load_mni152_wm_mask
+   load_mni152_wm_template
+
+Atlases
+-------
+
+**Functions**:
+
+.. currentmodule:: nilearn.datasets
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+
+   fetch_atlas_aal
+   fetch_atlas_allen_2011
+   fetch_atlas_basc_multiscale_2015
    fetch_atlas_craddock_2012
    fetch_atlas_destrieux_2009
+   fetch_atlas_difumo
    fetch_atlas_harvard_oxford
    fetch_atlas_juelich
    fetch_atlas_msdl
-   fetch_atlas_difumo
-   fetch_coords_power_2011
-   fetch_coords_seitzman_2018
-   fetch_atlas_smith_2009
-   fetch_atlas_yeo_2011
-   fetch_atlas_aal
-   fetch_atlas_basc_multiscale_2015
-   fetch_atlas_allen_2011
    fetch_atlas_pauli_2017
-   fetch_coords_dosenbach_2010
-   fetch_abide_pcp
-   fetch_adhd
-   fetch_development_fmri
-   fetch_haxby
-   fetch_icbm152_2009
-   fetch_icbm152_brain_gm_mask
-   fetch_localizer_button_task
-   fetch_localizer_contrasts
-   fetch_localizer_calculation_task
-   fetch_miyawaki2008
-   fetch_surf_nki_enhanced
-   fetch_surf_fsaverage
+   fetch_atlas_schaefer_2018
+   fetch_atlas_smith_2009
    fetch_atlas_surf_destrieux
    fetch_atlas_talairach
-   fetch_atlas_schaefer_2018
-   fetch_oasis_vbm
-   fetch_megatrawls_netmats
-   fetch_neurovault
-   fetch_neurovault_ids
-   fetch_neurovault_auditory_computation_task
-   fetch_neurovault_motor_task
-   get_data_dirs
-   load_mni152_template
-   load_mni152_gm_template
-   load_mni152_wm_template
-   load_mni152_brain_mask
-   load_mni152_gm_mask
-   load_mni152_wm_mask
-   fetch_language_localizer_demo_dataset
+   fetch_atlas_yeo_2011
+   fetch_coords_dosenbach_2010
+   fetch_coords_power_2011
+   fetch_coords_seitzman_2018
+
+Preprocessed datasets
+---------------------
+
+**Functions**:
+
+.. currentmodule:: nilearn.datasets
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+
+   fetch_abide_pcp
+   fetch_adhd
    fetch_bids_langloc_dataset
-   fetch_openneuro_dataset_index
-   select_from_index
-   patch_openneuro_dataset
-   fetch_openneuro_dataset
+   fetch_development_fmri
+   fetch_fiac_first_level
+   fetch_haxby
+   fetch_language_localizer_demo_dataset
    fetch_localizer_first_level
+   fetch_miyawaki2008
    fetch_spm_auditory
    fetch_spm_multimodal_fmri
-   fetch_fiac_first_level
+   fetch_surf_nki_enhanced
+
+Statistical maps/derivatives
+----------------------------
+
+**Functions**:
+
+.. currentmodule:: nilearn.datasets
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+
+   fetch_localizer_button_task
+   fetch_localizer_calculation_task
+   fetch_localizer_contrasts
+   fetch_megatrawls_netmats
+   fetch_oasis_vbm
+   fetch_neurovault_auditory_computation_task
+   fetch_neurovault_motor_task
+
+General functions
+-----------------
+
+**Functions**:
+
+.. currentmodule:: nilearn.datasets
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+
+   fetch_neurovault
+   fetch_neurovault_ids
+   fetch_openneuro_dataset
+   fetch_openneuro_dataset_index
+   get_data_dirs
+   patch_openneuro_dataset
+   select_from_index
 
 .. _decoding_ref:
 


### PR DESCRIPTION
Closes #3198.

~~I'm not sure if this merits a whatsnew entry.~~ Perhaps with the addition of `fetch_mixed_gambles` it does.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add subheadings for different dataset function types to the reference page.
- Organize dataset functions into the appropriate sections, then sort alphabetically within each section.
- Add `fetch_mixed_gambles` to reference page. It was missing.
- Add whatsnew entry.