### PR TITLE
[ENH] Add support for path-like objects where string filesystem paths are expected

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -33,6 +33,7 @@ Enhancements
 - Conform seeding and docstrings in module ``_utils.data_gen`` (:gh:`3262` by `Yasmin Mzayek`_).
 - Docstrings of module :mod:`~nilearn.glm.second_level` were improved (:gh:`3030` by `Nicolas Gensollen`_).
 - In :func:`~reporting.get_clusters_table`, when the center of mass of a binary cluster falls outside the cluster, report the nearest within-cluster voxel instead (:gh:`3292` by `Connor Lane`_).
+- Functions expecting string filesystem paths now also accept path-like objects (:gh:`3300` by `Yasmin Mzayek`_).
 
 Changes
 -------

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -17,7 +17,7 @@ from joblib import Memory
 MEMORY_CLASSES = (Memory, )
 
 import nilearn
-from .helpers import _stringify_path
+from .helpers import stringify_path
 
 
 __CACHE_CHECKED = dict()
@@ -28,7 +28,7 @@ def _check_memory(memory, verbose=0):
 
     Parameters
     ----------
-    memory : None or instance of joblib.Memory or str or path-like object
+    memory : None or instance of joblib.Memory or str or pathlib.Path
         Used to cache the masking process.
         If a str is given, it is the path to the caching directory.
 
@@ -42,7 +42,7 @@ def _check_memory(memory, verbose=0):
     """
     if memory is None:
         memory = Memory(location=None, verbose=verbose)
-    memory = _stringify_path(memory)
+    memory = stringify_path(memory)
     if isinstance(memory, str):
         cache_dir = memory
         if nilearn.EXPAND_PATH_WILDCARDS:
@@ -181,7 +181,7 @@ def cache(func, memory, func_memory_level=None, memory_level=None,
     func : function
         The function which output is to be cached.
 
-    memory : instance of joblib.Memory or string or path-like object
+    memory : instance of joblib.Memory or string or pathlib.Path
         Used to cache the function call.
 
     func_memory_level : int, optional
@@ -223,7 +223,7 @@ def cache(func, memory, func_memory_level=None, memory_level=None,
 
     if memory is not None and (func_memory_level is None or
                                memory_level >= func_memory_level):
-        memory = _stringify_path(memory)
+        memory = stringify_path(memory)
         if isinstance(memory, str):
             memory = Memory(location=memory, verbose=verbose)
         if not isinstance(memory, MEMORY_CLASSES):

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -17,6 +17,7 @@ from joblib import Memory
 MEMORY_CLASSES = (Memory, )
 
 import nilearn
+from .helpers import _stringify_path
 
 
 __CACHE_CHECKED = dict()
@@ -27,7 +28,7 @@ def _check_memory(memory, verbose=0):
 
     Parameters
     ----------
-    memory : None or instance of joblib.Memory or str
+    memory : None or instance of joblib.Memory or str or path-like object
         Used to cache the masking process.
         If a str is given, it is the path to the caching directory.
 
@@ -41,6 +42,7 @@ def _check_memory(memory, verbose=0):
     """
     if memory is None:
         memory = Memory(location=None, verbose=verbose)
+    memory = _stringify_path(memory)
     if isinstance(memory, str):
         cache_dir = memory
         if nilearn.EXPAND_PATH_WILDCARDS:
