### PR TITLE
[REF] Performance optimizations for TFCE

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -41,6 +41,8 @@ Enhancements
 - Add ``n_elements_`` attribute to masker classes (:gh:`3311` by `Taylor Salo`_).
 - Functions expecting string filesystem paths now also accept path-like objects (:gh:`3300` by `Yasmin Mzayek`_).
 - Contributing guidelines now include a recommendation to run flake8 locally on the branch diff with main (:gh:`3317` by `Yasmin Mzayek`_).
+- Improvements to :func:`~mass_univariate.permuted_ols` and :func:`~glm.second_level.non_parametric_inference` with :term:`TFCE` statistic runtime (:gh:`3333` by `Sage Hahn_`).
+
 
 Changes
 -------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -41,8 +41,7 @@ Enhancements
 - Add ``n_elements_`` attribute to masker classes (:gh:`3311` by `Taylor Salo`_).
 - Functions expecting string filesystem paths now also accept path-like objects (:gh:`3300` by `Yasmin Mzayek`_).
 - Contributing guidelines now include a recommendation to run flake8 locally on the branch diff with main (:gh:`3317` by `Yasmin Mzayek`_).
-- Improvements to :func:`~mass_univariate.permuted_ols` and :func:`~glm.second_level.non_parametric_inference` with :term:`TFCE` statistic runtime (:gh:`3333` by `Sage Hahn_`).
-
+- Improvements to :func:`~mass_univariate.permuted_ols` and :func:`~glm.second_level.non_parametric_inference` with :term:`TFCE` statistic runtime (:gh:`3333` by `Sage Hahn`_).
 
 Changes
 -------

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -80,6 +80,8 @@
 
 .. _Guillaume Lemaitre: https://glemaitre.github.io/
 
+.. _Sage Hahn: www.sagehahn.com/
+
 .. _Hao-Ting Wang: https://wanghaoting.com/
 
 .. _Himanshu Aggarwal: https://github.com/man-shu

