### PR TITLE
[ENH] Add n_elements_ attribute to masker classes

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -36,6 +36,7 @@ Enhancements
 - Conform seeding and docstrings in module ``_utils.data_gen`` (:gh:`3262` by `Yasmin Mzayek`_).
 - Docstrings of module :mod:`~nilearn.glm.second_level` were improved (:gh:`3030` by `Nicolas Gensollen`_).
 - In :func:`~reporting.get_clusters_table`, when the center of mass of a binary cluster falls outside the cluster, report the nearest within-cluster voxel instead (:gh:`3292` by `Connor Lane`_).
+- Add ``n_elements_`` attribute to masker classes (:gh:`3311` by `Taylor Salo`_).
 
 Changes
 -------
@@ -57,8 +58,8 @@ Changes
   them to int32 when possible (ie when it would not result in an overflow).
   Moreover, any atlas fetcher that returned int64 images now produces images
   containing smaller ints. (:gh:`3227` by `Jerome Dockes`_)
-- Refactors fmriprep confound loading such that that the parsing of the 
-  relevant image file and the loading of the confounds are done in 
+- Refactors fmriprep confound loading such that that the parsing of the
+  relevant image file and the loading of the confounds are done in
   separate steps (:gh:`3274` by `David G Ellis`_).
 - Private submodules, functions, and classes from the :mod:`~nilearn.decomposition` module now start with a "_" character to make it clear that they are not part of the public API (:gh:`3141` by `Nicolas Gensollen`_).
 - Convert references in ``nilearn/glm/regression.py`` and ``nilearn/glm/thresholding.py`` to use footcite/footbibliography (:gh:`3302` by `Ahmad Chamma`_).

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -135,8 +135,9 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         ----------
         imgs : 3D/4D Niimg-like object
             See http://nilearn.github.io/manipulating_images/input_output.html
-            Images to process. It must boil down to a 4D image with scans
-            number as last dimension.
+            Images to process.
+            If a 3D niimg is provided, a singleton dimension will be added to
+            the output to represent the single scan in the niimg.
 
         confounds : CSV file or array-like, optional
             This parameter is passed to signal.clean. Please see the related
@@ -170,8 +171,9 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         ----------
         imgs : 3D/4D Niimg-like object
             See http://nilearn.github.io/manipulating_images/input_output.html
-            Images to process. It must boil down to a 4D image with scans
-            number as last dimension.
+            Images to process.
+            If a 3D niimg is provided, a singleton dimension will be added to
+            the output to represent the single scan in the niimg.
 
         confounds : CSV file or array-like, optional
             This parameter is passed to signal.clean. Please see the related
@@ -276,7 +278,9 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
 
         Parameters
         ----------
-        X : Niimg-like object
+        X : 2D :obj:`numpy.ndarray`
+            Signal for each element in the mask.
+            shape: (number of scans, number of elements)
             See http://nilearn.github.io/manipulating_images/input_output.html
 
         Returns

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -243,7 +243,7 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
             if self.verbose > 0:
                 print('[{self.__class__.__name__}.fit] Computing mask')
 
-            imgs = stringify_path(imgs)
+            imgs = _utils.helpers.stringify_path(imgs)
             if not isinstance(imgs, collections.abc.Iterable) \
                     or isinstance(imgs, str):
                 raise ValueError(

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -272,8 +272,8 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
         else:
             self.affine_ = self.mask_img_.affine
 
-        # Load data in memory
-        data = get_data(self.mask_img_)
+        # Load data in memory, while also checking that mask is binary/valid
+        data, _ = masking._load_mask_img(self.mask_img_)
 
         # Infer the number of elements (voxels) in the mask
         self.n_elements_ = int(data.sum())

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -24,25 +24,28 @@ def _get_mask_strategy(strategy):
     elif strategy == 'epi':
         return masking.compute_multi_epi_mask
     elif strategy == 'whole-brain-template':
-        return partial(masking.compute_multi_brain_mask,
-                       mask_type='whole-brain')
+        return partial(
+            masking.compute_multi_brain_mask, mask_type='whole-brain'
+        )
     elif strategy == 'gm-template':
-        return partial(masking.compute_multi_brain_mask,
-                       mask_type='gm')
+        return partial(masking.compute_multi_brain_mask, mask_type='gm')
     elif strategy == 'wm-template':
-        return partial(masking.compute_multi_brain_mask,
-                       mask_type='wm')
+        return partial(masking.compute_multi_brain_mask, mask_type='wm')
     elif strategy == 'template':
-        warnings.warn("Masking strategy 'template' is deprecated."
-                      "Please use 'whole-brain-template' instead.")
-        return partial(masking.compute_multi_brain_mask,
-                       mask_type='whole-brain')
+        warnings.warn(
+            "Masking strategy 'template' is deprecated. "
+            "Please use 'whole-brain-template' instead."
+        )
+        return partial(
+            masking.compute_multi_brain_mask, mask_type='whole-brain'
+        )
     else:
-        raise ValueError("Unknown value of mask_strategy '%s'. "
-                         "Acceptable values are 'background', "
-                         "'epi', 'whole-brain-template', "
-                         "'gm-template', and "
-                         "'wm-template'." % strategy)
+        raise ValueError(
+            f"Unknown value of mask_strategy '{strategy}'. "
+            "Acceptable values are 'background', "
+            "'epi', 'whole-brain-template', "
+            "'gm-template', and 'wm-template'."
+        )
 
 
 @_utils.fill_doc
@@ -72,37 +75,37 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
         False : Do not standardize the data.
         Default=False.
 
-    standardize_confounds : boolean, optional
+    standardize_confounds : :obj:`bool`, optional
         If standardize_confounds is True, the confounds are z-scored:
         their mean is put to 0 and their variance to 1 in the time dimension.
         Default=True.
 
-    high_variance_confounds : boolean, optional
+    high_variance_confounds : :obj:`bool`, optional
         If True, high variance confounds are computed on provided image with
         :func:`nilearn.image.high_variance_confounds` and default parameters
         and regressed out. Default=False.
 
-    detrend : boolean, optional
+    detrend : :obj:`bool`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details. Default=False.
 
-    low_pass : None or float, optional
+    low_pass : None or :obj:`float`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    high_pass : None or float, optional
+    high_pass : None or :obj:`float`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    t_r : float, optional
+    t_r : :obj:`float`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    target_affine : 3x3 or 4x4 matrix, optional
+    target_affine : 3x3 or 4x4 :obj:`numpy.ndarray`, optional
         This parameter is passed to image.resample_img. Please see the
         related documentation for details.
 
-    target_shape : 3-tuple of integers, optional
+    target_shape : 3-:obj:`tuple` of :obj:`int`, optional
         This parameter is passed to image.resample_img. Please see the
         related documentation for details.
 
@@ -116,7 +119,7 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
 
         Default is 'background'.
 
-    mask_args : dict, optional
+    mask_args : :obj:`dict`, optional
         If mask is None, these are additional parameters passed to
         masking.compute_background_mask or masking.compute_epi_mask
         to fine-tune mask computation. Please see the related documentation
@@ -127,20 +130,20 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
         data will be converted to int32 if dtype is discrete and float32 if it
         is continuous.
 
-    memory : instance of joblib.Memory or string, optional
+    memory : instance of :obj:`joblib.Memory` or :obj:`str`, optional
         Used to cache the masking process.
         By default, no caching is done. If a string is given, it is the
         path to the caching directory.
 
-    memory_level : integer, optional
+    memory_level : :obj:`int`, optional
         Rough estimator of the amount of memory used by caching. Higher value
         means more memory for caching. Default=0.
 
-    n_jobs : integer, optional
+    n_jobs : :obj:`int`, optional
         The number of CPUs to use to do the computation. -1 means
         'all CPUs', -2 'all CPUs but one', and so on. Default=1.
 
-    verbose : integer, optional
+    verbose : :obj:`int`, optional
         Indicate the level of verbosity. By default, nothing is printed.
         Default=0.
 
@@ -166,13 +169,27 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
 
     """
 
-    def __init__(self, mask_img=None, smoothing_fwhm=None,
-                 standardize=False, standardize_confounds=True, detrend=False,
-                 high_variance_confounds=False, low_pass=None, high_pass=None,
-                 t_r=None, target_affine=None, target_shape=None,
-                 mask_strategy='background', mask_args=None,
-                 dtype=None, memory=Memory(location=None),
-                 memory_level=0, n_jobs=1, verbose=0):
+    def __init__(
+        self,
+        mask_img=None,
+        smoothing_fwhm=None,
+        standardize=False,
+        standardize_confounds=True,
+        detrend=False,
+        high_variance_confounds=False,
+        low_pass=None,
+        high_pass=None,
+        t_r=None,
+        target_affine=None,
+        target_shape=None,
+        mask_strategy='background',
+        mask_args=None,
+        dtype=None,
+        memory=Memory(location=None),
+        memory_level=0,
+        n_jobs=1,
+        verbose=0,
+    ):
         # Mask is provided or computed
         self.mask_img = mask_img
 
@@ -199,67 +216,79 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
         self._shelving = False
 
     def fit(self, imgs=None, y=None):
-        """Compute the mask corresponding to the data
+        """Compute the mask corresponding to the data.
 
         Parameters
         ----------
-        imgs : list of Niimg-like objects
+        imgs : :obj:`list` of Niimg-like objects
             See http://nilearn.github.io/manipulating_images/input_output.html
             Data on which the mask must be calculated. If this is a list,
             the affine is considered the same for all.
+
+        y : None
+            This parameter is unused. It is solely included for scikit-learn
+            compatibility.
 
         """
 
         # Load data (if filenames are given, load them)
         if self.verbose > 0:
-            print("[%s.fit] Loading data from %s" % (
-                self.__class__.__name__,
-                _utils._repr_niimgs(imgs, shorten=False)))
+            print(
+                f'[{self.__class__.__name__}.fit] Loading data from '
+                f'{_utils._repr_niimgs(imgs, shorten=False)}.'
+            )
 
         # Compute the mask if not given by the user
         if self.mask_img is None:
             if self.verbose > 0:
-                print("[%s.fit] Computing mask" % self.__class__.__name__)
+                print('[{self.__class__.__name__}.fit] Computing mask')
 
             if not isinstance(imgs, collections.abc.Iterable) \
                     or isinstance(imgs, str):
-                raise ValueError("[%s.fit] For multiple processing, you should"
-                                 " provide a list of data "
-                                 "(e.g. Nifti1Image objects or filenames)."
-                                 "%r is an invalid input"
-                                 % (self.__class__.__name__, imgs))
+                raise ValueError(
+                    f'[{self.__class__.__name__}.fit] '
+                    'For multiple processing, you should  provide a list of '
+                    'data (e.g. Nifti1Image objects or filenames). '
+                    f'{imgs} is an invalid input.'
+                )
 
-            mask_args = (self.mask_args if self.mask_args is not None
-                         else {})
+            mask_args = (self.mask_args if self.mask_args is not None else {})
             compute_mask = _get_mask_strategy(self.mask_strategy)
             self.mask_img_ = self._cache(
-                compute_mask, ignore=['n_jobs', 'verbose', 'memory'])(
-                    imgs,
-                    target_affine=self.target_affine,
-                    target_shape=self.target_shape,
-                    n_jobs=self.n_jobs,
-                    memory=self.memory,
-                    verbose=max(0, self.verbose - 1),
-                    **mask_args)
+                compute_mask,
+                ignore=['n_jobs', 'verbose', 'memory'],
+            )(
+                imgs,
+                target_affine=self.target_affine,
+                target_shape=self.target_shape,
+                n_jobs=self.n_jobs,
+                memory=self.memory,
+                verbose=max(0, self.verbose - 1),
+                **mask_args,
+            )
         else:
             if imgs is not None:
-                warnings.warn('[%s.fit] Generation of a mask has been'
-                              ' requested (imgs != None) while a mask has'
-                              ' been provided at masker creation. Given mask'
-                              ' will be used.' % self.__class__.__name__)
+                warnings.warn(
+                    f'[{self.__class__.__name__}.fit] '
+                    'Generation of a mask has been requested (imgs != None) '
+                    'while a mask has been provided at masker creation. '
+                    'Given mask will be used.'
+                )
 
             self.mask_img_ = _utils.check_niimg_3d(self.mask_img)
 
         # If resampling is requested, resample the mask as well.
         # Resampling: allows the user to change the affine, the shape or both.
         if self.verbose > 0:
-            print("[%s.transform] Resampling mask" % self.__class__.__name__)
+            print(f'[{self.__class__.__name__}.transform] Resampling mask')
 
         self.mask_img_ = self._cache(image.resample_img)(
             self.mask_img_,
             target_affine=self.target_affine,
             target_shape=self.target_shape,
-            interpolation='nearest', copy=False)
+            interpolation='nearest',
+            copy=False,
+        )
 
         if self.target_affine is not None:
             self.affine_ = self.target_affine
@@ -281,40 +310,42 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
         Parameters
         ----------
 
-        imgs_list : list of Niimg-like objects
+        imgs_list : :obj:`list` of Niimg-like objects
             See http://nilearn.github.io/manipulating_images/input_output.html
             List of imgs file to prepare. One item per subject.
 
-        confounds : list of confounds, optional
+        confounds : :obj:`list` of confounds, optional
             List of confounds (2D arrays or filenames pointing to CSV
             files or pandas DataFrames). Must be of same length than imgs_list.
 
-        sample_mask : list of sample_mask, optional
+        sample_mask : :obj:`list` of sample_mask, optional
             List of sample_mask (1D arrays) if scrubbing motion outliers.
             Must be of same length than imgs_list.
 
                 .. versionadded:: 0.8.0
 
