### PR TITLE
WIP: Deal with mpl deprecation of get_cmap

### DIFF
--- a/examples/01_plotting/plot_colormaps.py
+++ b/examples/01_plotting/plot_colormaps.py
@@ -44,7 +44,7 @@ m_cmaps.sort()
 
 for index, cmap in enumerate(m_cmaps):
     plt.subplot(1, len(m_cmaps) + 1, index + 1)
-    plt.imshow(a, cmap=plt.get_cmap(cmap), aspect='auto')
+    plt.imshow(a, cmap=plt.colormaps[cmap], aspect='auto')
     plt.axis('off')
     plt.title(cmap, fontsize=10, va='bottom', rotation=90)
 

--- a/nilearn/plotting/cm.py
+++ b/nilearn/plotting/cm.py
@@ -7,6 +7,7 @@ import numpy as _np
 
 from matplotlib import cm as _cm
 from matplotlib import colors as _colors
+from matplotlib import colormaps as _colormaps
 from matplotlib import rcParams as _rcParams
 
 ################################################################################
@@ -313,3 +314,9 @@ def replace_inside(outer_cmap, inner_cmap, vmin, vmax):
     return _colors.LinearSegmentedColormap(
         '%s_inside_%s' % (inner_cmap.name, outer_cmap.name),
         cdict, _rcParams['image.lut'])
+
+
+def _get_cmap(cmap):
+    if not isinstance(cmap, colors.Colormap):
+        cmap = _colormaps[cmap]
+    return cmap

--- a/nilearn/plotting/displays/_slicers.py
+++ b/nilearn/plotting/displays/_slicers.py
@@ -12,7 +12,7 @@ from matplotlib.colorbar import ColorbarBase
 from matplotlib.transforms import Bbox
 
 from nilearn.version import _compare_version
-from nilearn._utils import check_niimg_3d
+from nilearn._utils import check_niimg_3d, _get_cmap
 from nilearn.plotting.find_cuts import find_xyz_cut_coords, find_cut_slices
 from nilearn.plotting.displays import CutAxes
 from nilearn.plotting.edge_detect import _edge_map
@@ -465,7 +465,7 @@ class BaseSlicer(object):
         else:
             self._colorbar_ax.set_axis_bgcolor('w')
 
-        our_cmap = mpl_cm.get_cmap(cmap)
+        our_cmap = _get_cmap(cmap)
         # edge case where the data has a single value
         # yields a cryptic matplotlib error message
         # when trying to plot the color bar


### PR DESCRIPTION
Matplotlib is deprecating get_cmap. Let me know if this is on the right track for you all and I'll:

1. In cases where `cmap` is clearly `str`, use `colormaps[cmap`]
2. In cases where it's not clear (e.g., could be a `Colormap` already) replace `cm.get_cmap`s with a new `_get_cmap` from `plotting/cm.py`