### PR TITLE
[MAINT] [DOC] Add suggestion for running flake8 on diff locally before pushing changes

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -264,19 +264,6 @@ This is also useful for writing unit tests.
 Writing small functions is not always possible, and we do not recommend trying to reorganize larger,
 but well-tested, older functions in the codebase, unless there is a strong reason to do so (e.g., when adding a new feature).
 
-.. admonition:: Recommendation
-
-    To lint your code and verify PEP8 compliance, you can run
-    `flake8 <https://flake8.pycqa.org/en/latest/>`_ locally on the
-    changes you have made in your branch compared to the main branch or a
-    previous commit.
-    To do this before committing changes, get the diff between the working
-    directory and the last commit and pipe it to flake8 by running:
-
-    .. code-block:: bash
-
-        git diff HEAD | flake8 --diff
-
 Tests
 ------
 
@@ -378,7 +365,19 @@ Here are the key steps you need to go through to contribute code to `nilearn`:
 
 3. implement changes and (optional but highly recommended) lint::
 
-      git diff HEAD | flake8 --diff
+.. admonition:: Recommendation
+
+    To lint your code and verify PEP8 compliance, you can run
+    `flake8 <https://flake8.pycqa.org/en/latest/>`_ locally on the
+    changes you have made in your branch compared to the main branch.
+    To do this, find the latest common ancestor (commit) of your branch with
+    main and then get the diff between your working directory and this commit
+    and pipe it to flake8 by running:
+
+    .. code-block:: bash
+
+        COMMIT=$(git merge-base main @)
+        git diff $COMMIT | flake8 --diff
 
 4. commit your changes on this branch (don't forget to write tests!)
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -271,9 +271,11 @@ but well-tested, older functions in the codebase, unless there is a strong reaso
     changes you have made in your branch compared to the main branch or a
     previous commit.
     To do this before committing changes, get the diff between the working
-    directory and the last commit and pipe it to flake8 by running::
+    directory and the last commit and pipe it to flake8 by running:
 
-    git diff HEAD | flake8 --diff
+    .. code-block:: bash
+
+        git diff HEAD | flake8 --diff
 
 Tests
 ------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -264,6 +264,16 @@ This is also useful for writing unit tests.
 Writing small functions is not always possible, and we do not recommend trying to reorganize larger,
 but well-tested, older functions in the codebase, unless there is a strong reason to do so (e.g., when adding a new feature).
 
+.. admonition:: Recommendation
+
+    To lint your code and verify PEP8 compliance, you can run
+    `flake8 <https://flake8.pycqa.org/en/latest/>`_ locally on the
+    changes you have made in your branch compared to the main branch or a
+    a previous commit.
+    To do this before committing changes, get the diff between the working
+    directory and the last commit and pipe it to flake8 by running
+    `git diff HEAD | flake8 --diff`
+
 Tests
 ------
 
@@ -363,21 +373,25 @@ Here are the key steps you need to go through to contribute code to `nilearn`:
 
       git checkout -b your_branch
 
-3. implement and commit your changes on this branch (don't forget to write tests!)
+3. implement changes and (optional but highly recommended) lint::
 
-4. run the tests locally (to go faster, only run tests which are relevant to what
+      git diff HEAD | flake8 --diff
+
+4. commit your changes on this branch (don't forget to write tests!)
+
+5. run the tests locally (to go faster, only run tests which are relevant to what
    you work on with, for example)::
 
       pytest -v nilearn/plotting/tests/test_surf_plotting.py
 
-5. push your changes to your online fork::
+6. push your changes to your online fork::
 
       git push
 
-6. in github, open a pull request from your online fork to the main repo
+7. in github, open a pull request from your online fork to the main repo
    (most likely from `your_fork:your_branch` to `nilearn:main`).
 
-7. check that all continuous integration tests pass
+8. check that all continuous integration tests pass
 
 For more details about the Fork Clone Push workflows, read `here <https://guides.github.com/activities/forking/>`_.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -269,10 +269,11 @@ but well-tested, older functions in the codebase, unless there is a strong reaso
     To lint your code and verify PEP8 compliance, you can run
     `flake8 <https://flake8.pycqa.org/en/latest/>`_ locally on the
     changes you have made in your branch compared to the main branch or a
-    a previous commit.
+    previous commit.
     To do this before committing changes, get the diff between the working
-    directory and the last commit and pipe it to flake8 by running
-    `git diff HEAD | flake8 --diff`
+    directory and the last commit and pipe it to flake8 by running::
+
+    git diff HEAD | flake8 --diff
 
 Tests
 ------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -38,6 +38,7 @@ Enhancements
 - Docstrings of module :mod:`~nilearn.glm.second_level` were improved (:gh:`3030` by `Nicolas Gensollen`_).
 - In :func:`~reporting.get_clusters_table`, when the center of mass of a binary cluster falls outside the cluster, report the nearest within-cluster voxel instead (:gh:`3292` by `Connor Lane`_).
 - Functions expecting string filesystem paths now also accept path-like objects (:gh:`3300` by `Yasmin Mzayek`_).
+- Contributing guidelines now include a recommendation to run flake8 locally on the branch diff with main (:gh:`3317` by `Yasmin Mzayek`_).
 
 Changes
 -------


### PR DESCRIPTION
Closes #3308.
Also close #2528 in my opinion since there is consensus not to automate formatting and linting.

This PR proposes additional information to the contributing guidelines about running flake8 on the diff locally before pushing changes. This is meant to reduce PEP8 check failures.
