### PR TITLE
[DOC] Update links in `README.rst`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,10 +61,10 @@ a command prompt::
     pip install -U --user nilearn
 
 More detailed instructions are available at
-http://nilearn.github.io/introduction.html#installation.
+http://nilearn.github.io/stable/introduction.html#installation.
 
 Development
 ===========
 
 Detailed instructions on how to contribute are available at
-http://nilearn.github.io/development.html
+http://nilearn.github.io/stable/development.html


### PR DESCRIPTION
Links to the installation and development docs in `README.rst` are outdated and now broken after cleaning of Github pages in nilearn/nilearn.github.io#3. 
Added path to stable pages.