-        copy : boolean, optional
+        copy : :obj:`bool`, optional
             If True, guarantees that output array has no memory in common with
             input array. Default=True.
 
-        n_jobs : integer, optional
+        n_jobs : :obj:`int`, optional
             The number of cpus to use to do the computation. -1 means
             'all cpus'. Default=1.
 
         Returns
         -------
-        region_signals : list of 2D numpy.ndarray
+        region_signals : :obj:`list` of 2D :obj:`numpy.ndarray`
             List of signal for each element per subject.
             shape: list of (number of scans, number of elements)
 
         """
 
         if not hasattr(self, 'mask_img_'):
-            raise ValueError('It seems that %s has not been fitted. '
-                             'You must call fit() before calling transform().'
-                             % self.__class__.__name__)
+            raise ValueError(
+                f'It seems that {self.__class__.__name__} has not been '
+                'fitted. '
+                'You must call fit() before calling transform().'
+            )
         target_fov = None
         if self.target_affine is None:
             # Force resampling on first image
@@ -347,24 +378,33 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
             ],
         )
 
-        func = self._cache(_filter_and_mask,
-                           ignore=['verbose', 'memory', 'memory_level',
-                                   'copy'],
-                           shelve=self._shelving)
+        func = self._cache(
+            _filter_and_mask,
+            ignore=[
+                'verbose',
+                'memory',
+                'memory_level',
+                'copy',
+            ],
+            shelve=self._shelving,
+        )
         data = Parallel(n_jobs=n_jobs)(
-            delayed(func)(imgs, self.mask_img_, params,
-                          memory_level=self.memory_level,
-                          memory=self.memory,
-                          verbose=self.verbose,
-                          confounds=cfs,
-                          copy=copy,
-                          dtype=self.dtype
-                          )
+            delayed(func)(
+                imgs,
+                self.mask_img_,
+                params,
+                memory_level=self.memory_level,
+                memory=self.memory,
+                verbose=self.verbose,
+                confounds=cfs,
+                copy=copy,
+                dtype=self.dtype,
+            )
             for imgs, cfs in zip(niimg_iter, confounds))
         return data
 
     def transform(self, imgs, confounds=None, sample_mask=None):
-        """ Apply mask, spatial and temporal preprocessing
+        """Apply mask, spatial and temporal preprocessing.
 
         Parameters
         ----------
@@ -372,11 +412,12 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
             See http://nilearn.github.io/manipulating_images/input_output.html
             Data to be preprocessed
 
-        confounds : CSV file path or 2D array or pandas DataFrame, optional
+        confounds : CSV file or 2D :obj:`numpy.ndarray` or \
+                :obj:`pandas.DataFrame`, optional
             This parameter is passed to signal.clean. Please see the
             corresponding documentation for details.
 
-        sample_mask : list of sample_mask, optional
+        sample_mask : :obj:`list` of 1D :obj:`numpy.ndarray`, optional
             List of sample_mask (1D arrays) if scrubbing motion outliers.
             Must be of same length than imgs_list.
 
@@ -384,14 +425,17 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
 
         Returns
         -------
-        data : {list of numpy arrays}
+        data : :obj:`list` of :obj:`numpy.ndarrays`
             preprocessed images
 
         """
         self._check_fitted()
-        if not hasattr(imgs, '__iter__') \
-                or isinstance(imgs, str):
+        if not hasattr(imgs, '__iter__') or isinstance(imgs, str):
             return self.transform_single_imgs(imgs)
-        return self.transform_imgs(imgs, confounds=confounds,
-                                   sample_mask=sample_mask,
-                                   n_jobs=self.n_jobs)
+
+        return self.transform_imgs(
+            imgs,
+            confounds=confounds,
+            sample_mask=sample_mask,
+            n_jobs=self.n_jobs,
+        )

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -161,6 +161,8 @@ class MultiNiftiMasker(NiftiMasker, CacheMixin):
     n_elements_ : :obj:`int`
         The number of voxels in the mask.
 
+        .. versionadded:: 0.9.2.dev
+
     See Also
     --------
     nilearn.image.resample_img: image resampling

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -408,7 +408,7 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
 
         Parameters
         ----------
-        imgs : list of Niimg-like objects
+        imgs : :obj:`list` of Niimg-like objects
             See http://nilearn.github.io/manipulating_images/input_output.html
             Data to be preprocessed
 

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -296,7 +296,7 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
             self.affine_ = self.mask_img_.affine
 
         # Load data in memory, while also checking that mask is binary/valid
-        data, _ = masking._load_mask_img(self.mask_img_)
+        data, _ = masking._load_mask_img(self.mask_img_, allow_empty=True)
 
         # Infer the number of elements (voxels) in the mask
         self.n_elements_ = int(data.sum())

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -157,6 +157,8 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         This is equivalent to the number of unique values in the mask image,
         ignoring the background value.
 
+        .. versionadded:: 0.9.2.dev
+
     See also
     --------
     nilearn.maskers.NiftiMasker

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -146,6 +146,12 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
 
     Attributes
     ----------
+    mask_img_ : :obj:`nibabel.nifti1.Nifti1Image`
+        The mask of the data, or the computed one.
+
+    labels_img_ : :obj:`nibabel.nifti1.Nifti1Image`
+        The labels image.
+
     n_elements_ : :obj:`int`
         The number of discrete values in the mask.
         This is equivalent to the number of unique values in the mask image,

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -461,8 +461,9 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
         ----------
         imgs : 3D/4D Niimg-like object
             See http://nilearn.github.io/manipulating_images/input_output.html
-            Images to process. It must boil down to a 4D image with scans
-            number as last dimension.
+            Images to process.
+            If a 3D niimg is provided, a singleton dimension will be added to
+            the output to represent the single scan in the niimg.
 
         confounds : CSV file or array-like or :obj:`pandas.DataFrame`, optional
             This parameter is passed to signal.clean. Please see the related

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -141,8 +141,15 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         standard_deviation. Default='mean'.
 
     reports : boolean, optional
-         If set to True, data is saved in order to produce a report.
-         Default=True.
+        If set to True, data is saved in order to produce a report.
+        Default=True.
+
+    Attributes
+    ----------
+    n_elements_ : :obj:`int`
+        The number of discrete values in the mask.
+        This is equivalent to the number of unique values in the mask image,
+        ignoring the background value.
 
     See also
     --------
@@ -336,6 +343,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                                            shorten=(not self.verbose)),
                        verbose=self.verbose)
             self.mask_img_ = _utils.check_niimg_3d(self.mask_img)
+
         else:
             self.mask_img_ = None
 
@@ -344,6 +352,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             if self.resampling_target == "data":
                 # resampling will be done at transform time
                 pass
+
             elif self.resampling_target is None:
                 if self.mask_img_.shape != self.labels_img_.shape[:3]:
                     raise ValueError(
@@ -351,6 +360,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                             "Regions and mask do not have the same shape",
                             mask_img=self.mask_img,
                             labels_img=self.labels_img))
+
                 if not np.allclose(self.mask_img_.affine,
                                    self.labels_img_.affine):
                     raise ValueError(_compose_err_msg(
@@ -365,6 +375,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                     target_shape=self.labels_img_.shape[:3],
                     interpolation="nearest",
                     copy=True)
+
             else:
                 raise ValueError(
                     "Invalid value for "
@@ -386,6 +397,13 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                 'img': imgs}
         else:
             self._reporting_data = None
+
+        # Infer the number of elements in the mask
+        # This is equal to the number of unique values in the label image,
+        # minus the background value.
+        self.n_elements_ = np.unique(
+            image.get_data(self._resampled_labels_img_)
+        ).size - 1
 
         return self
 

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -479,7 +479,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
 
         Returns
         -------
-        region_signals : 2D :obj:`numpy.ndarray` 
+        region_signals : 2D :obj:`numpy.ndarray`
             Signal for each label.
             shape: (number of scans, number of labels)
 
@@ -502,8 +502,9 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
         ----------
         imgs : 3D/4D Niimg-like object
             See http://nilearn.github.io/manipulating_images/input_output.html
-            Images to process. It must boil down to a 4D image with scans
-            number as last dimension.
+            Images to process.
+            If a 3D niimg is provided, a singleton dimension will be added to
+            the output to represent the single scan in the niimg.
 
         confounds : CSV file or array-like or :obj:`pandas.DataFrame`, optional
             This parameter is passed to signal.clean. Please see the related

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -479,7 +479,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
 
         Returns
         -------
-        region_signals : 2D numpy.ndarray
+        region_signals : 2D :obj:`numpy.ndarray` 
             Signal for each label.
             shape: (number of scans, number of labels)
 

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -196,7 +196,8 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         self._report_content = dict()
         self._report_content['description'] = (
             'This reports shows the regions '
-            'defined by the labels of the mask.')
+            'defined by the labels of the mask.'
+        )
         self._report_content['warning_message'] = None
 
         available_reduction_strategies = {'mean', 'median', 'sum',
@@ -250,6 +251,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             # previously fitted with no func image and is re-fitted
             if 'warning_message' in self._report_content:
                 self._report_content['warning_message'] = None
+
             labels_image = image.load_img(labels_image, dtype='int32')
             labels_image_data = image.get_data(labels_image)
             labels_image_affine = labels_image.affine
@@ -264,19 +266,23 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                                   "labels ({0}) and the number of regions "
                                   "in provided label image ({1})").format(
                                       len(self.labels), number_of_regions + 1))
+
             self._report_content['number_of_regions'] = number_of_regions
 
             label_values = np.unique(labels_image_data)
             label_values = label_values[label_values != self.background_label]
             columns = ['label value', 'region name', 'size (in mm^3)',
                        'relative size (in %)']
+
             if self.labels is None:
                 columns.remove('region name')
+
             regions_summary = {c: [] for c in columns}
             for label in label_values:
                 regions_summary['label value'].append(label)
                 if self.labels is not None:
                     regions_summary['region name'].append(self.labels[label])
+
                 size = len(labels_image_data[labels_image_data == label])
                 voxel_volume = np.abs(np.linalg.det(
                     labels_image_affine[:3, :3]))
@@ -286,6 +292,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                     size / len(
                         labels_image_data[labels_image_data != 0]
                     ) * 100, 2))
+
             self._report_content['summary'] = regions_summary
 
             img = self._reporting_data['img']
@@ -359,7 +366,9 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                         _compose_err_msg(
                             "Regions and mask do not have the same shape",
                             mask_img=self.mask_img,
-                            labels_img=self.labels_img))
+                            labels_img=self.labels_img,
+                        )
+                    )
 
                 if not np.allclose(self.mask_img_.affine,
                                    self.labels_img_.affine):
@@ -385,8 +394,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             # Just check that the mask is valid
             masking._load_mask_img(self.mask_img_)
 
-        if not hasattr(self,
-                       '_resampled_labels_img_'):
+        if not hasattr(self, '_resampled_labels_img_'):
             # obviates need to run .transform() before .inverse_transform()
             self._resampled_labels_img_ = self.labels_img_
 

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -7,17 +7,8 @@ import warnings
 
 from joblib import Memory
 
-from .. import _utils
-from .._utils.niimg import _safe_get_data
-from .._utils import (logger,
-                      CacheMixin,
-                      _compose_err_msg,
-                      fill_doc)
-from .._utils.class_inspect import get_params
-from .._utils.niimg_conversions import _check_same_fov
-from .. import masking
-from .. import image
-from .base_masker import _filter_and_extract, BaseMasker
+from nilearn import _utils, image, masking
+from nilearn.maskers.base_masker import _filter_and_extract, BaseMasker
 
 
 class _ExtractionFunctor(object):
@@ -40,8 +31,8 @@ class _ExtractionFunctor(object):
             mask_img=self.mask_img)
 
 
-@fill_doc
-class NiftiLabelsMasker(BaseMasker, CacheMixin):
+@_utils.fill_doc
+class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
     """Class for masking of Niimg-like objects.
 
     NiftiLabelsMasker is useful when data from non-overlapping volumes should
@@ -55,13 +46,13 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         See http://nilearn.github.io/manipulating_images/input_output.html
         Region definitions, as one image of labels.
 
-    labels : list of str, optional
+    labels : :obj:`list` of :obj:`str`, optional
         Full labels corresponding to the labels image. This is used
         to improve reporting quality if provided.
         Warning: The labels must be consistent with the label
         values provided through `labels_img`.
 
-    background_label : number, optional
+    background_label : :obj:`int` or :obj:`float`, optional
         Label used in labels_img to represent background.
         Warning: This value must be consistent with label values and
         image provided.
@@ -82,29 +73,29 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         False : Do not standardize the data.
         Default=False.
 
-    standardize_confounds : boolean, optional
+    standardize_confounds : :obj:`bool`, optional
         If standardize_confounds is True, the confounds are z-scored:
         their mean is put to 0 and their variance to 1 in the time dimension.
         Default=True.
 
-    high_variance_confounds : boolean, optional
+    high_variance_confounds : :obj:`bool`, optional
         If True, high variance confounds are computed on provided image with
         :func:`nilearn.image.high_variance_confounds` and default parameters
         and regressed out. Default=False.
 
-    detrend : boolean, optional
+    detrend : :obj:`bool`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details. Default=False.
 
-    low_pass : None or float, optional
+    low_pass : None or :obj:`float`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    high_pass : None or float, optional
+    high_pass : None or :obj:`float`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    t_r : float, optional
+    t_r : :obj:`float`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
@@ -121,26 +112,26 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         affine of maps_img. "None" means no resampling: if shapes and
         affines do not match, a ValueError is raised. Default="data".
 
-    memory : joblib.Memory or str, optional
+    memory : :obj:`joblib.Memory` or :obj:`str`, optional
         Used to cache the region extraction process.
         By default, no caching is done. If a string is given, it is the
         path to the caching directory.
 
-    memory_level : int, optional
+    memory_level : :obj:`int`, optional
         Aggressiveness of memory caching. The higher the number, the higher
         the number of functions that will be cached. Zero means no caching.
         Default=1.
 
-    verbose : integer, optional
+    verbose : :obj:`int`, optional
         Indicate the level of verbosity. By default, nothing is printed
         Default=0.
 
-    strategy : str, optional
+    strategy : :obj:`str`, optional
         The name of a valid function to reduce the region with.
         Must be one of: sum, mean, median, minimum, maximum, variance,
         standard_deviation. Default='mean'.
 
-    reports : boolean, optional
+    reports : :obj:`bool`, optional
         If set to True, data is saved in order to produce a report.
         Default=True.
 
@@ -164,17 +155,29 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
     nilearn.maskers.NiftiMasker
 
     """
