### PR TITLE
[MAINT] Remove instructions on the maintenence page for updating the news section during releases

### DIFF
--- a/doc/maintenance.rst
+++ b/doc/maintenance.rst
@@ -212,26 +212,6 @@ to be:
     __version__ = x.y.z
 
 
-We also need to update the website news section by editing the file ``nilearn/doc/themes/nilearn/layout.html``. The news section typically contains links to the last 3 releases that should look like:
-
-.. code-block:: html
-
-    <h4> News </h4>
-        <ul>
-            <li><p><strong>November 2020</strong>:
-                <a href="whats_new.html#v0-7-0">Nilearn 0.7.0 released</a>
-            </p></li>
-            <li><p><strong>February 2020</strong>:
-                <a href="whats_new.html#v0-6-2">Nilearn 0.6.2 released</a>
-            </p></li>
-            <li><p><strong>January 2020</strong>:
-                <a href="whats_new.html#v0-6-1">Nilearn 0.6.1 released</a>
-            </p></li>
-        </ul>
-
-
-Here, we should remove the last entry and add the new release on top of the list.
-
 In addition, we can have a look at `MANIFEST.in` to check that all additional files that we want to be included or excluded from the release are indicated. Normally we shouldn't have to touch this file.
 
 Add these changes and submit a PR:


### PR DESCRIPTION
Since it was agreed at the last core developer meeting to not reinstate the news section in the new docs, I'm removing the instructions to update the section for releases.


