### PR TITLE
[FIX] Default to `np.uint8` for encoding boolean data based on image type

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -61,3 +61,4 @@ Changes
   separate steps (:gh:`3274` by `David G Ellis`_).
 - Private submodules, functions, and classes from the :mod:`~nilearn.decomposition` module now start with a "_" character to make it clear that they are not part of the public API (:gh:`3141` by `Nicolas Gensollen`_).
 - Convert references in ``nilearn/glm/regression.py`` and ``nilearn/glm/thresholding.py`` to use footcite/footbibliography (:gh:`3302` by `Ahmad Chamma`_).
+- Boolean input data in :func:`~image.new_img_like` now defaults to `np.uint8` instead of `np.int8`

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -61,4 +61,4 @@ Changes
   separate steps (:gh:`3274` by `David G Ellis`_).
 - Private submodules, functions, and classes from the :mod:`~nilearn.decomposition` module now start with a "_" character to make it clear that they are not part of the public API (:gh:`3141` by `Nicolas Gensollen`_).
 - Convert references in ``nilearn/glm/regression.py`` and ``nilearn/glm/thresholding.py`` to use footcite/footbibliography (:gh:`3302` by `Ahmad Chamma`_).
-- Boolean input data in :func:`~image.new_img_like` now defaults to `np.uint8` instead of `np.int8`
+- Boolean input data in :func:`~image.new_img_like` now defaults to `np.uint8` instead of `np.int8` (:gh:`3286` by `Yasmin Mzayek`_).

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -755,8 +755,7 @@ def new_img_like(ref_niimg, data, affine=None, copy_header=False):
     if affine is None:
         affine = ref_niimg.affine
     if data.dtype == bool:
-        default_dtype = np.uint8
-        data = as_ndarray(data, dtype=default_dtype)
+        data = as_ndarray(data, dtype=np.uint8)
     data = _downcast_from_int64_if_possible(data)
     header = None
     if copy_header:

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -716,7 +716,11 @@ def new_img_like(ref_niimg, data, affine=None, copy_header=False):
         Reference image. The new image will be of the same type.
 
     data : :class:`numpy.ndarray`
-        Data to be stored in the image.
+        Data to be stored in the image. If data dtype is a boolean, then data
+        is cast to 'uint8' by default.
+
+    .. versionchanged:: 0.9.2dev
+        Changed default dtype casting of booleans from 'int8' to 'uint8'.
 
     affine : 4x4 :class:`numpy.ndarray`, optional
         Transformation matrix.

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -755,9 +755,7 @@ def new_img_like(ref_niimg, data, affine=None, copy_header=False):
     if affine is None:
         affine = ref_niimg.affine
     if data.dtype == bool:
-        default_dtype = np.int8
-        if isinstance(ref_niimg, nibabel.freesurfer.mghformat.MGHImage):
-            default_dtype = np.uint8
+        default_dtype = np.uint8
         data = as_ndarray(data, dtype=default_dtype)
     data = _downcast_from_int64_if_possible(data)
     header = None

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -45,7 +45,7 @@ def test_get_data():
     assert data is img._data_cache
     mask_img = new_img_like(img, data > 0)
     data = get_data(mask_img)
-    assert data.dtype == np.dtype('int8')
+    assert data.dtype == np.dtype('uint8')
     img_3d = index_img(img, 0)
     with tempfile.TemporaryDirectory() as tempdir:
         filename = os.path.join(tempdir, 'img_{}.nii.gz')

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -826,10 +826,19 @@ def test_new_img_like_mgh_image():
     new_img_like(niimg, data.astype(float), niimg.affine, copy_header=True)
 
 
