### PR TITLE
[ENH] Shift centers of mass outside of clusters to closest in-cluster voxel

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -30,6 +30,7 @@ Enhancements
 - Function :func:`~glm.first_level.run_glm` and class :class:`~glm.first_level.FirstLevelModel` now accept a ``random_state`` parameter, which allows users to seed the ``KMeans`` cluster model used to estimate AR coefficients. (:gh:`3185` by `Sami Jawhar`_).
 - Conform seeding and docstrings in module ``_utils.data_gen`` (:gh:`3262` by `Yasmin Mzayek`_).
 - Docstrings of module :mod:`~nilearn.glm.second_level` were improved (:gh:`3030` by `Nicolas Gensollen`_).
+- In :func:`~reporting.get_clusters_table`, when the center of mass of a binary cluster falls outside the cluster, report the nearest within-cluster voxel instead (:gh:`3292` by `Connor Lane`_).
 
 Changes
 -------

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -42,6 +42,8 @@
 
 .. _Colin Reininger: https://github.com/reiningc
 
+.. _Connor Lane: https://github.com/clane9
+
 .. _Dan Gale: https://danjgale.github.io/
 
 .. _Daniel Gomez: https://github.com/dangom

--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -123,14 +123,14 @@ def _cluster_nearest_neighbor(ijk, labels_index, labeled):
     ----------
     ijk : :obj:`numpy.ndarray`
         (n_pts, 3) array of query points.
-    labels_index : `numpy.ndarray`
+    labels_index : :obj:`numpy.ndarray`
         (n_pts,) array of corresponding cluster indices.
-    labeled : `numpy.ndarray`
+    labeled : :obj:`numpy.ndarray`
         3D array with voxels labeled according to cluster index.
 
     Returns
     -------
-    nbrs : `numpy.ndarray`
+    nbrs : :obj:`numpy.ndarray`
         (n_pts, 3) nearest neighbor points.
     """
     labels = labeled[labeled > 0]

--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -102,7 +102,7 @@ def _identify_subpeaks(data):
     if np.any(subpeaks_outside_cluster):
         warnings.warn(
             "Attention: At least one of the (sub)peaks falls outside of the "
-            "cluster body."
+            "cluster body. Identifying the nearest in-cluster voxel."
         )
         # Replace centers of mass with their nearest neighbor points in the
         # corresponding clusters. Note this is also equivalent to computing the
@@ -121,7 +121,7 @@ def _cluster_nearest_neighbor(ijk, labels_index, labeled):
 
     Parameters
     ----------
-    ijk : `numpy.ndarray`
+    ijk : :obj:`numpy.ndarray`
         (n_pts, 3) array of query points.
     labels_index : `numpy.ndarray`
         (n_pts,) array of corresponding cluster indices.

--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -134,12 +134,12 @@ def _cluster_nearest_neighbor(ijk, labels_index, labeled):
         (n_pts, 3) nearest neighbor points.
     """
     labels = labeled[labeled > 0]
-    cluster_ijk = np.array(labeled.nonzero()).T
-    nbrs = []
-    for lab, point in zip(labels_index, ijk):
-        dist = np.linalg.norm(cluster_ijk[labels == lab] - point, axis=1)
-        nbrs.append(cluster_ijk[np.argmin(dist)])
-    nbrs = np.array(nbrs)
+    clusters_ijk = np.array(labeled.nonzero()).T
+    nbrs = np.zeros_like(ijk)
+    for ii, (lab, point) in enumerate(zip(labels_index, ijk)):
+        lab_ijk = clusters_ijk[labels == lab]
+        dist = np.linalg.norm(lab_ijk - point, axis=1)
+        nbrs[ii] = lab_ijk[np.argmin(dist)]
     return nbrs
 
 

--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -73,38 +73,74 @@ def _identify_subpeaks(data):
     -----
     When a cluster's local maximum corresponds to contiguous voxels with the
     same values (as in a binary cluster), this function determines the center
