### PR TITLE
[TST] Remove duplicate `permuted_ols` tests

### DIFF
--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -604,40 +604,6 @@ def test_permuted_ols_intercept_nocovar_multivariate(random_state=0):
     assert_array_almost_equal(ref_scores, own_scores_intercept, decimal=6)
 
 
-def test_permuted_ols_intercept_withcovar_multivariate(random_state=0):
-    rng = check_random_state(random_state)
-
-    # design parameters
-    n_samples = 50
-    n_descriptors = 10
-    n_regressors = 1
-    n_covars = 2
-
-    # create design
-    target_vars = rng.randn(n_samples, n_descriptors)
-    tested_var = np.ones((n_samples, n_regressors))
-    confounding_vars = rng.randn(n_samples, n_covars)
-
-    # compute t-scores with linalg or statsmodels
-    ref_scores = get_tvalue_with_alternative_library(tested_var, target_vars,
-                                                     confounding_vars)
-    assert ref_scores.shape == (n_regressors, n_descriptors)
-
-    # permuted OLS
-    _, own_scores, _ = permuted_ols(
-        tested_var, target_vars, confounding_vars, n_perm=0,
-        random_state=random_state)
-    assert own_scores.shape == (n_regressors, n_descriptors)
-    assert_almost_equal(ref_scores, own_scores, decimal=6)
-
-    # same thing but with model_intercept=True to check it has no effect
-    _, own_scores_intercept, _ = permuted_ols(
-        tested_var, target_vars, confounding_vars, model_intercept=True,
-        n_perm=0, random_state=random_state)
-    assert own_scores_intercept.shape == (n_regressors, n_descriptors)
-    assert_array_almost_equal(own_scores, own_scores_intercept, decimal=6)
-
-
 ### Test one-sided versus two-sided ###########################################
 def test_sided_test(random_state=0):
     """Check that a positive effect is always better recovered with one-sided.

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -573,37 +573,6 @@ def test_permuted_ols_intercept_statsmodels_withcovar(random_state=0):
     assert_array_almost_equal(ref_scores, own_scores_intercept, decimal=6)
 
 
-def test_permuted_ols_intercept_nocovar_multivariate(random_state=0):
-    rng = check_random_state(random_state)
-
-    # design parameters
-    n_samples = 50
-    n_descriptors = 10
-    n_regressors = 1
-
-    # create design
-    target_vars = rng.randn(n_samples, n_descriptors)
-    tested_vars = np.ones((n_samples, n_regressors))
-
-    # compute t-scores with nilearn routine
-    ref_scores = get_tvalue_with_alternative_library(tested_vars, target_vars)
-    assert ref_scores.shape == (n_regressors, n_descriptors)
-
-    # permuted OLS
-    _, own_scores, _ = permuted_ols(
-        tested_vars, target_vars, confounding_vars=None, n_perm=0,
-        random_state=random_state)
-    assert own_scores.shape == (n_regressors, n_descriptors)
-    assert_array_almost_equal(ref_scores, own_scores, decimal=6)
-
-    # same thing but with model_intercept=True to check it has no effect
-    _, own_scores_intercept, _ = permuted_ols(
-        tested_vars, target_vars, confounding_vars=None, model_intercept=True,
-        n_perm=0, random_state=random_state)
-    assert own_scores_intercept.shape == (n_regressors, n_descriptors)
-    assert_array_almost_equal(ref_scores, own_scores_intercept, decimal=6)
-
-
 ### Test one-sided versus two-sided ###########################################
 def test_sided_test(random_state=0):
     """Check that a positive effect is always better recovered with one-sided.

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -7,7 +7,7 @@ import numpy as np
 from scipy import stats
 from sklearn.utils import check_random_state
 
-from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
+from numpy.testing import (assert_array_almost_equal,
                            assert_array_less, assert_equal)
 import pytest
 

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -458,53 +458,6 @@ def test_permuted_ols_nocovar_multivariate(random_state=0):
                               decimal=6)
 
 
-def test_permuted_ols_withcovar_multivariate(random_state=0):
-    """Test permuted_ols with multiple tested variates and covariates.
-
-    It is equivalent to fitting several models with only one tested variate.
-
-    """
-    rng = check_random_state(random_state)
-
-    # design parameters
-    n_samples = 50
-    n_descriptors = 10
-    n_regressors = 1
-    n_covars = 2
-
-    # create design
-    target_vars = rng.randn(n_samples, n_descriptors)
-    tested_var = rng.randn(n_samples, n_regressors)
-    confounding_vars = rng.randn(n_samples, n_covars)
-
-    # compute t-scores with linalg or statmodels
-    ref_scores = get_tvalue_with_alternative_library(tested_var, target_vars,
-                                                     confounding_vars)
-    assert ref_scores.shape == (n_regressors, n_descriptors)
-
-    # permuted OLS
-    _, own_scores, _ = permuted_ols(
-        tested_var, target_vars, confounding_vars, model_intercept=False,
-        n_perm=0, random_state=random_state)
-    assert own_scores.shape == (n_regressors, n_descriptors)
-    assert_almost_equal(ref_scores, own_scores, decimal=6)
-
-    ### Adds intercept
-    # permuted OLS
-    _, own_scores_intercept, _ = permuted_ols(
-        tested_var, target_vars, confounding_vars, model_intercept=True,
-        n_perm=0, random_state=random_state)
-    assert own_scores_intercept.shape == (n_regressors, n_descriptors)
-
-    # compute t-scores with linalg or statmodels
-    confounding_vars = np.hstack((confounding_vars, np.ones((n_samples, 1))))
-    ref_scores_intercept = get_tvalue_with_alternative_library(
-        tested_var, target_vars, confounding_vars)
-    assert ref_scores_intercept.shape == (n_regressors, n_descriptors)
-    assert_array_almost_equal(ref_scores_intercept,
-                              own_scores_intercept, decimal=6)
-
-
 ### Tests for sign swapping permutation scheme ##############################
 def test_permuted_ols_intercept_nocovar(random_state=0):
     rng = check_random_state(random_state)


### PR DESCRIPTION
Closes #3246.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Remove the following duplicate tests, which do not test multiple regressors:
    - test_permuted_ols_intercept_withcovar_multivariate
    - test_permuted_ols_intercept_nocovar_multivariate
    - test_permuted_ols_withcovar_multivariate
