### PR TITLE
avoid creation of int64 nifti in cluster inference + update tests

### DIFF
--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -11,6 +11,7 @@ import joblib
 import nibabel as nib
 import numpy as np
 from nilearn.masking import apply_mask
+from nilearn import image
 from nilearn.mass_univariate._utils import (
     _calculate_cluster_measures,
     _calculate_tfce,
@@ -950,21 +951,13 @@ def permuted_ols(
                 # so we use apply_mask here.
                 cluster_dict[f'{metric}_pvals'][i_regressor, :] = np.squeeze(
                     apply_mask(
-                        nib.Nifti1Image(
-                            p_map,
-                            masker.mask_img_.affine,
-                            masker.mask_img_.header,
-                        ),
+                        image.new_img_like(masker.mask_img_, p_map),
                         masker.mask_img_,
                     )
                 )
                 cluster_dict[metric][i_regressor, :] = np.squeeze(
                     apply_mask(
-                        nib.Nifti1Image(
-                            metric_map.astype("float"),
-                            masker.mask_img_.affine,
-                            masker.mask_img_.header,
-                        ),
+                        image.new_img_like(masker.mask_img_, metric_map),
                         masker.mask_img_,
                     )
                 )

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -961,7 +961,7 @@ def permuted_ols(
                 cluster_dict[metric][i_regressor, :] = np.squeeze(
                     apply_mask(
                         nib.Nifti1Image(
-                            metric_map,
+                            metric_map.astype("float"),
                             masker.mask_img_.affine,
                             masker.mask_img_.header,
                         ),

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -628,7 +628,7 @@ def test_cluster_level_parameters_smoke(random_state=0):
 
     # masker is defined, but threshold is not.
     # no cluster-level inference is performed, but there's a warning.
-    with pytest.warns():
+    with pytest.warns(Warning):
         out = permuted_ols(
             tested_var,
             target_var,
@@ -646,7 +646,7 @@ def test_cluster_level_parameters_smoke(random_state=0):
 
     # threshold is defined, but output_type is "legacy".
     # raise a warning, and get a dictionary.
-    with pytest.warns():
+    with pytest.warns(Warning):
         out = permuted_ols(
             tested_var,
             target_var,


### PR DESCRIPTION
quick fix for #3227 recently breaking the build: ~store cluster sizes in floats not ints. another option is to store in int32 rather than int64, as for realistic resolutions even if a cluster fills the whole image it will still fit in int32. @tsalo  please advise which you prefer~

create the images with `nilearn.image.new_img_like` rather than `nib.Nifti1Image`; `new_img_like` takes care of converting int64 to int32 if it does not cause an overflow