### PR TITLE
[DOC] Improve handling of URLs in rendered docs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,11 +8,11 @@ Team
 
 This work is made available by a community of people, which
 originated from
-the `INRIA Parietal Project Team <https://team.inria.fr/parietal/>`_
-and the `scikit-learn <http://scikit-learn.org/>`_ but grew much further.
+the :parietal:`INRIA Parietal Project Team <>` and :sklearn:`scikit-learn <>`
+but grew much further.
 
-An up-to-date list of contributors can be seen in on `GitHub
-<https://github.com/nilearn/nilearn/graphs/contributors>`_
+An up-to-date list of contributors can be seen in on
+:nilearn:`GitHub <graphs/contributors>`.
 
 Additional credit goes to `Michael Hanke`_ and `Yaroslav Halchenko`_ for data and packaging.
 
@@ -73,8 +73,8 @@ Funding
 .......
 
 `Alexandre Abraham`_, `Gael Varoquaux`_, `Kamalakar Reddy Daddy`_, `Loic Estève`_,
-`Mehdi Rahim`_, `Philippe Gervais`_ were paid by the `NiConnect
-<https://team.inria.fr/parietal/research/spatial_patterns/niconnect/>`_
+`Mehdi Rahim`_, `Philippe Gervais`_ were paid by the
+:parietal:`NiConnect <research/spatial_patterns/niconnect/>`.
 project, funded by the French `Investissement d'Avenir
 <http://www.gouvernement.fr/investissements-d-avenir-cgi>`_.
 
@@ -103,16 +103,16 @@ We suggest that you read and cite the paper. Thank you.
 Citing scikit-learn
 -------------------
 
-A huge amount of work goes into `scikit-learn <http://scikit-learn.org/>`_,
+A huge amount of work goes into :sklearn:`scikit-learn <>`,
 upon which nilearn relies heavily.
 Researchers who invest their time in developing and maintaining the package
 deserve recognition with citations.
-In addition, the `Parietal team <https://team.inria.fr/parietal/>`_ needs citations
+In addition, the :parietal:`INRIA Parietal Project Team <>` needs citations
 to the paper in order to justify paying a software engineer on the project.
 To guarantee the future of the toolkit, if you use it, please cite it.
 
-See the scikit-learn documentation on `how to cite
-<http://scikit-learn.org/stable/about.html#citing-scikit-learn>`_.
+See the scikit-learn documentation on
+:sklearn:`how to cite <about.html#citing-scikit-learn>`.
 
 
 .. |digicosme logo| image:: logos/digi-saclay-logo-small.png

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,7 +8,7 @@ Team
 
 This work is made available by a community of people, which
 originated from
-the :parietal:`INRIA Parietal Project Team <>` and :sklearn:`scikit-learn <>`
+the :inria:`INRIA MIND Project Team <mind>` and :sklearn:`scikit-learn <>`
 but grew much further.
 
 An up-to-date list of contributors can be seen in on
@@ -74,7 +74,7 @@ Funding
 
 `Alexandre Abraham`_, `Gael Varoquaux`_, `Kamalakar Reddy Daddy`_, `Loic Estève`_,
 `Mehdi Rahim`_, `Philippe Gervais`_ were paid by the
-:parietal:`NiConnect <research/spatial_patterns/niconnect/>`.
+:inria:`NiConnect <parietal/research/spatial_patterns/niconnect/>`.
 project, funded by the French `Investissement d'Avenir
 <http://www.gouvernement.fr/investissements-d-avenir-cgi>`_.
 
@@ -107,7 +107,7 @@ A huge amount of work goes into :sklearn:`scikit-learn <>`,
 upon which nilearn relies heavily.
 Researchers who invest their time in developing and maintaining the package
 deserve recognition with citations.
-In addition, the :parietal:`INRIA Parietal Project Team <>` needs citations
+In addition, the :inria:`INRIA MIND Project Team <mind>` needs citations
 to the paper in order to justify paying a software engineer on the project.
 To guarantee the future of the toolkit, if you use it, please cite it.
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,7 +12,7 @@ the :parietal:`INRIA Parietal Project Team <>` and :sklearn:`scikit-learn <>`
 but grew much further.
 
 An up-to-date list of contributors can be seen in on
-:nilearn:`GitHub <graphs/contributors>`.
+:nilearn-gh:`GitHub <graphs/contributors>`.
 
 Additional credit goes to `Michael Hanke`_ and `Yaroslav Halchenko`_ for data and packaging.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -331,7 +331,7 @@ Installing
 
 Here are the key steps you need to go through to copy the repo before contributing:
 
-1. fork the repo from github (fork button in the top right corner of our :nilearn-gh:`main github page`) and clone your fork locally::
+1. fork the repo from github (fork button in the top right corner of our :nilearn-gh:`main github page <>`) and clone your fork locally::
 
       git clone git@github.com:<your_username>/nilearn.git
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -6,12 +6,12 @@ How to get help?
 
 If you have issues when using Nilearn, or if you have questions on how to use it, please don't hesitate to reach out!
 
-There are currently three ways to interact with the Nilearn team: through the `neurostars`_ forum, our `github`_ issues, and through our weekly `office hours <https://github.com/nilearn/nilearn/issues/2882>`_, usually **every Friday from 4pm to 5pm UTC**.
+There are currently three ways to interact with the Nilearn team: through the :neurostars:`neurostars <>` forum, our :nilearn-gh:`github <>` issues, and through our weekly :nilearn-gh:`office hours <issues/2882>`, usually **every Friday from 4pm to 5pm UTC**.
 
-If you have a *usage question*, that is if you need help troubleshooting scripts using Nilearn, we would appreciate it if you either ask it during office hours or create a topic on `neurostars <https://neurostars.org/tag/nilearn>`_ with the "nilearn" tag.
+If you have a *usage question*, that is if you need help troubleshooting scripts using Nilearn, we would appreciate it if you either ask it during office hours or create a topic on :neurostars:`neurostars <>` with the "nilearn" tag.
 Asking questions or reporting issues is always valuable because it will help other users having the same problem. So, please don't hold onto a burning question!
 
-We ask that you *don't* open an issue on `GitHub`_ for usage questions. We use our `GitHub`_ issue board for bug reports, feature requests, and documentation changes only.
+We ask that you *don't* open an issue on :nilearn-gh:`GitHub <>` for usage questions. We use our :nilearn-gh:`GitHub <>` issue board for bug reports, feature requests, and documentation changes only.
 
 How to help the project?
 ========================
@@ -23,32 +23,35 @@ Report bugs or discuss enhancement ideas
 
 We welcome open discussion around improvements---both to the documentation as well as to the code base---through our GitHub issue board!
 
-    * If you think you have discovered a bug, please start by searching through the existing `issues`_ to make sure it has not already been reported. If the bug has not been reported yet,  create an `new issue`_ including a `minimal runnable example <https://stackoverflow.com/help/minimal-reproducible-example>`_ to showcase it (using Nilearn data) as well as your OS and Nilearn version.
+    * If you think you have discovered a bug, please start by searching through the existing :nilearn-gh:`issues <issues>` to make sure it has not already been reported. If the bug has not been reported yet,  create an :nilearn-gh:`new issue <issues/new/choose>` including a `minimal runnable example <https://stackoverflow.com/help/minimal-reproducible-example>`_ to showcase it (using Nilearn data) as well as your OS and Nilearn version.
 
-    * If you have an idea for a new feature, check if it is in the :ref:`nilearn_scope` and feel free to open a `new issue`_ to discuss it.
+    * If you have an idea for a new feature, check if it is in the :ref:`nilearn_scope` and feel free to open a :nilearn-gh:`new issue <issues/new/choose>` to discuss it.
 
-    * If you think the documentation can be improved, please open a `new issue`_ to discuss what you would like to change! This helps to confirm that your proposed improvements don't overlap with any ongoing work.
+    * If you think the documentation can be improved, please open a :nilearn-gh:`new issue <issues/new/choose>` to discuss what you would like to change! This helps to confirm that your proposed improvements don't overlap with any ongoing work.
 
 Answer questions
 ----------------
 
-Another way to help the project is to answer questions on `neurostars`_, or comment on github `issues`_.
-Some `issues`_ are used to gather user opinions on various questions, and any input from the community is valuable to us.
+Another way to help the project is to answer questions on :neurostars:`neurostars <>`, or comment on github :nilearn-gh:`issues <issues>`.
+Some :nilearn-gh:`issues <issues>` are used to gather user opinions on various questions, and any input from the community is valuable to us.
 
 Review Pull Requests
 --------------------
 
 Any addition to the Nilearn's code base has to be reviewed and approved by several people including at least two :ref:`core_devs`.
-This can put a heavy burden on :ref:`core_devs` when a lot of `pull requests`_ are opened at the same time.
-We welcome help in reviewing `pull requests`_ from any community member.
+This can put a heavy burden on :ref:`core_devs` when a lot of
+:nilearn-gh:`pull requests <pulls>` are opened at the same time.
+We welcome help in reviewing :nilearn-gh:`pull requests <pulls>` from any
+community member.
 We do not expect community members to be experts in all changes included in