--- a/nilearn/mass_univariate/_utils.py
+++ b/nilearn/mass_univariate/_utils.py
@@ -119,7 +119,7 @@ def _calculate_tfce(
                 cluster_counts = np.bincount(labeled_non_zero)
 
                 # Next, we convert each unique cluster count to its TFCE value.
-                # Where each voxel's tfce value is based
+                # Where each cluster's tfce value is based
                 # on both its cluster extent and z-value (via the current score_thresh)
                 # NOTE: We do not multiply by dh, based on fslmaths'
                 # implementation. This differs from the original paper.

--- a/nilearn/mass_univariate/_utils.py
+++ b/nilearn/mass_univariate/_utils.py
@@ -99,8 +99,10 @@ def _calculate_tfce(
                 temp_arr3d[temp_arr3d < score_thresh] = 0
 
                 # Label into clusters - importantly (for the next step)
-                # this returns clusters labelled ordinally from 1 to n_clusters+1,
-                # which allows us to use bincount to count frequencies directly.
+                # this returns clusters labelled ordinally
+                # from 1 to n_clusters+1,
+                # which allows us to use bincount to count
+                # frequencies directly.
                 labeled_arr3d, _ = label(temp_arr3d, bin_struct)
 
                 # Next, we want to replace each label with its cluster
@@ -112,7 +114,7 @@ def _calculate_tfce(
                 labeled_non_zero = labeled_arr3d_flat[non_zero_inds]
 
                 # Count the size of each unique cluster, via its label.
-	        # The reason why we pass only the non-zero labels to bincount
+                # The reason why we pass only the non-zero labels to bincount
                 # is because it includes a bin for zeros, and in our labels
                 # zero represents the background,
                 # which we want to have a TFCE value of 0.
@@ -120,16 +122,19 @@ def _calculate_tfce(
 
                 # Next, we convert each unique cluster count to its TFCE value.
                 # Where each cluster's tfce value is based
-                # on both its cluster extent and z-value (via the current score_thresh)
+                # on both its cluster extent and z-value
+                # (via the current score_thresh)
                 # NOTE: We do not multiply by dh, based on fslmaths'
                 # implementation. This differs from the original paper.
-                cluster_tfces = sign * (cluster_counts ** E) * (score_thresh ** H)
+                cluster_tfces = sign * (cluster_counts ** E) *\
+                    (score_thresh ** H)
 
                 # Before we can add these values to tfce_4d, we need to
                 # map cluster-wise tfce values back to a voxel-wise array,
                 # including any zero / background voxels.
                 tfce_step_values = np.zeros(labeled_arr3d_flat.shape)
-                tfce_step_values[non_zero_inds] = cluster_tfces[labeled_non_zero]
+                tfce_step_values[non_zero_inds] =\
+                    cluster_tfces[labeled_non_zero]
 
                 # Now, we just need to reshape these values back to 3D
                 # and they can be incremented to tfce_4d.

--- a/nilearn/mass_univariate/_utils.py
+++ b/nilearn/mass_univariate/_utils.py
@@ -88,45 +88,53 @@ def _calculate_tfce(
         # If we apply the sign first...
         for sign in signs:
 
-            # Then init a temp array, we can re-use the
-            # same array and save a little bit of time
+            # Init a temp array, which can re-use
+            # by incrementally setting more background
+            # voxel's to background, given that each score
+            # thresh applied is incrementally larger than the one before.
             temp_arr3d = arr3d.copy() * sign
 
             # Prep step
             for score_thresh in score_threshs:
-
-                # Assumes each score thresh is incrementally larger
                 temp_arr3d[temp_arr3d < score_thresh] = 0
 
-                # Label into clusters
+                # Label into clusters - importantly (for the next step)
+                # this returns clusters labelled ordinally from 1 to n_clusters+1,
+                # which allows us to use bincount to count frequencies directly.
                 labeled_arr3d, _ = label(temp_arr3d, bin_struct)
 
-                # Get flattened version of the array
+                # Next, we want to replace each label the it's cluster
+                # extent, that is, the size of the cluster it is part of
+                # To do this, we will first compute a flattened version of the
+                # only the non-zero cluster labels.
                 labeled_arr3d_flat = labeled_arr3d.flatten()
-
-                # And keep track of non-zero inds
                 non_zero_inds = np.where(labeled_arr3d_flat != 0)[0]
+                labeled_non_zero = labeled_arr3d_flat[non_zero_inds]
 
-                # Get unique values / counts to compute frequencies
-                idx = labeled_arr3d_flat[non_zero_inds]
-                freqs_idx = np.bincount(idx)
+                # Count the size of each unique cluster, via its label.
+	            # The reason why we pass only the non-zero labels to bincount
+                # is because it includes a bin for zeros, and in our labels
+                # zero represents the background,
+                # which we want to have a TFCE value of 0.
+                cluster_counts = np.bincount(labeled_non_zero)
 
-                # Easier / slightly faster to compute if we apply
-                # the E / H / sign computations
-                # here on each unique value
-                # Where are calculating each voxel's tfce value based
-                # on its cluster extent and z-value
+                # Next, we convert each unique cluster count to its TFCE value.
+                # Where each voxel's tfce value is based
+                # on both its cluster extent and z-value (via the current score_thresh)
                 # NOTE: We do not multiply by dh, based on fslmaths'
                 # implementation. This differs from the original paper.
-                adj_freqs_idx = sign * (freqs_idx ** E) * (score_thresh ** H)
+                cluster_tfces = sign * (cluster_counts ** E) * (score_thresh ** H)
 
-                # Gen and fill flat tfce_step_values w/ adjusted freqs directly
+                # Before we can add these values to tfce_4d, we need to
+                # map from each voxel's cluster label to that cluster's tfce value,
+                # but also keep account for adding back in any zero / background labels.
                 tfce_step_values = np.zeros(labeled_arr3d_flat.shape)
-                tfce_step_values[non_zero_inds] = adj_freqs_idx[idx]
+                tfce_step_values[non_zero_inds] = cluster_tfces[labeled_non_zero]
 
-                # Add the values to the tfce array in the correct spots
-                tfce_4d[..., i_regressor] +=\
-                    tfce_step_values.reshape(temp_arr3d.shape)
+                # Now, we just need to reshape these values back to 3D
+                # and they can be incremented to tfce_4d.
+                tfce_4d[..., i_regressor] += tfce_step_values.reshape(
+                    temp_arr3d.shape)
 
     return tfce_4d
 

--- a/nilearn/mass_univariate/_utils.py
+++ b/nilearn/mass_univariate/_utils.py
@@ -126,8 +126,8 @@ def _calculate_tfce(
                 cluster_tfces = sign * (cluster_counts ** E) * (score_thresh ** H)
 
                 # Before we can add these values to tfce_4d, we need to
-                # map from each voxel's cluster label to that cluster's tfce value,
-                # but also keep account for adding back in any zero / background labels.
+                # map cluster-wise tfce values back to a voxel-wise array,
+                # including any zero / background voxels.
                 tfce_step_values = np.zeros(labeled_arr3d_flat.shape)
                 tfce_step_values[non_zero_inds] = cluster_tfces[labeled_non_zero]
 

--- a/nilearn/mass_univariate/_utils.py
+++ b/nilearn/mass_univariate/_utils.py
@@ -112,7 +112,7 @@ def _calculate_tfce(
                 labeled_non_zero = labeled_arr3d_flat[non_zero_inds]
 
                 # Count the size of each unique cluster, via its label.
-	            # The reason why we pass only the non-zero labels to bincount
+	        # The reason why we pass only the non-zero labels to bincount
                 # is because it includes a bin for zeros, and in our labels
                 # zero represents the background,
                 # which we want to have a TFCE value of 0.

--- a/nilearn/mass_univariate/_utils.py
+++ b/nilearn/mass_univariate/_utils.py
@@ -105,7 +105,7 @@ def _calculate_tfce(
 
                 # Next, we want to replace each label the it's cluster
                 # extent, that is, the size of the cluster it is part of
-                # To do this, we will first compute a flattened version of the
+                # To do this, we will first compute a flattened version of
                 # only the non-zero cluster labels.
                 labeled_arr3d_flat = labeled_arr3d.flatten()
                 non_zero_inds = np.where(labeled_arr3d_flat != 0)[0]

--- a/nilearn/mass_univariate/_utils.py
+++ b/nilearn/mass_univariate/_utils.py
@@ -103,7 +103,7 @@ def _calculate_tfce(
                 # which allows us to use bincount to count frequencies directly.
                 labeled_arr3d, _ = label(temp_arr3d, bin_struct)
 
-                # Next, we want to replace each label the it's cluster
+                # Next, we want to replace each label with its cluster
                 # extent, that is, the size of the cluster it is part of
                 # To do this, we will first compute a flattened version of
                 # only the non-zero cluster labels.

--- a/nilearn/mass_univariate/_utils.py
+++ b/nilearn/mass_univariate/_utils.py
@@ -88,11 +88,11 @@ def _calculate_tfce(
         # If we apply the sign first...
         for sign in signs:
 
-            # Init a temp array, which can re-use
-            # by incrementally setting more background
-            # voxel's to background, given that each score
-            # thresh applied is incrementally larger than the one before.
-            temp_arr3d = arr3d.copy() * sign
+            # Init a temp copy of arr3d with the current sign applied,
+            # which can then be re-used by incrementally setting more
+            # voxel's to background, by taking advantage that each score_thresh
+            # is incrementally larger
+            temp_arr3d = arr3d * sign
 
             # Prep step
             for score_thresh in score_threshs:


### PR DESCRIPTION
This PR is designed as a first pass at solving performance issues as noted in [#3266](https://github.com/nilearn/nilearn/issues/3266).

This PR is rather minimal in scope in that it only changes the internal content of the '_calculate_tfce' method and produces identical results to the previous version of the code. The change is of course that the code is now a bit faster. Running the updated code on the same benchmark as mentioned in https://github.com/nilearn/nilearn/pull/3196 the 'plot_localizer_mass_univariate_methods' now runs in ~7 minutes on a single core, whereas the old version of the code ran in ~30 minutes on my machine with the same settings. 

Notably with the example above and to some extent the current code, the runtime is very dependent on the shape of the original images. For example, the task contrast maps have shape (53, 63, 46) which is a bit borderline on where the existing code starts to get very slow (some of my tests suggest that it gets about 40x slower jumping up to just sizes 75x75x75).

I have a more in depth notebook with a breakdown on each of the individual changes / some thoughts on areas we still might be able to improve which I will post soon, but I just thought I would put up the actual changes here first.