-def test_new_img_like_boolean_data():
+def test_new_img_like_boolean_data_mgh():
+    """Check defaulting boolean input data to np.uint8 dtype is valid for
+    encoding with nibabel image class MGHImage.
+    """
+    data = np.random.randn(5, 5, 5).astype('uint8')
+    in_img = nibabel.freesurfer.MGHImage(dataobj=data, affine=np.eye(4))
+    new_img_like(in_img, data=in_img.get_fdata() > 0.5)
+
+
+def test_new_img_like_boolean_data_analyzeimage():
     """Check defaulting boolean input data to np.uint8 dtype is valid for
     encoding with nibabel image class AnalyzeImage.
     """
     data = np.random.default_rng().random((5, 5, 5))
-    in_img_analyze = nibabel.AnalyzeImage(dataobj=data, affine=np.eye(4))
-    new_img_like(in_img_analyze, data=in_img_analyze.get_fdata() > 0.5)
+    in_img = nibabel.AnalyzeImage(dataobj=data, affine=np.eye(4))
+    new_img_like(in_img, data=in_img.get_fdata() > 0.5)

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -824,3 +824,12 @@ def test_new_img_like_mgh_image():
     data = np.zeros((5, 5, 5), dtype=np.uint8)
     niimg = nibabel.freesurfer.MGHImage(dataobj=data, affine=np.eye(4))
     new_img_like(niimg, data.astype(float), niimg.affine, copy_header=True)
+
+
+def test_new_img_like_boolean_data():
+    """Check defaulting boolean input data to np.uint8 dtype is valid for
+    encoding with nibabel image class AnalyzeImage.
+    """
+    data = np.random.default_rng().random((5, 5, 5))
+    in_img_analyze = nibabel.AnalyzeImage(dataobj=data, affine=np.eye(4))
+    new_img_like(in_img_analyze, data=in_img_analyze.get_fdata() > 0.5)

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -7,7 +7,8 @@ import sys
 import tempfile
 
 import nibabel
-from nibabel import Nifti1Image
+from nibabel import Nifti1Image, AnalyzeImage
+from nibabel.freesurfer import MGHImage
 import numpy as np
 import pytest
 
@@ -826,19 +827,11 @@ def test_new_img_like_mgh_image():
     new_img_like(niimg, data.astype(float), niimg.affine, copy_header=True)
 
 
-def test_new_img_like_boolean_data_mgh():
+@pytest.mark.parametrize("image", [MGHImage, AnalyzeImage])
+def test_new_img_like_boolean_data(image):
     """Check defaulting boolean input data to np.uint8 dtype is valid for
-    encoding with nibabel image class MGHImage.
+    encoding with nibabel image classes MGHImage and AnalyzeImage.
     """
     data = np.random.randn(5, 5, 5).astype('uint8')
-    in_img = nibabel.freesurfer.MGHImage(dataobj=data, affine=np.eye(4))
-    new_img_like(in_img, data=in_img.get_fdata() > 0.5)
-
-
-def test_new_img_like_boolean_data_analyzeimage():
-    """Check defaulting boolean input data to np.uint8 dtype is valid for
-    encoding with nibabel image class AnalyzeImage.
-    """
-    data = np.random.default_rng().random((5, 5, 5))
-    in_img = nibabel.AnalyzeImage(dataobj=data, affine=np.eye(4))
+    in_img = image(dataobj=data, affine=np.eye(4))
     new_img_like(in_img, data=in_img.get_fdata() > 0.5)

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -834,4 +834,5 @@ def test_new_img_like_boolean_data(image):
     """
     data = np.random.randn(5, 5, 5).astype('uint8')
     in_img = image(dataobj=data, affine=np.eye(4))
-    new_img_like(in_img, data=in_img.get_fdata() > 0.5)
+    out_img = new_img_like(in_img, data=in_img.get_fdata() > 0.5)
+    assert get_data(out_img).dtype == 'uint8'


### PR DESCRIPTION
Replaces and closes #1500 
Related to nipy/nibabel#913

Changes proposed in this pull request:

- Defaulting boolean input to `np.uint8` instead of `np.int8` for function `image.new_img_like`