-`pull requests`_, and we encourage you to concentrate on those code changes that you feel comfortable with.
+:nilearn-gh:`pull requests <pulls>`, and we encourage you to concentrate on those code changes that you feel comfortable with.
 As always, more eyes on a code change means that the code is more likely to work in a wide variety of contexts!
 
 Join the triage team
 --------------------
 
-The :ref:`triage` is composed of community members who have permission on `github`_ to label and close `issues`_.
+The :ref:`triage` is composed of community members who have permission on
+:nilearn-gh:`github <>` to label and close :nilearn-gh:`issues <issues>`.
 Their work is crucial to improve the communication in the project and limit the crowding of the issue tracker.
 The :ref:`issue_labels` and :ref:`closing_policy` of the project is defined in more details in the :ref:`maintenance_process` page.
 
@@ -60,8 +63,8 @@ Contribute code
 
 If you want to contribute code:
 
-    * For new features, please be sure to create a `new issue`_ first, to discuss whether it can be included and its specifications.
-    * To help with known `issues`_, please check `good first issues <https://github.com/nilearn/nilearn/labels/Good%20first%20issue>`_ to get started, `known bugs <https://github.com/nilearn/nilearn/labels/Bug>`_, or `proposed enhancements <https://github.com/nilearn/nilearn/labels/Enhancement>`_.
+    * For new features, please be sure to create a :nilearn-gh:`new issue <issues/new/choose>` first, to discuss whether it can be included and its specifications.
+    * To help with known :nilearn-gh:`issues <issues>`, please check :nilearn-gh:`good first issues <labels/Good%20first%20issue>` to get started, :nilearn-gh:`known bugs <labels/Bug>`, or :nilearn-gh:`proposed enhancements <labels/Enhancement>`.
 
 Please see the :ref:`contributing_code` section for more detailed information, including
 instructions for  `Setting up your environment`_ and a description of the `Contribution Guidelines`_.
@@ -123,7 +126,8 @@ Who makes decisions
 
 We strongly aim to be a community oriented project where decisions are
 made based on consensus according to the criteria described above.
-Discussions are public, held on `issues`_ and `pull requests`_ in Github.
+Discussions are public, held on :nilearn-gh:`issues <issues>` and
+:nilearn-gh:`pull requests <pulls>` in Github.
 All modifications of the codebase are ultimately checked during a reviewing
 process, where maintainers or contributors make sure they respect the
 :ref:`contribution_guidelines`.
@@ -137,21 +141,23 @@ listed :ref:`here <core_devs>`.
 How to contribute to nilearn
 =============================
 
-This project, hosted on https://github.com/nilearn/nilearn, is a community
+This project, hosted on :nilearn-gh:`\ `, is a community
 effort, and everyone is welcome to contribute.
 We value very much your feedback and opinion on features that should be
 improved or added.
-All discussions are public and held on relevant `issues`_ or `pull requests`_.
+All discussions are public and held on relevant :nilearn-gh:`issues <issues>` or
+:nilearn-gh:`pull requests <pulls>`.
 To discuss your matter, please comment on a relevant
-`issue <https://github.com/nilearn/nilearn/issues>`_ or open a new one.
+:nilearn-gh:`issue <issues>` or open a new one.
 
 The best way to contribute and to help the project is to start working on known
-`issues`_ such as `good first issues <https://github.com/nilearn/nilearn/labels/Good%20first%20issue>`_,
-`known bugs <https://github.com/nilearn/nilearn/labels/Bug>`_ or
-`proposed enhancements <https://github.com/nilearn/nilearn/labels/Enhancement>`_.
+:nilearn-gh:`issues <issues>` such as
+:nilearn-gh:`good first issues <labels/Good%20first%20issue>`,
+:nilearn-gh:`known bugs <labels/Bug>` or
+:nilearn-gh:`proposed enhancements <labels/Enhancement>`.
 If an issue does not already exist for a potential contribution, we ask that
-you first open a `new issue`_ before sending a :ref:`pull request` to discuss
-scope and potential design choices in advance.
+you first open a :nilearn-gh:`new issue <issues/new/choose>` before sending a
+:ref:`pull request` to discuss scope and potential design choices in advance.
 
 .. _contribution_guidelines:
 
@@ -160,8 +166,7 @@ Contribution Guidelines
 
 When modifying the codebase, we ask every contributor to respect common
 guidelines.
-Those are inspired from `scikit-learn
-<https://scikit-learn.org/stable/developers/contributing.html#contributing-code>`_
+Those are inspired from :sklearn:`scikit-learn <developers/contributing.html#contributing-code>`
 and ensure Nilearn remains simple to understand, efficient and maintainable.
 For example, code needs to be tested and those tests need to run quickly in order
 not to burden the development process.
@@ -326,7 +331,7 @@ Installing
 
 Here are the key steps you need to go through to copy the repo before contributing:
 
-1. fork the repo from github (fork button in the top right corner of our `main github page <https://github.com/nilearn/nilearn>`_) and clone your fork locally::
+1. fork the repo from github (fork button in the top right corner of our :nilearn_gh:`main github page`) and clone your fork locally::
 
       git clone git@github.com:<your_username>/nilearn.git
 
@@ -454,11 +459,10 @@ atlases):
   label, in the same (numerical) order as the atlas labels
 - ``maps`` (list or string): the path to the nifti image, or a list of paths
 
-In addition, the atlas will need to be called by a fetcher. For example, see `here <https://github.com/nilearn/nilearn/blob/main/nilearn/datasets/atlas.py>`__.
+In addition, the atlas will need to be called by a fetcher. For example, see :nilearn-gh:`here <blob/main/nilearn/datasets/atlas.py>`.
 
 Finally, as with other features, please provide a test for your atlas.
-Examples can be found `here
-<https://github.com/nilearn/nilearn/blob/main/nilearn/datasets/tests/test_atlas.py>`__
+Examples can be found :nilearn-gh:`here <blob/main/nilearn/datasets/tests/test_atlas.py>`.
 
 
 How to contribute a dataset fetcher
@@ -480,8 +484,8 @@ datasets or the APIs that provide them sometimes change, in which case the
 downloader needs to be adapted.
 
 As for any contributed feature, before starting working on a new downloader,
-we recommend opening a `new issue`_ to discuss whether it is necessary or if
-existing downloaders could be used instead.
+we recommend opening a :nilearn-gh:`new issue <issues/new/choose>` to discuss
+whether it is necessary or if existing downloaders could be used instead.
 
 
 To add a new fetcher, ``nilearn.datasets.utils`` provides some helper functions,
@@ -509,21 +513,3 @@ Maintenance
 
 More information about the project organization, conventions, and maintenance
 process can be found there : :ref:`maintenance_process`.
-
-.. _`discord`:
-    https://discord.gg/bMBhb7w
-
-.. _`github`:
-    https://github.com/nilearn/nilearn
-
-.. _`issues`:
-    https://github.com/nilearn/nilearn/issues
-
-.. _`neurostars`:
-    https://neurostars.org/tag/nilearn
-
-.. _`new issue`:
-    https://github.com/nilearn/nilearn/issues/new/choose
-
-.. _`pull requests`:
-    https://github.com/nilearn/nilearn/pulls

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -331,7 +331,7 @@ Installing
 
 Here are the key steps you need to go through to copy the repo before contributing:
 
-1. fork the repo from github (fork button in the top right corner of our :nilearn_gh:`main github page`) and clone your fork locally::
+1. fork the repo from github (fork button in the top right corner of our :nilearn-gh:`main github page`) and clone your fork locally::
 
       git clone git@github.com:<your_username>/nilearn.git
 

--- a/README.rst
+++ b/README.rst
@@ -23,12 +23,12 @@ nilearn
 
 Nilearn enables approachable and versatile analyses of brain volumes. It provides statistical and machine-learning tools, with instructive documentation & friendly community.
 
-It supports general linear model (GLM) based analysis and leverages the :sklearn:`scikit-learn <>` Python toolbox for multivariate statistics with applications such as predictive modelling, classification, decoding, or connectivity analysis.
+It supports general linear model (GLM) based analysis and leverages the `scikit-learn <https://scikit-learn.org>`_ Python toolbox for multivariate statistics with applications such as predictive modelling, classification, decoding, or connectivity analysis.
 
 Important links
 ===============
 
-- Official source code repo: :nilearn-gh:`\ `
+- Official source code repo: https://github.com/nilearn/nilearn/
 - HTML documentation (stable release): https://nilearn.github.io/
 
 Install
@@ -40,7 +40,8 @@ a command prompt::
 
     pip install -U --user nilearn
 
-More detailed instructions are available at :ref:`installation`.
+More detailed instructions are available at
+https://nilearn.github.io/stable/introduction.html#installation.
 
 Office Hours
 ============