-    # memory and memory_level are used by CacheMixin.
+    # memory and memory_level are used by _utils.CacheMixin.
 
-    def __init__(self, labels_img, labels=None, background_label=0,
-                 mask_img=None, smoothing_fwhm=None,
-                 standardize=False, standardize_confounds=True,
-                 high_variance_confounds=False, detrend=False,
-                 low_pass=None, high_pass=None, t_r=None, dtype=None,
-                 resampling_target="data",
-                 memory=Memory(location=None, verbose=0),
-                 memory_level=1, verbose=0, strategy="mean",
-                 reports=True):
+    def __init__(
+        self, labels_img,
+        labels=None,
+        background_label=0,
+        mask_img=None,
+        smoothing_fwhm=None,
+        standardize=False,
+        standardize_confounds=True,
+        high_variance_confounds=False,
+        detrend=False,
+        low_pass=None,
+        high_pass=None,
+        t_r=None,
+        dtype=None,
+        resampling_target='data',
+        memory=Memory(location=None, verbose=0),
+        memory_level=1,
+        verbose=0,
+        strategy='mean',
+        reports=True,
+    ):
         self.labels_img = labels_img
         self.labels = labels
         self.background_label = background_label
@@ -203,27 +206,33 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         self.reports = reports
         self._report_content = dict()
         self._report_content['description'] = (
-            'This reports shows the regions '
-            'defined by the labels of the mask.'
+            'This reports shows the regions defined by the labels of the mask.'
         )
         self._report_content['warning_message'] = None
 
-        available_reduction_strategies = {'mean', 'median', 'sum',
-                                          'minimum', 'maximum',
-                                          'standard_deviation', 'variance'}
+        available_reduction_strategies = {
+            'mean',
+            'median',
+            'sum',
+            'minimum',
+            'maximum',
+            'standard_deviation',
+            'variance',
+        }
 
         if strategy not in available_reduction_strategies:
-            raise ValueError(str.format(
-                "Invalid strategy '{}'. Valid strategies are {}.",
-                strategy,
-                available_reduction_strategies
-            ))
+            raise ValueError(
+                f"Invalid strategy '{strategy}'. "
+                f"Valid strategies are {available_reduction_strategies}."
+            )
 
         self.strategy = strategy
 
-        if resampling_target not in ("labels", "data", None):
-            raise ValueError("invalid value for 'resampling_target' "
-                             "parameter: " + str(resampling_target))
+        if resampling_target not in ('labels', 'data', None):
+            raise ValueError(
+                "invalid value for 'resampling_target' "
+                f"parameter: {resampling_target}"
+            )
 
     def generate_report(self):
         from nilearn.reporting.html_report import generate_report
@@ -242,11 +251,11 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             from nilearn import plotting
         except ImportError:
             with warnings.catch_warnings():
-                mpl_unavail_msg = ('Matplotlib is not imported! '
-                                   'No reports will be generated.')
+                mpl_unavail_msg = (
+                    'Matplotlib is not imported! No reports will be generated.'
+                )
                 warnings.filterwarnings('always', message=mpl_unavail_msg)
-                warnings.warn(category=ImportWarning,
-                              message=mpl_unavail_msg)
+                warnings.warn(category=ImportWarning, message=mpl_unavail_msg)
                 return [None]
 
         if self._reporting_data is not None:
@@ -270,17 +279,22 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             # have regions (plus background).
             if(self.labels is not None
                and len(self.labels) != number_of_regions + 1):
-                raise ValueError(("Mismatch between the number of provided "
-                                  "labels ({0}) and the number of regions "
-                                  "in provided label image ({1})").format(
-                                      len(self.labels), number_of_regions + 1))
+                raise ValueError(
+                    'Mismatch between the number of provided labels '
+                    f'({len(self.labels)}) and the number of regions in '
+                    f'provided label image ({number_of_regions + 1}).'
+                )
 
             self._report_content['number_of_regions'] = number_of_regions
 
             label_values = np.unique(labels_image_data)
             label_values = label_values[label_values != self.background_label]
-            columns = ['label value', 'region name', 'size (in mm^3)',
-                       'relative size (in %)']
+            columns = [
+                'label value',
+                'region name',
+                'size (in mm^3)',
+                'relative size (in %)',
+            ]
 
             if self.labels is None:
                 columns.remove('region name')
@@ -310,20 +324,22 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                 if len(dim) == 4:
                     # compute middle image from 4D series for plotting
                     img = image.index_img(img, dim[-1] // 2)
-                display = plotting.plot_img(img,
-                                            black_bg=False,
-                                            cmap='CMRmap_r')
+                display = plotting.plot_img(
+                    img,
+                    black_bg=False,
+                    cmap='CMRmap_r',
+                )
                 plt.close()
-                display.add_contours(labels_image,
-                                     filled=False,
-                                     linewidths=3)
+                display.add_contours(labels_image, filled=False, linewidths=3)
 
             # Otherwise, simply plot the ROI of the label image
             # and give a warning to the user
             else:
-                msg = ("No image provided to fit in NiftiLabelsMasker. "
-                       "Plotting ROIs of label image on the "
-                       "MNI152Template for reporting.")
+                msg = (
+                    'No image provided to fit in NiftiLabelsMasker. '
+                    'Plotting ROIs of label image on the '
+                    'MNI152Template for reporting.'
+                )
                 warnings.warn(msg)
                 self._report_content['warning_message'] = msg
                 display = plotting.plot_roi(labels_image)
@@ -331,10 +347,12 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
 
             # If we have a mask, show its contours
             if self._reporting_data['mask'] is not None:
-                display.add_contours(self._reporting_data['mask'],
-                                     filled=False,
-                                     colors="g",
-                                     linewidths=3)
+                display.add_contours(
+                    self._reporting_data['mask'],
+                    filled=False,
+                    colors="g",
+                    linewidths=3,
+                )
         else:
             self._report_content['summary'] = None
             display = None
@@ -347,16 +365,22 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         All parameters are unused, they are for scikit-learn compatibility.
 
         """
-        logger.log("loading data from %s" %
-                   _utils._repr_niimgs(self.labels_img,
-                                       shorten=(not self.verbose)),
-                   verbose=self.verbose)
+        _utils.logger.log(
+            'loading data from %s' % _utils._repr_niimgs(
+                self.labels_img,
+                shorten=(not self.verbose),
+            ),
+            verbose=self.verbose,
+        )
         self.labels_img_ = _utils.check_niimg_3d(self.labels_img)
         if self.mask_img is not None:
-            logger.log("loading data from %s" %
-                       _utils._repr_niimgs(self.mask_img,
-                                           shorten=(not self.verbose)),
-                       verbose=self.verbose)
+            _utils.logger.log(
+                'loading data from %s' % _utils._repr_niimgs(
+                    self.mask_img,
+                    shorten=(not self.verbose),
+                ),
+                verbose=self.verbose,
+            )
             self.mask_img_ = _utils.check_niimg_3d(self.mask_img)
 
         else:
@@ -364,39 +388,45 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
 
         # Check shapes and affines or resample.
         if self.mask_img_ is not None:
-            if self.resampling_target == "data":
+            if self.resampling_target == 'data':
                 # resampling will be done at transform time
                 pass
 
             elif self.resampling_target is None:
                 if self.mask_img_.shape != self.labels_img_.shape[:3]:
                     raise ValueError(
-                        _compose_err_msg(
-                            "Regions and mask do not have the same shape",
+                        _utils._compose_err_msg(
+                            'Regions and mask do not have the same shape',
                             mask_img=self.mask_img,
                             labels_img=self.labels_img,
                         )
                     )
 
-                if not np.allclose(self.mask_img_.affine,
-                                   self.labels_img_.affine):
-                    raise ValueError(_compose_err_msg(
-                        "Regions and mask do not have the same affine.",
-                        mask_img=self.mask_img, labels_img=self.labels_img))
+                if not np.allclose(
+                    self.mask_img_.affine,
+                    self.labels_img_.affine,
+                ):
+                    raise ValueError(
+                        _utils._compose_err_msg(
+                            'Regions and mask do not have the same affine.',
+                            mask_img=self.mask_img,
+                            labels_img=self.labels_img,
+                        ),
+                    )
 
-            elif self.resampling_target == "labels":
-                logger.log("resampling the mask", verbose=self.verbose)
+            elif self.resampling_target == 'labels':
+                _utils.logger.log('resampling the mask', verbose=self.verbose)
                 self.mask_img_ = image.resample_img(
                     self.mask_img_,
                     target_affine=self.labels_img_.affine,
                     target_shape=self.labels_img_.shape[:3],
-                    interpolation="nearest",
+                    interpolation='nearest',
                     copy=True)
 
             else:
                 raise ValueError(
-                    "Invalid value for "
-                    f"resampling_target: {self.resampling_target}"
+                    'Invalid value for '
+                    f'resampling_target: {self.resampling_target}'
                 )
 
             # Just check that the mask is valid
@@ -410,7 +440,8 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             self._reporting_data = {
                 'labels_image': self._resampled_labels_img_,
                 'mask': self.mask_img_,
-                'img': imgs}
+                'img': imgs,
+            }
         else:
             self._reporting_data = None
 
@@ -424,17 +455,45 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
         return self
 
     def fit_transform(self, imgs, confounds=None, sample_mask=None):
-        """ Prepare and perform signal extraction from regions.
+        """Prepare and perform signal extraction from regions.
+
+        Parameters
+        ----------
+        imgs : 3D/4D Niimg-like object
+            See http://nilearn.github.io/manipulating_images/input_output.html
+            Images to process. It must boil down to a 4D image with scans
+            number as last dimension.
+
+        confounds : CSV file or array-like or :obj:`pandas.DataFrame`, optional
+            This parameter is passed to signal.clean. Please see the related
+            documentation for details.
+            shape: (number of scans, number of confounds)
+
+        sample_mask : Any type compatible with numpy-array indexing, optional
+            shape: (number of scans - number of volumes removed, )
+            Masks the niimgs along time/fourth dimension to perform scrubbing
+            (remove volumes with high motion) and/or non-steady-state volumes.
+            This parameter is passed to signal.clean.
+
+                .. versionadded:: 0.8.0
+
+        Returns
+        -------
+        region_signals : 2D numpy.ndarray
+            Signal for each label.
+            shape: (number of scans, number of labels)
 
         """
         return self.fit().transform(imgs, confounds=confounds,
                                     sample_mask=sample_mask)
 
     def _check_fitted(self):
-        if not hasattr(self, "labels_img_"):
-            raise ValueError('It seems that %s has not been fitted. '
-                             'You must call fit() before calling transform().'
-                             % self.__class__.__name__)
+        if not hasattr(self, 'labels_img_'):
+            raise ValueError(
+                f'It seems that {self.__class__.__name__} has not been '
+                'fitted. '
+                'You must call fit() before calling transform().'
+            )
 
     def transform_single_imgs(self, imgs, confounds=None, sample_mask=None):
         """Extract signals from a single 4D niimg.
@@ -446,7 +505,7 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             Images to process. It must boil down to a 4D image with scans
             number as last dimension.
 
-        confounds : CSV file or array-like or pandas DataFrame, optional
+        confounds : CSV file or array-like or :obj:`pandas.DataFrame`, optional
             This parameter is passed to signal.clean. Please see the related
             documentation for details.
             shape: (number of scans, number of confounds)
@@ -475,11 +534,18 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             self._resampled_mask_img = self.mask_img_
         if self.resampling_target == "data":
             imgs_ = _utils.check_niimg(imgs, atleast_4d=True)
-            if not _check_same_fov(imgs_, self._resampled_labels_img_):
+            if not _utils.niimg_conversions._check_same_fov(
+                imgs_,
+                self._resampled_labels_img_,
+            ):
                 if self.verbose > 0:
                     print("Resampling labels")
                 labels_before_resampling = set(
-                    np.unique(_safe_get_data(self._resampled_labels_img_))
+                    np.unique(
+                        _utils.niimg._safe_get_data(
+                            self._resampled_labels_img_,
+                        )
+                    )
                 )
                 self._resampled_labels_img_ = self._cache(
                     image.resample_img, func_memory_level=2)(
@@ -487,7 +553,11 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                         target_shape=imgs_.shape[:3],
                         target_affine=imgs_.affine)
                 labels_after_resampling = set(
-                    np.unique(_safe_get_data(self._resampled_labels_img_))
+                    np.unique(
+                        _utils.niimg._safe_get_data(
+                            self._resampled_labels_img_,
+                        )
+                    )
                 )
                 labels_diff = labels_before_resampling.difference(
                     labels_after_resampling
@@ -499,8 +569,12 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
                                   "Label image only contains "
                                   f"{len(labels_after_resampling)} labels "
                                   "(including background).")
-            if self.mask_img is not None and not _check_same_fov(
-                    imgs_, self._resampled_mask_img):
+            if (self.mask_img is not None) and (
+                not _utils.niimg_conversions._check_same_fov(
+                    imgs_,
+                    self._resampled_mask_img,
+                )
+            ):
                 if self.verbose > 0:
                     print("Resampling mask")
                 self._resampled_mask_img = self._cache(
@@ -518,19 +592,25 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             target_shape = self._resampled_labels_img_.shape[:3]
             target_affine = self._resampled_labels_img_.affine
 
-        params = get_params(NiftiLabelsMasker, self,
-                            ignore=['resampling_target'])
+        params = _utils.class_inspect.get_params(
+            NiftiLabelsMasker,
+            self,
+            ignore=['resampling_target'],
+        )
         params['target_shape'] = target_shape
         params['target_affine'] = target_affine
 
         region_signals, labels_ = self._cache(
             _filter_and_extract,
-            ignore=['verbose', 'memory', 'memory_level']
+            ignore=['verbose', 'memory', 'memory_level'],
         )(
             # Images
-            imgs, _ExtractionFunctor(self._resampled_labels_img_,
-                                     self.background_label, self.strategy,
-                                     self._resampled_mask_img),
+            imgs, _ExtractionFunctor(
+                self._resampled_labels_img_,
+                self.background_label,
+                self.strategy,
+                self._resampled_mask_img,
+            ),
             # Pre-processing
             params,
             confounds=confounds,
@@ -539,7 +619,8 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
             # Caching
             memory=self.memory,
             memory_level=self.memory_level,
-            verbose=self.verbose)
+            verbose=self.verbose,
+        )
 
         self.labels_ = labels_
 
@@ -552,22 +633,25 @@ class NiftiLabelsMasker(BaseMasker, CacheMixin):
 
         Parameters
         ----------
-        signals : (2D numpy.ndarray)
+        signals : 2D :obj:`numpy.ndarray`
             Signal for each region.
             shape: (number of scans, number of regions)
 
         Returns
         -------
-        voxel_signals : (Nifti1Image)
+        img : :obj:`nibabel.nifti1.Nifti1Image`
             Signal for each voxel
-            shape: (number of scans, number of voxels)
+            shape: (X, Y, Z, number of scans)
 
         """
         from ..regions import signal_extraction
 
         self._check_fitted()
 
-        logger.log("computing image from signals", verbose=self.verbose)
+        _utils.logger.log("computing image from signals", verbose=self.verbose)
         return signal_extraction.signals_to_img_labels(
-            signals, self._resampled_labels_img_, self.mask_img_,
-            background_label=self.background_label)
+            signals,
+            self._resampled_labels_img_,
+            self.mask_img_,
+            background_label=self.background_label,
+        )

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -464,8 +464,9 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
         ----------
         imgs : 3D/4D Niimg-like object
             See http://nilearn.github.io/manipulating_images/input_output.html
