### PR TITLE
[FIX] Pass alpha on to glass brain when plotting connectome

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -26,6 +26,7 @@ Fixes
 - Fix usage of ``scipy.stats.gamma.pdf`` in ``_gamma_difference_hrf`` function under ``nilearn/glm/first_level/hemodynamic_models.py``, which resulted in slight distortion of HRF (:gh:`3297` by `Kun CHEN`_).
 - Fix bug introduced due to a fix in the pre-release version of scipy (``1.9.0rc1``) which now enforces that elements of a band-pass filter must meet condition ``Wn[0] < Wn[1]``.
   Now if band-pass elements are equal :func:`~nilearn.signal.butterworth` returns an unfiltered signal with a warning (:gh:`3293` by `Yasmin Mzayek`_).
+- Fix bug in behavior of ``alpha`` in ``nilearn.plotting.plot_connectome`` (:gh:`3306` by `Koen Helwegen`_).
 
 Enhancements
 ------------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -26,7 +26,7 @@ Fixes
 - Fix usage of ``scipy.stats.gamma.pdf`` in ``_gamma_difference_hrf`` function under ``nilearn/glm/first_level/hemodynamic_models.py``, which resulted in slight distortion of HRF (:gh:`3297` by `Kun CHEN`_).
 - Fix bug introduced due to a fix in the pre-release version of scipy (``1.9.0rc1``) which now enforces that elements of a band-pass filter must meet condition ``Wn[0] < Wn[1]``.
   Now if band-pass elements are equal :func:`~nilearn.signal.butterworth` returns an unfiltered signal with a warning (:gh:`3293` by `Yasmin Mzayek`_).
-- Fix bug in behavior of ``alpha`` in ``nilearn.plotting.plot_connectome`` (:gh:`3306` by `Koen Helwegen`_).
+- The parameter ``alpha`` is now correctly passed to :func:`~plotting.plot_glass_brain` in :func:`~plotting.plot_connectome` (:gh:`3306` by `Koen Helwegen`_).
 
 Enhancements
 ------------

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -118,6 +118,8 @@
 
 .. _Kamalakar Reddy Daddy: https://github.com/KamalakerDadi
 
+.. _Koen Helwegen: https://github.com/koenhelwegen
+
 .. _Konstantin Shmelkov: https://github.com/kshmelkov
 
 .. _Kshitij Chawla: https://github.com/kchawla-pi

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -1154,7 +1154,8 @@ def plot_connectome(adjacency_matrix, node_coords,
                                display_mode=display_mode,
                                figure=figure, axes=axes, title=title,
                                annotate=annotate,
-                               black_bg=black_bg)
+                               black_bg=black_bg,
+                               alpha=alpha)
 
     display.add_graph(adjacency_matrix, node_coords,
                       node_color=node_color, node_size=node_size,

--- a/nilearn/plotting/tests/test_img_plotting/test_plot_connectome.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_plot_connectome.py
@@ -112,12 +112,14 @@ def test_plot_connectome_colorbar(colorbar, adjacency, node_coords):
     plot_connectome(adjacency, node_coords, colorbar=colorbar)
     plt.close()
 
+
 @pytest.mark.parametrize("alpha", [0.0, 0.3, 0.7, 1.0])
 def test_plot_connectome_alpha(alpha, adjacency, node_coords):
     """Smoke test for plot_connectome with various alpha values.
     """
     plot_connectome(adjacency, node_coords, alpha=alpha)
     plt.close()
+
 
 def test_plot_connectome_to_file(adjacency, node_coords, base_params, tmpdir):
     """Smoke test for plot_connectome and saving to file."""

--- a/nilearn/plotting/tests/test_img_plotting/test_plot_connectome.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_plot_connectome.py
@@ -112,6 +112,12 @@ def test_plot_connectome_colorbar(colorbar, adjacency, node_coords):
     plot_connectome(adjacency, node_coords, colorbar=colorbar)
     plt.close()
 
+@pytest.mark.parametrize("alpha", [0.0, 0.3, 0.7, 1.0])
+def test_plot_connectome_alpha(alpha, adjacency, node_coords):
+    """Smoke test for plot_connectome with various alpha values.
+    """
+    plot_connectome(adjacency, node_coords, alpha=alpha)
+    plt.close()
 
 def test_plot_connectome_to_file(adjacency, node_coords, base_params, tmpdir):
     """Smoke test for plot_connectome and saving to file."""


### PR DESCRIPTION
Minor fix: `alpha` in `plotting.plot_connectome` is currently not passed on to `plot_glass_brain()`.