@@ -52,12 +53,12 @@ least one member of the core-developer team is available. These events are held
 on our on `Discord server <https://discord.gg/bMBhb7w>`_ and are fully open,
 anyone is welcome to join!
 For more information and ways to engage with the Nilearn team see
-:ref:`How to get help <contributing>`.
+`How to get help <https://nilearn.github.io/stable/development.html#how-to-get-help>`_.
 
 Dependencies
 ============
 
-The required dependencies to use the software are listed in the file :nilearn-gh:`nilearn/setup.cfg <blob/main/setup.cfg>`.
+The required dependencies to use the software are listed in the file `nilearn/setup.cfg <https://github.com/nilearn/nilearn/blob/main/setup.cfg>`_.
 
 If you are using nilearn plotting functionalities or running the examples, matplotlib >= 3.0 is required.
 
@@ -70,4 +71,4 @@ Development
 ===========
 
 Detailed instructions on how to contribute are available at
-:ref:`contributing <contributing>`.
+http://nilearn.github.io/stable/development.html

--- a/README.rst
+++ b/README.rst
@@ -23,12 +23,12 @@ nilearn
 
 Nilearn enables approachable and versatile analyses of brain volumes. It provides statistical and machine-learning tools, with instructive documentation & friendly community.
 
-It supports general linear model (GLM) based analysis and leverages the `scikit-learn <https://scikit-learn.org>`_ Python toolbox for multivariate statistics with applications such as predictive modelling, classification, decoding, or connectivity analysis.
+It supports general linear model (GLM) based analysis and leverages the :sklearn:`scikit-learn <>` Python toolbox for multivariate statistics with applications such as predictive modelling, classification, decoding, or connectivity analysis.
 
 Important links
 ===============
 
-- Official source code repo: https://github.com/nilearn/nilearn/
+- Official source code repo: :nilearn-gh:`\ `
 - HTML documentation (stable release): https://nilearn.github.io/
 
 Install
@@ -40,8 +40,7 @@ a command prompt::
 
     pip install -U --user nilearn
 
-More detailed instructions are available at
-https://nilearn.github.io/stable/introduction.html#installation.
+More detailed instructions are available at :ref:`installation`.
 
 Office Hours
 ============
@@ -58,7 +57,7 @@ For more information and ways to engage with the Nilearn team see
 Dependencies
 ============
 
-The required dependencies to use the software are listed in the file `nilearn/setup.cfg <https://github.com/nilearn/nilearn/blob/main/setup.cfg>`_.
+The required dependencies to use the software are listed in the file :nilearn-gh:`nilearn/setup.cfg <blob/main/setup.cfg>`.
 
 If you are using nilearn plotting functionalities or running the examples, matplotlib >= 3.0 is required.
 
@@ -71,4 +70,4 @@ Development
 ===========
 
 Detailed instructions on how to contribute are available at
