### PR TITLE
[MAINT] Fix `scipy.ndimage` deprecations

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -315,8 +315,8 @@ Basic numerics
 
  ::
 
-    >>> from scipy import ndimage
-    >>> t_smooth = ndimage.gaussian_filter(t, sigma=2)
+    >>> from scipy.ndimage import gaussian_filter
+    >>> t_smooth = gaussian_filter(t, sigma=2)
 
  `More documentation ...
  <http://scipy-lectures.github.io/advanced/image_processing/index.html>`__

--- a/examples/02_decoding/plot_simulated_data.py
+++ b/examples/02_decoding/plot_simulated_data.py
@@ -36,7 +36,8 @@ from time import time
 
 import numpy as np
 import matplotlib.pyplot as plt
-from scipy import linalg, ndimage
+from scipy import linalg
+from scipy.ndimage import gaussian_filter
 
 from sklearn import linear_model, svm
 from sklearn.utils import check_random_state
@@ -73,7 +74,7 @@ def create_simulation_data(snr=0, n_samples=2 * 100, size=12, random_state=1):
     XX = generator.randn(n_samples, size, size, size)
     noise = []
     for i in range(n_samples):
-        Xi = ndimage.filters.gaussian_filter(XX[i, :, :, :], smooth_X)
+        Xi = gaussian_filter(XX[i, :, :, :], smooth_X)
         Xi = Xi.ravel()
         noise.append(Xi)
     noise = np.array(noise)

