### PR TITLE
[ENH] Improve test checking for removal of temporary file

### DIFF
--- a/nilearn/plotting/html_document.py
+++ b/nilearn/plotting/html_document.py
@@ -21,7 +21,9 @@ def set_max_img_views_before_warning(new_value):
 
 def _remove_after_n_seconds(file_name, n_seconds):
     script = os.path.join(os.path.dirname(__file__), 'rm_file.py')
-    subprocess.Popen([sys.executable, script, file_name, str(n_seconds)])
+    proc = subprocess.Popen([sys.executable, script, file_name,
+                             str(n_seconds)])
+    return proc
 
 
 class HTMLDocument(object):
@@ -44,6 +46,7 @@ class HTMLDocument(object):
         self.height = height
         self._temp_file = None
         self._check_n_open()
+        self._pid = None
 
     def _check_n_open(self):
         HTMLDocument._all_open_html_repr.add(self)
@@ -161,7 +164,8 @@ class HTMLDocument(object):
                      "for example by calling this.remove_temp_file").format(
                          file_name, file_size))
         else:
-            _remove_after_n_seconds(self._temp_file, temp_file_lifetime)
+            proc = _remove_after_n_seconds(self._temp_file, temp_file_lifetime)
+            self._pid = proc.pid
         webbrowser.open('file://{}'.format(file_name))
 
     def remove_temp_file(self):

--- a/nilearn/plotting/html_document.py
+++ b/nilearn/plotting/html_document.py
@@ -46,7 +46,7 @@ class HTMLDocument(object):
         self.height = height
         self._temp_file = None
         self._check_n_open()
-        self._proc = None
+        self._temp_file_removing_proc = None
 
     def _check_n_open(self):
         HTMLDocument._all_open_html_repr.add(self)
@@ -164,8 +164,8 @@ class HTMLDocument(object):
                      "for example by calling this.remove_temp_file").format(
                          file_name, file_size))
         else:
-            self._proc = _remove_after_n_seconds(self._temp_file,
-                                                 temp_file_lifetime)
+            self._temp_file_removing_proc = _remove_after_n_seconds(
+                self._temp_file, temp_file_lifetime)
         webbrowser.open('file://{}'.format(file_name))
 
     def remove_temp_file(self):

--- a/nilearn/plotting/html_document.py
+++ b/nilearn/plotting/html_document.py
@@ -46,7 +46,7 @@ class HTMLDocument(object):
         self.height = height
         self._temp_file = None
         self._check_n_open()
-        self._pid = None
+        self._proc = None
 
     def _check_n_open(self):
         HTMLDocument._all_open_html_repr.add(self)
@@ -164,8 +164,8 @@ class HTMLDocument(object):
                      "for example by calling this.remove_temp_file").format(
                          file_name, file_size))
         else:
-            proc = _remove_after_n_seconds(self._temp_file, temp_file_lifetime)
-            self._pid = proc.pid
+            self._proc = _remove_after_n_seconds(self._temp_file,
+                                                 temp_file_lifetime)
         webbrowser.open('file://{}'.format(file_name))
 
     def remove_temp_file(self):

--- a/nilearn/plotting/tests/test_html_document.py
+++ b/nilearn/plotting/tests/test_html_document.py
@@ -29,7 +29,7 @@ def test_temp_file_removing():
             assert "Saved HTML in temporary file" not in str(warning.message)
         html.open_in_browser(temp_file_lifetime=0.5)
         assert os.path.isfile(html._temp_file)
-        time.sleep(1.5)
+        os.waitpid(html._pid, 0)
         assert not os.path.isfile(html._temp_file)
         with pytest.warns(UserWarning, match="Saved HTML in temporary file"):
             html.open_in_browser(temp_file_lifetime=None)

--- a/nilearn/plotting/tests/test_html_document.py
+++ b/nilearn/plotting/tests/test_html_document.py
@@ -29,7 +29,7 @@ def test_temp_file_removing():
             assert "Saved HTML in temporary file" not in str(warning.message)
         html.open_in_browser(temp_file_lifetime=0.5)
         assert os.path.isfile(html._temp_file)
-        html._proc.wait()
+        html._temp_file_removing_proc.wait()
         assert not os.path.isfile(html._temp_file)
         with pytest.warns(UserWarning, match="Saved HTML in temporary file"):
             html.open_in_browser(temp_file_lifetime=None)

--- a/nilearn/plotting/tests/test_html_document.py
+++ b/nilearn/plotting/tests/test_html_document.py
@@ -29,7 +29,7 @@ def test_temp_file_removing():
             assert "Saved HTML in temporary file" not in str(warning.message)
         html.open_in_browser(temp_file_lifetime=0.5)
         assert os.path.isfile(html._temp_file)
-        os.waitpid(html._pid, 0)
+        html._proc.wait()
         assert not os.path.isfile(html._temp_file)
         with pytest.warns(UserWarning, match="Saved HTML in temporary file"):
             html.open_in_browser(temp_file_lifetime=None)


### PR DESCRIPTION
Closes #3301.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add ~~`_pid`~~ `_temp_file_removing_proc` attribute to class `HTMLDocument`
- Store suprocess in  `_remove_after_n_seconds` and return it
- ~~Use returned object to get pid of subprocess and store it in `_pid`~~
- Use ~~`os.waitpid`~~ `subprocess.Popen.wait` to pause process until subprocess is finished
    - This replaces `time.sleep(1.5)` 
