### PR TITLE
[DOC] Mention versionadded/versionchanged directives in contributing guidelines

### DIFF
--- a/.github/workflows/auto-comment.yml
+++ b/.github/workflows/auto-comment.yml
@@ -23,6 +23,8 @@ jobs:
 
             - [ ] PR links to Github issue with mention "Closes #XXXX"
 
+            - [ ] A new changelog entry has been added to `doc/changes/latest.rst`
+
             - [ ] Code is PEP8-compliant.
 
             - [ ] (Bug fixes) There is at least one test that would fail

--- a/.github/workflows/auto-comment.yml
+++ b/.github/workflows/auto-comment.yml
@@ -23,8 +23,6 @@ jobs:
 
             - [ ] PR links to Github issue with mention "Closes #XXXX"
 
-            - [ ] A new changelog entry has been added to `doc/changes/latest.rst`
-
             - [ ] Code is PEP8-compliant.
 
             - [ ] (Bug fixes) There is at least one test that would fail

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -190,6 +190,7 @@ with the tools we use for development and deployment.
 |                    |               | - All internal imports are absolute, not relative   |
 |                    |               | - Impacted docstrings have versionadded and/or      |
 |                    |               |   versionchanged directives as needed.              |
+|                    |               |   These should use the current dev version.         |
 +--------------------+---------------+-----------------------------------------------------+
 |                    |               | - Test type is adapted to function behavior         |
 |                    |               | - Tests pass continuous integration                 |

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -188,6 +188,7 @@ with the tools we use for development and deployment.
 |                    |               | - No new dependency                                 |
 |                    |               | - Backward compatibility                            |
 |                    |               | - All internal imports are absolute, not relative   |
+|                    |               | - version[added|changed] directives in docstring    |
 +--------------------+---------------+-----------------------------------------------------+
 |                    |               | - Test type is adapted to function behavior         |
 |                    |               | - Tests pass continuous integration                 |

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -184,11 +184,12 @@ with the tools we use for development and deployment.
 |                    |               | - Variables, functions, arguments have clear names  |
 |                    |               | - Easy to read, PEP8_ compliant                     |
 |                    |               | - Public functions have docstring (numpydoc_ format)|
-|   `Coding Style`_  |    Any        | - Low redundancy                                    |
-|                    |               | - No new dependency                                 |
+|                    |               | - Low redundancy                                    |
+|   `Coding Style`_  |    Any        | - No new dependency                                 |
 |                    |               | - Backward compatibility                            |
 |                    |               | - All internal imports are absolute, not relative   |
-|                    |               | - version[added|changed] directives in docstring    |
+|                    |               | - Impacted docstrings have versionadded and/or      |
+|                    |               |   versionchanged directives as needed.              |
 +--------------------+---------------+-----------------------------------------------------+
 |                    |               | - Test type is adapted to function behavior         |
 |                    |               | - Tests pass continuous integration                 |

--- a/doc/maintenance.rst
+++ b/doc/maintenance.rst
@@ -143,7 +143,17 @@ This section describes how to make a new release of Nilearn. It is targeted to t
 
 We assume that we are in a clean state where all the Pull Requests (PR) that we wish to include in the new release have been merged.
 
-For example, make sure all deprecations that are supposed to be removed with this new version have been addressed. Furthermore, if this new release comes with dependency version bumps (Python, Numpy...), make sure to implement and test these changes beforehand. Ideally, these would have been done before such as to update the code base if necessary. Finally, make sure the documentation can be built correctly.
+Prepare code for the release
+----------------------------
+
+The repository should be checked and updated in preparation for the release.
+
+One thing that **must** be done before the release is made is to Update all versionchanged and versionadded directives from the current ``[x.y.z].dev`` tag to the new version number.
+
+Additionally, make sure all deprecations that are supposed to be removed with this new version have been addressed.
+If this new release comes with dependency version bumps (Python, Numpy...), make sure to implement and test these changes beforehand.
+Ideally, these would have been done before such as to update the code base if necessary.
+Finally, make sure the documentation can be built correctly.
 
 Prepare the release
 -------------------

--- a/doc/maintenance.rst
+++ b/doc/maintenance.rst
@@ -148,7 +148,7 @@ Prepare code for the release
 
 The repository should be checked and updated in preparation for the release.
 
-One thing that **must** be done before the release is made is to Update all versionchanged and versionadded directives from the current ``[x.y.z].dev`` tag to the new version number.
+One thing that **must** be done before the release is made is to update all versionchanged and versionadded directives from the current ``[x.y.z].dev`` tag to the new version number.
 
 Additionally, make sure all deprecations that are supposed to be removed with this new version have been addressed.
 If this new release comes with dependency version bumps (Python, Numpy...), make sure to implement and test these changes beforehand.


### PR DESCRIPTION
Closes #1865. I don't think this needs a whatsnew entry.

Changes proposed:

- Add a bullet point about including versionadded and versionchanged directives to the contributing guidelines.