### PR TITLE
[MAINT] Update sphinx version directives for release

### DIFF
--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -446,7 +446,7 @@ class FirstLevelModel(BaseGLM):
             and/or remove non-steady-state volumes.
             Default=None.
 
-            .. versionadded:: 0.9.2.dev
+            .. versionadded:: 0.9.2
 
         design_matrices : pandas DataFrame or \
                           list of pandas DataFrames, optional

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -712,7 +712,7 @@ def non_parametric_inference(
             Performing cluster-level inference will increase the computation
             time of the permutation procedure.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     tfce : :obj:`bool`, optional
         Whether to calculate :term:`TFCE` as part of the permutation procedure
@@ -729,7 +729,7 @@ def non_parametric_inference(
             permutations are requested and how many jobs are performed in
             parallel.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     Returns
     -------
@@ -748,7 +748,7 @@ def non_parametric_inference(
         .. note::
             This is returned if ``tfce`` is False or ``threshold`` is not None.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
         Here are the keys:
 

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -158,7 +158,7 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
     n_elements_ : :obj:`int`
         The number of voxels in the mask.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     See Also
     --------

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -148,7 +148,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
         This is equivalent to the number of unique values in the mask image,
         ignoring the background value.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     See also
     --------

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -129,7 +129,7 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
         The number of overlapping maps in the mask.
         This is equivalent to the number of volumes in the mask image.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     Notes
     -----

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -229,7 +229,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
     n_elements_ : :obj:`int`
         The number of voxels in the mask.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     See also
     --------

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -297,7 +297,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
     n_elements_ : :obj:`int`
         The number of seeds in the masker.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     seeds_ : :obj:`list` of :obj:`list`
         The coordinates of the seeds in the masker.

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -66,7 +66,7 @@ def _permuted_ols_on_chunk(
         If ``threshold`` is not None, but ``masker`` is, an exception will be
         raised.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     confounding_vars : array-like, shape=(n_samples, n_covars), optional
         Clinical data (covariates).
@@ -79,7 +79,7 @@ def _permuted_ols_on_chunk(
         If ``threshold`` is not None, but ``masker`` is, an exception will be
         raised.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     n_perm : int, optional
         Total number of permutations to perform, only used for
@@ -109,13 +109,13 @@ def _permuted_ols_on_chunk(
         :footcite:t:`Smith2009a`.
         Default=False.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     tfce_original_data : None or array-like, \
             shape=(n_descriptors, n_regressors), optional
         TFCE values obtained for the original (non-permuted) data.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     random_state : int or None, optional
         Seed for random number generator, to have the same permutations
@@ -143,7 +143,7 @@ def _permuted_ols_on_chunk(
         Only calculated if ``masker`` is not None.
         Otherwise, these will both be None.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     tfce_scores_as_ranks_part : array-like, shape=(n_regressors, n_descriptors)
         The ranks of the original TFCE values in ``h0_tfce_part``.
@@ -152,13 +152,13 @@ def _permuted_ols_on_chunk(
         Here, it is performed in parallel by the workers involved in the
         permutation computation.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     h0_tfce_part : array-like, shape=(n_perm_chunk, n_regressors)
         Distribution of the (max) TFCE value under the null hypothesis
         (limited to this permutation chunk).
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     References
     ----------
@@ -400,7 +400,7 @@ def permuted_ols(
         This is required for cluster-level inference, so it must be provided
         if ``threshold`` is not None.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     threshold : None or :obj:`float`, optional
         Cluster-forming threshold in p-scale.
@@ -413,7 +413,7 @@ def permuted_ols(
             Performing cluster-level inference will increase the computation
             time of the permutation procedure.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     tfce : :obj:`bool`, optional
         Whether to calculate :term:`TFCE` as part of the permutation procedure
@@ -430,7 +430,7 @@ def permuted_ols(
             permutations are requested and how many jobs are performed in
             parallel.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     output_type : {'legacy', 'dict'}, optional
         Determines how outputs should be returned.
@@ -451,7 +451,7 @@ def permuted_ols(
             'dict' in 0.13, and the parameter will be removed completely in
             0.15.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
     Returns
     -------
@@ -500,7 +500,7 @@ def permuted_ols(
             The default value will change to 'dict' in 0.13,
             and the ``output_type`` parameter will be removed in 0.15.
 
-        .. versionchanged:: 0.9.2.dev
+        .. versionchanged:: 0.9.2
 
             Return H0 for all regressors, instead of only the first one.
 
@@ -512,7 +512,7 @@ def permuted_ols(
             This is returned if ``output_type`` == 'dict'.
             This will be the default output starting in version 0.13.
 
-        .. versionadded:: 0.9.2.dev
+        .. versionadded:: 0.9.2
 
         Here are the keys:
 

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -1337,7 +1337,7 @@ def plot_carpet(img, mask_img=None, mask_labels=None, t_r=None,
             If ``t_r`` is not provided, it will be inferred from ``img``'s
             header (``img.header.get_zooms()[-1]``).
 
-        .. versionadded:: 0.9.1.dev
+        .. versionadded:: 0.9.1
             Prior to this, ``t_r`` would be inferred from ``img`` without
             user input.
 


### PR DESCRIPTION
This removes the `dev` tag from the version number in `versionadded`/`versionchanged` directives in preparation for the release