-            Images to process. It must boil down to a 4D image with scans
-            number as last dimension.
+            Images to process.
+            If a 3D niimg is provided, a singleton dimension will be added to
+            the output to represent the single scan in the niimg.
 
         confounds : CSV file or array-like, optional
             This parameter is passed to signal.clean. Please see the related

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -128,8 +128,8 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
 
     Attributes
     ----------
-    mask_img_ : :obj:`nibabel.nifti1.Nifti1Image`
-        The mask of the data, or the computed one.
+    maps_img_ : :obj:`nibabel.nifti1.Nifti1Image`
+        The maps mask of the data.
 
     n_elements_ : :obj:`int`
         The number of overlapping maps in the mask.
@@ -396,7 +396,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
             self._reporting_data = None
 
         # The number of elements is equal to the number of volumes
-        self.n_elements_ = self.mask_img_.shape[3]
+        self.n_elements_ = self.maps_img_.shape[3]
 
         return self
 

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -135,6 +135,8 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         The number of overlapping maps in the mask.
         This is equivalent to the number of volumes in the mask image.
 
+        .. versionadded:: 0.9.2.dev
+
     Notes
     -----
     If resampling_target is set to "maps", every 3D image processed by

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -1,19 +1,13 @@
 """
 Transformer for computing ROI signals.
 """
+import warnings
 
 import numpy as np
-import warnings
 from joblib import Memory
 
-from .. import _utils
-from .._utils import logger, CacheMixin
-from .._utils.class_inspect import get_params
-from .._utils import fill_doc
-from .._utils.niimg_conversions import _check_same_fov
-from .. import image
-from .base_masker import _filter_and_extract, BaseMasker
-from nilearn.image import get_data
+from nilearn import _utils, image
+from nilearn.maskers.base_masker import _filter_and_extract, BaseMasker
 
 
 class _ExtractionFunctor(object):
@@ -32,8 +26,8 @@ class _ExtractionFunctor(object):
             mask_img=self._resampled_mask_img_)
 
 
-@fill_doc
-class NiftiMapsMasker(BaseMasker, CacheMixin):
+@_utils.fill_doc
+class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
     """Class for masking of Niimg-like objects.
 
     NiftiMapsMasker is useful when data from overlapping volumes should be
@@ -55,7 +49,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         See http://nilearn.github.io/manipulating_images/input_output.html
         Mask to apply to regions before extracting signals.
 
-    allow_overlap : boolean, optional
+    allow_overlap : :obj:`bool`, optional
         If False, an error is raised if the maps overlaps (ie at least two
         maps have a non-zero value for the same voxel). Default=True.
     %(smoothing_fwhm)s
@@ -70,29 +64,29 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         False : Do not standardize the data.
         Default=False.
 
-    standardize_confounds : boolean, optional
+    standardize_confounds : :obj:`bool`, optional
         If standardize_confounds is True, the confounds are z-scored:
         their mean is put to 0 and their variance to 1 in the time dimension.
         Default=True.
 
-    high_variance_confounds : boolean, optional
+    high_variance_confounds : :obj:`bool`, optional
         If True, high variance confounds are computed on provided image with
         :func:`nilearn.image.high_variance_confounds` and default parameters
         and regressed out. Default=False.
 
-    detrend : boolean, optional
+    detrend : :obj:`bool`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details. Default=False.
 
-    low_pass : None or float, optional
+    low_pass : None or :obj:`float`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    high_pass : None or float, optional
+    high_pass : None or :obj:`float`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
-    t_r : float, optional
+    t_r : :obj:`float`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details
 
@@ -108,21 +102,21 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         no resampling: if shapes and affines do not match, a ValueError is
         raised. Default="data".
 
-    memory : joblib.Memory or str, optional
+    memory : :obj:`joblib.Memory` or :obj:`str`, optional
         Used to cache the region extraction process.
         By default, no caching is done. If a string is given, it is the
         path to the caching directory.
 
-    memory_level : int, optional
+    memory_level : :obj:`int`, optional
         Aggressiveness of memory caching. The higher the number, the higher
         the number of functions that will be cached. Zero means no caching.
         Default=0.
 
-    verbose : integer, optional
+    verbose : :obj:`int`, optional
         Indicate the level of verbosity. By default, nothing is printed.
         Default=0.
 
-    reports : boolean, optional
+    reports : :obj:`bool`, optional
         If set to True, data is saved in order to produce a report.
         Default=True.
 
@@ -151,13 +145,26 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
     """
     # memory and memory_level are used by CacheMixin.
 
-    def __init__(self, maps_img, mask_img=None,
-                 allow_overlap=True, smoothing_fwhm=None, standardize=False,
-                 standardize_confounds=True, high_variance_confounds=False,
-                 detrend=False, low_pass=None, high_pass=None, t_r=None,
-                 dtype=None, resampling_target="data",
-                 memory=Memory(location=None, verbose=0), memory_level=0,
-                 verbose=0, reports=True):
+    def __init__(
+        self,
+        maps_img,
+        mask_img=None,
+        allow_overlap=True,
+        smoothing_fwhm=None,
+        standardize=False,
+        standardize_confounds=True,
+        high_variance_confounds=False,
+        detrend=False,
+        low_pass=None,
+        high_pass=None,
+        t_r=None,
+        dtype=None,
+        resampling_target="data",
+        memory=Memory(location=None, verbose=0),
+        memory_level=0,
+        verbose=0,
+        reports=True,
+    ):
         self.maps_img = maps_img
         self.mask_img = mask_img
 
@@ -189,18 +196,22 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         self.report_id = -1
         self._report_content = dict()
         self._report_content['description'] = (
-            'This reports shows the spatial maps provided to the mask.')
+            'This reports shows the spatial maps provided to the mask.'
+        )
         self._report_content['warning_message'] = None
 
         if resampling_target not in ("mask", "maps", "data", None):
-            raise ValueError("invalid value for 'resampling_target'"
-                             " parameter: " + str(resampling_target))
+            raise ValueError(
+                "invalid value for 'resampling_target' "
+                f"parameter: {resampling_target}"
+            )
 
         if self.mask_img is None and resampling_target == "mask":
             raise ValueError(
                 "resampling_target has been set to 'mask' but no mask "
-                "has been provided.\nSet resampling_target to something else"
-                " or provide a mask.")
+                "has been provided.\n"
+                "Set resampling_target to something else or provide a mask."
+            )
 
     def generate_report(self, displayed_maps=10):
         """Generate an HTML report for the current ``NiftiMapsMasker`` object.
@@ -251,12 +262,17 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
             HTML report for the masker.
         """
         from nilearn.reporting.html_report import generate_report
-        if(displayed_maps != "all"
-           and not isinstance(displayed_maps, (list, np.ndarray, int))):
-            raise TypeError("Parameter ``displayed_maps`` of "
-                            "``generate_report()`` should be either 'all' or "
-                            "an int, or a list/array of ints. You provided a "
-                            f"{type(displayed_maps)}")
+
+        if (
+            displayed_maps != "all"
+            and not isinstance(displayed_maps, (list, np.ndarray, int))
+        ):
+            raise TypeError(
+                "Parameter ``displayed_maps`` of "
+                "``generate_report()`` should be either 'all' or "
+                "an int, or a list/array of ints. You provided a "
+                f"{type(displayed_maps)}"
+            )
         self.displayed_maps = displayed_maps
         self.report_id += 1
         return generate_report(self)
@@ -271,6 +287,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         """
         from nilearn.reporting.html_report import _embed_img
         from nilearn import plotting
+
         if self._reporting_data is not None:
             maps_image = self._reporting_data['maps_image']
         else:
@@ -281,19 +298,22 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
             maps_to_be_displayed = range(n_maps)
             if isinstance(self.displayed_maps, int):
                 if n_maps < self.displayed_maps:
-                    msg = ("`generate_report()` received "
-                           f"{self.displayed_maps} to be displayed. "
-                           f"But masker only has {n_maps} maps."
-                           f"Setting number of displayed maps to {n_maps}.")
+                    msg = (
+                        '`generate_report()` received '
+                        f'{self.displayed_maps} to be displayed. '
+                        f'But masker only has {n_maps} maps.'
+                        f'Setting number of displayed maps to {n_maps}.'
+                    )
                     warnings.warn(category=UserWarning, message=msg)
                     self.displayed_maps = n_maps
                 maps_to_be_displayed = range(self.displayed_maps)
             elif isinstance(self.displayed_maps, (list, np.ndarray)):
                 if max(self.displayed_maps) > n_maps:
-                    raise ValueError("Report cannot display the "
-                                     "following maps "
-                                     f"{self.displayed_maps} because "
-                                     f"masker only has {n_maps} maps.")
+                    raise ValueError(
+                        'Report cannot display the following maps '
+                        f'{self.displayed_maps} because '
+                        f'masker only has {n_maps} maps.'
+                    )
                 maps_to_be_displayed = self.displayed_maps
             self._report_content['report_id'] = self.report_id
             self._report_content['number_of_maps'] = n_maps
@@ -311,19 +331,23 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
                         maps_image, i)) for i in maps_to_be_displayed]
                 for idx, component in enumerate(maps_to_be_displayed):
                     display = plotting.plot_img(
-                        img, cut_coords=cut_coords[idx],
-                        black_bg=False, cmap='CMRmap_r'
+                        img,
+                        cut_coords=cut_coords[idx],
+                        black_bg=False,
+                        cmap='CMRmap_r',
                     )
                     display.add_overlay(
                         image.index_img(maps_image, idx),
-                        cmap=plotting.cm.black_blue
+                        cmap=plotting.cm.black_blue,
                     )
                     embeded_images.append(_embed_img(display))
                     display.close()
                 return embeded_images
             else:
-                msg = ("No image provided to fit in NiftiMapsMasker. "
-                       "Plotting only spatial maps for reporting.")
+                msg = (
+                    'No image provided to fit in NiftiMapsMasker. '
+                    'Plotting only spatial maps for reporting.'
+                )
                 warnings.warn(msg)
                 self._report_content['warning_message'] = msg
                 for component in maps_to_be_displayed:
@@ -343,30 +367,42 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
 
         """
         # Load images
-        logger.log("loading regions from %s" %
-                   _utils._repr_niimgs(self.maps_img,
-                                       shorten=(not self.verbose)),
-                   verbose=self.verbose)
+        _utils.logger.log(
+            "loading regions from %s" % _utils._repr_niimgs(
+                self.maps_img,
+                shorten=(not self.verbose),
+            ),
+            verbose=self.verbose,
+        )
         self.maps_img_ = _utils.check_niimg(
             self.maps_img, dtype=self.dtype, atleast_4d=True
         )
-        self.maps_img_ = image.clean_img(self.maps_img_, detrend=False,
-                                         standardize=False,
-                                         ensure_finite=True)
+        self.maps_img_ = image.clean_img(
+            self.maps_img_,
+            detrend=False,
+            standardize=False,
+            ensure_finite=True,
+        )
 
         if self.mask_img is not None:
