### PR TITLE
Fix carpet_plot's cmap argument

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -31,3 +31,4 @@ Changes
 -------
 
 - Requirements files have been consolidated into a ``setup.cfg`` file and installation instructions have been simplified (:gh:`2953` by `Taylor Salo`_).
+- Function :func:`~plotting.plot_carpet` argument ``cmap`` now respects behaviour specified by docs and changes the color of the carpet_plot. Changing the label colors is now delegated to a new variable ``cmap_labels`` (:gh:`3209` by `Daniel Gomez`_).

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -1309,7 +1309,7 @@ def plot_markers(node_values, node_coords, node_size='auto',
 def plot_carpet(img, mask_img=None, mask_labels=None, t_r=None,
                 detrend=True, output_file=None,
                 figure=None, axes=None, vmin=None, vmax=None, title=None,
-                cmap=plt.cm.gist_ncar):
+                cmap="gray", cmap_labels=plt.cm.gist_ncar):
     """Plot an image representation of voxel intensities across time.
 
     This figure is also known as a "grayplot" or "Power plot".
@@ -1351,8 +1351,12 @@ def plot_carpet(img, mask_img=None, mask_labels=None, t_r=None,
     %(title)s
     %(cmap)s
 
-        .. note::
-            This argument is used only if an atlas is used.
+        Default=`gray`.
+
+    cmap_labels : :class:`matplotlib.colors.Colormap`, or :obj:`str`,
+        optional If ``mask_img`` corresponds to an atlas, then cmap_labels
+        can be used to define the colormap for coloring the labels placed
+        on the side of the carpet plot.
 
         Default=`plt.cm.gist_ncar`.
 
@@ -1463,7 +1467,7 @@ def plot_carpet(img, mask_img=None, mask_labels=None, t_r=None,
             atlas_values[:, np.newaxis],
             interpolation='none',
             aspect='auto',
-            cmap=cmap
+            cmap=cmap_labels
         )
         if mask_labels:
             # Add labels to middle of each associated band
@@ -1485,7 +1489,7 @@ def plot_carpet(img, mask_img=None, mask_labels=None, t_r=None,
             data.T,
             interpolation='nearest',
             aspect='auto',
-            cmap='gray',
+            cmap=cmap,
             vmin=vmin or default_vmin,
             vmax=vmax or default_vmax,
         )
@@ -1495,7 +1499,7 @@ def plot_carpet(img, mask_img=None, mask_labels=None, t_r=None,
             data.T,
             interpolation='nearest',
             aspect='auto',
-            cmap='gray',
+            cmap=cmap,
             vmin=vmin or default_vmin,
             vmax=vmax or default_vmax,
         )


### PR DESCRIPTION
The cmap argument was out of sync with the docs, and with the behaviour expected
from matplotlib, which is to map color to the data being plotted. Cmap now works
as expected, and a new variable `cmap_labels` was introduced to change the color
of labels.

Closes #3205 