-    of mass for those voxels.
+    of mass for those voxels. If the center of mass falls outside the cluster,
+    we instead report the nearest cluster voxel.
     """
-    # Initial identification of subpeaks with minimal minimum distance
     data_max = maximum_filter(data, 3)
     maxima = data == data_max
-    data_min = minimum_filter(data, 3)
-    diff = (data_max - data_min) > 0
-    maxima[diff == 0] = 0
+    zero_mask = data == 0
+    maxima[zero_mask] = 0
+
+    # Don't treat constant patches as maxima unless the entire cluster is
+    # constant (as in a binary cluster).
+    is_constant = np.isclose(data[~zero_mask].max(), data[~zero_mask].min())
+    if not is_constant:
+        data_min = minimum_filter(data, 3)
+        diff = (data_max - data_min) > 0
+        maxima[diff == 0] = 0
 
     labeled, n_subpeaks = label(maxima)
-    labels_index = range(1, n_subpeaks + 1)
+    labels_index = np.arange(1, n_subpeaks + 1)
     ijk = np.array(center_of_mass(data, labeled, labels_index))
     ijk = np.round(ijk).astype(int)
-    vals = np.apply_along_axis(
-        arr=ijk, axis=1, func1d=_get_val, input_arr=data
-    )
     # Determine if all subpeaks are within the cluster
     # They may not be if the cluster is binary and has a shape where the COM is
     # outside the cluster, like a donut.
-    cluster_idx = np.vstack(np.where(labeled)).T.tolist()
-    subpeaks_outside_cluster = [
-        i
-        for i, peak_idx in enumerate(ijk.tolist())
-        if peak_idx not in cluster_idx
-    ]
-    vals[subpeaks_outside_cluster] = np.nan
-    if subpeaks_outside_cluster:
+    subpeaks_outside_cluster = (
+        labeled[ijk[:, 0], ijk[:, 1], ijk[:, 2]] != labels_index
+    )
+    if np.any(subpeaks_outside_cluster):
         warnings.warn(
             "Attention: At least one of the (sub)peaks falls outside of the "
             "cluster body."
         )
+        # Replace centers of mass with their nearest neighbor points in the
+        # corresponding clusters. Note this is also equivalent to computing the
+        # centers of mass constrained to points within the cluster.
+        ijk[subpeaks_outside_cluster] = _cluster_nearest_neighbor(
+            ijk[subpeaks_outside_cluster],
+            labels_index[subpeaks_outside_cluster],
+            labeled
+        )
+    vals = data[ijk[:, 0], ijk[:, 1], ijk[:, 2]]
     return ijk, vals
+
+
+def _cluster_nearest_neighbor(ijk, labels_index, labeled):
+    """Find the nearest neighbor for given points in the corresponding cluster.
+
+    Parameters
+    ----------
+    ijk : `numpy.ndarray`
+        (n_pts, 3) array of query points.
+    labels_index : `numpy.ndarray`
+        (n_pts,) array of corresponding cluster indices.
+    labeled : `numpy.ndarray`
+        3D array with voxels labeled according to cluster index.
+
+    Returns
+    -------
+    nbrs : `numpy.ndarray`
+        (n_pts, 3) nearest neighbor points.
+    """
+    labels = labeled[labeled > 0]
+    cluster_ijk = np.array(labeled.nonzero()).T
+    nbrs = []
+    for lab, point in zip(labels_index, ijk):
+        dist = np.linalg.norm(cluster_ijk[labels == lab] - point, axis=1)
+        nbrs.append(cluster_ijk[np.argmin(dist)])
+    nbrs = np.array(nbrs)
+    return nbrs
 
 
 def _sort_subpeaks(ijk, vals, affine):
@@ -169,25 +205,6 @@ def _pare_subpeaks(xyz, ijk, vals, min_distance):
     return ijk, vals
 
 
-def _get_val(row, input_arr):
-    """Extract values from array based on index.
-
-    Parameters
-    ----------
-    row : :obj:`tuple` of length 3
-        3-length index into ``input_arr``.
-    input_arr : 3D :obj:`numpy.ndarray`
-        Array from which to extract value.
-
-    Returns
-    -------
-    :obj:`float` or :obj:`int`
-        The value from ``input_arr`` at the row index.
-    """
-    i, j, k = row
-    return input_arr[i, j, k]
-
-
 def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
                        two_sided=False, min_distance=8.):
     """Creates pandas dataframe with img cluster statistics.
@@ -204,6 +221,10 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
         rather than any peaks/subpeaks.
 
         This center of mass may, in some cases, appear outside of the cluster.
+
+        .. versionchanged:: 0.9.2dev
+            In this case, the cluster voxel nearest to the center of mass is
+            reported.
 
     Parameters
     ----------

--- a/nilearn/reporting/tests/test_reporting.py
+++ b/nilearn/reporting/tests/test_reporting.py
@@ -65,8 +65,8 @@ def test_local_max():
     affine = np.eye(4)
 
     ijk, vals = _local_max(data, affine, min_distance=9)
-    assert np.array_equal(ijk, np.array([[5., 5., 5.]]))
-    assert np.all(np.isnan(vals))
+    assert np.array_equal(ijk, np.array([[4., 5., 5.]]))
+    assert np.array_equal(vals, np.array([1]))
 
 
 def test_get_clusters_table(tmp_path):

--- a/nilearn/reporting/tests/test_reporting.py
+++ b/nilearn/reporting/tests/test_reporting.py
@@ -73,6 +73,9 @@ def test_local_max():
 
 
 def test_cluster_nearest_neighbor():
+    """Check that _cluster_nearest_neighbor preserves within-cluster voxels,
+    projects voxels to the correct cluster, and handles singleton clusters.
+    """
     shape = (9, 10, 11)
     labeled = np.zeros(shape)
     # cluster 1 is half the volume, cluster 2 is a single voxel


### PR DESCRIPTION
Closes #3278.

Changes proposed in this pull request:

- For binary clusters whose center of mass falls outside of the cluster, report the nearest within-cluster voxel instead.
- Don't filter locally constant "maxima" in the binary cluster case.
- Vectorize some operations.