-            logger.log("loading mask from %s" %
-                       _utils._repr_niimgs(self.mask_img,
-                                           shorten=(not self.verbose)),
-                       verbose=self.verbose)
+            _utils.logger.log(
+                "loading mask from %s" % _utils._repr_niimgs(
+                    self.mask_img,
+                    shorten=(not self.verbose),
+                ),
+                verbose=self.verbose,
+            )
             self.mask_img_ = _utils.check_niimg_3d(self.mask_img)
         else:
             self.mask_img_ = None
 
         # Check shapes and affines or resample.
         if self.resampling_target is None and self.mask_img_ is not None:
-            _check_same_fov(mask=self.mask_img_, maps=self.maps_img_,
-                            raise_error=True)
+            _utils.niimg_conversions._check_same_fov(
+                mask=self.mask_img_,
+                maps=self.maps_img_,
+                raise_error=True,
+            )
 
         elif self.resampling_target == "mask" and self.mask_img_ is not None:
             if self.verbose > 0:
@@ -377,7 +413,8 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
                 target_affine=self.mask_img_.affine,
                 target_shape=self.mask_img_.shape,
                 interpolation="continuous",
-                copy=True)
+                copy=True,
+            )
 
         elif self.resampling_target == "maps" and self.mask_img_ is not None:
             if self.verbose > 0:
@@ -388,12 +425,15 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
                 target_affine=self.maps_img_.affine,
                 target_shape=self.maps_img_.shape[:3],
                 interpolation="nearest",
-                copy=True)
+                copy=True,
+            )
 
         if self.reports:
-            self._reporting_data = {'maps_image': self.maps_img_,
-                                    'mask': self.mask_img_,
-                                    'img': imgs}
+            self._reporting_data = {
+                'maps_image': self.maps_img_,
+                'mask': self.mask_img_,
+                'img': imgs,
+            }
         else:
             self._reporting_data = None
 
@@ -404,9 +444,11 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
 
     def _check_fitted(self):
         if not hasattr(self, "maps_img_"):
-            raise ValueError('It seems that %s has not been fitted. '
-                             'You must call fit() before calling transform().'
-                             % self.__class__.__name__)
+            raise ValueError(
+                f'It seems that {self.__class__.__name__} has not been '
+                'fitted. '
+                'You must call fit() before calling transform().'
+            )
 
     def fit_transform(self, imgs, confounds=None, sample_mask=None):
         """Prepare and perform signal extraction.
@@ -459,7 +501,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
             images = dict(maps=self.maps_img_, data=imgs_)
             if self.mask_img_ is not None:
                 images['mask'] = self.mask_img_
-            _check_same_fov(raise_error=True, **images)
+            _utils.niimg_conversions._check_same_fov(raise_error=True, **images)
         else:
             if self.resampling_target == "data":
                 imgs_ = _utils.check_niimg(imgs, atleast_4d=True)
@@ -471,7 +513,10 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
                 self._resampled_maps_img_ = self.maps_img_
                 ref_img = self.maps_img_
 
-            if not _check_same_fov(ref_img, self._resampled_maps_img_):
+            if not _utils.niimg_conversions._check_same_fov(
+                ref_img,
+                self._resampled_maps_img_,
+            ):
                 if self.verbose > 0:
                     print("Resampling maps")
                 self._resampled_maps_img_ = self._cache(image.resample_img)(
@@ -479,20 +524,27 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
                     target_shape=ref_img.shape[:3],
                     target_affine=ref_img.affine)
 
-            if (self.mask_img_ is not None
-                    and not _check_same_fov(ref_img, self.mask_img_)):
+            if (
+                self.mask_img_ is not None and not
+                _utils.niimg_conversions._check_same_fov(
+                    ref_img,
+                    self.mask_img_,
+                )
+            ):
                 if self.verbose > 0:
                     print("Resampling mask")
                 self._resampled_mask_img_ = self._cache(image.resample_img)(
-                    self.mask_img_, interpolation="nearest",
+                    self.mask_img_,
+                    interpolation="nearest",
                     target_shape=ref_img.shape[:3],
-                    target_affine=ref_img.affine)
+                    target_affine=ref_img.affine,
+                )
 
         if not self.allow_overlap:
             # Check if there is an overlap.
 
             # If float, we set low values to 0
-            data = get_data(self._resampled_maps_img_)
+            data = image.get_data(self._resampled_maps_img_)
             dtype = data.dtype
             if dtype.kind == 'f':
                 data[data < np.finfo(dtype).eps] = 0.
@@ -502,7 +554,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
                 raise ValueError(
                     'Overlap detected in the maps. The overlap may be '
                     'due to the atlas itself or possibly introduced by '
-                    'resampling'
+                    'resampling.'
                 )
 
         target_shape = None
@@ -511,26 +563,34 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
             target_shape = self._resampled_maps_img_.shape[:3]
             target_affine = self._resampled_maps_img_.affine
 
-        params = get_params(NiftiMapsMasker, self,
-                            ignore=['resampling_target'])
+        params = _utils.class_inspect.get_params(
+            NiftiMapsMasker,
+            self,
+            ignore=['resampling_target'],
+        )
         params['target_shape'] = target_shape
         params['target_affine'] = target_affine
 
         region_signals, labels_ = self._cache(
-            _filter_and_extract, ignore=['verbose', 'memory', 'memory_level'])(
-                # Images
-                imgs, _ExtractionFunctor(self._resampled_maps_img_,
-                                         self._resampled_mask_img_),
-                # Pre-treatments
-                params,
-                confounds=confounds,
-                sample_mask=sample_mask,
-                dtype=self.dtype,
-                # Caching
-                memory=self.memory,
-                memory_level=self.memory_level,
-                # kwargs
-                verbose=self.verbose)
+            _filter_and_extract,
+            ignore=['verbose', 'memory', 'memory_level'],
+        )(
+            # Images
+            imgs, _ExtractionFunctor(
+                self._resampled_maps_img_,
+                self._resampled_mask_img_,
+            ),
+            # Pre-treatments
+            params,
+            confounds=confounds,
+            sample_mask=sample_mask,
+            dtype=self.dtype,
+            # Caching
+            memory=self.memory,
+            memory_level=self.memory_level,
+            # kwargs
+            verbose=self.verbose,
+        )
         self.labels_ = labels_
         return region_signals
 
@@ -555,6 +615,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
 
         self._check_fitted()
 
-        logger.log("computing image from signals", verbose=self.verbose)
+        _utils.logger.log("computing image from signals", verbose=self.verbose)
         return signal_extraction.signals_to_img_maps(
-            region_signals, self.maps_img_, mask_img=self.mask_img_)
+            region_signals, self.maps_img_, mask_img=self.mask_img_
+        )

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -501,7 +501,10 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
             images = dict(maps=self.maps_img_, data=imgs_)
             if self.mask_img_ is not None:
                 images['mask'] = self.mask_img_
-            _utils.niimg_conversions._check_same_fov(raise_error=True, **images)
+            _utils.niimg_conversions._check_same_fov(
+                raise_error=True,
+                **images,
+            )
         else:
             if self.resampling_target == "data":
                 imgs_ = _utils.check_niimg(imgs, atleast_4d=True)

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -126,6 +126,15 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         If set to True, data is saved in order to produce a report.
         Default=True.
 
+    Attributes
+    ----------
+    mask_img_ : :obj:`nibabel.nifti1.Nifti1Image`
+        The mask of the data, or the computed one.
+
+    n_elements_ : :obj:`int`
+        The number of overlapping maps in the mask.
+        This is equivalent to the number of volumes in the mask image.
+
     Notes
     -----
     If resampling_target is set to "maps", every 3D image processed by
@@ -342,6 +351,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         self.maps_img_ = image.clean_img(self.maps_img_, detrend=False,
                                          standardize=False,
                                          ensure_finite=True)
+
         if self.mask_img is not None:
             logger.log("loading mask from %s" %
                        _utils._repr_niimgs(self.mask_img,
@@ -359,6 +369,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         elif self.resampling_target == "mask" and self.mask_img_ is not None:
             if self.verbose > 0:
                 print("Resampling maps")
+
             self.maps_img_ = image.resample_img(
                 self.maps_img_,
                 target_affine=self.mask_img_.affine,
@@ -369,6 +380,7 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
         elif self.resampling_target == "maps" and self.mask_img_ is not None:
             if self.verbose > 0:
                 print("Resampling mask")
+
             self.mask_img_ = image.resample_img(
                 self.mask_img_,
                 target_affine=self.maps_img_.affine,
@@ -382,6 +394,9 @@ class NiftiMapsMasker(BaseMasker, CacheMixin):
                                     'img': imgs}
         else:
             self._reporting_data = None
+
+        # The number of elements is equal to the number of volumes
+        self.n_elements_ = self.mask_img_.shape[3]
 
         return self
 

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -421,8 +421,8 @@ class NiftiMasker(BaseMasker, CacheMixin):
         else:  # resample image to mask affine
             self.affine_ = self.mask_img_.affine
 
-        # Load data in memory
-        data = get_data(self.mask_img_)
+        # Load data in memory, while also checking that mask is binary/valid
+        data, _ = masking._load_mask_img(self.mask_img_)
 
         # Infer the number of elements (voxels) in the mask
         self.n_elements_ = int(data.sum())

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -411,7 +411,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
 
         Parameters
         ----------
-        imgs : list of Niimg-like objects
+        imgs : :obj:`list` of Niimg-like objects
             See http://nilearn.github.io/manipulating_images/input_output.html
             Data on which the mask must be calculated. If this is a list,
             the affine is considered the same for all.
@@ -503,8 +503,9 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         ----------
         imgs : 3D/4D Niimg-like object
             See http://nilearn.github.io/manipulating_images/input_output.html
-            Images to process. It must boil down to a 4D image with scans
-            number as last dimension.
+            Images to process.
+            If a 3D niimg is provided, a singleton dimension will be added to
+            the output to represent the single scan in the niimg.
 
         confounds : CSV file or array-like or :obj:`pandas.DataFrame`, optional
             This parameter is passed to signal.clean. Please see the related

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -407,7 +407,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
             )
 
     def fit(self, imgs=None, y=None):
-        """Compute the mask corresponding to the data
+        """Compute the mask corresponding to the data.
 
         Parameters
         ----------
@@ -497,7 +497,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         sample_mask=None,
         copy=True,
     ):
-        """Apply mask, spatial and temporal preprocessing
+        """Apply mask, spatial and temporal preprocessing.
 
         Parameters
         ----------

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -464,7 +464,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
             self.affine_ = self.mask_img_.affine
 
         # Load data in memory, while also checking that mask is binary/valid
-        data, _ = masking._load_mask_img(self.mask_img_)
+        data, _ = masking._load_mask_img(self.mask_img_, allow_empty=True)
 
         # Infer the number of elements (voxels) in the mask
         self.n_elements_ = int(data.sum())

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -21,7 +21,7 @@ class _ExtractionFunctor(object):
         self.mask_img_ = mask_img_
 
     def __call__(self, imgs):
-        return(
+        return (
             masking.apply_mask(
                 imgs,
                 self.mask_img_,

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -131,7 +131,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         resampled first. After this, the images are resampled to the
         resampled mask.
 
-    runs : numpy array, optional
+    runs : :obj:`numpy.ndarray`, optional
         Add a run level to the preprocessing. Each run will be
         detrended independently. Must be a 1D array of n_samples elements.
     %(smoothing_fwhm)s
@@ -146,38 +146,38 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         False : Do not standardize the data.
         Default=False.
 
-    standardize_confounds : boolean, optional
+    standardize_confounds : :obj:`bool`, optional
         If standardize_confounds is True, the confounds are z-scored:
         their mean is put to 0 and their variance to 1 in the time dimension.
         Default=True.
 
-    high_variance_confounds : boolean, optional
+    high_variance_confounds : :obj:`bool`, optional
         If True, high variance confounds are computed on provided image with
         :func:`nilearn.image.high_variance_confounds` and default parameters
         and regressed out. Default=False.
 
-    detrend : boolean, optional
+    detrend : :obj:`bool`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details: :func:`nilearn.signal.clean`.
         Default=False.
 
-    low_pass : None or float, optional
+    low_pass : None or :obj:`float`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details: :func:`nilearn.signal.clean`.
 
-    high_pass : None or float, optional
+    high_pass : None or :obj:`float`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details: :func:`nilearn.signal.clean`.
 
-    t_r : float, optional
+    t_r : :obj:`float`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details: :func:`nilearn.signal.clean`.
 
-    target_affine : 3x3 or 4x4 matrix, optional
+    target_affine : 3x3 or 4x4 :obj:`numpy.ndarray`, optional
         This parameter is passed to image.resample_img. Please see the
         related documentation for details.
 
-    target_shape : 3-tuple of integers, optional
+    target_shape : 3-:obj:`tuple` of :obj:`int`, optional
         This parameter is passed to image.resample_img. Please see the
         related documentation for details.
     %(mask_strategy)s
@@ -190,7 +190,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
 
         Default is 'background'.
 
-    mask_args : dict, optional
+    mask_args : :obj:`dict`, optional
         If mask is None, these are additional parameters passed to
         masking.compute_background_mask or masking.compute_epi_mask
         to fine-tune mask computation. Please see the related documentation
@@ -201,20 +201,20 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         data will be converted to int32 if dtype is discrete and float32 if it
         is continuous.
 
-    memory : instance of joblib.Memory or string, optional
+    memory : instance of :obj:`joblib.Memory` or :obj:`str`, optional
         Used to cache the masking process.
         By default, no caching is done. If a string is given, it is the
         path to the caching directory.
 
-    memory_level : integer, optional
+    memory_level : :obj:`int`, optional
         Rough estimator of the amount of memory used by caching. Higher value
         means more memory for caching. Default=1.
 
-    verbose : integer, optional
+    verbose : :obj:`int`, optional
         Indicate the level of verbosity. By default, nothing is printed.
         Default=0.
 
-    reports : boolean, optional
+    reports : :obj:`bool`, optional
         If set to True, data is saved in order to produce a report.
         Default=True.
 
@@ -241,14 +241,28 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
     nilearn.signal.clean
 
     """