@@ -179,7 +181,7 @@ def cache(func, memory, func_memory_level=None, memory_level=None,
     func : function
         The function which output is to be cached.
 
-    memory : instance of joblib.Memory or string
+    memory : instance of joblib.Memory or string or path-like object
         Used to cache the function call.
 
     func_memory_level : int, optional
@@ -221,6 +223,7 @@ def cache(func, memory, func_memory_level=None, memory_level=None,
 
     if memory is not None and (func_memory_level is None or
                                memory_level >= func_memory_level):
+        memory = _stringify_path(memory)
         if isinstance(memory, str):
             memory = Memory(location=memory, verbose=verbose)
         if not isinstance(memory, MEMORY_CLASSES):

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -269,7 +269,7 @@ mask_img : Niimg-like object
 
 # Memory
 docdict['memory'] = """
-memory : instance of :class:`joblib.Memory` or :obj:`str` or 
+memory : instance of :class:`joblib.Memory` or :obj:`str` or
     :class:`os.PathLike`
     Used to cache the masking process.
     By default, no caching is done. If a :obj:`str` is given, it is the

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -269,7 +269,8 @@ mask_img : Niimg-like object
 
 # Memory
 docdict['memory'] = """
-memory : instance of :class:`joblib.Memory` or :obj:`str`
+memory : instance of :class:`joblib.Memory` or :obj:`str` or 
+    :class:`os.PathLike`
     Used to cache the masking process.
     By default, no caching is done. If a :obj:`str` is given, it is the
     path to the caching directory."""

--- a/nilearn/_utils/glm.py
+++ b/nilearn/_utils/glm.py
@@ -12,7 +12,7 @@ import pandas as pd
 import scipy.linalg as spl
 from scipy.stats import norm
 
-from .helpers import _stringify_path
+from .helpers import stringify_path
 
 
 def _check_list_length_match(list_1, list_2, var_name_1, var_name_2):
@@ -55,7 +55,7 @@ def _check_and_load_tables(tables_, var_name):
     """Check tables can be loaded in DataFrame to raise error if necessary"""
     tables = []
     for table_idx, table in enumerate(tables_):
-        table = _stringify_path(table)
+        table = stringify_path(table)
         if isinstance(table, str):
             loaded = _read_events_table(table)
             tables.append(loaded)

--- a/nilearn/_utils/glm.py
+++ b/nilearn/_utils/glm.py
@@ -12,6 +12,8 @@ import pandas as pd
 import scipy.linalg as spl
 from scipy.stats import norm
 
+from .helpers import _stringify_path
+
 
 def _check_list_length_match(list_1, list_2, var_name_1, var_name_2):
     """Check length match of two given lists to raise error if necessary"""
@@ -53,6 +55,7 @@ def _check_and_load_tables(tables_, var_name):
     """Check tables can be loaded in DataFrame to raise error if necessary"""
     tables = []
     for table_idx, table in enumerate(tables_):
+        table = _stringify_path(table)
         if isinstance(table, str):
             loaded = _read_events_table(table)
             tables.append(loaded)

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -148,7 +148,7 @@ def remove_parameters(removed_params,
     return _remove_params
 
 
-def _stringify_path(path):
+def stringify_path(path):
     """Converts path-like objects to string.
 
     This is used to allow functions expecting string filesystem paths to accept

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -1,5 +1,6 @@
 import functools
 import warnings
+import os
 
 
 def rename_parameters(replacement_params,
@@ -145,3 +146,7 @@ def remove_parameters(removed_params,
             return func(*args, **kwargs)
         return wrapper
     return _remove_params
+
+
+def _stringify_path(path):
+    return path.__fspath__() if isinstance(path, os.PathLike) else path

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -149,4 +149,18 @@ def remove_parameters(removed_params,
 
 
 def _stringify_path(path):
+    """Converts path-like objects to string.
+
+    This is used to allow functions expecting string filesystem paths to accept
+    objects using `__fspath__` protocol.
+
+    Parameters
+    ----------
+    path : str or path-like object
+
+    Returns
+    -------
+    str
+
+    """
     return path.__fspath__() if isinstance(path, os.PathLike) else path

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -14,6 +14,8 @@ import nibabel
 
 from pathlib import Path
 
+from .helpers import _stringify_path
+
 
 def _get_data(img):
     # copy-pasted from https://github.com/nipy/nibabel/blob/de44a105c1267b07ef9e28f6c35b31f851d5a005/nibabel/dataobj_images.py#L204
@@ -123,7 +125,7 @@ def load_niimg(niimg, dtype=None):
     """
     from ..image import new_img_like  # avoid circular imports
 
-    niimg = nibabel.filename_parser._stringify_path(niimg)
+    niimg = _stringify_path(niimg)
 
     if isinstance(niimg, str):
         # data is a filename, we load it

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -7,14 +7,13 @@ Neuroimaging file input and output.
 import copy
 import gc
 import collections.abc
+import os
 from warnings import warn
 
 import numpy as np
 import nibabel
 
 from pathlib import Path
-
-from .helpers import _stringify_path
 
 
 def _get_data(img):
@@ -125,9 +124,7 @@ def load_niimg(niimg, dtype=None):
     """
     from ..image import new_img_like  # avoid circular imports
 
-    niimg = _stringify_path(niimg)
-
-    if isinstance(niimg, str):
+    if isinstance(niimg, (str, os.PathLike)):
         # data is a filename, we load it
         niimg = nibabel.load(niimg)
     elif not isinstance(niimg, nibabel.spatialimages.SpatialImage):

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -15,6 +15,8 @@ import nibabel
 
 from pathlib import Path
 
+from .helpers import stringify_path
+
 
 def _get_data(img):
     # copy-pasted from https://github.com/nipy/nibabel/blob/de44a105c1267b07ef9e28f6c35b31f851d5a005/nibabel/dataobj_images.py#L204
@@ -124,7 +126,8 @@ def load_niimg(niimg, dtype=None):
     """
     from ..image import new_img_like  # avoid circular imports
 
-    if isinstance(niimg, (str, os.PathLike)):
+    niimg = stringify_path(niimg)
+    if isinstance(niimg, str):
         # data is a filename, we load it
         niimg = nibabel.load(niimg)
     elif not isinstance(niimg, nibabel.spatialimages.SpatialImage):

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -123,6 +123,8 @@ def load_niimg(niimg, dtype=None):
     """
     from ..image import new_img_like  # avoid circular imports
 
+    niimg = nibabel.filename_parser._stringify_path(niimg)
+
     if isinstance(niimg, str):
         # data is a filename, we load it
         niimg = nibabel.load(niimg)

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -7,7 +7,6 @@ Neuroimaging file input and output.
 import copy
 import gc
 import collections.abc
-import os
 from warnings import warn
 
 import numpy as np

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -192,9 +192,9 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False, dtype=None,
     ----------
     niimg : Niimg-like object
         See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
-        If niimg is a string, consider it as a path to Nifti image and
-        call nibabel.load on it. The '~' symbol is expanded to the user home
-        folder.
+        If niimg is a string or path-like object, consider it as a path to
+        Nifti image and call nibabel.load on it. The '~' symbol is expanded to
+        the user home folder.
         If it is an object, check if the affine attribute present and that
         nilearn.image.get_data returns a result, raise TypeError otherwise.
 

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -10,7 +10,6 @@ import glob
 import nilearn as ni
 import numpy as np
 import itertools
-import nibabel
 
 from joblib import Memory
 

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -6,10 +6,12 @@ Conversion utilities.
 import warnings
 import os.path
 import glob
+from pathlib import Path
 
 import nilearn as ni
 import numpy as np
 import itertools
+import nibabel
 
 from joblib import Memory
 
@@ -246,6 +248,8 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False, dtype=None,
 
     """
     from ..image import new_img_like  # avoid circular imports
+
+    niimg = nibabel.filename_parser._stringify_path(niimg)
 
     if isinstance(niimg, str):
         if wildcards and ni.EXPAND_PATH_WILDCARDS:

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -19,7 +19,7 @@ from .path_finding import _resolve_globbing
 
 from .exceptions import DimensionError
 from .niimg import _get_data
-from .helpers import _stringify_path
+from .helpers import stringify_path
 
 
 def _check_fov(img, affine, shape):
@@ -192,7 +192,7 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False, dtype=None,
     ----------
     niimg : Niimg-like object
         See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
-        If niimg is a string or path-like object, consider it as a path to
+        If niimg is a string or pathlib.Path, consider it as a path to
         Nifti image and call nibabel.load on it. The '~' symbol is expanded to
         the user home folder.
         If it is an object, check if the affine attribute present and that
@@ -248,7 +248,7 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False, dtype=None,
     """
     from ..image import new_img_like  # avoid circular imports
 
-    niimg = _stringify_path(niimg)
+    niimg = stringify_path(niimg)
 
     if isinstance(niimg, str):
         if wildcards and ni.EXPAND_PATH_WILDCARDS:

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -6,7 +6,6 @@ Conversion utilities.
 import warnings
 import os.path
 import glob
-from pathlib import Path
 
 import nilearn as ni
 import numpy as np

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -20,6 +20,7 @@ from .path_finding import _resolve_globbing
 
 from .exceptions import DimensionError
 from .niimg import _get_data
+from .helpers import _stringify_path
 
 
 def _check_fov(img, affine, shape):
@@ -248,7 +249,7 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False, dtype=None,
     """
     from ..image import new_img_like  # avoid circular imports
 
-    niimg = nibabel.filename_parser._stringify_path(niimg)
+    niimg = _stringify_path(niimg)
 
     if isinstance(niimg, str):
         if wildcards and ni.EXPAND_PATH_WILDCARDS:

--- a/nilearn/_utils/numpy_conversions.py
+++ b/nilearn/_utils/numpy_conversions.py
@@ -7,6 +7,8 @@ Validation and conversion utilities for numpy.
 import csv
 import numpy as np
 
+from .helpers import _stringify_path
+
 
 def _asarray(arr, dtype=None, order=None):
     # np.asarray does not take "K" and "A" orders in version 1.3.0
@@ -133,7 +135,7 @@ def csv_to_array(csv_path, delimiters=' \t,;', **kwargs):
 
     Parameters
     ----------
-    csv_path: string
+    csv_path: string or path-like object
         Path of the CSV file to load.
 
     delimiters: string
@@ -149,6 +151,7 @@ def csv_to_array(csv_path, delimiters=' \t,;', **kwargs):
     array: numpy.ndarray
         An array containing the data loaded from the CSV file.
     """
+    csv_path = _stringify_path(csv_path)
     if not isinstance(csv_path, str):
         raise TypeError('CSV must be a file path. Got a CSV of type: %s' %
                         type(csv_path))

--- a/nilearn/_utils/numpy_conversions.py
+++ b/nilearn/_utils/numpy_conversions.py
@@ -7,7 +7,7 @@ Validation and conversion utilities for numpy.
 import csv
 import numpy as np
 
-from .helpers import _stringify_path
+from .helpers import stringify_path
 
 
 def _asarray(arr, dtype=None, order=None):
@@ -135,7 +135,7 @@ def csv_to_array(csv_path, delimiters=' \t,;', **kwargs):
 
     Parameters
     ----------
-    csv_path: string or path-like object
+    csv_path: string or pathlib.Path
         Path of the CSV file to load.
 
     delimiters: string
@@ -151,7 +151,7 @@ def csv_to_array(csv_path, delimiters=' \t,;', **kwargs):
     array: numpy.ndarray
         An array containing the data loaded from the CSV file.
     """
-    csv_path = _stringify_path(csv_path)
+    csv_path = stringify_path(csv_path)
     if not isinstance(csv_path, str):
         raise TypeError('CSV must be a file path. Got a CSV of type: %s' %
                         type(csv_path))

--- a/nilearn/_utils/path_finding.py
+++ b/nilearn/_utils/path_finding.py
@@ -4,11 +4,11 @@ Path finding utilities
 import glob
 import os.path
 
-from .helpers import _stringify_path
+from .helpers import stringify_path
 
 
 def _resolve_globbing(path):
-    path = _stringify_path(path)
+    path = stringify_path(path)
     if isinstance(path, str):
         path_list = sorted(glob.glob(os.path.expanduser(path)))
         # Raise an error in case the list is empty.

--- a/nilearn/_utils/path_finding.py
+++ b/nilearn/_utils/path_finding.py
@@ -4,8 +4,11 @@ Path finding utilities
 import glob
 import os.path
 
+from .helpers import _stringify_path
+
 
 def _resolve_globbing(path):
+    path = _stringify_path(path)
     if isinstance(path, str):
         path_list = sorted(glob.glob(os.path.expanduser(path)))
         # Raise an error in case the list is empty.

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -111,7 +111,7 @@ def serialize_niimg(img, gzipped=True):
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_dir = Path(tmp_dir)
         file_path = tmp_dir / "img.nii{}".format(".gz" if gzipped else "")
-        img.to_filename(str(file_path))
+        img.to_filename(file_path)
         with file_path.open("rb") as f:
             return f.read()
 

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -282,7 +282,7 @@ class FirstLevelModel(BaseGLM):
         This parameter is passed to nilearn.image.resample_img.
         Please see the related documentation for details.
     %(smoothing_fwhm)s
-    memory : string, optional
+    memory : string or os.PathLike, optional
         Path to the directory used to cache the masking process and the glm
         fit. By default, no caching is done.
         Creates instance of joblib.Memory.

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -27,6 +27,7 @@ from nilearn._utils import fill_doc
 from nilearn._utils.glm import (_check_events_file_uses_tab_separators,
                                 _check_run_tables, _check_run_sample_masks)
 from nilearn._utils.niimg_conversions import check_niimg
+from nilearn._utils.helpers import _stringify_path
 from nilearn.glm.contrasts import (_compute_fixed_effect_contrast,
                                    expression_to_contrast_vector)
 from nilearn.glm.first_level.design_matrix import \
@@ -375,6 +376,7 @@ class FirstLevelModel(BaseGLM):
         self.target_affine = target_affine
         self.target_shape = target_shape
         self.smoothing_fwhm = smoothing_fwhm
+        memory = _stringify_path(memory)
         if isinstance(memory, str):
             self.memory = Memory(memory)
         else:

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -27,7 +27,7 @@ from nilearn._utils import fill_doc
 from nilearn._utils.glm import (_check_events_file_uses_tab_separators,
                                 _check_run_tables, _check_run_sample_masks)
 from nilearn._utils.niimg_conversions import check_niimg
-from nilearn._utils.helpers import _stringify_path
+from nilearn._utils.helpers import stringify_path
 from nilearn.glm.contrasts import (_compute_fixed_effect_contrast,
                                    expression_to_contrast_vector)
 from nilearn.glm.first_level.design_matrix import \
@@ -376,7 +376,7 @@ class FirstLevelModel(BaseGLM):
         self.target_affine = target_affine
         self.target_shape = target_shape
         self.smoothing_fwhm = smoothing_fwhm
-        memory = _stringify_path(memory)
+        memory = stringify_path(memory)
         if isinstance(memory, str):
             self.memory = Memory(memory)
         else:

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -20,7 +20,7 @@ from sklearn.base import clone
 
 from nilearn._utils import fill_doc
 from nilearn._utils.niimg_conversions import check_niimg
-from nilearn._utils.helpers import _stringify_path
+from nilearn._utils.helpers import stringify_path
 from nilearn.maskers import NiftiMasker
 from nilearn.glm.contrasts import (compute_contrast,
                                    expression_to_contrast_vector)
@@ -329,7 +329,7 @@ class SecondLevelModel(BaseGLM):
         self.target_affine = target_affine
         self.target_shape = target_shape
         self.smoothing_fwhm = smoothing_fwhm
-        memory = _stringify_path(memory)
+        memory = stringify_path(memory)
         if isinstance(memory, str):
             self.memory = Memory(memory)
         else:

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -20,6 +20,7 @@ from sklearn.base import clone
 
 from nilearn._utils import fill_doc
 from nilearn._utils.niimg_conversions import check_niimg
+from nilearn._utils.helpers import _stringify_path
 from nilearn.maskers import NiftiMasker
 from nilearn.glm.contrasts import (compute_contrast,
                                    expression_to_contrast_vector)
@@ -328,6 +329,7 @@ class SecondLevelModel(BaseGLM):
         self.target_affine = target_affine
         self.target_shape = target_shape
         self.smoothing_fwhm = smoothing_fwhm
+        memory = _stringify_path(memory)
         if isinstance(memory, str):
             self.memory = Memory(memory)
         else:

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -247,7 +247,8 @@ def smooth_img(imgs, fwhm):
 
     Parameters
     ----------
-    imgs : Niimg-like object or iterable of Niimg-like objects
+    imgs : Niimg-like object or iterable of Niimg-like objects, str, or
+        os.PathLike
         Image(s) to smooth (see
         http://nilearn.github.io/manipulating_images/input_output.html
         for a detailed description of the valid input types).
@@ -495,7 +496,8 @@ def mean_img(imgs, target_affine=None, target_shape=None,
 
     Parameters
     ----------
-    imgs : Niimg-like object or iterable of Niimg-like objects
+    imgs : Niimg-like object or iterable of Niimg-like objects, str, or
+        os.PathLike
         Images to be averaged over time (see
         http://nilearn.github.io/manipulating_images/input_output.html
         for a detailed description of the valid input types).
@@ -1285,7 +1287,8 @@ def largest_connected_component_img(imgs):
 
     Parameters
     ----------
-    imgs : Niimg-like object or iterable of Niimg-like objects (3D)
+    imgs : Niimg-like object or iterable of Niimg-like objects (3D), str, or
+        os.PathLike
         Image(s) to extract the largest connected component from.
         See http://nilearn.github.io/manipulating_images/input_output.html.
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -30,7 +30,7 @@ from .._utils import (_repr_niimgs,
 from .._utils.niimg import _get_data, _safe_get_data
 from .._utils.niimg_conversions import _check_same_fov, _index_img
 from .._utils.param_validation import check_threshold
-from .._utils.helpers import rename_parameters, _stringify_path
+from .._utils.helpers import rename_parameters, stringify_path
 
 
 def get_data(img):
@@ -264,7 +264,7 @@ def smooth_img(imgs, fwhm):
 
     # Use hasattr() instead of isinstance to workaround a Python 2.6/2.7 bug
     # See http://bugs.python.org/issue7624
-    imgs = _stringify_path(imgs)
+    imgs = stringify_path(imgs)
     if hasattr(imgs, "__iter__") \
        and not isinstance(imgs, str):
         single_img = False
@@ -529,7 +529,7 @@ def mean_img(imgs, target_affine=None, target_shape=None,
     nilearn.image.math_img : For more general operations on images.
 
     """
-    imgs = _stringify_path(imgs)
+    imgs = stringify_path(imgs)
     is_str = isinstance(imgs, str)
     is_iterable = isinstance(imgs, collections.abc.Iterable)
     if is_str or not is_iterable:
@@ -1307,7 +1307,7 @@ def largest_connected_component_img(imgs):
 
     """
     from .._utils.ndimage import largest_connected_component
-    imgs = _stringify_path(imgs)
+    imgs = stringify_path(imgs)
     if hasattr(imgs, "__iter__") and not isinstance(imgs, str):
         single_img = False
     else:

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -30,7 +30,7 @@ from .._utils import (_repr_niimgs,
 from .._utils.niimg import _get_data, _safe_get_data
 from .._utils.niimg_conversions import _check_same_fov, _index_img
 from .._utils.param_validation import check_threshold
-from .._utils.helpers import rename_parameters
+from .._utils.helpers import rename_parameters, _stringify_path
 
 
 def get_data(img):
@@ -263,6 +263,7 @@ def smooth_img(imgs, fwhm):
 
     # Use hasattr() instead of isinstance to workaround a Python 2.6/2.7 bug
     # See http://bugs.python.org/issue7624
+    imgs = _stringify_path(imgs)
     if hasattr(imgs, "__iter__") \
        and not isinstance(imgs, str):
         single_img = False
@@ -526,6 +527,7 @@ def mean_img(imgs, target_affine=None, target_shape=None,
     nilearn.image.math_img : For more general operations on images.
 
     """
+    imgs = _stringify_path(imgs)
     is_str = isinstance(imgs, str)
     is_iterable = isinstance(imgs, collections.abc.Iterable)
     if is_str or not is_iterable:
@@ -1302,7 +1304,7 @@ def largest_connected_component_img(imgs):
 
     """
     from .._utils.ndimage import largest_connected_component
-
+    imgs = _stringify_path(imgs)
     if hasattr(imgs, "__iter__") and not isinstance(imgs, str):
         single_img = False
     else:

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -17,6 +17,7 @@ from scipy.ndimage import find_objects, affine_transform
 from .image import crop_img
 from .. import _utils
 from .._utils.niimg import _get_data
+from .._utils.helpers import stringify_path
 
 ###############################################################################
 # Affine utils
@@ -435,7 +436,8 @@ def resample_img(img, target_affine=None, target_shape=None,
                    "or 'nearest' but it was set to '{0}'").format(interpolation)
         raise ValueError(message)
 
-    if isinstance(img, (str, os.PathLike)):
+    img = stringify_path(img)
+    if isinstance(img, str):
         # Avoid a useless copy
         input_img_is_string = True
     else:

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -17,6 +17,7 @@ from scipy.ndimage import find_objects, affine_transform
 from .image import crop_img
 from .. import _utils
 from .._utils.niimg import _get_data
+from .._utils.helpers import _stringify_path
 
 ###############################################################################
 # Affine utils
@@ -435,6 +436,7 @@ def resample_img(img, target_affine=None, target_shape=None,
                    "or 'nearest' but it was set to '{0}'").format(interpolation)
         raise ValueError(message)
 
+    img = _stringify_path(img)
     if isinstance(img, str):
         # Avoid a useless copy
         input_img_is_string = True

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -4,7 +4,6 @@ See http://nilearn.github.io/manipulating_images/input_output.html
 """
 # Author: Gael Varoquaux, Alexandre Abraham, Michael Eickenberg
 # License: simplified BSD
-import os
 import warnings
 from nilearn.version import _compare_version
 import numbers

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -314,7 +314,7 @@ def resample_img(img, target_affine=None, target_shape=None,
 
     Parameters
     ----------
-    img : Niimg-like object
+    img : Niimg-like object, str, or os.PathLike
         See http://nilearn.github.io/manipulating_images/input_output.html
         Image(s) to resample.
 

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -4,7 +4,7 @@ See http://nilearn.github.io/manipulating_images/input_output.html
 """
 # Author: Gael Varoquaux, Alexandre Abraham, Michael Eickenberg
 # License: simplified BSD
-
+import os
 import warnings
 from nilearn.version import _compare_version
 import numbers
@@ -17,7 +17,6 @@ from scipy.ndimage import find_objects, affine_transform
 from .image import crop_img
 from .. import _utils
 from .._utils.niimg import _get_data
-from .._utils.helpers import _stringify_path
 
 ###############################################################################
 # Affine utils
@@ -436,8 +435,7 @@ def resample_img(img, target_affine=None, target_shape=None,
                    "or 'nearest' but it was set to '{0}'").format(interpolation)
         raise ValueError(message)
 
-    img = _stringify_path(img)
-    if isinstance(img, str):
+    if isinstance(img, (str, os.PathLike)):
         # Avoid a useless copy
         input_img_is_string = True
     else:

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -4,6 +4,7 @@ Test the resampling code.
 import os
 import copy
 import math
+from pathlib import Path
 
 from numpy.testing import (assert_almost_equal,
                            assert_array_equal,
@@ -841,3 +842,16 @@ def test_resampling_with_int64_types_no_crash(dtype):
     data = np.zeros((2, 2, 2))
     img = Nifti1Image(data.astype(dtype), affine)
     resample_img(img, target_affine=2. * affine)
+
+
+def test_resample_input():
+    rng = np.random.RandomState(42)
+    shape = (3, 2, 5, 2)
+    data = rng.randint(0, 10, shape, dtype="int32")
+    affine = np.eye(4)
+    affine[:3, -1] = 0.5 * np.array(shape[:3])
+    img = Nifti1Image(data, affine)
+
+    with testing.write_tmp_imgs(img, create_files=True) as filename:
+        filename = Path(filename)
+        resample_img(filename, target_affine=affine, interpolation='nearest')

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -32,7 +32,7 @@ def _filter_and_extract(
 
     Parameters
     ----------
-    imgs : 3D/4D Niimg-like object
+    imgs : 3D/4D Niimg-like object or str or os.PathLike
         Images to be masked. Can be 3-dimensional or 4-dimensional.
 
     extraction_function : function

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -18,6 +18,7 @@ from .. import signal
 from .. import _utils
 from .._utils.cache_mixin import CacheMixin, cache
 from .._utils.class_inspect import enclosing_scope_name
+from .._utils.helpers import _stringify_path
 from nilearn.image import high_variance_confounds
 
 
@@ -57,6 +58,7 @@ def _filter_and_extract(
 
     # If we have a string (filename), we won't need to copy, as
     # there will be no side effect
+    imgs = _stringify_path(imgs)
     if isinstance(imgs, str):
         copy = False
 

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -18,7 +18,7 @@ from .. import signal
 from .. import _utils
 from .._utils.cache_mixin import CacheMixin, cache
 from .._utils.class_inspect import enclosing_scope_name
-from .._utils.helpers import _stringify_path
+from .._utils.helpers import stringify_path
 from nilearn.image import high_variance_confounds
 
 
@@ -58,7 +58,7 @@ def _filter_and_extract(
 
     # If we have a string (filename), we won't need to copy, as
     # there will be no side effect
-    imgs = _stringify_path(imgs)
+    imgs = stringify_path(imgs)
     if isinstance(imgs, str):
         copy = False
 

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -17,7 +17,7 @@ from .. import masking
 from .._utils import CacheMixin, fill_doc
 from .._utils.class_inspect import get_params
 from .._utils.niimg_conversions import _iter_check_niimg
-from .._utils.helpers import _stringify_path
+from .._utils.helpers import stringify_path
 from .nifti_masker import NiftiMasker, _filter_and_mask
 from nilearn.image import get_data
 
@@ -221,7 +221,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         if self.mask_img is None:
             if self.verbose > 0:
                 print("[%s.fit] Computing mask" % self.__class__.__name__)
-            imgs = _stringify_path(imgs)
+            imgs = stringify_path(imgs)
             if not isinstance(imgs, collections.abc.Iterable) \
                     or isinstance(imgs, str):
                 raise ValueError("[%s.fit] For multiple processing, you should"

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -17,6 +17,7 @@ from .. import masking
 from .._utils import CacheMixin, fill_doc
 from .._utils.class_inspect import get_params
 from .._utils.niimg_conversions import _iter_check_niimg
+from .._utils.helpers import _stringify_path
 from .nifti_masker import NiftiMasker, _filter_and_mask
 from nilearn.image import get_data
 
@@ -220,6 +221,7 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         if self.mask_img is None:
             if self.verbose > 0:
                 print("[%s.fit] Computing mask" % self.__class__.__name__)
+            imgs = _stringify_path(imgs)
             if not isinstance(imgs, collections.abc.Iterable) \
                     or isinstance(imgs, str):
                 raise ValueError("[%s.fit] For multiple processing, you should"

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -15,6 +15,7 @@ from nilearn.maskers import NiftiLabelsMasker
 from .._utils.niimg import _safe_get_data
 from .._utils.niimg_conversions import _iter_check_niimg
 from .._utils import fill_doc
+from .._utils.helpers import _stringify_path
 
 
 def _estimator_fit(data, estimator, method=None):
@@ -65,6 +66,8 @@ def _check_parameters_transform(imgs, confounds):
     as a list.
 
     """
+    imgs = _stringify_path(imgs)
+    confounds = _stringify_path(confounds)
     if not isinstance(imgs, (list, tuple)) or \
             isinstance(imgs, str):
         imgs = [imgs, ]

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -15,7 +15,7 @@ from nilearn.maskers import NiftiLabelsMasker
 from .._utils.niimg import _safe_get_data
 from .._utils.niimg_conversions import _iter_check_niimg
 from .._utils import fill_doc
-from .._utils.helpers import _stringify_path
+from .._utils.helpers import stringify_path
 
 
 def _estimator_fit(data, estimator, method=None):
@@ -66,8 +66,8 @@ def _check_parameters_transform(imgs, confounds):
     as a list.
 
     """
-    imgs = _stringify_path(imgs)
-    confounds = _stringify_path(confounds)
+    imgs = stringify_path(imgs)
+    confounds = stringify_path(confounds)
     if not isinstance(imgs, (list, tuple)) or \
             isinstance(imgs, str):
         imgs = [imgs, ]

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -17,6 +17,7 @@ from sklearn.utils import gen_even_slices, as_float_array
 from ._utils.numpy_conversions import csv_to_array, as_ndarray
 from ._utils import fill_doc
 from nilearn._utils.glm import _check_run_sample_masks
+from ._utils.helpers import _stringify_path
 
 availiable_filters = ['butterworth',
                       'cosine'
@@ -557,6 +558,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
     nilearn.image.clean_img
     """
     # Raise warning for some parameter combinations when confounds present
+    confounds = _stringify_path(confounds)
     if confounds is not None:
         _check_signal_parameters(detrend, standardize_confounds)
 

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -17,7 +17,7 @@ from sklearn.utils import gen_even_slices, as_float_array
 from ._utils.numpy_conversions import csv_to_array, as_ndarray
 from ._utils import fill_doc
 from nilearn._utils.glm import _check_run_sample_masks
-from ._utils.helpers import _stringify_path
+from ._utils.helpers import stringify_path
 
 availiable_filters = ['butterworth',
                       'cosine'
@@ -558,7 +558,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
     nilearn.image.clean_img
     """
     # Raise warning for some parameter combinations when confounds present
-    confounds = _stringify_path(confounds)
+    confounds = stringify_path(confounds)
     if confounds is not None:
         _check_signal_parameters(detrend, standardize_confounds)
 

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -480,7 +480,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
         Default is None.
 
     confounds : :class:`numpy.ndarray`, :obj:`str`,\
-    :class:`pandas.DataFrame` or :obj:`list` of
+    :class:`pandas.DataFrame` or :obj:`list` or :class:`os.PathLike` of
         Confounds timeseries. Shape must be
         (instant number, confound number), or just (instant number,)
         The number of time instants in ``signals`` and ``confounds`` must be

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -478,7 +478,7 @@ def vol_to_surf(img, surf_mesh,
     img : Niimg-like object, 3d or 4d.
         See http://nilearn.github.io/manipulating_images/input_output.html
 
-    surf_mesh : str or numpy.ndarray or Mesh
+    surf_mesh : str or numpy.ndarray or Mesh or os.PathLike
         Either a file containing surface mesh geometry (valid formats
         are .gii or Freesurfer specific files such as .orig, .pial,
         .sphere, .white, .inflated) or two Numpy arrays organized in a list,
@@ -678,7 +678,7 @@ def load_surf_data(surf_data):
 
     Parameters
     ----------
-    surf_data : str or numpy.ndarray
+    surf_data : str or numpy.ndarray or os.PathLike
         Either a file containing surface data (valid format are .gii,
         .gii.gz, .mgz, .nii, .nii.gz, or Freesurfer specific files such as
         .thickness, .curv, .sulc, .annot, .label), lists of 1D data files are
@@ -785,7 +785,7 @@ def load_surf_mesh(surf_mesh):
 
     Parameters
     ----------
-    surf_mesh : str or numpy.ndarray or Mesh
+    surf_mesh : str or numpy.ndarray or Mesh or os.PathLike
         Either a file containing surface mesh geometry (valid formats
         are .gii .gii.gz or Freesurfer specific files such as .orig, .pial,
         .sphere, .white, .inflated) or two Numpy arrays organized in a list,

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -25,6 +25,7 @@ from nilearn import datasets
 from nilearn.image import load_img
 from nilearn.image import resampling
 from nilearn._utils.path_finding import _resolve_globbing
+from .._utils.helpers import _stringify_path
 from nilearn import _utils
 from nilearn.image import get_data
 
@@ -690,6 +691,7 @@ def load_surf_data(surf_data):
 
     """
     # if the input is a filename, load it
+    surf_data = _stringify_path(surf_data)
     if isinstance(surf_data, str):
 
         # resolve globbing
@@ -799,6 +801,7 @@ def load_surf_mesh(surf_mesh):
     """
 
     # if input is a filename, try to load it
+    surf_mesh = _stringify_path(surf_mesh)
     if isinstance(surf_mesh, str):
         # resolve globbing
         file_list = _resolve_globbing(surf_mesh)

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -25,7 +25,6 @@ from nilearn import datasets
 from nilearn.image import load_img
 from nilearn.image import resampling
 from nilearn._utils.path_finding import _resolve_globbing
-from .._utils.helpers import _stringify_path
 from nilearn import _utils
 from nilearn.image import get_data
 
@@ -691,8 +690,7 @@ def load_surf_data(surf_data):
 
     """
     # if the input is a filename, load it
-    surf_data = _stringify_path(surf_data)
-    if isinstance(surf_data, str):
+    if isinstance(surf_data, (str, os.PathLike)):
 
         # resolve globbing
         file_list = _resolve_globbing(surf_data)
@@ -801,8 +799,7 @@ def load_surf_mesh(surf_mesh):
     """
 
     # if input is a filename, try to load it
-    surf_mesh = _stringify_path(surf_mesh)
-    if isinstance(surf_mesh, str):
+    if isinstance(surf_mesh, (str, os.PathLike)):
         # resolve globbing
         file_list = _resolve_globbing(surf_mesh)
         if len(file_list) == 1:

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -25,6 +25,7 @@ from nilearn import datasets
 from nilearn.image import load_img
 from nilearn.image import resampling
 from nilearn._utils.path_finding import _resolve_globbing
+from nilearn._utils.helpers import stringify_path
 from nilearn import _utils
 from nilearn.image import get_data
 
@@ -799,7 +800,8 @@ def load_surf_mesh(surf_mesh):
     """
 
     # if input is a filename, try to load it
-    if isinstance(surf_mesh, (str, os.PathLike)):
+    surf_mesh = stringify_path(surf_mesh)
+    if isinstance(surf_mesh, str):
         # resolve globbing
         file_list = _resolve_globbing(surf_mesh)
         if len(file_list) == 1:

--- a/nilearn/tests/test_niimg.py
+++ b/nilearn/tests/test_niimg.py
@@ -1,5 +1,6 @@
 import os
 import numpy as np
+from pathlib import Path
 
 import joblib
 import nibabel as nb
@@ -8,7 +9,7 @@ from nibabel import Nifti1Image
 from nibabel.tmpdirs import InTemporaryDirectory
 
 from nilearn.image import new_img_like
-from nilearn._utils import niimg
+from nilearn._utils import niimg, testing, load_niimg
 from nilearn.image import get_data
 
 
@@ -77,3 +78,11 @@ def test_img_data_dtype():
     # Verify that the distinction is worth making
     assert any(dtype_matches)
     assert not all(dtype_matches)
+
+
+def test_load_niimg():
+    img = Nifti1Image(np.zeros((10, 10, 10)), np.eye(4))
+
+    with testing.write_tmp_imgs(img, create_files=True) as filename:
+        filename = Path(filename)
+        load_niimg(filename)

--- a/nilearn/tests/test_niimg_conversions.py
+++ b/nilearn/tests/test_niimg_conversions.py
@@ -229,6 +229,14 @@ def test_check_niimg():
         get_data(img_4d).dtype.kind == get_data(img_4d_check).dtype.kind)
 
 
+def test_check_niimg_pathlike():
+    img = Nifti1Image(np.zeros((10, 10, 10)), np.eye(4))
+
+    with testing.write_tmp_imgs(img, create_files=True) as filename:
+        filename = Path(filename)
+        _utils.check_niimg_3d(filename)
+
+
 def test_check_niimg_wildcards():
     tmp_dir = tempfile.tempdir + os.sep
     nofile_path = "/tmp/nofile"

--- a/nilearn/tests/test_numpy_conversions.py
+++ b/nilearn/tests/test_numpy_conversions.py
@@ -236,7 +236,7 @@ def test_as_ndarray():
 def test_csv_to_array(tmp_path):
     # Create a phony CSV file
     fd, filename = tempfile.mkstemp(suffix='.csv',
-                                    dir=str(tmp_path))
+                                    dir=tmp_path)
     os.close(fd)
     try:
         with open(filename, mode='wt') as fp:


### PR DESCRIPTION
Closes #2642.
Replaces and closes #2803.
Also replaces #2644.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

Allow `os.PathLike` and `pathlib.Path` objects to be passed to functions expecting a string.
Use function based on `nibabel.filename_parser._stringify_path` to convert them to string.

- [x] Add conversion to all relevant functions
- [x] Add tests
- [x] Update docstrings
- [x] Add whatsnew entry