--- a/examples/06_manipulating_images/plot_roi_extraction.py
+++ b/examples/06_manipulating_images/plot_roi_extraction.py
@@ -247,10 +247,10 @@ plot_roi(bin_p_values_and_vt_img, mean_img, cut_coords=cut_coords,
 # such operations can fill "holes" in masked voxel representations.
 
 # We use ndimage function from scipy Python library for mask dilation
-from scipy import ndimage
+from scipy.ndimage import binary_dilation
 
 # Input here is a binarized and intersected mask data from previous section
-dil_bin_p_values_and_vt = ndimage.binary_dilation(bin_p_values_and_vt)
+dil_bin_p_values_and_vt = binary_dilation(bin_p_values_and_vt)
 
 # Now, we visualize the same using `plot_roi` with data being converted to Nifti
 # image. In all new image like, reference image is the same but second argument
@@ -273,7 +273,8 @@ plot_roi(dil_bin_p_values_and_vt_img, mean_img,
 # :func:`scipy.ndimage.label` from the scipy Python library identifies
 # immediately neighboring voxels in our voxels mask. It assigns a separate
 # integer label to each one of them.
-labels, n_labels = ndimage.label(dil_bin_p_values_and_vt)
+from scipy.ndimage import label
+labels, n_labels = label(dil_bin_p_values_and_vt)
 # we take first roi data with labels assigned as integer 1
 first_roi_data = (labels == 5).astype(int)
 # Similarly, second roi data is assigned as integer 2

--- a/nilearn/_utils/data_gen.py
+++ b/nilearn/_utils/data_gen.py
@@ -8,7 +8,7 @@ import string
 import numpy as np
 import pandas as pd
 import scipy.signal
-from scipy import ndimage
+from scipy.ndimage import binary_dilation
 
 from sklearn.utils import check_random_state
 import scipy.linalg
@@ -31,7 +31,7 @@ def generate_mni_space_img(n_scans=1, res=30, random_state=0, mask_dilation=2):
     data = rng.randn(n_scans, n_voxels)
     if mask_dilation is not None and mask_dilation > 0:
         mask_img = image.new_img_like(
-            mask_img, ndimage.binary_dilation(
+            mask_img, binary_dilation(
                 image.get_data(mask_img), iterations=mask_dilation))
     return masker.inverse_transform(data), mask_img
 

--- a/nilearn/_utils/ndimage.py
+++ b/nilearn/_utils/ndimage.py
@@ -5,7 +5,7 @@ N-dimensional image manipulation
 # License: simplified BSD
 
 import numpy as np
-from scipy import ndimage
+from scipy.ndimage import label, maximum_filter
 ###############################################################################
 # Operating on connected components
 ###############################################################################
@@ -48,7 +48,7 @@ def largest_connected_component(volume):
 
     # We use asarray to be able to work with masked arrays.
     volume = np.asarray(volume)
-    labels, label_nb = ndimage.label(volume)
+    labels, label_nb = label(volume)
     if not label_nb:
         raise ValueError('No non-zero values: no connected components')
     if label_nb == 1:
@@ -131,7 +131,7 @@ def _peak_local_max(image, min_distance=10, threshold_abs=0, threshold_rel=0.1,
     image = image.copy()
 
     size = 2 * min_distance + 1
-    image_max = ndimage.maximum_filter(image, size=size, mode='constant')
+    image_max = maximum_filter(image, size=size, mode='constant')
 
     mask = (image == image_max)
     image *= mask

--- a/nilearn/datasets/struct.py
+++ b/nilearn/datasets/struct.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-from scipy import ndimage
+from scipy.ndimage import binary_closing
 from sklearn.utils import Bunch
 
 from .utils import (_get_dataset_dir, _fetch_files, _get_dataset_descr)
@@ -440,7 +440,7 @@ def load_mni152_gm_mask(resolution=None, threshold=0.2, n_iter=2):
 
     gm_target_mask = (gm_target_data > threshold).astype("int8")
 
-    gm_target_mask = ndimage.binary_closing(gm_target_mask, iterations=n_iter)
+    gm_target_mask = binary_closing(gm_target_mask, iterations=n_iter)
     gm_mask_img = new_img_like(gm_target_img, gm_target_mask)
 
     return gm_mask_img
@@ -498,7 +498,7 @@ def load_mni152_wm_mask(resolution=None, threshold=0.2, n_iter=2):
 
     wm_target_mask = (wm_target_data > threshold).astype("int8")
 
-    wm_target_mask = ndimage.binary_closing(wm_target_mask, iterations=n_iter)
+    wm_target_mask = binary_closing(wm_target_mask, iterations=n_iter)
     wm_mask_img = new_img_like(wm_target_img, wm_target_mask)
 
     return wm_mask_img
@@ -563,7 +563,7 @@ def fetch_icbm152_brain_gm_mask(data_dir=None, threshold=0.2, resume=True,
     # getting one fifth of the values
     gm_mask = (gm_data > threshold).astype("int8")
 
-    gm_mask = ndimage.binary_closing(gm_mask, iterations=n_iter)
+    gm_mask = binary_closing(gm_mask, iterations=n_iter)
     gm_mask_img = new_img_like(gm_img, gm_mask)
 
     return gm_mask_img

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -17,7 +17,12 @@ import time
 import sys
 from functools import partial
 import numpy as np
-from scipy import stats, ndimage
+from scipy import stats
+from scipy.ndimage import (
+    gaussian_filter,
+    binary_dilation,
+    binary_erosion,
+)
 from sklearn.utils.extmath import safe_sparse_dot
 from sklearn.utils import check_array
 from sklearn.linear_model import LinearRegression
@@ -105,7 +110,7 @@ def _univariate_feature_screening(
     if smoothing_fwhm > 0.:
         sX = np.empty(X.shape)
         for sample in range(sX.shape[0]):
-            sX[sample] = ndimage.gaussian_filter(
+            sX[sample] = gaussian_filter(
                 _unmask_from_to_3d_array(X[sample].copy(),  # avoid modifying X
                                          mask), (smoothing_fwhm, smoothing_fwhm,
                                                  smoothing_fwhm))[mask]
@@ -121,7 +126,7 @@ def _univariate_feature_screening(
     # the mask on which a spatial prior actually makes sense
     mask_ = mask.copy()
     mask_[mask] = (support > 0)
-    mask_ = ndimage.binary_dilation(ndimage.binary_erosion(
+    mask_ = binary_dilation(binary_erosion(
         mask_)).astype(bool)
     mask_[np.logical_not(mask)] = 0
     support = mask_[mask]

--- a/nilearn/decoding/tests/simulate_graph_net_data.py
+++ b/nilearn/decoding/tests/simulate_graph_net_data.py
@@ -3,7 +3,8 @@ Simple code to simulate data
 """
 
 import numpy as np
-from scipy import linalg, ndimage
+from scipy import linalg
+from scipy.ndimage import gaussian_filter
 from sklearn.utils import check_random_state
 
 
@@ -22,14 +23,14 @@ def create_graph_net_simulation_data(
                  generator.randint(0, size))
         w[point] = 1.0
     mask = np.ones((size, size, size), dtype=bool)
-    w = ndimage.gaussian_filter(w, sigma=1)
+    w = gaussian_filter(w, sigma=1)
     w = w[mask]
 
     # Generate smooth background noise
     XX = generator.randn(n_samples, size, size, size)
     noise = []
     for i in range(n_samples):
-        Xi = ndimage.filters.gaussian_filter(XX[i, :, :, :], smooth_X)
+        Xi = gaussian_filter(XX[i, :, :, :], smooth_X)
         Xi = Xi[mask]
         noise.append(Xi)
     noise = np.array(noise)

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -7,7 +7,7 @@ import warnings
 import numbers
 
 import numpy as np
-from scipy import ndimage
+from scipy.ndimage import binary_dilation, binary_erosion
 from joblib import Parallel, delayed
 
 from sklearn.utils import deprecated
@@ -78,7 +78,7 @@ def _extrapolate_out_mask(data, mask, iterations=1):
     if iterations > 1:
         data, mask = _extrapolate_out_mask(data, mask,
                                            iterations=iterations - 1)
-    new_mask = ndimage.binary_dilation(mask)
+    new_mask = binary_dilation(mask)
     larger_mask = np.zeros(np.array(mask.shape) + 2, dtype=bool)
     larger_mask[1:-1, 1:-1, 1:-1] = mask
     # Use nans as missing value: ugly
@@ -182,7 +182,7 @@ def _post_process_mask(mask, affine, opening=2, connected=True,
     """
     if opening:
         opening = int(opening)
-        mask = ndimage.binary_erosion(mask, iterations=opening)
+        mask = binary_erosion(mask, iterations=opening)
     mask_any = mask.any()
     if not mask_any:
         warnings.warn("Computed an empty mask. %s" % warning_msg,
@@ -190,8 +190,8 @@ def _post_process_mask(mask, affine, opening=2, connected=True,
     if connected and mask_any:
         mask = largest_connected_component(mask)
     if opening:
-        mask = ndimage.binary_dilation(mask, iterations=2 * opening)
-        mask = ndimage.binary_erosion(mask, iterations=opening)
+        mask = binary_dilation(mask, iterations=2 * opening)
+        mask = binary_erosion(mask, iterations=opening)
     return mask, affine
 
 

--- a/nilearn/mass_univariate/_utils.py
+++ b/nilearn/mass_univariate/_utils.py
@@ -1,6 +1,7 @@
 """Utility functions for the permuted_least_squares module."""
 import numpy as np
-from scipy import ndimage, linalg
+from scipy import linalg
+from scipy.ndimage import label
 
 
 def _null_to_p(test_values, null_array, alternative='two-sided'):
@@ -117,12 +118,12 @@ def _calculate_cluster_measures(
         else:
             arr3d[arr3d <= threshold] = 0
 
-        labeled_arr3d, _ = ndimage.measurements.label(arr3d > 0, bin_struct)
+        labeled_arr3d, _ = label(arr3d > 0, bin_struct)
 
         if two_sided_test:
             # Label positive and negative clusters separately
             n_positive_clusters = np.max(labeled_arr3d)
-            temp_labeled_arr3d, _ = ndimage.measurements.label(
+            temp_labeled_arr3d, _ = label(
                 arr3d < 0,
                 bin_struct,
             )

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -11,7 +11,8 @@ import joblib
 import nibabel as nib
 import numpy as np
 from nilearn.masking import apply_mask
-from scipy import ndimage, stats
+from scipy import stats
+from scipy.ndimage import generate_binary_structure, label
 from sklearn.utils import check_random_state
 
 from nilearn.mass_univariate._utils import (
@@ -139,7 +140,7 @@ def _permuted_ols_on_chunk(
     if threshold is not None:
         h0_csfwe_part = np.empty((n_regressors, n_perm_chunk))
         h0_cmfwe_part = np.empty((n_regressors, n_perm_chunk))
-        bin_struct = ndimage.generate_binary_structure(3, 1)
+        bin_struct = generate_binary_structure(3, 1)
     else:
         h0_csfwe_part, h0_cmfwe_part = None, None
 
@@ -702,13 +703,13 @@ def permuted_ols(
         scores_original_data_4d = masker.inverse_transform(
             scores_original_data.T
         ).get_fdata()
-        bin_struct = ndimage.generate_binary_structure(3, 1)
+        bin_struct = generate_binary_structure(3, 1)
 
         for i_regressor in range(n_regressors):
             scores_original_data_3d = scores_original_data_4d[..., i_regressor]
 
             # Label the clusters for both cluster mass and size inference
-            labeled_arr3d, _ = ndimage.measurements.label(
+            labeled_arr3d, _ = label(
                 scores_original_data_3d > threshold_t,
                 bin_struct,
             )
@@ -716,7 +717,7 @@ def permuted_ols(
             if two_sided_test:
                 # Label positive and negative clusters separately
                 n_positive_clusters = np.max(labeled_arr3d)
-                temp_labeled_arr3d, _ = ndimage.measurements.label(
+                temp_labeled_arr3d, _ = label(
                     scores_original_data_3d < -threshold_t,
                     bin_struct,
                 )

--- a/nilearn/mass_univariate/tests/test__utils.py
+++ b/nilearn/mass_univariate/tests/test__utils.py
@@ -4,8 +4,8 @@ import math
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal
-from scipy import ndimage
 from sklearn.utils import check_random_state
+from scipy.ndimage import generate_binary_structure
 
 from nilearn.mass_univariate import _utils
 from nilearn.mass_univariate.tests.utils import (
@@ -85,7 +85,7 @@ def test_null_to_p_array():
 def test_calculate_cluster_measures():
     """Test _calculate_cluster_measures."""
     threshold = 0.001
-    bin_struct = ndimage.generate_binary_structure(3, 1)
+    bin_struct = generate_binary_structure(3, 1)
 
     test_arr4d = np.zeros((10, 10, 10, 1))
     test_arr4d[:2, :2, :2, 0] = 5  # 8-voxel cluster, high intensity
@@ -120,7 +120,7 @@ def test_calculate_cluster_measures():
     assert test_mass[0] == true_mass
 
     # Two-sided test with edge connectivity
-    bin_struct = ndimage.generate_binary_structure(3, 2)
+    bin_struct = generate_binary_structure(3, 2)
 
     true_size = 28  # should include edge-connected single voxel cluster
     true_mass = 79.992  # (8 vox * 5 intensity) - (8 vox * 0.001 thresh)
@@ -134,7 +134,7 @@ def test_calculate_cluster_measures():
     assert test_mass[0] == true_mass
 
     # Two-sided test with corner connectivity
-    bin_struct = ndimage.generate_binary_structure(3, 3)
+    bin_struct = generate_binary_structure(3, 3)
 
     true_size = 29  # should include corner-connected single voxel cluster
     true_mass = 79.992  # (8 vox * 5 intensity) - (8 vox * 0.001 thresh)

--- a/nilearn/plotting/edge_detect.py
+++ b/nilearn/plotting/edge_detect.py
@@ -3,8 +3,13 @@ Edge detection routines: this file provides a Canny filter
 """
 
 import numpy as np
-from scipy import ndimage, signal
-
+from scipy import signal
+from scipy.ndimage import (
+    sobel,
+    maximum_filter,
+    binary_dilation,
+    distance_transform_cdt,
+)
 from .._utils.extmath import fast_abs_percentile
 
 # Author: Gael Varoquaux
@@ -74,8 +79,8 @@ def _edge_detect(image, high_threshold=.75, low_threshold=.4):
     # Where the noise variance is 0, Wiener can create nans
     img[np.isnan(img)] = image[np.isnan(img)]
     img /= img.max()
-    grad_x = ndimage.sobel(img, mode='constant', axis=0)
-    grad_y = ndimage.sobel(img, mode='constant', axis=1)
+    grad_x = sobel(img, mode='constant', axis=0)
+    grad_y = sobel(img, mode='constant', axis=1)
     grad_mag = np.sqrt(grad_x ** 2 + grad_y ** 2)
     grad_angle = np.arctan2(grad_y, grad_x)
     # Scale the angles in the range [0, 2]
@@ -85,7 +90,7 @@ def _edge_detect(image, high_threshold=.75, low_threshold=.4):
     thinner = np.zeros(grad_mag.shape, dtype=bool)
     for angle in np.arange(0, 2, .25):
         thinner = thinner | (
-                (grad_mag > .85 * ndimage.maximum_filter(
+                (grad_mag > .85 * maximum_filter(
                     grad_mag, footprint=_orientation_kernel(angle)))
                 & (((grad_angle - angle) % 2) < .75)
                 )
@@ -103,8 +108,9 @@ def _edge_detect(image, high_threshold=.75, low_threshold=.4):
                                               100 * high_threshold)
     low = thinned_grad > fast_abs_percentile(grad_values,
                                              100 * low_threshold)
-    edge_mask = ndimage.binary_dilation(
-        high, structure=np.ones((3, 3)), iterations=-1, mask=low)
+    edge_mask = binary_dilation(
+        high, structure=np.ones((3, 3)), iterations=-1, mask=low
+    )
     return grad_mag, edge_mask
 
 
@@ -126,7 +132,7 @@ def _edge_map(image):
     """
     edge_mask = _edge_detect(image)[-1]
     edge_mask = edge_mask.astype(float)
-    edge_mask = -np.sqrt(ndimage.distance_transform_cdt(edge_mask))
+    edge_mask = -np.sqrt(distance_transform_cdt(edge_mask))
     edge_mask[edge_mask != 0] -= -.05 + edge_mask.min()
     edge_mask = np.ma.masked_less(edge_mask, .01)
     return edge_mask

--- a/nilearn/plotting/edge_detect.py
+++ b/nilearn/plotting/edge_detect.py
@@ -89,11 +89,13 @@ def _edge_detect(image, high_threshold=.75, low_threshold=.4):
     # greater than its neighbors normal to the edge direction.
     thinner = np.zeros(grad_mag.shape, dtype=bool)
     for angle in np.arange(0, 2, .25):
-        thinner = thinner | (
+        thinner = (
+            thinner | (
                 (grad_mag > .85 * maximum_filter(
-                    grad_mag, footprint=_orientation_kernel(angle)))
-                & (((grad_angle - angle) % 2) < .75)
-                )
+                    grad_mag, footprint=_orientation_kernel(angle)
+                )) & (((grad_angle - angle) % 2) < .75)
+            )
+        )
     # Remove the edges next to the side of the image: they are not reliable
     thinner[0]     = 0
     thinner[-1]    = 0

--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -8,8 +8,11 @@ Tools to find activations and cut on maps
 import warnings
 import numbers
 import numpy as np
-from scipy import ndimage
-
+from scipy.ndimage import (
+    center_of_mass,
+    find_objects,
+    label,
+)
 # Local imports
 from ..image import new_img_like, reorder_img, iter_img
 from ..image.resampling import get_mask_bounds, coord_transform
@@ -104,11 +107,11 @@ def find_xyz_cut_coords(img, mask_img=None, activation_threshold=None):
                 "Could not determine cut coords: "
                 "Provided mask is empty. "
                 "Returning center of mass instead.")
-            cut_coords = ndimage.center_of_mass(np.abs(my_map)) + offset
+            cut_coords = center_of_mass(np.abs(my_map)) + offset
             x_map, y_map, z_map = cut_coords
             return np.asarray(coord_transform(x_map, y_map, z_map,
                                               img.affine)).tolist()
-        slice_x, slice_y, slice_z = ndimage.find_objects(mask)[0]
+        slice_x, slice_y, slice_z = find_objects(mask)[0]
         my_map = my_map[slice_x, slice_y, slice_z]
         mask = mask[slice_x, slice_y, slice_z]
         my_map *= mask
@@ -121,7 +124,7 @@ def find_xyz_cut_coords(img, mask_img=None, activation_threshold=None):
             "Returning center of mass of unmasked data instead.")
         # Call center of mass on initial data since my_map is zero.
         # Therefore, do not add offset to cut_coords.
-        cut_coords = ndimage.center_of_mass(np.abs(data))
+        cut_coords = center_of_mass(np.abs(data))
         x_map, y_map, z_map = cut_coords
         return np.asarray(coord_transform(x_map, y_map, z_map,
                                           img.affine)).tolist()
@@ -141,13 +144,13 @@ def find_xyz_cut_coords(img, mask_img=None, activation_threshold=None):
             "Could not determine cut coords: "
             "All voxels were masked by the thresholding. "
             "Returning the center of mass instead.")
-        cut_coords = ndimage.center_of_mass(np.abs(my_map)) + offset
+        cut_coords = center_of_mass(np.abs(my_map)) + offset
         x_map, y_map, z_map = cut_coords
         return np.asarray(coord_transform(x_map, y_map, z_map,
                                           img.affine)).tolist()
 
     mask = largest_connected_component(mask)
-    slice_x, slice_y, slice_z = ndimage.find_objects(mask)[0]
+    slice_x, slice_y, slice_z = find_objects(mask)[0]
     my_map = my_map[slice_x, slice_y, slice_z]
     mask = mask[slice_x, slice_y, slice_z]
     my_map *= mask
@@ -159,7 +162,7 @@ def find_xyz_cut_coords(img, mask_img=None, activation_threshold=None):
     second_mask = (np.abs(my_map) > second_threshold)
     if second_mask.sum() > 50:
         my_map *= largest_connected_component(second_mask)
-    cut_coords = ndimage.center_of_mass(np.abs(my_map))
+    cut_coords = center_of_mass(np.abs(my_map))
     x_map, y_map, z_map = cut_coords + offset
 
     # Return as a list of scalars
@@ -452,13 +455,13 @@ def find_parcellation_cut_coords(labels_img, background_label=0, return_label_na
                 cur_img = right_hemi.astype(int)
 
         # Take the largest connected component
-        labels, label_nb = ndimage.label(cur_img)
+        labels, label_nb = label(cur_img)
         label_count = np.bincount(labels.ravel().astype(int))
         label_count[0] = 0
         component = labels == label_count.argmax()
 
         # Get parcellation center of mass
-        x, y, z = ndimage.center_of_mass(component)
+        x, y, z = center_of_mass(component)
 
         # Dump label region and coordinates into a dictionary
         label_list.append(cur_label)

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -19,7 +19,7 @@ from nilearn.version import _compare_version
 # Standard scientific libraries imports (more specific imports are
 # delayed, so that the part module can be used without them).
 import numpy as np
-from scipy import ndimage
+from scipy.ndimage import binary_fill_holes
 from scipy import stats
 from nibabel.spatialimages import SpatialImage
 
@@ -301,8 +301,7 @@ class _MNI152Template(SpatialImage):
             anat_img = reorder_img(anat_img)
             data = get_data(anat_img)
             data = data.astype(np.float64)
-            anat_mask = ndimage.morphology.binary_fill_holes(
-                data > np.finfo(float).eps)
+            anat_mask = binary_fill_holes(data > np.finfo(float).eps)
             data = np.ma.masked_array(data, np.logical_not(anat_mask))
             self._affine = anat_img.affine
             self.data = data

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -6,7 +6,7 @@ import numbers
 import collections.abc
 import numpy as np
 
-from scipy import ndimage
+from scipy.ndimage import label
 from scipy.stats import scoreatpercentile
 
 from joblib import Memory
@@ -214,7 +214,7 @@ def connected_regions(maps_img, min_region_size=1350,
         if extract_type == 'local_regions':
             smooth_map = _smooth_array(map_3d, affine=affine, fwhm=smoothing_fwhm)
             seeds = _peak_local_max(smooth_map)
-            seeds_label, seeds_id = ndimage.label(seeds)
+            seeds_label, seeds_id = label(seeds)
             # Assign -1 to values which are 0. to indicate to ignore
             seeds_label[map_3d == 0.] = -1
             rw_maps = _random_walker(map_3d, seeds_label)
@@ -223,7 +223,7 @@ def connected_regions(maps_img, min_region_size=1350,
             label_maps = rw_maps
         else:
             # Connected component extraction
-            label_maps, n_labels = ndimage.label(map_3d)
+            label_maps, n_labels = label(map_3d)
 
         # Takes the size of each labelized region data
         labels_size = np.bincount(label_maps.ravel())
@@ -525,10 +525,11 @@ def connected_label_regions(labels_img, min_size=None, connect_diag=True,
         # Extract regions assigned to each label id
         if connect_diag:
             structure = np.ones((3, 3, 3), dtype=np.int)
-            regions, this_n_labels = ndimage.label(
-                this_label_mask.astype(np.int), structure=structure)
+            regions, this_n_labels = label(
+                this_label_mask.astype(np.int), structure=structure
+            )
         else:
-            regions, this_n_labels = ndimage.label(this_label_mask.astype(np.int))
+            regions, this_n_labels = label(this_label_mask.astype(np.int))
 
         if min_size is not None:
             index = np.arange(this_n_labels + 1)

--- a/nilearn/regions/tests/test_region_extractor.py
+++ b/nilearn/regions/tests/test_region_extractor.py
@@ -3,7 +3,7 @@
 import numpy as np
 import nibabel
 import pytest
-from scipy import ndimage
+from scipy.ndimage import label
 
 from nilearn.regions import (connected_regions, RegionExtractor,
                              connected_label_regions)
@@ -258,7 +258,7 @@ def test_remove_small_regions():
                       [1., 0., 0.],
                       [0., 1., 1.]]])
     # To remove small regions, data should be labelled
-    label_map, n_labels = ndimage.label(data)
+    label_map, n_labels = label(data)
     sum_label_data = np.sum(label_map)
 
     affine = np.eye(4)

--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -10,8 +10,13 @@ from string import ascii_lowercase
 import numpy as np
 import pandas as pd
 import nibabel as nib
-from scipy import ndimage
-
+from scipy.ndimage import (
+    maximum_filter,
+    minimum_filter,
+    label,
+    center_of_mass,
+    generate_binary_structure,
+)
 from nilearn.image import threshold_img
 from nilearn.image.resampling import coord_transform
 from nilearn._utils import check_niimg_3d
@@ -71,15 +76,15 @@ def _identify_subpeaks(data):
     of mass for those voxels.
     """
     # Initial identification of subpeaks with minimal minimum distance
-    data_max = ndimage.filters.maximum_filter(data, 3)
+    data_max = maximum_filter(data, 3)
     maxima = data == data_max
-    data_min = ndimage.filters.minimum_filter(data, 3)
+    data_min = minimum_filter(data, 3)
     diff = (data_max - data_min) > 0
     maxima[diff == 0] = 0
 
-    labeled, n_subpeaks = ndimage.label(maxima)
+    labeled, n_subpeaks = label(maxima)
     labels_index = range(1, n_subpeaks + 1)
-    ijk = np.array(ndimage.center_of_mass(data, labeled, labels_index))
+    ijk = np.array(center_of_mass(data, labeled, labels_index))
     ijk = np.round(ijk).astype(int)
     vals = np.apply_along_axis(
         arr=ijk, axis=1, func1d=_get_val, input_arr=data
@@ -265,7 +270,7 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
                               copy_data=(cluster_threshold is not None))
 
     # Define array for 6-connectivity, aka NN1 or "faces"
-    bin_struct = ndimage.generate_binary_structure(rank=3, connectivity=1)
+    bin_struct = generate_binary_structure(rank=3, connectivity=1)
 
     voxel_size = np.prod(stat_img.header.get_zooms())
 
@@ -291,7 +296,7 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
             continue
 
         # Now re-label and create table
-        label_map = ndimage.measurements.label(binarized, bin_struct)[0]
+        label_map = label(binarized, bin_struct)[0]
         clust_ids = sorted(list(np.unique(label_map)[1:]))
         peak_vals = np.array(
             [np.max(temp_stat_map * (label_map == c)) for c in clust_ids])


### PR DESCRIPTION
This PR proposes to fix some deprecations we have when importing the `ndimage` module from `spicy` in the following way : `from scipy import ndimage`.

For example:

```
nilearn/mass_univariate/tests/test_permuted_least_squares.py: 10 warnings
[10101](https://github.com/nilearn/nilearn/runs/6442110474?check_suite_focus=true#step:8:10101)
  /home/runner/work/nilearn/nilearn/nilearn/mass_univariate/_utils.py:120: DeprecationWarning: Please use `label` from the `scipy.ndimage` namespace, the `scipy.ndimage.measurements` namespace is deprecated.
[10102](https://github.com/nilearn/nilearn/runs/6442110474?check_suite_focus=true#step:8:10102)
    labeled_arr3d, _ = ndimage.measurements.label(arr3d > 0, bin_struct)
```

Indeed, submodules of `scipy.ndimage` were recently made private even if they do not start with "_" (see  https://github.com/scipy/scipy/pull/14474).
I've removed all instances of `from scipy import ndimage` with more specific imports like `from scipy.ndimage import label`.