-http://nilearn.github.io/stable/development.html
+:ref:`contributing <contributing>`.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -335,9 +335,9 @@ intersphinx_mapping = {
 }
 
 extlinks = {
-    'sklearn': ('https://scikit-learn.org/stable/', ''),
-    'parietal': ('https://team.inria.fr/parietal/', ''),
-    'nilearn': ('https://github.com/nilearn/nilearn/', ''),
+    'sklearn': ('https://scikit-learn.org/stable/', None),
+    'parietal': ('https://team.inria.fr/parietal/', None),
+    'nilearn-gh': ('https://github.com/nilearn/nilearn/', None),
 }
 
 if 'dev' in release:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -335,11 +335,11 @@ intersphinx_mapping = {
 }
 
 extlinks = {
-    'sklearn': ('https://scikit-learn.org/stable/', None),
-    'parietal': ('https://team.inria.fr/parietal/', None),
-    'nilearn-gh': ('https://github.com/nilearn/nilearn/', None),
-    'neurostars': ('https://neurostars.org/tag/nilearn/', None),
-    'nipy': ('https://nipy.org/', None),
+    'sklearn': ('https://scikit-learn.org/stable/%s', None),
+    'parietal': ('https://team.inria.fr/parietal/%s', None),
+    'nilearn-gh': ('https://github.com/nilearn/nilearn/%s', None),
+    'neurostars': ('https://neurostars.org/tag/nilearn/%s', None),
+    'nipy': ('https://nipy.org/%s', None),
 }
 
 if 'dev' in release:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -336,7 +336,7 @@ intersphinx_mapping = {
 
 extlinks = {
     'sklearn': ('https://scikit-learn.org/stable/%s', None),
-    'parietal': ('https://team.inria.fr/parietal/%s', None),
+    'inria': ('https://team.inria.fr/%s', None),
     'nilearn-gh': ('https://github.com/nilearn/nilearn/%s', None),
     'neurostars': ('https://neurostars.org/tag/nilearn/%s', None),
     'nipy': ('https://nipy.org/%s', None),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -339,7 +339,7 @@ extlinks = {
     'parietal': ('https://team.inria.fr/parietal/', None),
     'nilearn-gh': ('https://github.com/nilearn/nilearn/', None),
     'neurostars': ('https://neurostars.org/tag/nilearn/', None),
-    'nibabel': ('https://nipy.org/nibabel/', None),
+    'nipy': ('https://nipy.org/', None),
 }
 
 if 'dev' in release:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,6 +51,7 @@ extensions = [
     'sphinxext.opengraph',
     'myst_parser',
     'sphinx_design',
+    'sphinx.ext.extlinks',
 ]
 
 autosummary_generate = True
@@ -324,7 +325,7 @@ _python_doc_base = 'https://docs.python.org/3.8'
 intersphinx_mapping = {
     'python': (_python_doc_base, None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('http://scipy.github.io/devdocs/', None),
+    'scipy': ('https://scipy.github.io/devdocs/', None),
     'matplotlib': ('https://matplotlib.org/stable/', None),
     'sklearn': ('https://scikit-learn.org/stable/', None),
     'nibabel': ('https://nipy.org/nibabel', None),
@@ -334,8 +335,9 @@ intersphinx_mapping = {
 }
 
 extlinks = {
-    'simple': (_python_doc_base + '/reference/simple_stmts.html#%s', ''),
-    'compound': (_python_doc_base + '/reference/compound_stmts.html#%s', ''),
+    'sklearn': ('https://scikit-learn.org/stable/', ''),
+    'parietal': ('https://team.inria.fr/parietal/', ''),
+    'nilearn': ('https://github.com/nilearn/nilearn/', ''),
 }
 
 if 'dev' in release:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -338,6 +338,8 @@ extlinks = {
     'sklearn': ('https://scikit-learn.org/stable/', None),
     'parietal': ('https://team.inria.fr/parietal/', None),
     'nilearn-gh': ('https://github.com/nilearn/nilearn/', None),
+    'neurostars': ('https://neurostars.org/tag/nilearn/', None),
+    'nibabel': ('https://nipy.org/nibabel/', None),
 }
 
 if 'dev' in release:

--- a/doc/decoding/searchlight.rst
+++ b/doc/decoding/searchlight.rst
@@ -58,9 +58,9 @@ Classifier
 
 The classifier used by default by :class:`SearchLight` is LinearSVC with C=1 but
 this can be customized easily by passing an estimator parameter to the
-Searchlight. See scikit-learn documentation for `other classifiers
-<http://scikit-learn.org/stable/supervised_learning.html>`_. You can
-also pass scikit-learn `Pipelines <https://scikit-learn.org/stable/modules/compose.html>`_
+Searchlight. See scikit-learn documentation for :sklearn:`other classifiers
+<supervised_learning.html>`. You can
+also pass scikit-learn :sklearn:`Pipelines <modules/compose.html>`
 to the :class:`SearchLight` in order to combine estimators and preprocessing steps
 (e.g., feature scaling) for your searchlight.
 
@@ -68,8 +68,8 @@ Score function
 --------------
 
 Metrics can be specified by the "scoring" argument to the :class:`SearchLight`, as
-detailed in the `scikit-learn documentation
-<http://scikit-learn.org/dev/modules/model_evaluation.html#the-scoring-parameter-defining-model-evaluation-rules>`_
+detailed in the :sklearn:`scikit-learn documentation
+<modules/model_evaluation.html#the-scoring-parameter-defining-model-evaluation-rules>`
 
 Cross validation
 ----------------
@@ -81,8 +81,8 @@ cross-validation is used.
 
 Cross-validation can be defined using the "cv" argument. As it
 is computationally costly, *K*-Fold cross validation with *K* = 3 is set as the
-default. A `scikit-learn cross-validation generator
-<https://scikit-learn.org/stable/modules/classes.html#splitter-classes>`_ can also
+default. A :sklearn:`scikit-learn cross-validation generator
+<modules/classes.html#splitter-classes>` can also
 be passed to set a specific type of cross-validation.
 
 Leave-one-run-out cross-validation (LOROCV) is a common approach for searchlights.
@@ -90,8 +90,8 @@ This approach is a specific use-case of grouped cross-validation, where the
 cross-validation folds are determined by the acquisition runs. The held-out fold
 in a given iteration of cross-validation consist of data from a separate run,
 which keeps training and validation sets properly independent. For this reason,
-LOROCV is often recommended. This can be performed by using `LeaveOneGroupOut
-<https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.LeaveOneGroupOut.html>`_,
+LOROCV is often recommended. This can be performed by using :sklearn:`LeaveOneGroupOut
+<modules/generated/sklearn.model_selection.LeaveOneGroupOut.html>`,
 and then setting the group/run labels when fitting the estimator.
 
 Sphere radius

--- a/doc/glm/first_level_model.rst
+++ b/doc/glm/first_level_model.rst
@@ -90,8 +90,8 @@ The :class:`nilearn.glm.first_level.FirstLevelModel` class provides the tools to
 the fMRI data. The :func:`nilearn.glm.first_level.FirstLevelModel.fit()` function takes the fMRI data
 and design matrix as input and fits the GLM. Like other Nilearn functions,
 :func:`nilearn.glm.first_level.FirstLevelModel.fit()` accepts file names as input, but can also
-work with `NiftiImage objects <https://nipy.org/nibabel/nibabel_images.html>`_. More information about
-input formats is available `here <http://nilearn.github.io/manipulating_images/input_output.html#inputing-data-file-names-or-image-objects>`_ ::
+work with :nipy:`NiftiImage objects <nibabel/nibabel_images.html>`. More information about
+input formats is available :ref:`here <loading_data>` ::
 
   from nilearn.glm.first_level import FirstLevelModel
   fmri_glm = FirstLevelModel()

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -140,7 +140,7 @@ If you wish to add a missing term, please
         patterns in two or more regions.
 
     functional connectome
-        A :ref:`functional connectome <functional_connectomes>`_ is a set of
+        A :ref:`functional connectome <functional_connectomes>` is a set of
         connections representing brain interactions between regions.
 
     FWER correction

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -6,8 +6,9 @@ Glossary
 The Glossary provides short definitions of neuro-imaging concepts as well
 as Nilearn specific vocabulary.
 
-If you wish to add a missing term, please `create a new issue`_ or
-`open a Pull Request`_.
+If you wish to add a missing term, please
+:nilearn-gh:`create an issue <issues/new/choose>` or
+:nilearn-gh:`open a Pull Request <compare>`.
 
 .. glossary::
     :sorted:
@@ -19,7 +20,7 @@ If you wish to add a missing term, please `create a new issue`_ or
         among means.
 
     AUC
-        `Area under the curve`_.
+        :sklearn:`Area under the curve <modules/model_evaluation.html#roc-metrics>`.
 
     Beta
         See :term:`Parameter estimate`.
@@ -47,8 +48,8 @@ If you wish to add a missing term, please `create a new issue`_ or
         of different treatments.
 
     Decoding
-        `Decoding`_ consists in predicting, from brain images, the conditions
-        associated to trial.
+        :ref:`Decoding <decoding_intro>` consists in predicting, from brain
+        images, the conditions associated to trial.
 
     Deterministic atlas
         A deterministic atlas is a hard parcellation of the brain into
@@ -139,8 +140,8 @@ If you wish to add a missing term, please `create a new issue`_ or
         patterns in two or more regions.
 
     functional connectome
-        A `functional connectome`_ is a set of connections representing brain
-        interactions between regions.
+        A :ref:`functional connectome <functional_connectomes>`_ is a set of
+        connections representing brain interactions between regions.
 
     FWER correction
         `Family-wise error rate`_ is the probability of making one or more
@@ -232,7 +233,7 @@ If you wish to add a missing term, please `create a new issue`_ or
         (TPR) against the false positive rate (FPR) at various threshold settings.
 
     Searchlight
-        `Searchlight analysis`_ consists of scanning the brain with a searchlight.
+        :ref:`Searchlight analysis <searchlight>` consists of scanning the brain with a searchlight.
         That is, a ball of given radius is scanned across the brain volume and the
         prediction accuracy of a classifier trained on the corresponding voxels is measured.
 
@@ -241,8 +242,8 @@ If you wish to add a missing term, please `create a new issue`_ or
         of a given signal to the level of the background noise.
 
     SpaceNet
-        `SpaceNet`_ is a decoder implementing spatial penalties which improve brain
-        decoding power as well as decoder maps.
+        :ref:`SpaceNet <space_net>` is a decoder implementing spatial penalties
+        which improve brain decoding power as well as decoder maps.
 
     SPM
         `Statistical Parametric Mapping`_ is a statistical technique for examining
@@ -276,8 +277,9 @@ If you wish to add a missing term, please `create a new issue`_ or
         (e.g., schizophrenia versus healthy) from brain images.
 
     SVM
-        `Support vector machines`_ are a set of :term:`supervised learning` methods used
-        for :term:`classification`, :term:`regression` and outliers detection.
+        :sklearn:`Support vector machines <modules/svm.html>` are a set of
+        :term:`supervised learning` methods used for :term:`classification`,
+        :term:`regression` and outliers detection.
 
     TFCE
         Threshold-free cluster enhancement is a voxel-level metric that combines signal
@@ -318,17 +320,8 @@ If you wish to add a missing term, please `create a new issue`_ or
 
 .. LINKS
 
-.. _`create a new issue`:
-    https://github.com/nilearn/nilearn/issues/new/choose
-
-.. _`open a Pull Request`:
-    https://github.com/nilearn/nilearn/compare
-
 .. _`Analysis of variance`:
     https://en.wikipedia.org/wiki/Analysis_of_variance
-
-.. _`Area under the curve`:
-    https://scikit-learn.org/stable/modules/model_evaluation.html#roc-metrics
 
 .. _`Brain Imaging Data Structure`:
     https://bids.neuroimaging.io/
@@ -341,9 +334,6 @@ If you wish to add a missing term, please `create a new issue`_ or
 
 .. _`contrast`:
     https://en.wikipedia.org/wiki/Contrast_(statistics)
-
-.. _`Decoding`:
-    https://nilearn.github.io/stable/decoding/decoding_intro.html
 
 .. _`Dictionary learning`:
     https://en.wikipedia.org/wiki/Sparse_dictionary_learning
@@ -368,9 +358,6 @@ If you wish to add a missing term, please `create a new issue`_ or
 
 .. _`FREM`:
     https://www.sciencedirect.com/science/article/abs/pii/S1053811917308182
-
-.. _`functional connectome`:
-    https://nilearn.github.io/stable/connectivity/functional_connectomes.html
 
 .. _`FWHM`:
     https://en.wikipedia.org/wiki/Full_width_at_half_maximum
@@ -402,17 +389,11 @@ If you wish to add a missing term, please `create a new issue`_ or
 .. _`Resting state`:
     https://en.wikipedia.org/wiki/Resting_state_fMRI
 
-.. _`Searchlight analysis`:
-    https://nilearn.github.io/stable/decoding/searchlight.html
-
 .. _`SNR`:
     https://en.wikipedia.org/wiki/Signal-to-noise_ratio
 
 .. _`software`:
     https://www.fil.ion.ucl.ac.uk/spm/software/
-
-.. _`SpaceNet`:
-    https://nilearn.github.io/stable/decoding/space_net.html
 
 .. _`Statistical Parametric Mapping`:
     https://en.wikipedia.org/wiki/Statistical_parametric_mapping
@@ -422,9 +403,6 @@ If you wish to add a missing term, please `create a new issue`_ or
 
 .. _`Unsupervised learning`:
     https://en.wikipedia.org/wiki/Unsupervised_learning
-
-.. _`Support vector machines`:
-    https://scikit-learn.org/stable/modules/svm.html
 
 .. _`Voxel-Based Morphometry`:
     https://en.wikipedia.org/wiki/Voxel-based_morphometry

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,7 +8,7 @@ Nilearn
     **instructive documentation & open community**.
 
     It supports general linear model (GLM) based analysis and leverages
-    the `scikit-learn <http://scikit-learn.org>`__ Python toolbox
+    the :sklearn:`scikit-learn <>` Python toolbox
     for multivariate statistics with applications such as predictive modelling,
     classification, decoding, or connectivity analysis.
 
@@ -322,4 +322,4 @@ Featured examples
    GitHub Repository <https://github.com/nilearn/nilearn>
 
 
-Nilearn is part of the `NiPy ecosystem <http://nipy.org>`_.
+Nilearn is part of the :nipy:`NiPy ecosystem <>`.

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -222,7 +222,7 @@ It is typically used interactively in IPython or in an automated way by Python
 code.
 Most importantly, nilearn functions that process neuroimaging data accept
 either a filename (i.e., a string variable) or a
-:nibabel:`NiftiImage object <nibabel_images.html>`. We call the latter
+:nipy:`NiftiImage object <nibabel/nibabel_images.html>`. We call the latter
 "niimg-like".
 
 Suppose for instance that you have a Tmap image saved in the Nifti file
@@ -265,8 +265,8 @@ the :mod:`nilearn.image` module for image manipulation, e.g.
     >>> smoothed_img = image.smooth_img("/home/user/t_map000.nii", fwhm=5)   # doctest: +SKIP
 
 The returned value `smoothed_img` is a
-:nibabel:`NiftiImage object <nibabel_images.html>`. It can either be passed
-to other nilearn functions operating on niimgs (neuroimaging images) or
+:nipy:`NiftiImage object <nibabel/nibabel_images.html>`. It can either be
+passed to other nilearn functions operating on niimgs (neuroimaging images) or
 saved to disk with::
 
     >>> smoothed_img.to_filename("/home/user/t_map000_smoothed.nii")   # doctest: +SKIP

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -221,8 +221,8 @@ But you will soon realize that you don't really need one.
 It is typically used interactively in IPython or in an automated way by Python
 code.
 Most importantly, nilearn functions that process neuroimaging data accept
-either a filename (i.e., a string variable) or a `NiftiImage object
-<http://nipy.org/nibabel/nibabel_images.html>`_. We call the latter
+either a filename (i.e., a string variable) or a
+:nibabel:`NiftiImage object <nibabel_images.html>`. We call the latter
 "niimg-like".
 
 Suppose for instance that you have a Tmap image saved in the Nifti file
@@ -264,8 +264,8 @@ the :mod:`nilearn.image` module for image manipulation, e.g.
     >>> from nilearn import image
     >>> smoothed_img = image.smooth_img("/home/user/t_map000.nii", fwhm=5)   # doctest: +SKIP
 
-The returned value `smoothed_img` is a `NiftiImage object
-<http://nipy.org/nibabel/nibabel_images.html>`_. It can either be passed
+The returned value `smoothed_img` is a
+:nibabel:`NiftiImage object <nibabel_images.html>`. It can either be passed
 to other nilearn functions operating on niimgs (neuroimaging images) or
 saved to disk with::
 
@@ -426,16 +426,16 @@ Scikit-learn: machine learning in Python
 
 .. topic:: **What is scikit-learn?**
 
-    `Scikit-learn <http://scikit-learn.org>`_ is a Python library for machine
+    :sklearn:`Scikit-learn <>` is a Python library for machine
     learning. Its strong points are:
 
     - Easy to use and well documented
     - Computationally efficient
     - Provides a wide variety of standard machine learning methods for non-experts
 
-The core concept in `scikit-learn <http://scikit-learn.org>`_ is the
-estimator object, for instance an SVC (`support vector classifier
-<http://scikit-learn.org/stable/modules/svm.html>`_).
+The core concept in :sklearn:`scikit-learn <>` is the
+estimator object, for instance an SVC
+(:sklearn:`support vector classifier <modules/svm.html>`).
 It is first created with the relevant parameters::
 
     >>> import sklearn; sklearn.set_config(print_changed_only=False)
@@ -479,8 +479,8 @@ and try predicting the labels on the left-out data::
     >>> labels[-10:]    # The actual labels
     array([5, 4, 8, 8, 4, 9, 0, 8, 9, 8])
 
-To find out more, try the `scikit-learn tutorials
-<http://scikit-learn.org/stable/tutorial/index.html>`_.
+To find out more, try the
+:sklearn:`scikit-learn tutorials <tutorial/index.html>`.
 
 Finding help
 -------------
@@ -493,15 +493,14 @@ Finding help
 
     * The documentation of scikit-learn explains each method with tips on
       practical use and examples:
-      `http://scikit-learn.org/ <http://scikit-learn.org/>`_.
+      :sklearn:`\ `.
       While not specific to neuroimaging, it is often a recommended read.
       Be careful to consult the documentation of the scikit-learn version
       that you are using.
 
 :Mailing lists and forums:
 
-    * Don't hesitate to ask questions about nilearn on `neurostars
-      <https://neurostars.org/tag/nilearn>`_.
+    * Don't hesitate to ask questions about nilearn on :neurostars:`neurostars <>`.
 
     * You can find help with neuroimaging in Python (file I/O,
       neuroimaging-specific questions) via the nipy user group:

--- a/doc/maintenance.rst
+++ b/doc/maintenance.rst
@@ -12,7 +12,7 @@ This section describes how the project is organized.
 Issues
 ------
 
-Nilearn uses `issues <https://github.com/nilearn/nilearn/issues>`_ for
+Nilearn uses :nilearn-gh:`issues <issues>` for
 tracking bugs, requesting potential features, and holding project discussions.
 
 .. _issue_labels:
@@ -20,12 +20,11 @@ tracking bugs, requesting potential features, and holding project discussions.
 Labels
 ......
 
-`Labels <https://github.com/nilearn/nilearn/labels>`_ are useful to
-quickly sort `issues <https://github.com/nilearn/nilearn/issues>`_
+:nilearn-gh:`Labels <labels>` are useful to
+quickly sort :nilearn-gh:`issues <issues>`
 and easily find what you are looking for in the issue tracker.
 
-When `creating an issue
-<https://github.com/nilearn/nilearn/issues/new/choose>`_, the user
+When :nilearn-gh:`creating an issue <issues/new/choose>`, the user
 is responsible for a very basic labeling categorizing the issue:
 
 	- |Bug| for bug reports.
@@ -72,7 +71,7 @@ Other labels can be used to describe further the topic of the issue:
 	- |Maintenance| This issue is related to maintenance work.
 	- |Plotting| The issue is related to plotting functionalities.
 	- |Testing| The issue is related to testing.
-	- |Usage| This issue is a usage question and should have been posted on `neurostars <https://neurostars.org/>`_.
+	- |Usage| This issue is a usage question and should have been posted on :neurostars:`neurostars <>`.
 
 Finally, we use the following labels to indicate how the work on the issue
 is going:
@@ -118,7 +117,7 @@ Usually we expect the issue's author to close the issue, but there are several
 possible reasons for a community member to close an issue:
 
 	- The issue has been solved: kindly asked the author whether the issue can be closed. In the absence of reply, close the issue after two weeks.
-	- The issue is a usage question: label the issue with |Usage| and kindly redirect the author to `neurostars <https://neurostars.org/>`_. Close the issue afterwards.
+	- The issue is a usage question: label the issue with |Usage| and kindly redirect the author to :neurostars:`neurostars <>`. Close the issue afterwards.
 	- The issue has no recent activity (no messages in the last three months): ping the author to see if the issue is still relevant. In the absence of reply, label the issue with |stalled| and close it after 2 weeks.
 
 .. _pull request:
@@ -128,8 +127,8 @@ Pull Requests
 
 We welcome pull requests from all community members, if they follow the
 :ref:`contribution_guidelines` inspired from scikit learn conventions. (More
-details on their process are available `here
-<https://scikit-learn.org/stable/developers/contributing.html#contributing-code>`_)
+details on their process are available
+:sklearn:`here <developers/contributing.html#contributing-code>`).
 
 
 How to make a release?
@@ -313,7 +312,7 @@ We are now ready to upload to `Pypi`. Note that you will need to have an `accoun
 
 Once the upload is completed, make sure everything looks good on `Pypi <https://pypi.org/project/nilearn/>`_. Otherwise you will probably have to fix the issue and start over a new release with the patch number incremented.
 
-At this point, we need to upload the binaries to GitHub and link them to the tag. To do so, go to the `Nilearn GitHub page <https://github.com/nilearn/nilearn/tags>`_ under the "Releases" tab, and edit the `x.y.z` tag by providing a description, and upload the distributions we just created (you can just drag and drop the files).
+At this point, we need to upload the binaries to GitHub and link them to the tag. To do so, go to the :nilearn-gh:`Nilearn GitHub page <tags>` under the "Releases" tab, and edit the `x.y.z` tag by providing a description, and upload the distributions we just created (you can just drag and drop the files).
 
 
 Build and deploy the documentation

--- a/examples/02_decoding/plot_haxby_anova_svm.py
+++ b/examples/02_decoding/plot_haxby_anova_svm.py
@@ -73,7 +73,8 @@ y_pred = decoder.predict(func_img)
 # leave a session out scheme, then pass the cross-validator object to the cv
 # parameter of decoder.leave-one-session-out For more details please take a
 # look at:
-# <https://nilearn.github.io/stable/auto_examples/plot_decoding_tutorial.html#measuring-prediction-scores-using-cross-validation>
+# `Measuring prediction scores using cross-validation\
+# <../00_tutorials/plot_decoding_tutorial.html#measuring-prediction-scores-using-cross-validation>`_
 from sklearn.model_selection import LeaveOneGroupOut
 cv = LeaveOneGroupOut()
 

--- a/examples/04_glm_first_level/plot_first_level_details.py
+++ b/examples/04_glm_first_level/plot_first_level_details.py
@@ -404,10 +404,8 @@ plt.show()
 # is to estimate confounding effects from the data themselves, using
 # the CompCor approach, and take those into account in the model.
 #
-# For this we rely on the so-called `high_variance_confounds`_
-# routine of Nilearn.
-#
-# .. _high_variance_confounds: https://nilearn.github.io/modules/generated/nilearn.image.high_variance_confounds.html
+# For this we rely on the so-called
+# :func:`~nilearn.image.high_variance_confounds` routine of Nilearn.
 
 
 from nilearn.image import high_variance_confounds

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -16,12 +16,6 @@ import sys
 #
 docdict = dict()
 
-NILEARN_LINKS = {"landing_page": "http://nilearn.github.io"}
-NILEARN_LINKS["input_output"] = (
-    "{}/manipulating_images/input_output.html".format(
-        NILEARN_LINKS["landing_page"])
-)
-
 # Verbose
 verbose = """
 verbose : :obj:`int`, optional
@@ -306,14 +300,14 @@ docdict['n_jobs_all'] = n_jobs.format("-1")
 # img
 docdict['img'] = """
 img : Niimg-like object
-    See `input-output <%(input_output)s>`_.
-""" % NILEARN_LINKS
+    See :ref:`extracting_data`.
+"""
 
 # imgs
 docdict['imgs'] = """
 imgs : :obj:`list` of Niimg-like objects
-    See `input-output <%(input_output)s>`_.
-""" % NILEARN_LINKS
+    See :ref:`extracting_data`.
+"""
 
 # cut_coords
 docdict['cut_coords'] = """
@@ -457,9 +451,9 @@ cbar_tick_format : :obj:`str`, optional
 # bg_img
 docdict['bg_img'] = """
 bg_img : Niimg-like object, optional
-    See `input_output <%(input_output)s>`_.
+    See :ref:`extracting_data`.
     The background image to plot on top of.
-""" % NILEARN_LINKS
+"""
 
 # vmin
 docdict['vmin'] = """

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -191,7 +191,7 @@ def check_niimg(niimg, ensure_ndim=None, atleast_4d=False, dtype=None,
     Parameters
     ----------
     niimg : Niimg-like object
-        See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
+        See :ref:`extracting_data`.
         If niimg is a string or pathlib.Path, consider it as a path to
         Nifti image and call nibabel.load on it. The '~' symbol is expanded to
         the user home folder.
@@ -310,7 +310,7 @@ def check_niimg_3d(niimg, dtype=None):
     Parameters
     ----------
     niimg : Niimg-like object
-        See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
+        See :ref:`extracting_data`.
         If niimg is a string, consider it as a path to Nifti image and
         call nibabel.load on it.
         If it is an object, check if the affine attribute present and that
@@ -347,7 +347,7 @@ def check_niimg_4d(niimg, return_iterator=False, dtype=None):
     Parameters
     ----------
     niimg : 4D Niimg-like object
-        See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
+        See :ref:`extracting_data`.
         If niimgs is an iterable, checks if data is really 4D. Then,
         considering that it is a list of niimg and load them one by one.
         If niimg is a string, consider it as a path to Nifti image and
@@ -395,7 +395,7 @@ def concat_niimgs(niimgs, dtype=np.float32, ensure_ndim=None,
     Parameters
     ----------
     niimgs : iterable of Niimg-like objects or glob pattern
-        See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
+        See :ref:`extracting_data`.
         Niimgs to concatenate.
 
     dtype : numpy dtype, optional

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -361,7 +361,7 @@ class _BaseDecoder(LinearRegression, CacheMixin):
         Parameters
         ----------
         X: list of Niimg-like objects
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             Data on which model is to be fitted. If this is a list,
             the affine is considered the same for all.
 
@@ -593,8 +593,7 @@ class _BaseDecoder(LinearRegression, CacheMixin):
         Parameters
         ----------
         X: list of Niimg-like objects
-            See
-            <http://nilearn.github.io/manipulating_images/input_output.html>
+            See :ref:`extracting_data`.
             Data on prediction is to be made. If this is a list,
             the affine is considered the same for all.
 

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -199,12 +199,12 @@ class SearchLight(BaseEstimator):
     Parameters
     -----------
     mask_img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
-        boolean image giving location of voxels containing usable signals.
+        See :ref:`extracting_data`.
+        Boolean image giving location of voxels containing usable signals.
 
     process_mask_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_images/input_output.html
-        boolean image giving voxels on which searchlight should be
+        See :ref:`extracting_data`.
+        Boolean image giving voxels on which searchlight should be
         computed.
 
     radius : float, optional
@@ -263,7 +263,7 @@ class SearchLight(BaseEstimator):
         Parameters
         ----------
         imgs : Niimg-like object
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             4D image.
 
         y : 1D array-like

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -739,7 +739,7 @@ class BaseSpaceNet(LinearRegression, CacheMixin):
         Parameters
         ----------
         X : list of Niimg-like objects
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             Data on which model is to be fitted. If this is a list,
             the affine is considered the same for all.
 
@@ -932,7 +932,7 @@ class BaseSpaceNet(LinearRegression, CacheMixin):
         Parameters
         ----------
         X : list of Niimg-like objects
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             Data on prediction is to be made. If this is a list,
             the affine is considered the same for all.
 
@@ -1155,7 +1155,7 @@ class SpaceNetClassifier(BaseSpaceNet):
         Parameters
         ----------
         X : list of Niimg-like objects
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             Data on which model is to be fitted. If this is a list,
             the affine is considered the same for all.
 

--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -148,7 +148,7 @@ class CanICA(_MultiPCA):
         of `mask` and other NiftiMasker related parameters as initialization.
 
     `mask_img_` : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         The mask of the data. If no mask was given at masker creation, contains
         the automatically computed mask.
 

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -168,7 +168,7 @@ class DictLearning(_BaseDecomposition):
         of `mask` and other NiftiMasker related parameters as initialization.
 
     `mask_img_` : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         The mask of the data. If no mask was given at masker creation, contains
         the automatically computed mask.
 

--- a/nilearn/glm/_base.py
+++ b/nilearn/glm/_base.py
@@ -108,7 +108,7 @@ class BaseGLM(BaseEstimator, TransformerMixin, CacheMixin):
 
         bg_img : Niimg-like object, optional
             Default is the MNI152 template (Default='MNI152TEMPLATE')
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             The background image for mask and stat maps to be plotted on upon.
             To turn off background image, just pass "bg_img=None".
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -39,7 +39,7 @@ def get_data(img):
     Parameters
     ----------
     img : Niimg-like object or iterable of Niimg-like objects
-        See http://nilearn.github.io/manipulating_images/input_output.html.
+        See :ref:`extracting_data`.
 
     Returns
     -------
@@ -62,12 +62,12 @@ def high_variance_confounds(imgs, n_confounds=5, percentile=2.,
         ----------
         imgs : Niimg-like object
             4D image.
-            See http://nilearn.github.io/manipulating_images/input_output.html.
+            See :ref:`extracting_data`.
 
         mask_img : Niimg-like object
             If not provided, all voxels are used.
             If provided, confounds are extracted from voxels inside the mask.
-            See http://nilearn.github.io/manipulating_images/input_output.html.
+            See :ref:`extracting_data`.
 
         n_confounds : :obj:`int`, optional
             Number of confounds to return. Default=5.
@@ -248,8 +248,7 @@ def smooth_img(imgs, fwhm):
     Parameters
     ----------
     imgs : Niimg-like object or iterable of Niimg-like objects
-        Image(s) to smooth (see
-        http://nilearn.github.io/manipulating_images/input_output.html
+        Image(s) to smooth (see :ref:`extracting_data`
         for a detailed description of the valid input types).
     %(fwhm)s
 
@@ -295,7 +294,7 @@ def _crop_img_to(img, slices, copy=True):
     img : Niimg-like object
         Image to be cropped. If slices has less entries than `img` has dimensions,
         the slices will be applied to the first `len(slices)` dimensions (See
-        http://nilearn.github.io/manipulating_images/input_output.html).
+        :ref:`extracting_data`).
 
     slices : list of slices
         Defines the range of the crop.
@@ -347,9 +346,8 @@ def crop_img(img, rtol=1e-8, copy=True, pad=True, return_offset=False):
     Parameters
     ----------
     img : Niimg-like object
-        Image to be cropped (see
-        http://nilearn.github.io/manipulating_images/input_output.html
-        for a detailed description of the valid input types).
+        Image to be cropped (see :ref:`extracting_data` for a detailed
+        description of the valid input types).
 
     rtol : :obj:`float`, optional
         relative tolerance (with respect to maximal absolute value of the
@@ -496,8 +494,7 @@ def mean_img(imgs, target_affine=None, target_shape=None,
     Parameters
     ----------
     imgs : Niimg-like object or iterable of Niimg-like objects
-        Images to be averaged over time (see
-        http://nilearn.github.io/manipulating_images/input_output.html
+        Images to be averaged over time (see :ref:`extracting_data`
         for a detailed description of the valid input types).
 
     target_affine : :class:`numpy.ndarray`, optional
@@ -568,9 +565,8 @@ def swap_img_hemispheres(img):
     Parameters
     ----------
     img : Niimg-like object
-        Images to swap (see
-        http://nilearn.github.io/manipulating_images/input_output.html
-        for a detailed description of the valid input types).
+        Images to swap (see :ref:`extracting_data` for a detailed description
+        of the valid input types).
 
     Returns
     -------
@@ -611,7 +607,7 @@ def index_img(imgs, index):
     Parameters
     ----------
     imgs : 4D Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html.
+        See :ref:`extracting_data`.
 
     index : Any type compatible with numpy array indexing
         Used for indexing the 4D data array in the fourth dimension.
@@ -668,7 +664,7 @@ def iter_img(imgs):
     Parameters
     ----------
     imgs : 4D Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html.
+        See :ref:`extracting_data`.
 
     Returns
     -------
@@ -1128,8 +1124,8 @@ def clean_img(imgs, runs=None, detrend=True, standardize=True,
     ----------
     imgs : Niimg-like object
         4D image. The signals in the last dimension are filtered (see
-        http://nilearn.github.io/manipulating_images/input_output.html
-        for a detailed description of the valid input types).
+        :ref:`extracting_data` for a detailed description of the valid input
+        types).
 
     runs : :class:`numpy.ndarray`, optional
         Add a run level to the cleaning process. Each run will be
@@ -1177,7 +1173,7 @@ def clean_img(imgs, runs=None, detrend=True, standardize=True,
         If provided, signal is only cleaned from voxels inside the mask. If
         mask is provided, it should have same shape and affine as imgs.
         If not provided, all voxels are used.
-        See http://nilearn.github.io/manipulating_images/input_output.html.
+        See :ref:`extracting_data`.
 
     Returns
     -------
@@ -1252,7 +1248,7 @@ def load_img(img, wildcards=True, dtype=None):
         on it. The '~' symbol is expanded to the user home folder.
         If it is an object, check if affine attribute is present, raise
         `TypeError` otherwise.
-        See http://nilearn.github.io/manipulating_images/input_output.html.
+        See :ref:`extracting_data`.
 
     wildcards : :obj:`bool`, optional
         Use `img` as a regular expression to get a list of matching input
@@ -1288,7 +1284,7 @@ def largest_connected_component_img(imgs):
     ----------
     imgs : Niimg-like object or iterable of Niimg-like objects (3D)
         Image(s) to extract the largest connected component from.
-        See http://nilearn.github.io/manipulating_images/input_output.html.
+        See :ref:`extracting_data`.
 
     Returns
     -------

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -194,7 +194,7 @@ def get_mask_bounds(img):
         Parameters
         ----------
         img : Niimg-like object
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             The image to inspect. Zero values are considered as
             background.
 
@@ -314,7 +314,7 @@ def resample_img(img, target_affine=None, target_shape=None,
     Parameters
     ----------
     img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Image(s) to resample.
 
     target_affine : numpy.ndarray, optional
@@ -638,11 +638,11 @@ def resample_to_img(source_img, target_img,
     Parameters
     ----------
     source_img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Image(s) to resample.
 
     target_img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Reference image taken for resampling.
 
     interpolation : str, optional
@@ -707,7 +707,7 @@ def reorder_img(img, resample=None):
     Parameters
     -----------
     img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Image to reorder.
 
     resample : None or string in {'continuous', 'linear', 'nearest'}, optional

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -134,7 +134,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         Parameters
         ----------
         imgs : 3D/4D Niimg-like object
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             Images to process.
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.
@@ -170,7 +170,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         Parameters
         ----------
         imgs : 3D/4D Niimg-like object
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             Images to process.
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.
@@ -224,7 +224,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         Parameters
         ----------
         X : Niimg-like object
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
 
         y : numpy array of shape [n_samples], optional
             Target values.
@@ -281,7 +281,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
         X : 2D :obj:`numpy.ndarray`
             Signal for each element in the mask.
             shape: (number of scans, number of elements)
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
 
         Returns
         -------

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -59,7 +59,7 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
     Parameters
     ----------
     mask_img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Mask of the data. If not given, a mask is computed in the fit step.
         Optional parameters can be set using mask_args and mask_strategy to
         fine tune the mask extraction.
@@ -221,7 +221,7 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
         Parameters
         ----------
         imgs : :obj:`list` of Niimg-like objects
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             Data on which the mask must be calculated. If this is a list,
             the affine is considered the same for all.
 
@@ -312,7 +312,7 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
         ----------
 
         imgs_list : :obj:`list` of Niimg-like objects
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             List of imgs file to prepare. One item per subject.
 
         confounds : :obj:`list` of confounds, optional
@@ -410,7 +410,7 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
         Parameters
         ----------
         imgs : :obj:`list` of Niimg-like objects
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             Data to be preprocessed
 
         confounds : CSV file or 2D :obj:`numpy.ndarray` or \

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -43,7 +43,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
     Parameters
     ----------
     labels_img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Region definitions, as one image of labels.
 
     labels : :obj:`list` of :obj:`str`, optional
@@ -59,7 +59,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
         Default=0.
 
     mask_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Mask to apply to regions before extracting signals.
     %(smoothing_fwhm)s
     standardize : {False, True, 'zscore', 'psc'}, optional
@@ -460,7 +460,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
         Parameters
         ----------
         imgs : 3D/4D Niimg-like object
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             Images to process.
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.
@@ -502,7 +502,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
         Parameters
         ----------
         imgs : 3D/4D Niimg-like object
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             Images to process.
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -41,12 +41,12 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
     Parameters
     ----------
     maps_img : 4D niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Set of continuous maps. One representative time course per map is
         extracted using least square regression.
 
     mask_img : 3D niimg-like object, optional
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Mask to apply to regions before extracting signals.
 
     allow_overlap : :obj:`bool`, optional
@@ -463,7 +463,7 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
         Parameters
         ----------
         imgs : 3D/4D Niimg-like object
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             Images to process.
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -121,7 +121,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
     Parameters
     ----------
     mask_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Mask for the data. If not given, a mask is computed in the fit step.
         Optional parameters (mask_args and mask_strategy) can be set to
         fine tune the mask extraction.
@@ -412,7 +412,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         Parameters
         ----------
         imgs : :obj:`list` of Niimg-like objects
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             Data on which the mask must be calculated. If this is a list,
             the affine is considered the same for all.
 
@@ -502,7 +502,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         Parameters
         ----------
         imgs : 3D/4D Niimg-like object
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             Images to process.
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -35,7 +35,7 @@ def _apply_mask_and_get_affinity(seeds, niimg, radius, allow_overlap,
         as target_affine.
 
     niimg : 3D/4D Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Images to process.
         If a 3D niimg is provided, a singleton dimension will be added to
         the output to represent the single scan in the niimg.
@@ -160,7 +160,7 @@ def _iter_signals_from_spheres(seeds, niimg, radius, allow_overlap,
         as the images (typically MNI or TAL).
 
     niimg : 3D/4D Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Images to process.
         If a 3D niimg is provided, a singleton dimension will be added to
         the output to represent the single scan in the niimg.
@@ -173,7 +173,7 @@ def _iter_signals_from_spheres(seeds, niimg, radius, allow_overlap,
         maps have a non-zero value for the same voxel).
 
     mask_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Mask to apply to regions before extracting signals.
 
     """
@@ -229,7 +229,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         Default is None (signal is extracted on a single voxel).
 
     mask_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Mask to apply to regions before extracting signals.
 
     allow_overlap : :obj:`bool`, optional
@@ -406,7 +406,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         Parameters
         ----------
         imgs : 3D/4D Niimg-like object
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             Images to process.
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.
@@ -446,7 +446,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         Parameters
         ----------
         imgs : 3D/4D Niimg-like object
-            See http://nilearn.github.io/manipulating_images/input_output.html
+            See :ref:`extracting_data`.
             Images to process.
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -124,7 +124,7 @@ def intersect_masks(mask_imgs, threshold=0.5, connected=True):
     Parameters
     ----------
     mask_imgs : :obj:`list` of Niimg-like objects
-        See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
+        See :ref:`extracting_data`.
         3D individual masks with same shape and affine.
 
     threshold : :obj:`float`, optional
@@ -220,7 +220,7 @@ def compute_epi_mask(epi_img, lower_cutoff=0.2, upper_cutoff=0.85,
     Parameters
     ----------
     epi_img : Niimg-like object
-        See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
+        See :ref:`extracting_data`.
         :term:`EPI` image, used to compute the mask.
         3D and 4D images are accepted.
 
@@ -316,7 +316,7 @@ def compute_multi_epi_mask(epi_imgs, lower_cutoff=0.2, upper_cutoff=0.85,
     Parameters
     ----------
     epi_imgs : :obj:`list` of Niimg-like objects
-        See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
+        See :ref:`extracting_data`.
         A list of arrays, each item being a subject or a session.
         3D and 4D images are accepted.
 
@@ -390,7 +390,7 @@ def compute_background_mask(data_imgs, border_size=2,
     Parameters
     ----------
     data_imgs : Niimg-like object
-        See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
+        See :ref:`extracting_data`.
         Images used to compute the mask. 3D and 4D images are accepted.
 
         .. note::
@@ -463,7 +463,7 @@ def compute_multi_background_mask(data_imgs, border_size=2, upper_cutoff=0.85,
     Parameters
     ----------
     data_imgs : :obj:`list` of Niimg-like objects
-        See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
+        See :ref:`extracting_data`.
         A list of arrays, each item being a subject or a session.
         3D and 4D images are accepted.
 
@@ -526,7 +526,7 @@ def compute_brain_mask(target_img, threshold=.5, connected=True, opening=2,
     Parameters
     ----------
     target_img : Niimg-like object
-        See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
+        See :ref:`extracting_data`.
         Images used to compute the mask. 3D and 4D images are accepted.
         Only the shape and affine of ``target_img`` will be used here.
 
@@ -593,7 +593,7 @@ def compute_multi_gray_matter_mask(target_imgs, threshold=.5,
     Parameters
     ----------
     target_imgs : :obj:`list` of Niimg-like object
-        See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
+        See :ref:`extracting_data`.
         Images used to compute the mask. 3D and 4D images are accepted.
 
         .. note::
@@ -650,7 +650,7 @@ def compute_multi_brain_mask(target_imgs, threshold=.5, connected=True,
     Parameters
     ----------
     target_imgs : :obj:`list` of Niimg-like object
-        See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
+        See :ref:`extracting_data`.
         Images used to compute the mask. 3D and 4D images are accepted.
 
         .. note::
@@ -718,11 +718,11 @@ def apply_mask(imgs, mask_img, dtype='f',
     Parameters
     -----------
     imgs : :obj:`list` of 4D Niimg-like objects
-        See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
+        See :ref:`extracting_data`.
         Images to be masked. list of lists of 3D images are also accepted.
 
     mask_img : Niimg-like object
-        See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
+        See :ref:`extracting_data`.
         3D mask array: True where a :term:`voxel` should be used.
 
     dtype: numpy dtype or 'f'
@@ -877,7 +877,7 @@ def unmask(X, mask_img, order="F"):
         If X is one-dimensional, it is assumed that samples# == 1.
 
     mask_img : Niimg-like object
-        See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa:E501
+        See :ref:`extracting_data`.
         Must be 3-dimensional.
 
     Returns

--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -233,8 +233,8 @@ def find_cut_slices(img, direction='z', n_cuts=7, spacing='auto'):
     Parameters
     ----------
     img : 3D Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
-        the brain map.
+        See :ref:`extracting_data`.
+        The brain map.
 
     direction : string, optional
         Sectional direction; possible values are "x", "y", or "z".

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -438,7 +438,7 @@ def view_img(stat_map_img, bg_img='MNI152',
     Parameters
     ----------
     stat_map_img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         The statistical map image. Can be either a 3D volume or a 4D volume
         with exactly one time point.
     %(bg_img)s

--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -137,7 +137,7 @@ def view_img_on_surf(stat_map_img, surf_mesh='fsaverage5',
     Parameters
     ----------
     stat_map_img : Niimg-like object, 3D
-        See https://nilearn.github.io/stable/manipulating_images/input_output.html  # noqa: E501
+        See :ref:`extracting_data`.
 
     surf_mesh : str or dict, optional.
         If a string, it should be one of the following values:

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -423,7 +423,7 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
     Parameters
     ----------
     anat_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         The anatomical image to be used as a background. If None is
         given, nilearn tries to find a T1 template.
         Default=MNI152TEMPLATE.
@@ -538,7 +538,7 @@ def _plot_roi_contours(display, roi_img, cmap, alpha, linewidths):
         An object with background image on which contours are shown.
 
     roi_img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         The ROI/mask image, it could be binary mask or an atlas or ROIs
         with integer values.
 
@@ -590,7 +590,7 @@ def plot_roi(roi_img, bg_img=MNI152TEMPLATE, cut_coords=None,
     Parameters
     ----------
     roi_img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         The ROI/mask image, it could be binary mask or an atlas or ROIs
         with integer values.
     %(bg_img)s
@@ -872,7 +872,7 @@ def plot_stat_map(stat_map_img, bg_img=MNI152TEMPLATE, cut_coords=None,
     Parameters
     ----------
     stat_map_img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         The statistical map image
     %(bg_img)s
         If nothing is specified, the MNI152 template will be used.
@@ -975,7 +975,7 @@ def plot_glass_brain(stat_map_img,
     Parameters
     ----------
     stat_map_img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         The statistical map image. It needs to be in MNI space
         in order to align with the brain schematics.
     %(output_file)s
@@ -1325,7 +1325,7 @@ def plot_carpet(img, mask_img=None, mask_labels=None, t_r=None,
         value and a colorbar will be added to the left side of the figure
         with atlas labels.
         If not specified, a new mask will be derived from data.
-        See http://nilearn.github.io/manipulating_images/input_output.html.
+        See :ref:`extracting_data`.
 
     mask_labels : :obj:`dict`, optional
         If ``mask_img`` corresponds to an atlas, then this dictionary maps

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -1137,7 +1137,7 @@ def plot_img_on_surf(stat_map, surf_mesh='fsaverage5', mask_img=None,
     Parameters
     ----------
     stat_map : str or 3D Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
 
     surf_mesh : str, dict, or None, optional
         If str, either one of the two:

--- a/nilearn/regions/signal_extraction.py
+++ b/nilearn/regions/signal_extraction.py
@@ -33,12 +33,12 @@ def img_to_signals_labels(imgs, labels_img, mask_img=None,
         Input images.
 
     labels_img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
-        regions definition as labels. By default, the label zero is used to
+        See :ref:`extracting_data`.
+        Regions definition as labels. By default, the label zero is used to
         denote an absence of region. Use background_label to change it.
 
     mask_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Mask to apply to labels before extracting signals. Every point
         outside the mask is considered as background (i.e. no region).
 
@@ -148,7 +148,7 @@ def signals_to_img_labels(signals, labels_img, mask_img=None,
         2D array with shape: (scan number, number of regions in labels_img).
 
     labels_img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Region definitions using labels.
 
     mask_img : Niimg-like object, optional
@@ -231,13 +231,13 @@ def img_to_signals_maps(imgs, maps_img, mask_img=None):
         Input images.
 
     maps_img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
-        regions definition as maps (array of weights).
+        See :ref:`extracting_data`.
+        Regions definition as maps (array of weights).
         shape: imgs.shape + (region number, )
 
     mask_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_images/input_output.html
-        mask to apply to regions before extracting signals. Every point
+        See :ref:`extracting_data`.
+        Mask to apply to regions before extracting signals. Every point
         outside the mask is considered as background (i.e. outside of any
         region).
 
@@ -310,11 +310,11 @@ def signals_to_img_maps(region_signals, maps_img, mask_img=None):
                 region_signals.shape[1] == maps_img.shape[-1]
 
     maps_img : Niimg-like object
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Region definitions using maps.
 
     mask_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         Boolean array giving :term:`voxels<voxel>` to process.
         Integer arrays also accepted, zero meaning False.
 

--- a/nilearn/reporting/glm_reporter.py
+++ b/nilearn/reporting/glm_reporter.py
@@ -107,7 +107,7 @@ def make_glm_report(model,
         using contrast names.
 
     bg_img : Niimg-like object, optional
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
         The background image for mask and stat maps to be plotted on upon.
         To turn off background image, just pass "bg_img=None".
         Default='MNI152TEMPLATE'.

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -476,7 +476,7 @@ def vol_to_surf(img, surf_mesh,
     Parameters
     ----------
     img : Niimg-like object, 3d or 4d.
-        See http://nilearn.github.io/manipulating_images/input_output.html
+        See :ref:`extracting_data`.
 
     surf_mesh : str, pathlib.Path, numpy.ndarray, or Mesh
         Either a file containing surface mesh geometry (valid formats

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,9 @@ with open('README.rst') as fp:
     LONG_DESCRIPTION = fp.read()
 MAINTAINER = 'Gael Varoquaux'
 MAINTAINER_EMAIL = 'gael.varoquaux@normalesup.org'
-URL = 'http://nilearn.github.io'
+URL = 'https://nilearn.github.io'
 LICENSE = 'new BSD'
-DOWNLOAD_URL = 'http://nilearn.github.io'
+DOWNLOAD_URL = 'https://nilearn.github.io'
 VERSION = _VERSION_GLOBALS['__version__']
 
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3321 and closes #3303.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Replace rendered URLs with sphinx internal referencing
- If external referencing is needed, use intersphinx mapping or external links (in `doc/conf.py`)
