### PR TITLE
[MAINT] Remove extraneous `doc` requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ doc =
 	flake8
 	kaleido
  	memory_profiler
-	mkl
 	numpydoc
 	pillow
 	plotly

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ doc =
 	%(plotly)s
 	coverage
 	flake8
- 	memory_profiler
+ 	memory_profiler  # measuring memory during docs building
 	numpydoc
 	pillow
 	sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ doc =
 	flake8
  	memory_profiler  # measuring memory during docs building
 	numpydoc
-	pillow
 	sphinx
 	sphinx-copybutton
 	sphinx-gallery

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,14 +27,13 @@ plotly =
 
 # Requirements necessary for building the documentation
 doc =
+	%(plotly)s
 	cython
 	coverage
 	flake8
-	kaleido
  	memory_profiler
 	numpydoc
 	pillow
-	plotly
 	sphinx
 	sphinx-copybutton
 	sphinx-gallery

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ plotly =
 # Requirements necessary for building the documentation
 doc =
 	%(plotly)s
-	cython
 	coverage
 	flake8
  	memory_profiler
@@ -53,7 +52,6 @@ min =
 test =
 	codecov
 	coverage
-	cython
 	pytest>=3.9
 	pytest-cov
 


### PR DESCRIPTION
Closes #3244.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Remove `mkl`, `cython`, and `pillow` from the documentation requirement group in `setup.cfg`.
- Remove `cython` from the testing requirement group.
- Reference the `plotly` requirement group in the documentation requirement group instead of duplicating the requirements.

Open questions:

- [x] Do we need `cython`?
    - Cython is mentioned in the Makefile, but only in reference to `pyx` files, and I couldn't find any of those.
- [x] Do we need `pillow`?
    - Neither `pillow` nor `PIL` appears outside `setup.cfg`.
- [x] Is `memory_profiler` necessary for building the documentation, or is it used for tests?
    - Per @NicolasGensollen, it's used to profile the documentation build.