-    def __init__(self, mask_img=None, runs=None, smoothing_fwhm=None,
-                 standardize=False, standardize_confounds=True, detrend=False,
-                 high_variance_confounds=False, low_pass=None, high_pass=None,
-                 t_r=None, target_affine=None, target_shape=None,
-                 mask_strategy='background', mask_args=None,
-                 dtype=None, memory_level=1, memory=Memory(location=None),
-                 verbose=0, reports=True,
-                 ):
+    def __init__(
+        self,
+        mask_img=None,
+        runs=None,
+        smoothing_fwhm=None,
+        standardize=False,
+        standardize_confounds=True,
+        detrend=False,
+        high_variance_confounds=False,
+        low_pass=None,
+        high_pass=None,
+        t_r=None,
+        target_affine=None,
+        target_shape=None,
+        mask_strategy='background',
+        mask_args=None,
+        dtype=None,
+        memory_level=1,
+        memory=Memory(location=None),
+        verbose=0,
+        reports=True,
+    ):
         # Mask is provided or computed
         self.mask_img = mask_img
         self.runs = runs
@@ -275,10 +289,13 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
             'This report shows the input Nifti image overlaid '
             'with the outlines of the mask (in green). We '
             'recommend to inspect the report for the overlap '
-            'between the mask and its input image. ')
+            'between the mask and its input image. '
+        )
         self._report_content['warning_message'] = None
-        self._overlay_text = ('\n To see the input Nifti image before '
-                              'resampling, hover over the displayed image.')
+        self._overlay_text = (
+            '\n To see the input Nifti image before resampling, '
+            'hover over the displayed image.'
+        )
         self._shelving = False
 
     def generate_report(self):
@@ -286,7 +303,8 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         return generate_report(self)
 
     def _reporting(self):
-        """
+        """Load displays needed for report.
+
         Returns
         -------
         displays : list
@@ -296,14 +314,17 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         try:
             from nilearn import plotting
             import matplotlib.pyplot as plt
+
         except ImportError:
             with warnings.catch_warnings():
-                mpl_unavail_msg = ('Matplotlib is not imported! '
-                                   'No reports will be generated.')
+                mpl_unavail_msg = (
+                    'Matplotlib is not imported! '
+                    'No reports will be generated.'
+                )
                 warnings.filterwarnings('always', message=mpl_unavail_msg)
                 warnings.warn(
                     category=ImportWarning,
-                    message=mpl_unavail_msg
+                    message=mpl_unavail_msg,
                 )
                 return [None]
 
@@ -320,22 +341,31 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
             if len(dim) == 4:
                 # compute middle image from 4D series for plotting
                 img = image.index_img(img, dim[-1] // 2)
+
         else:  # images were not provided to fit
-            msg = ("No image provided to fit in NiftiMasker. "
-                   "Setting image to mask for reporting.")
+            msg = (
+                'No image provided to fit in NiftiMasker. '
+                'Setting image to mask for reporting.'
+            )
             warnings.warn(msg)
             self._report_content['warning_message'] = msg
             img = mask
 
         # create display of retained input mask, image
         # for visual comparison
-        init_display = plotting.plot_img(img,
-                                         black_bg=False,
-                                         cmap='CMRmap_r')
+        init_display = plotting.plot_img(
+            img,
+            black_bg=False,
+            cmap='CMRmap_r',
+        )
         plt.close()
         if mask is not None:
-            init_display.add_contours(mask, levels=[.5], colors='g',
-                                      linewidths=2.5)
+            init_display.add_contours(
+                mask,
+                levels=[.5],
+                colors='g',
+                linewidths=2.5,
+            )
 
         if 'transform' not in self._reporting_data:
             return [init_display]
@@ -353,20 +383,28 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
             else:  # images were not provided to fit
                 resampl_img = resampl_mask
 
-            final_display = plotting.plot_img(resampl_img,
-                                              black_bg=False,
-                                              cmap='CMRmap_r')
+            final_display = plotting.plot_img(
+                resampl_img,
+                black_bg=False,
+                cmap='CMRmap_r',
+            )
             plt.close()
-            final_display.add_contours(resampl_mask, levels=[.5],
-                                       colors='g', linewidths=2.5)
+            final_display.add_contours(
+                resampl_mask,
+                levels=[.5],
+                colors='g',
+                linewidths=2.5,
+            )
 
         return [init_display, final_display]
 
     def _check_fitted(self):
         if not hasattr(self, 'mask_img_'):
-            raise ValueError('It seems that %s has not been fitted. '
-                             'You must call fit() before calling transform().'
-                             % self.__class__.__name__)
+            raise ValueError(
+                f'It seems that {self.__class__.__name__} has not been '
+                'fitted. '
+                'You must call fit() before calling transform().'
+            )
 
     def fit(self, imgs=None, y=None):
         """Compute the mask corresponding to the data
@@ -378,24 +416,27 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
             Data on which the mask must be calculated. If this is a list,
             the affine is considered the same for all.
 
-        """
-        # y=None is for scikit-learn compatibility (unused here).
+        y : None
+            This parameter is unused. It is solely included for scikit-learn
+            compatibility.
 
+        """
         # Load data (if filenames are given, load them)
         if self.verbose > 0:
-            print("[%s.fit] Loading data from %s" % (
-                self.__class__.__name__,
-                _utils._repr_niimgs(imgs, shorten=False)))
+            print(
+                f'[{self.__class__.__name__}.fit] '
+                f'Loading data from {_utils._repr_niimgs(imgs, shorten=False)}'
+            )
 
         # Compute the mask if not given by the user
         if self.mask_img is None:
-            mask_args = (self.mask_args if self.mask_args is not None
-                         else {})
+            mask_args = (self.mask_args if self.mask_args is not None else {})
             compute_mask = _get_mask_strategy(self.mask_strategy)
             if self.verbose > 0:
-                print("[%s.fit] Computing the mask" % self.__class__.__name__)
+                print(f'[{self.__class__.__name__}.fit] Computing the mask')
             self.mask_img_ = self._cache(compute_mask, ignore=['verbose'])(
-                imgs, verbose=max(0, self.verbose - 1), **mask_args)
+                imgs, verbose=max(0, self.verbose - 1), **mask_args
+            )
         else:
             self.mask_img_ = _utils.check_niimg_3d(self.mask_img)
 
@@ -407,13 +448,15 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         # If resampling is requested, resample also the mask
         # Resampling: allows the user to change the affine, the shape or both
         if self.verbose > 0:
-            print("[%s.fit] Resampling mask" % self.__class__.__name__)
+            print(f'[{self.__class__.__name__}.fit] Resampling mask')
 
         self.mask_img_ = self._cache(image.resample_img)(
             self.mask_img_,
             target_affine=self.target_affine,
             target_shape=self.target_shape,
-            copy=False, interpolation='nearest')
+            copy=False,
+            interpolation='nearest',
+        )
 
         if self.target_affine is not None:  # resample image to target affine
             self.affine_ = self.target_affine
@@ -427,14 +470,17 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         self.n_elements_ = int(data.sum())
 
         if self.verbose > 10:
-            print("[%s.fit] Finished fit" % self.__class__.__name__)
+            print(f'[{self.__class__.__name__}.fit] Finished fit')
 
         if (self.target_shape is not None) or (self.target_affine is not None):
             if self.reports:
                 if imgs is not None:
                     resampl_imgs = self._cache(image.resample_img)(
-                        imgs, target_affine=self.affine_,
-                        copy=False, interpolation='nearest')
+                        imgs,
+                        target_affine=self.affine_,
+                        copy=False,
+                        interpolation='nearest',
+                    )
                 else:  # imgs not provided to fit
                     resampl_imgs = None
 
@@ -444,8 +490,13 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
 
         return self
 
-    def transform_single_imgs(self, imgs, confounds=None, sample_mask=None,
-                              copy=True):
+    def transform_single_imgs(
+        self,
+        imgs,
+        confounds=None,
+        sample_mask=None,
+        copy=True,
+    ):
         """Apply mask, spatial and temporal preprocessing
 
         Parameters
@@ -455,7 +506,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
             Images to process. It must boil down to a 4D image with scans
             number as last dimension.
 
-        confounds : CSV file or array-like or pandas DataFrame, optional
+        confounds : CSV file or array-like or :obj:`pandas.DataFrame`, optional
             This parameter is passed to signal.clean. Please see the related
             documentation for details: :func:`nilearn.signal.clean`.
             shape: (number of scans, number of confounds)
@@ -466,12 +517,12 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
             (remove volumes with high motion) and/or non-steady-state volumes.
             This parameter is passed to signal.clean.
 
-        copy : Boolean, optional
+        copy : :obj:`bool`, optional
             Indicates whether a copy is returned or not. Default=True.
 
         Returns
         -------
-        region_signals : 2D numpy.ndarray
+        region_signals : 2D :obj:`numpy.ndarray`
             Signal for each voxel inside the mask.
             shape: (number of scans, number of voxels)
 
@@ -492,18 +543,26 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
             ],
         )
 
