### PR TITLE
[FIX] Change setting of critical frequencies to meet `Wn[0] < Wn[1]`

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -24,6 +24,8 @@ Fixes
 - Function ``nilearn.glm.second_level.second_level._check_second_level_input`` now raises an error when ``flm_object`` argument is ``False`` and ``second_level_input`` is a list of :class:`~glm.first_level.FirstLevelModel` (:gh:`3283` by `Matthieu Joulot`_).
 - Function :func:`~image.resample_img` now warns the user if the provided image has an ``sform`` code equal to 0 or None  (:gh:`3284` by `Matthieu Joulot`_).
 - Fix usage of ``scipy.stats.gamma.pdf`` in ``_gamma_difference_hrf`` function under ``nilearn/glm/first_level/hemodynamic_models.py``, which resulted in slight distortion of HRF (:gh:`3297` by `Kun CHEN`_).
+- Fix bug introduced due to a fix in the pre-release version of scipy (``1.9.0rc1``) which now enforces that elements of a band-pass filter must meet condition ``Wn[0] < Wn[1]``.
+  Now if band-pass elements are equal :func:`nilearn.signals.butterworth` returns an unfiltered signal with a warning (:gh:`3293` by `Yasmin Mzayek`_).
 
 Enhancements
 ------------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -25,7 +25,7 @@ Fixes
 - Function :func:`~image.resample_img` now warns the user if the provided image has an ``sform`` code equal to 0 or None  (:gh:`3284` by `Matthieu Joulot`_).
 - Fix usage of ``scipy.stats.gamma.pdf`` in ``_gamma_difference_hrf`` function under ``nilearn/glm/first_level/hemodynamic_models.py``, which resulted in slight distortion of HRF (:gh:`3297` by `Kun CHEN`_).
 - Fix bug introduced due to a fix in the pre-release version of scipy (``1.9.0rc1``) which now enforces that elements of a band-pass filter must meet condition ``Wn[0] < Wn[1]``.
-  Now if band-pass elements are equal :func:`nilearn.signals.butterworth` returns an unfiltered signal with a warning (:gh:`3293` by `Yasmin Mzayek`_).
+  Now if band-pass elements are equal :func:`~nilearn.signal.butterworth` returns an unfiltered signal with a warning (:gh:`3293` by `Yasmin Mzayek`_).
 
 Enhancements
 ------------

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -261,8 +261,6 @@ def _check_wn(btype, freq, nyq):
         # results as pointed in the issue above. Hence, we forced the
         # critical frequencies to be slightly less than 1. but not 1.
         wn = 1 - 10 * np.finfo(1.).eps
-        if btype == 'low':
-            wn += 10e-16
         warnings.warn(
             'The frequency specified for the %s pass filter is '
             'too high to be handled by a digital filter (superior to '
@@ -342,6 +340,20 @@ def butterworth(signals, sampling_rate, low_pass=None, high_pass=None,
 
     if len(critical_freq) == 2:
         btype = 'band'
+        # Inappropriate parameter input might lead to coercion of both
+        # elements of critical_freq to a value just below 1.
+        # Scipy fix now enforces that critical frequencies cannot be equal.
+        # See https://github.com/scipy/scipy/pull/15886. If this is the case,
+        # we return the signals unfiltered.
+        if critical_freq[0] == critical_freq[1]:
+            warnings.warn(
+                'Signals are returned unfiltered because band-pass critical '
+                'frequencies are equal. Please check that inputs for '
+                'sampling_rate, low_pass, and high_pass are valid.')
+            if copy:
+                return signals.copy()
+            else:
+                return signals
     else:
         critical_freq = critical_freq[0]
 

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -261,6 +261,8 @@ def _check_wn(btype, freq, nyq):
         # results as pointed in the issue above. Hence, we forced the
         # critical frequencies to be slightly less than 1. but not 1.
         wn = 1 - 10 * np.finfo(1.).eps
+        if btype == 'low':
+            wn += 10e-16
         warnings.warn(
             'The frequency specified for the %s pass filter is '
             'too high to be handled by a digital filter (superior to '

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -178,6 +178,14 @@ def test_butterworth():
     np.testing.assert_almost_equal(out1, out2)
     np.testing.assert_(id(out1) != id(out2))
 
+    # Test check for equal values in critical frequencies
+    sampling = 1
+    low_pass = 2
+    high_pass = 1
+    nisignal.butterworth(data, sampling,
+                         low_pass=low_pass, high_pass=high_pass,
+                         copy=True)
+
 
 def test_standardize():
     rng = np.random.RandomState(42)

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -182,10 +182,15 @@ def test_butterworth():
     sampling = 1
     low_pass = 2
     high_pass = 1
-    out1 = nisignal.butterworth(data, sampling,
-                                low_pass=low_pass, high_pass=high_pass,
-                                copy=True)
-    assert (out1 == data).all()
+    with pytest.warns(UserWarning,
+                      match='Signals are returned unfiltered because '
+                      'band-pass critical frequencies are equal. '
+                      'Please check that inputs for sampling_rate, '
+                      'low_pass, and high_pass are valid.'):
+        out = nisignal.butterworth(data, sampling,
+                                   low_pass=low_pass, high_pass=high_pass,
+                                   copy=True)
+    assert (out == data).all()
 
 
 def test_standardize():

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -182,9 +182,10 @@ def test_butterworth():
     sampling = 1
     low_pass = 2
     high_pass = 1
-    nisignal.butterworth(data, sampling,
-                         low_pass=low_pass, high_pass=high_pass,
-                         copy=True)
+    out1 = nisignal.butterworth(data, sampling,
+                                low_pass=low_pass, high_pass=high_pass,
+                                copy=True)
+    assert (out1 == data).all()
 
 
 def test_standardize():


### PR DESCRIPTION
Closes #3288.
Currently `signal._check_wn` sets critical frequencies to an equal value below 1 if they are above the threshold of 1. A scipy update now enforces that its two-element sequence `Wn` for upper and lower critical frequencies should meet the condition `Wn[0] < Wn[1]`. This causes `test_decoder_apply_mask` to fail. 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- ~~Add negligible value to low-pass filter to satisfy condition~~
- Give warning to user to input appropriate values if critical frequencies are coerced into the same value
