### PR TITLE
Added encoding parameter to np.genfromtxt to remove VisibleDeprecationWarning

### DIFF
--- a/nilearn/_utils/numpy_conversions.py
+++ b/nilearn/_utils/numpy_conversions.py
@@ -155,7 +155,7 @@ def csv_to_array(csv_path, delimiters=' \t,;', **kwargs):
 
     try:
         # First, we try genfromtxt which works in most cases.
-        array = np.genfromtxt(csv_path, loose=False, **kwargs)
+        array = np.genfromtxt(csv_path, loose=False, encoding=None, **kwargs)
     except ValueError:
         # There was an error during the conversion to numpy array, probably
         # because the delimiter is wrong.
@@ -167,6 +167,7 @@ def csv_to_array(csv_path, delimiters=' \t,;', **kwargs):
             raise TypeError(
                 'Could not read CSV file [%s]: %s' % (csv_path, e.args[0]))
 
-        array = np.genfromtxt(csv_path, delimiter=dialect.delimiter, **kwargs)
+        array = np.genfromtxt(csv_path, delimiter=dialect.delimiter,
+                              encoding=None, **kwargs)
 
     return array

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1359,7 +1359,7 @@ def fetch_coords_seitzman_2018(ordered_regions=True, legacy_format=True):
         i, region = r.split("=")
         region_mapping[int(i)] = region
 
-    anatomical = np.genfromtxt(anatomical_file, skip_header=1)
+    anatomical = np.genfromtxt(anatomical_file, skip_header=1, encoding=None)
     anatomical_names = np.array([region_mapping[a] for a in anatomical])
 
     rois = pd.concat([rois, pd.DataFrame(anatomical_names)], axis=1)
@@ -1910,7 +1910,8 @@ def fetch_atlas_schaefer_2018(n_rois=400, yeo_networks=7, resolution_mm=1,
     labels_file, atlas_file = _fetch_files(data_dir, files, resume=resume,
                                            verbose=verbose)
 
-    labels = np.genfromtxt(labels_file, usecols=1, dtype="S", delimiter="\t")
+    labels = np.genfromtxt(labels_file, usecols=1, dtype="S", delimiter="\t",
+                           encoding=None)
     fdescr = _get_dataset_descr(dataset_name)
 
     return Bunch(maps=atlas_file,

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -248,7 +248,7 @@ def fetch_adhd(n_subjects=30, data_dir=None, url=None, resume=True,
 
     # Load the csv file
     phenotypic = np.genfromtxt(phenotypic, names=True, delimiter=',',
-                               dtype=None)
+                               dtype=None, encoding=None)
 
     # Keep phenotypic information for selected subjects
     int_ids = np.asarray(ids, dtype=int)
@@ -1355,7 +1355,8 @@ def fetch_surf_nki_enhanced(n_subjects=10, data_dir=None,
                                names=['Subject', 'Age',
                                       'Dominant Hand', 'Sex'],
                                delimiter=',', dtype=['U9', '<f8',
-                                                     'U1', 'U1'])
+                                                     'U1', 'U1'],
+                               encoding=None)
 
     # Keep phenotypic information for selected subjects
     int_ids = np.asarray(ids)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Resolves stalled pull request #1947 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add encoding=None to np.genfromtxt to remove warning when fetching data:
`VisibleDeprecationWarning: Reading unicode strings without specifying the encoding argument is deprecated. Set the encoding, use None for the system default.
  phenotypic = np.genfromtxt(phenotypic, names=True, delimiter=',',`