-        data = self._cache(_filter_and_mask,
-                           ignore=['verbose', 'memory', 'memory_level',
-                                   'copy'],
-                           shelve=self._shelving)(
-            imgs, self.mask_img_, params,
+        data = self._cache(
+            _filter_and_mask,
+            ignore=[
+                'verbose',
+                'memory',
+                'memory_level',
+                'copy',
+            ],
+            shelve=self._shelving,
+        )(
+            imgs,
+            self.mask_img_,
+            params,
             memory_level=self.memory_level,
             memory=self.memory,
             verbose=self.verbose,
             confounds=confounds,
             sample_mask=sample_mask,
             copy=copy,
-            dtype=self.dtype
+            dtype=self.dtype,
         )
 
         return data

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -230,6 +230,8 @@ class NiftiMasker(BaseMasker, CacheMixin):
     n_elements_ : :obj:`int`
         The number of voxels in the mask.
 
+        .. versionadded:: 0.9.2.dev
+
     See also
     --------
     nilearn.masking.compute_background_mask

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -154,7 +154,7 @@ def _iter_signals_from_spheres(seeds, niimg, radius, allow_overlap,
 
     Parameters
     ----------
-    seeds : list of triplets of coordinates in native space
+    seeds : :obj:`list` of triplets of coordinates in native space
         Seed definitions. List of coordinates of the seeds in the same space
         as the images (typically MNI or TAL).
 

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -283,6 +283,8 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
     n_elements_ : :obj:`int`
         The number of seeds in the masker.
 
+        .. versionadded:: 0.9.2.dev
+
     seeds_ : :obj:`list` of :obj:`list`
         The coordinates of the seeds in the masker.
 

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -278,6 +278,14 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         Indicate the level of verbosity. By default, nothing is printed.
         Default=0.
 
+    Attributes
+    ----------
+    n_elements_ : :obj:`int`
+        The number of seeds in the masker.
+
+    seeds_ : :obj:`list` of :obj:`list`
+        The coordinates of the seeds in the masker.
+
     See also
     --------
     nilearn.maskers.NiftiMasker
@@ -352,6 +360,8 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
                                  "instead of 3." % (i, len(seed)))
 
             self.seeds_.append(seed)
+
+        self.n_elements_ = len(self.seeds_)
 
         return self
 

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -36,8 +36,9 @@ def _apply_mask_and_get_affinity(seeds, niimg, radius, allow_overlap,
 
     niimg : 3D/4D Niimg-like object
         See http://nilearn.github.io/manipulating_images/input_output.html
-        Images to process. It must boil down to a 4D image with scans
-        number as last dimension.
+        Images to process.
+        If a 3D niimg is provided, a singleton dimension will be added to
+        the output to represent the single scan in the niimg.
 
     radius : float
         Indicates, in millimeters, the radius for the sphere around the seed.
@@ -160,8 +161,9 @@ def _iter_signals_from_spheres(seeds, niimg, radius, allow_overlap,
 
     niimg : 3D/4D Niimg-like object
         See http://nilearn.github.io/manipulating_images/input_output.html
-        Images to process. It must boil down to a 4D image with scans
-        number as last dimension.
+        Images to process.
+        If a 3D niimg is provided, a singleton dimension will be added to
+        the output to represent the single scan in the niimg.
 
     radius: float
         Indicates, in millimeters, the radius for the sphere around the seed.
@@ -405,8 +407,9 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         ----------
         imgs : 3D/4D Niimg-like object
             See http://nilearn.github.io/manipulating_images/input_output.html
-            Images to process. It must boil down to a 4D image with scans
-            number as last dimension.
+            Images to process.
+            If a 3D niimg is provided, a singleton dimension will be added to
+            the output to represent the single scan in the niimg.
 
         confounds : CSV file or array-like or :obj:`pandas.DataFrame`, optional
             This parameter is passed to signal.clean. Please see the related

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -444,8 +444,9 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         ----------
         imgs : 3D/4D Niimg-like object
             See http://nilearn.github.io/manipulating_images/input_output.html
-            Images to process. It must boil down to a 4D image with scans
-            number as last dimension.
+            Images to process.
+            If a 3D niimg is provided, a singleton dimension will be added to
+            the output to represent the single scan in the niimg.
 
         confounds : CSV file or array-like or :obj:`pandas.DataFrame`, optional
             This parameter is passed to signal.clean. Please see the related

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -10,20 +10,21 @@ from sklearn import neighbors
 from joblib import Memory
 from scipy import sparse
 
-from ..image.resampling import coord_transform
-from .._utils.niimg_conversions import _safe_get_data
-from .._utils import CacheMixin, logger, fill_doc
-from .._utils.niimg import img_data_dtype
-from .._utils.niimg_conversions import check_niimg_4d, check_niimg_3d
-from .._utils.class_inspect import get_params
-from .. import image
-from .. import masking
-from .base_masker import _filter_and_extract, BaseMasker
+from nilearn import image, masking
+from nilearn._utils import CacheMixin, logger, fill_doc
+from nilearn.maskers.base_masker import _filter_and_extract, BaseMasker
+from nilearn._utils.class_inspect import get_params
+from nilearn._utils.niimg import img_data_dtype
+from nilearn._utils.niimg_conversions import (
+    _safe_get_data,
+    check_niimg_4d,
+    check_niimg_3d,
+)
 
 
 def _apply_mask_and_get_affinity(seeds, niimg, radius, allow_overlap,
                                  mask_img=None):
-    '''Utility function to get only the rows which are occupied by sphere at
+    """Utility function to get only the rows which are occupied by sphere at
     given seed locations and the provided radius. Rows are in target_affine and
     target_shape space.
 
@@ -41,7 +42,7 @@ def _apply_mask_and_get_affinity(seeds, niimg, radius, allow_overlap,
     radius : float
         Indicates, in millimeters, the radius for the sphere around the seed.
 
-    allow_overlap: boolean
+    allow_overlap : boolean
         If False, a ValueError is raised if VOIs overlap
 
     mask_img : Niimg-like object, optional
@@ -59,7 +60,7 @@ def _apply_mask_and_get_affinity(seeds, niimg, radius, allow_overlap,
         Contains the boolean indices for each sphere.
         shape: (number of seeds, number of voxels)
 
-    '''
+    """
     seeds = list(seeds)
 
     # Compute world coordinates of all in-mask voxels.
@@ -72,29 +73,39 @@ def _apply_mask_and_get_affinity(seeds, niimg, radius, allow_overlap,
     elif mask_img is not None:
         affine = niimg.affine
         mask_img = check_niimg_3d(mask_img)
-        mask_img = image.resample_img(mask_img, target_affine=affine,
-                                      target_shape=niimg.shape[:3],
-                                      interpolation='nearest')
+        mask_img = image.resample_img(
+            mask_img,
+            target_affine=affine,
+            target_shape=niimg.shape[:3],
+            interpolation='nearest',
+        )
         mask, _ = masking._load_mask_img(mask_img)
         mask_coords = list(zip(*np.where(mask != 0)))
 
         X = masking._apply_mask_fmri(niimg, mask_img)
+
     elif niimg is not None:
         affine = niimg.affine
         if np.isnan(np.sum(_safe_get_data(niimg))):
-            warnings.warn('The imgs you have fed into fit_transform() contains'
-                          ' NaN values which will be converted to zeroes ')
+            warnings.warn(
+                'The imgs you have fed into fit_transform() contains NaN '
+                'values which will be converted to zeroes.'
+            )
             X = _safe_get_data(niimg, True).reshape([-1, niimg.shape[3]]).T
         else:
             X = _safe_get_data(niimg).reshape([-1, niimg.shape[3]]).T
+
         mask_coords = list(np.ndindex(niimg.shape[:3]))
+
     else:
         raise ValueError("Either a niimg or a mask_img must be provided.")
 
     # For each seed, get coordinates of nearest voxel
     nearests = []
     for sx, sy, sz in seeds:
-        nearest = np.round(coord_transform(sx, sy, sz, np.linalg.inv(affine)))
+        nearest = np.round(image.resampling.coord_transform(
+            sx, sy, sz, np.linalg.inv(affine)
+        ))
         nearest = nearest.astype(int)
         nearest = (nearest[0], nearest[1], nearest[2])
         try:
@@ -103,8 +114,9 @@ def _apply_mask_and_get_affinity(seeds, niimg, radius, allow_overlap,
             nearests.append(None)
 
     mask_coords = np.asarray(list(zip(*mask_coords)))
-    mask_coords = coord_transform(mask_coords[0], mask_coords[1],
-                                  mask_coords[2], affine)
+    mask_coords = image.resampling.coord_transform(
+        mask_coords[0], mask_coords[1], mask_coords[2], affine
+    )
     mask_coords = np.asarray(mask_coords).T
 
     clf = neighbors.NearestNeighbors(radius=radius)
@@ -113,6 +125,7 @@ def _apply_mask_and_get_affinity(seeds, niimg, radius, allow_overlap,
     for i, nearest in enumerate(nearests):
         if nearest is None:
             continue
+
         A[i, nearest] = True
 
     # Include the voxel containing the seed itself if not masked
@@ -127,11 +140,10 @@ def _apply_mask_and_get_affinity(seeds, niimg, radius, allow_overlap,
     sphere_sizes = np.asarray(A.tocsr().sum(axis=1)).ravel()
     empty_spheres = np.nonzero(sphere_sizes == 0)[0]
     if len(empty_spheres) != 0:
-        raise ValueError("These spheres are empty: {}".format(empty_spheres))
+        raise ValueError(f'These spheres are empty: {empty_spheres}')
 
-    if not allow_overlap:
-        if np.any(A.sum(axis=0) >= 2):
-            raise ValueError('Overlap detected between spheres')
+    if (not allow_overlap) and np.any(A.sum(axis=0) >= 2):
+        raise ValueError('Overlap detected between spheres')
 
     return X, A
 
@@ -142,7 +154,7 @@ def _iter_signals_from_spheres(seeds, niimg, radius, allow_overlap,
 
     Parameters
     ----------
-    seeds : List of triplets of coordinates in native space
+    seeds : list of triplets of coordinates in native space
         Seed definitions. List of coordinates of the seeds in the same space
         as the images (typically MNI or TAL).
 
@@ -206,11 +218,11 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
 
     Parameters
     ----------
-    seeds : List of triplet of coordinates in native space
+    seeds : :obj:`list` of triplet of coordinates in native space
         Seed definitions. List of coordinates of the seeds in the same space
         as the images (typically MNI or TAL).
 
-    radius : float, optional
+    radius : :obj:`float`, optional
         Indicates, in millimeters, the radius for the sphere around the seed.
         Default is None (signal is extracted on a single voxel).
 
@@ -218,7 +230,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         See http://nilearn.github.io/manipulating_images/input_output.html
         Mask to apply to regions before extracting signals.
 
-    allow_overlap : boolean, optional
+    allow_overlap : :obj:`bool`, optional
         If False, an error is raised if the maps overlaps (ie at least two
         maps have a non-zero value for the same voxel). Default=False.
     %(smoothing_fwhm)s
@@ -233,29 +245,29 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         False : Do not standardize the data.
         Default=False.
 
-    standardize_confounds : boolean, optional
+    standardize_confounds : :obj:`bool`, optional
         If standardize_confounds is True, the confounds are z-scored:
         their mean is put to 0 and their variance to 1 in the time dimension.
         Default=True.
 
-    high_variance_confounds : boolean, optional
+    high_variance_confounds : :obj:`bool`, optional
         If True, high variance confounds are computed on provided image with
         :func:`nilearn.image.high_variance_confounds` and default parameters
         and regressed out. Default=False.
 
-    detrend : boolean, optional
+    detrend : :obj:`bool`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details. Default=False.
 
-    low_pass : None or float, optional
+    low_pass : None or :obj:`float`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details.
 
-    high_pass : None or float, optional
+    high_pass : None or :obj:`float`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details.
 
-    t_r : float, optional
+    t_r : :obj:`float`, optional
         This parameter is passed to signal.clean. Please see the related
         documentation for details.
 
@@ -264,17 +276,17 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         data will be converted to int32 if dtype is discrete and float32 if it
         is continuous.
 
-    memory : joblib.Memory or str, optional
+    memory : :obj:`joblib.Memory` or :obj:`str`, optional
         Used to cache the region extraction process.
         By default, no caching is done. If a string is given, it is the
         path to the caching directory.
 
-    memory_level : int, optional
+    memory_level : :obj:`int`, optional
         Aggressiveness of memory caching. The higher the number, the higher
         the number of functions that will be cached. Zero means no caching.
         Default=1.
 
-    verbose : integer, optional
+    verbose : :obj:`int`, optional
         Indicate the level of verbosity. By default, nothing is printed.
         Default=0.
 
@@ -295,12 +307,25 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
     """
     # memory and memory_level are used by CacheMixin.
 
-    def __init__(self, seeds, radius=None, mask_img=None, allow_overlap=False,
-                 smoothing_fwhm=None, standardize=False,
-                 standardize_confounds=True, high_variance_confounds=False,
-                 detrend=False, low_pass=None, high_pass=None, t_r=None,
-                 dtype=None, memory=Memory(location=None, verbose=0),
-                 memory_level=1, verbose=0):
+    def __init__(
+        self,
+        seeds,
+        radius=None,
+        mask_img=None,
+        allow_overlap=False,
+        smoothing_fwhm=None,
+        standardize=False,
+        standardize_confounds=True,
+        high_variance_confounds=False,
+        detrend=False,
+        low_pass=None,
+        high_pass=None,
+        t_r=None,
+        dtype=None,
+        memory=Memory(location=None, verbose=0),
+        memory_level=1,
+        verbose=0,
+    ):
         self.seeds = seeds
         self.mask_img = mask_img
         self.radius = radius
@@ -328,27 +353,31 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
     def fit(self, X=None, y=None):
         """Prepare signal extraction from regions.
 
-        All parameters are unused, they are for scikit-learn compatibility.
+        All parameters are unused; they are for scikit-learn compatibility.
 
         """
         if hasattr(self, 'seeds_'):
             return self
 
-        error = ("Seeds must be a list of triplets of coordinates in "
-                 "native space.\n")
+        error = (
+            'Seeds must be a list of triplets of coordinates in '
+            'native space.\n'
+        )
 
         if not hasattr(self.seeds, '__iter__'):
             raise ValueError(
-                error + "Given seed list is of type: " + type(self.seeds)
+                error + 'Given seed list is of type: ' + type(self.seeds)
             )
+
         self.seeds_ = []
         # Check seeds and convert them to lists if needed
         for i, seed in enumerate(self.seeds):
             # Check the type first
             if not hasattr(seed, '__len__'):
-                raise ValueError(error + "Seed #%i is not a valid triplet "
-                                 "of coordinates. It is of type %s."
-                                 % (i, type(seed)))
+                raise ValueError(
+                    error + f'Seed #{i} is not a valid triplet '
+                    f'of coordinates. It is of type {type(seed)}.'
+                )
             # Convert to list because it is easier to process
             if isinstance(seed, np.ndarray):
                 seed = seed.tolist()
@@ -358,8 +387,10 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
 
             # Check the length
             if len(seed) != 3:
-                raise ValueError(error + "Seed #%i is of length %i "
-                                 "instead of 3." % (i, len(seed)))
+                raise ValueError(
+                    error + f'Seed #{i} is of length %{len(seed)} '
+                    'instead of 3.'
+                )
 
             self.seeds_.append(seed)
 
@@ -368,7 +399,35 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         return self
 
     def fit_transform(self, imgs, confounds=None, sample_mask=None):
-        """Prepare and perform signal extraction"""
+        """Prepare and perform signal extraction.
+
+        Parameters
+        ----------
+        imgs : 3D/4D Niimg-like object
+            See http://nilearn.github.io/manipulating_images/input_output.html
+            Images to process. It must boil down to a 4D image with scans
+            number as last dimension.
+
+        confounds : CSV file or array-like or :obj:`pandas.DataFrame`, optional
+            This parameter is passed to signal.clean. Please see the related
+            documentation for details.
+            shape: (number of scans, number of confounds)
+
+        sample_mask : Any type compatible with numpy-array indexing, optional
+            Masks the niimgs along time/fourth dimension to perform scrubbing
+            (remove volumes with high motion) and/or non-steady-state volumes.
+            This parameter is passed to signal.clean.
+            shape: (number of scans - number of volumes removed, )
+
+                .. versionadded:: 0.8.0
+
+        Returns
+        -------
+        region_signals : 2D :obj:`numpy.ndarray`
+            Signal for each sphere.
+            shape: (number of scans, number of spheres)
+
+        """
         return self.fit().transform(imgs, confounds=confounds,
                                     sample_mask=sample_mask)
 
@@ -388,7 +447,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
             Images to process. It must boil down to a 4D image with scans
             number as last dimension.
 
-        confounds : CSV file or array-like or pandas DataFrame, optional
+        confounds : CSV file or array-like or :obj:`pandas.DataFrame`, optional
             This parameter is passed to signal.clean. Please see the related
             documentation for details.
             shape: (number of scans, number of confounds)
@@ -403,7 +462,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
 
         Returns
         -------
-        region_signals : 2D numpy.ndarray
+        region_signals : 2D :obj:`numpy.ndarray`
             Signal for each sphere.
             shape: (number of scans, number of spheres)
 
@@ -441,13 +500,13 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
 
         Parameters
         ----------
-        region_signals : 2D numpy.ndarray
+        region_signals : 2D :obj:`numpy.ndarray`
             Signal for each region.
             shape: (number of scans, number of spheres)
 
         Returns
         -------
-        voxel_signals : nibabel.Nifti1Image
+        voxel_signals : :obj:`nibabel.nifti1.Nifti1Image`
             Signal for each sphere.
             shape: (mask_img, number of scans).
 
@@ -459,10 +518,13 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         if self.mask_img is not None:
             mask = check_niimg_3d(self.mask_img)
         else:
-            raise ValueError('Please provide mask_img at initialization to'
-                             ' provide a reference for the inverse_transform.')
+            raise ValueError(
+                'Please provide mask_img at initialization to '
+                'provide a reference for the inverse_transform.'
+            )
         _, adjacency = _apply_mask_and_get_affinity(
-            self.seeds_, None, self.radius, self.allow_overlap, mask_img=mask)
+            self.seeds_, None, self.radius, self.allow_overlap, mask_img=mask
+        )
         adjacency = adjacency.tocsr()
         # Compute overlap scaling for mean signal:
         if self.allow_overlap:

--- a/nilearn/maskers/tests/test_multi_nifti_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_masker.py
@@ -183,11 +183,18 @@ def test_mask_strategy_errors():
     with pytest.raises(ValueError,
                        match="Unknown value of mask_strategy 'foo'"):
         mask.fit(imgs)
-    # Warning with deprecated 'template' strategy
+    # Warning with deprecated 'template' strategy,
+    # plus an exception because there's no resulting mask
     mask = MultiNiftiMasker(mask_strategy='template')
-    with pytest.warns(UserWarning,
-                      match="Masking strategy 'template' is deprecated."):
-        mask.fit(imgs)
+    with pytest.warns(
+        UserWarning,
+        match="Masking strategy 'template' is deprecated."
+    ):
+        with pytest.raises(
+            ValueError,
+            match='The mask is invalid as it is empty'
+        ):
+            mask.fit(imgs)
 
 
 @pytest.mark.parametrize('strategy',

--- a/nilearn/maskers/tests/test_multi_nifti_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_masker.py
@@ -97,9 +97,19 @@ def test_3d_images():
     epi_img2 = Nifti1Image(np.ones((2, 2, 2)),
                            affine=np.diag((2, 2, 2, 1)))
     masker = MultiNiftiMasker(mask_img=mask_img)
+
+    # Check attributes defined at fit
+    assert not hasattr(masker, "mask_img_")
+    assert not hasattr(masker, "n_elements_")
+
     epis = masker.fit_transform([epi_img1, epi_img2])
+
     # This is mostly a smoke test
     assert len(epis) == 2
+
+    # Check attributes defined at fit
+    assert hasattr(masker, "mask_img_")
+    assert hasattr(masker, "n_elements_")
 
     # verify that 4D mask arguments are refused
     mask_img_4d = Nifti1Image(np.ones((2, 2, 2, 2), dtype=np.int8),

--- a/nilearn/maskers/tests/test_multi_nifti_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_masker.py
@@ -190,11 +190,7 @@ def test_mask_strategy_errors():
         UserWarning,
         match="Masking strategy 'template' is deprecated."
     ):
-        with pytest.raises(
-            ValueError,
-            match='The mask is invalid as it is empty'
-        ):
-            mask.fit(imgs)
+        mask.fit(imgs)
 
 
 @pytest.mark.parametrize('strategy',

--- a/nilearn/maskers/tests/test_nifti_maps_masker.py
+++ b/nilearn/maskers/tests/test_nifti_maps_masker.py
@@ -1,8 +1,8 @@
-"""Test the nifti_region module
+"""Test nilearn.maskers.nifti_maps_masker.
 
-Functions in this file only test features added by the NiftiLabelsMasker class,
-non_overlappingt the underlying functions (clean(), img_to_signals_labels(),
-etc.).
+Functions in this file only test features added by the NiftiMapsMasker class,
+rather than the underlying functions (clean(), img_to_signals_labels(), etc.).
+
 See test_masking.py and test_signal.py for details.
 """
 

--- a/nilearn/maskers/tests/test_nifti_maps_masker.py
+++ b/nilearn/maskers/tests/test_nifti_maps_masker.py
@@ -1,8 +1,9 @@
 """Test the nifti_region module
 
 Functions in this file only test features added by the NiftiLabelsMasker class,
-non_overlappingt the underlying functions (clean(), img_to_signals_labels(), etc.). See
-test_masking.py and test_signal.py for details.
+non_overlappingt the underlying functions (clean(), img_to_signals_labels(),
+etc.).
+See test_masking.py and test_signal.py for details.
 """
 
 import numpy as np
@@ -41,8 +42,9 @@ def test_nifti_maps_masker():
     fmri21_img, mask21_img = generate_random_img(shape2, affine=affine1,
                                                  length=length)
 
-    labels11_img, labels_mask_img = \
-        data_gen.generate_maps(shape1, n_regions, affine=affine1)
+    labels11_img, labels_mask_img = data_gen.generate_maps(
+        shape1, n_regions, affine=affine1
+    )
 
     # No exception raised here
     for create_files in (True, False):
@@ -84,9 +86,22 @@ def test_nifti_maps_masker():
     pytest.raises(ValueError, masker11.fit)
 
     # Transform, with smoothing (smoke test)
-    masker11 = NiftiMapsMasker(labels11_img, smoothing_fwhm=3,
-                               resampling_target=None)
-    signals11 = masker11.fit().transform(fmri11_img)
+    masker11 = NiftiMapsMasker(
+        labels11_img, smoothing_fwhm=3, resampling_target=None
+    )
+    # Check attributes defined at fit
+    assert not hasattr(masker11, "maps_img_")
+    assert not hasattr(masker11, "n_elements_")
+
+    masker11.fit()
+
+    # Check attributes defined at fit
+    assert hasattr(masker11, "maps_img_")
+    assert hasattr(masker11, "n_elements_")
+    assert masker11.n_elements_ == n_regions
+
+    signals11 = masker11.transform(fmri11_img)
+
     assert signals11.shape == (length, n_regions)
 
     masker11 = NiftiMapsMasker(labels11_img, smoothing_fwhm=3,
@@ -337,8 +352,7 @@ def test_nifti_maps_masker_2():
     fmri11_img_r = masker.inverse_transform(transformed)
     np.testing.assert_almost_equal(fmri11_img_r.affine,
                                    masker.maps_img_.affine)
-    assert (fmri11_img_r.shape ==
-                 (masker.maps_img_.shape[:3] + (length,)))
+    assert (fmri11_img_r.shape == (masker.maps_img_.shape[:3] + (length,)))
 
 
 def test_nifti_maps_masker_overlap():
@@ -407,10 +421,12 @@ def test_standardization():
 
     np.testing.assert_almost_equal(trans_signals.mean(0), 0)
     np.testing.assert_almost_equal(
-            trans_signals,
+        trans_signals,
+        (
             unstandarized_label_signals /
-            unstandarized_label_signals.mean(0) * 100 - 100,
-            )
+            unstandarized_label_signals.mean(0) * 100 - 100
+        ),
+    )
 
 
 def test_3d_images():
@@ -420,12 +436,12 @@ def test_3d_images():
     shape3 = (16, 17, 18)
 
     maps33_img, _ = data_gen.generate_maps(shape3, n_regions)
-    mask_img = nibabel.Nifti1Image(np.ones(shape3, dtype=np.int8),
-                           affine=affine)
-    epi_img1 = nibabel.Nifti1Image(np.ones(shape3),
-                           affine=affine)
-    epi_img2 = nibabel.Nifti1Image(np.ones(shape3),
-                           affine=affine)
+    mask_img = nibabel.Nifti1Image(
+        np.ones(shape3, dtype=np.int8),
+        affine=affine,
+    )
+    epi_img1 = nibabel.Nifti1Image(np.ones(shape3), affine=affine)
+    epi_img2 = nibabel.Nifti1Image(np.ones(shape3), affine=affine)
     masker = NiftiMapsMasker(maps33_img, mask_img=mask_img)
 
     epis = masker.fit_transform(epi_img1)

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -293,13 +293,20 @@ def test_mask_strategy_errors():
             ValueError,
             match="Unknown value of mask_strategy 'oops'"):
         mask.fit()
-    # Warning with deprecated 'template' strategy
+    # Warning with deprecated 'template' strategy,
+    # plus an exception because there's no resulting mask
     img = np.random.RandomState(42).uniform(size=(9, 9, 5))
     img = Nifti1Image(img, np.eye(4))
     mask = NiftiMasker(mask_strategy='template')
-    with pytest.warns(UserWarning,
-                      match="Masking strategy 'template' is deprecated."):
-        mask.fit(img)
+    with pytest.warns(
+        UserWarning,
+        match="Masking strategy 'template' is deprecated."
+    ):
+        with pytest.raises(
+            ValueError,
+            match='The mask is invalid as it is empty'
+        ):
+            mask.fit(img)
 
 
 def test_compute_epi_mask():
@@ -367,11 +374,11 @@ def expected_mask(mask_args):
 def test_compute_brain_mask(strategy, mask_args, expected_mask):
     # Check masker for template masking strategy
     img = _get_random_img((9, 9, 5))
-    masker = NiftiMasker(mask_strategy=strategy,
-                         mask_args=mask_args)
+
+    masker = NiftiMasker(mask_strategy=strategy, mask_args=mask_args)
     masker.fit(img)
-    np.testing.assert_array_equal(get_data(masker.mask_img_),
-                                  expected_mask)
+
+    np.testing.assert_array_equal(get_data(masker.mask_img_), expected_mask)
 
 
 def test_filter_and_mask_error():

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -193,7 +193,6 @@ def test_4d_single_scan():
 
     # Test that, in list of 4d images with last dimension=1, they are
     # considered as 3d
-
     rng = np.random.RandomState(42)
     data_5d = [rng.random_sample((10, 10, 10, 1)) for i in range(5)]
     data_4d = [d[..., 0] for d in data_5d]
@@ -201,7 +200,18 @@ def test_4d_single_scan():
     data_4d = [nibabel.Nifti1Image(d, np.eye(4)) for d in data_4d]
 
     masker = NiftiMasker(mask_img=mask_img)
+
+    # Check attributes defined at fit
+    assert not hasattr(masker, "mask_img_")
+    assert not hasattr(masker, "n_elements_")
+
     masker.fit()
+
+    # Check attributes defined at fit
+    assert hasattr(masker, "mask_img_")
+    assert hasattr(masker, "n_elements_")
+    assert masker.n_elements_ == np.sum(mask)
+
     data_trans_5d = masker.transform(data_5d)
     data_trans_4d = masker.transform(data_4d)
 
@@ -331,8 +341,7 @@ def test_compute_epi_mask():
     masker4.fit(mean_image2)
     mask4 = masker4.mask_img_
 
-    assert not np.allclose(get_data(mask1),
-                             get_data(mask4)[3:12, 3:12])
+    assert not np.allclose(get_data(mask1), get_data(mask4)[3:12, 3:12])
 
 
 def _get_random_img(shape):

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -302,11 +302,7 @@ def test_mask_strategy_errors():
         UserWarning,
         match="Masking strategy 'template' is deprecated."
     ):
-        with pytest.raises(
-            ValueError,
-            match='The mask is invalid as it is empty'
-        ):
-            mask.fit(img)
+        mask.fit(img)
 
 
 def test_compute_epi_mask():

--- a/nilearn/maskers/tests/test_nifti_spheres_masker.py
+++ b/nilearn/maskers/tests/test_nifti_spheres_masker.py
@@ -23,8 +23,21 @@ def test_sphere_extraction():
     data = np.random.RandomState(42).random_sample((3, 3, 3, 5))
     img = nibabel.Nifti1Image(data, np.eye(4))
     masker = NiftiSpheresMasker([(1, 1, 1)], radius=1)
+
+    # Check attributes defined at fit
+    assert not hasattr(masker, "seeds_")
+    assert not hasattr(masker, "n_elements_")
+
+    masker.fit()
+
+    # Check attributes defined at fit
+    assert hasattr(masker, "seeds_")
+    assert hasattr(masker, "n_elements_")
+    assert masker.n_elements_ == 1
+
     # Test the fit
     masker.fit()
+
     # Test the transform
     s = masker.transform(img)
     mask = np.zeros((3, 3, 3), dtype=bool)
@@ -32,6 +45,7 @@ def test_sphere_extraction():
     mask[1, :, 1] = True
     mask[1, 1, :] = True
     assert_array_equal(s[:, 0], np.mean(data[mask], axis=0))
+
     # Now with a mask
     mask_img = np.zeros((3, 3, 3))
     mask_img[1, :, :] = 1

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -57,17 +57,21 @@ def _load_mask_img(mask_img, allow_empty=False):
         # We accept a single value if it is not 0 (full true mask).
         if values[0] == 0 and not allow_empty:
             raise ValueError(
-                'The mask is invalid as it is empty: it masks all data.')
+                'The mask is invalid as it is empty: it masks all data.'
+            )
     elif len(values) == 2:
         # If there are 2 different values, one of them must be 0 (background)
         if 0 not in values:
-            raise ValueError('Background of the mask must be represented with'
-                             '0. Given mask contains: %s.' % values)
+            raise ValueError(
+                'Background of the mask must be represented with 0. '
+                f'Given mask contains: {values}.'
+            )
     elif len(values) != 2:
         # If there are more than 2 values, the mask is invalid
-        raise ValueError('Given mask is not made of 2 values: %s'
-                         '. Cannot interpret as true or false'
-                         % values)
+        raise ValueError(
+            f'Given mask is not made of 2 values: {values}. '
+            'Cannot interpret as true or false.'
+        )
 
     mask = _utils.as_ndarray(mask, dtype=bool)
     return mask, mask_img.affine


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3296.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add an `n_elements_` attribute to each of the masker classes.
- Document any post-fit attributes in the masker class docstrings.
- Expand masker tests to check the post-fit attributes.
- Some minor improvements to coding style in the masker code files.
- Replace relative imports in multi_nifti_masker.py and nifti_masker.py with absolute ones.
- Check that mask is binary/valid in fit, rather than just in transform, for NiftiMasker and MultiNiftiMasker.
    - Still allow empty mask at this stage, though it will fail at transform.
- Apply consistent, black-like formatting to the masker files (except using single quotes, of course).