### PR TITLE
[DOC] Fix docstring of `fetch_mixed_gambles` and broken ref in `latest.rst`

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -26,7 +26,7 @@ Enhancements
   to demonstrate how to implement common beta series models with nilearn (:gh:`3127` by `Taylor Salo`_).
 - Function :func:`~plotting.plot_carpet` now accepts a ``t_r`` parameter, which allows users to provide the TR of the image when the image's header may not be accurate. (:gh:`3165` by `Taylor Salo`_).
 - Terms :term:`Probabilistic atlas` and :term:`Deterministic atlas` were added to the glossary and references were added to atlas fetchers (:gh:`3152` by `Nicolas Gensollen`_).
-- Functions in :mod:`~datasets` have been organized by the type of data in the references page and :func:`~datasets.fetch_mixed_gambles` has been added to the documentation (:gh:`3207` by `Taylor Salo`_).
+- Functions in :mod:`nilearn.datasets` have been organized by the type of data in the references page and :func:`~datasets.fetch_mixed_gambles` has been added to the documentation (:gh:`3207` by `Taylor Salo`_).
 
 Changes
 -------

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -1114,11 +1114,13 @@ def fetch_mixed_gambles(n_subjects=1, data_dir=None, url=None, resume=True,
 
         - 'zmaps': :obj:`list` of :obj:`str`
           Paths to realigned gain betamaps (one nifti per subject).
-        - 'gain': :obj:`list` of :class:`~nibabel.nifti1.Nifti1Image` or ``None``
+        - 'gain': :obj:`list` of :class:`~nibabel.nifti1.Nifti1Image` \
+        or ``None``
           If ``make_Xy`` is ``True``, this is a list of
           ``n_subjects * 48`` :class:`~nibabel.nifti1.Nifti1Image`
           objects, else it is ``None``.
-        - 'y': :class:`~numpy.ndarray` of shape ``(n_subjects * 48,)`` or ``None``
+        - 'y': :class:`~numpy.ndarray` of shape ``(n_subjects * 48,)`` \
+        or ``None``
           If ``make_Xy`` is ``True``, then this is a
           :class:`~numpy.ndarray` of shape ``(n_subjects * 48,)``,
           else it is ``None``.

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -1092,32 +1092,36 @@ def fetch_mixed_gambles(n_subjects=1, data_dir=None, url=None, resume=True,
 
     Parameters
     ----------
-    n_subjects : int, optional
-        The number of subjects to load. If None is given, all the
+    n_subjects : :obj:`int`, optional
+        The number of subjects to load. If ``None`` is given, all the
         subjects are used. Default=1.
     %(data_dir)s
     %(url)s
     %(resume)s
     %(verbose)s
-    return_raw_data : bool, optional
-        If false, then the data will transformed into and (X, y) pair, suitable
-        for machine learning routines. X is a list of n_subjects * 48
-        Nifti1Image objects (where 48 is the number of trials),
-        and y is an array of shape (n_subjects * 48,).
+    return_raw_data : :obj:`bool`, optional
+        If ``False``, then the data will transformed into an ``(X, y)``
+        pair, suitable for machine learning routines. ``X`` is a list
+        of ``n_subjects * 48`` :class:`~nibabel.nifti1.Nifti1Image`
+        objects (where 48 is the number of trials), and ``y`` is an
+        array of shape ``(n_subjects * 48,)``.
         Default=False.
 
     Returns
     -------
-    data : Bunch
-        Dictionary-like object, the interest attributes are :
-        'zmaps': string list
-            Paths to realigned gain betamaps (one nifti per subject).
-        'gain': ..
-            If make_Xy is true, this is a list of n_subjects * 48
-            Nifti1Image objects, else it is None.
-        'y': array of shape (n_subjects * 48,) or None
-            If make_Xy is true, then this is an array of shape
-            (n_subjects * 48,), else it is None.
+    data : :func:`~sklearn.utils.Bunch`
+        Dictionary-like object, the interest attributes are:
+
+        - 'zmaps': :obj:`list` of :obj:`str`
+          Paths to realigned gain betamaps (one nifti per subject).
+        - 'gain': :obj:`list` of :class:`~nibabel.nifti1.Nifti1Image` or ``None``
+          If ``make_Xy`` is ``True``, this is a list of
+          ``n_subjects * 48`` :class:`~nibabel.nifti1.Nifti1Image`
+          objects, else it is ``None``.
+        - 'y': :class:`~numpy.ndarray` of shape ``(n_subjects * 48,)`` or ``None``
+          If ``make_Xy`` is ``True``, then this is a
+          :class:`~numpy.ndarray` of shape ``(n_subjects * 48,)``,
+          else it is ``None``.
 
     References
     ----------

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -1110,7 +1110,7 @@ def fetch_mixed_gambles(n_subjects=1, data_dir=None, url=None, resume=True,
     Returns
     -------
     data : :func:`~sklearn.utils.Bunch`
-        Dictionary-like object, the interest attributes are:
+        Dictionary-like object, the attributes of interest are:
 
         - 'zmaps': :obj:`list` of :obj:`str`
           Paths to realigned gain betamaps (one nifti per subject).


### PR DESCRIPTION
Trying to run a full build locally I had a few errors related mainly to the docstring of ``fetch_mixed_gambles`` (added to the API docs in recently merged #3207).
We didn't catch these since the CI is not running full build anymore.
This PR fixes these issues and improves the rendering of the docstring a little bit.