### PR TITLE
Fix 3238

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -14,6 +14,7 @@ Fixes
 -----
 
 - Convert references in ``nilearn/mass_univariate/permuted_least_squares.py`` to use bibtex format (:gh:`3222` by `Yasmin Mzayek`_).
+- :func:`~plotting.plot_roi` failed before when used with the "contours" view type and passing a list of cut coordinates in display mode "x", "y" or "z"; this has been corrected (:gh:`3241` by `Jerome Dockes`_).
 
 Enhancements
 ------------

--- a/nilearn/plotting/displays/_slicers.py
+++ b/nilearn/plotting/displays/_slicers.py
@@ -1311,7 +1311,8 @@ class BaseStackedSlicer(BaseSlicer):
         if img is None or img is False:
             bounds = ((-40, 40), (-30, 30), (-30, 75))
             lower, upper = bounds['xyz'.index(cls._direction)]
-            cut_coords = np.linspace(lower, upper, cut_coords).tolist()
+            if isinstance(cut_coords, numbers.Number):
+                cut_coords = np.linspace(lower, upper, cut_coords).tolist()
         else:
             if (not isinstance(cut_coords, collections.abc.Sequence) and
                     isinstance(cut_coords, numbers.Number)):

--- a/nilearn/plotting/tests/test_img_plotting/test_plot_roi.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_plot_roi.py
@@ -26,7 +26,10 @@ def demo_plot_roi(**kwargs):
 @pytest.mark.parametrize('black_bg', [True, False])
 @pytest.mark.parametrize('threshold', [.5, .2])
 @pytest.mark.parametrize('alpha', [.7, .1])
-def test_plot_roi_view_types(view_type, black_bg, threshold, alpha):
+@pytest.mark.parametrize('display_mode,cut_coords', [("ortho", None), ("z", 3),
+                                                     ("x", [2., 10])])
+def test_plot_roi_view_types(view_type, black_bg, threshold, alpha,
+                             display_mode, cut_coords):
     """Smoke-test for plot_roi.
 
     Tests different combinations of parameters `view_type`, `black_bg`,
@@ -35,8 +38,13 @@ def test_plot_roi_view_types(view_type, black_bg, threshold, alpha):
     kwargs = dict()
     if view_type == 'contours':
         kwargs["linewidth"] = 2.
-    demo_plot_roi(view_type=view_type, black_bg=black_bg, threshold=threshold,
-                  alpha=alpha, **kwargs)
+    demo_plot_roi(view_type=view_type,
+                  black_bg=black_bg,
+                  threshold=threshold,
+                  alpha=alpha,
+                  display_mode=display_mode,
+                  cut_coords=cut_coords,
+                  **kwargs)
     plt.close()
 
 


### PR DESCRIPTION
Closes #3238 

When initializing the slicer the given cut coords can be either a list of coordinates or a number of cuts; the first case had been overlooked