### PR TITLE
REF: refactors _load_single to split parsing and loading

### DIFF
--- a/nilearn/interfaces/fmriprep/load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_utils.py
@@ -117,10 +117,20 @@ def _get_file_name(nii_file):
         return confounds_raw[0]
 
 
-def _get_json(confounds_raw_path, flag_acompcor):
-    """Load json data companion to the confounds tsv file."""
+def _get_confounds_file(image_file, flag_full_aroma):
+    _check_images(image_file, flag_full_aroma)
+    confounds_raw_path = _get_file_name(image_file)
+    return confounds_raw_path
+
+
+def _get_json(confounds_raw_path):
+    """return json data companion file to the confounds tsv file."""
     # Load JSON file
-    confounds_json = confounds_raw_path.replace("tsv", "json")
+    return confounds_raw_path.replace("tsv", "json")
+
+
+def _load_confounds_json(confounds_json, flag_acompcor):
+    """Load json data companion to the confounds tsv file."""
     try:
         with open(confounds_json, "rb") as f:
             confounds_json = json.load(f)
@@ -137,7 +147,7 @@ def _get_json(confounds_raw_path, flag_acompcor):
     return confounds_json
 
 
-def _get_file_raw(confounds_raw_path):
+def _load_confounds_file_as_dataframe(confounds_raw_path):
     """Load raw confounds as a pandas DataFrame."""
     confounds_raw = pd.read_csv(
         confounds_raw_path, delimiter="\t", encoding="utf-8"
@@ -195,15 +205,6 @@ def _check_images(image_file, flag_full_aroma):
         valid_img, error_message = _ext_validator([image_file], ext)
     if not valid_img:
         raise ValueError(error_message)
-
-
-def _confounds_to_df(image_file, flag_acompcor, flag_full_aroma):
-    """Load raw confounds and associated metadata."""
-    _check_images(image_file, flag_full_aroma)
-    confounds_raw_path = _get_file_name(image_file)
-    confounds_json = _get_json(confounds_raw_path, flag_acompcor)
-    confounds_raw = _get_file_raw(confounds_raw_path)
-    return confounds_raw, confounds_json
 
 
 def _prepare_output(confounds, demean):

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
@@ -8,7 +8,7 @@ import pytest
 from nibabel import Nifti1Image
 from nilearn.maskers import NiftiMasker
 from nilearn.interfaces.fmriprep import load_confounds
-from nilearn.interfaces.fmriprep.load_confounds import _check_strategy
+from nilearn.interfaces.fmriprep.load_confounds import _check_strategy, _load_single_confounds_file
 
 from nilearn._utils.fmriprep_confounds import _to_camel_case
 
@@ -240,6 +240,25 @@ def test_confounds2df(tmp_path):
     img_nii, _ = create_tmp_filepath(tmp_path, copy_confounds=True)
     confounds, _ = load_confounds(img_nii)
     assert "trans_x" in confounds.columns
+
+
+def test_load_single_confounds_file(tmp_path):
+    """Check that the load_confounds function returns the same confounds as _load_single_confounds_file."""
+    nii_file, confounds_file = create_tmp_filepath(tmp_path, copy_confounds=True)
+
+    # get defaults from load_confounds
+    import inspect
+    _defaults = {key: value.default for key, value in inspect.signature(load_confounds).parameters.items()}
+    _defaults.pop("img_files")
+    _default_strategy = _defaults.pop("strategy")
+
+    _, confounds = _load_single_confounds_file(str(confounds_file),
+                                               strategy=_default_strategy,
+                                               **_defaults)
+    confounds_nii, _ = load_confounds(nii_file,
+                                      strategy=_default_strategy,
+                                      **_defaults)
+    pd.testing.assert_frame_equal(confounds, confounds_nii)
 
 
 @pytest.mark.parametrize("strategy,message",


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3273 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Renamed ```_load_single``` to ```_load_confounds_for_single_image_file```
- Moved confound loading to ```_load_single_confounds_file```
- Renamed several variables for added clarity
- Split ```_confounds_to_df``` into smaller functions such that parsing and reading of confound and metadata is done in separate functions
- Wrote test to assure that loaded confounds are the same between ```load_confounds``` and ```_load_single_confounds``` using the default parameters.
