### PR TITLE
MAINT: Avoid deprecation

### DIFF
--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -216,7 +216,7 @@ def get_mask_bounds(img):
     mask = _utils.numpy_conversions._asarray(_get_data(img), dtype=bool)
     affine = img.affine
     (xmin, xmax), (ymin, ymax), (zmin, zmax) = get_bounds(mask.shape, affine)
-    slices = find_objects(mask)
+    slices = find_objects(mask.astype(int))
     if len(slices) == 0:
         warnings.warn("empty mask", stacklevel=2)
     else:

--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -111,7 +111,7 @@ def find_xyz_cut_coords(img, mask_img=None, activation_threshold=None):
             x_map, y_map, z_map = cut_coords
             return np.asarray(coord_transform(x_map, y_map, z_map,
                                               img.affine)).tolist()
-        slice_x, slice_y, slice_z = find_objects(mask)[0]
+        slice_x, slice_y, slice_z = find_objects(mask.astype(int))[0]
         my_map = my_map[slice_x, slice_y, slice_z]
         mask = mask[slice_x, slice_y, slice_z]
         my_map *= mask
@@ -150,7 +150,7 @@ def find_xyz_cut_coords(img, mask_img=None, activation_threshold=None):
                                           img.affine)).tolist()
 
     mask = largest_connected_component(mask)
-    slice_x, slice_y, slice_z = find_objects(mask)[0]
+    slice_x, slice_y, slice_z = find_objects(mask.astype(int))[0]
     my_map = my_map[slice_x, slice_y, slice_z]
     mask = mask[slice_x, slice_y, slice_z]
     my_map *= mask


### PR DESCRIPTION
Avoids warnings of the form:
```
  File "/Users/larsoner/python/mne-python/tutorials/inverse/70_eeg_mri_coords.py", line 73, in <module>
    plot_glass_brain(img_mni, cmap='hot_black_bone', threshold=0., black_bg=True,
  File "/Users/larsoner/python/nilearn/nilearn/plotting/img_plotting.py", line 1051, in plot_glass_brain
    display = _plot_img_with_bg(
  File "/Users/larsoner/python/nilearn/nilearn/plotting/img_plotting.py", line 201, in _plot_img_with_bg
    display.add_overlay(new_img_like(img, data, affine),
  File "/Users/larsoner/python/nilearn/nilearn/plotting/displays/_slicers.py", line 274, in add_overlay
    ims = self._map_show(img, type='imshow', threshold=threshold, **kwargs)
  File "/Users/larsoner/python/nilearn/nilearn/plotting/displays/_slicers.py", line 383, in _map_show
    get_mask_bounds(new_img_like(img, not_mask, affine))
  File "/Users/larsoner/python/nilearn/nilearn/image/resampling.py", line 219, in get_mask_bounds
    slices = find_objects(mask)
  File "/Users/larsoner/python/scipy/scipy/ndimage/_measurements.py", line 305, in find_objects
    return _nd_image.find_objects(input, max_label)
DeprecationWarning: In future, it will be an error for 'np.bool_' scalars to be interpreted as an index
```
Perhaps this should be fixed at the SciPy end (?), but the `find_objects` docstring does say that it wants `int`, so let's give it the type it wants.