### PR TITLE
[FIX] Allow invalid identifiers for design matrix column names

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -11,6 +11,8 @@ NEW
 Fixes
 -----
 
+- Regressor names can now be invalid identifiers but will raise an error with :meth:`~glm.first_level.FirstLevelModel.compute_contrast` if combined to make an invalid expression (:gh:`3374` by `Yasmin Mzayek`_).
+
 Enhancements
 ------------
 

--- a/nilearn/glm/contrasts.py
+++ b/nilearn/glm/contrasts.py
@@ -42,7 +42,7 @@ def expression_to_contrast_vector(expression, design_columns):
     df = pd.DataFrame(np.eye(len(design_columns)), columns=design_columns)
     try:
         contrast_vector = df.eval(expression, engine="python").values
-    except AttributeError:
+    except Exception:
         raise ValueError(
             'The expression (%s) is not valid. This could be due to '
             'defining the contrasts using design matrix columns that are '

--- a/nilearn/glm/contrasts.py
+++ b/nilearn/glm/contrasts.py
@@ -43,7 +43,7 @@ def expression_to_contrast_vector(expression, design_columns):
     try:
         contrast_vector = df.eval(expression, engine="python").values
     except AttributeError:
-        raise SyntaxError(
+        raise ValueError(
             'The expression (%s) is not valid. This could be due to '
             'defining the contrasts using design matrix columns that are '
             'invalid python identifiers. '

--- a/nilearn/glm/contrasts.py
+++ b/nilearn/glm/contrasts.py
@@ -40,7 +40,15 @@ def expression_to_contrast_vector(expression, design_columns):
         contrast_vector[list(design_columns).index(expression)] = 1.
         return contrast_vector
     df = pd.DataFrame(np.eye(len(design_columns)), columns=design_columns)
-    contrast_vector = df.eval(expression, engine="python").values
+    try:
+        contrast_vector = df.eval(expression, engine="python").values
+    except AttributeError:
+        raise SyntaxError(
+            'The expression (%s) is not valid. This could be due to '
+            'defining the contrasts using design matrix columns that are '
+            'invalid python identifiers. '
+            % expression
+        )
     return contrast_vector
 
 

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -657,11 +657,11 @@ class FirstLevelModel(BaseGLM):
             where ``n_col`` is the number of columns of the design matrix,
             (one array per run). If only one array is provided when there
             are several runs, it will be assumed that the same contrast is
-            desired for all runs. The string can be a formula compatible with
-            `pandas.DataFrame.eval`. Basically one can use the name of the
-            conditions as they appear in the design matrix of the fitted model
-            combined with operators +- and combined with numbers
-            with operators +-`*`/.
+            desired for all runs. One can use the name of the conditions as
+            they appear in the design matrix of the fitted model combined with
+            operators +- and combined with numbers with operators +-`*`/. In
+            this case, the string defining the contrasts must be a valid
+            expression for compatibility with :meth:`pandas.DataFrame.eval`.
 
         stat_type : {'t', 'F'}, optional
             Type of the contrast.

--- a/nilearn/glm/first_level/hemodynamic_models.py
+++ b/nilearn/glm/first_level/hemodynamic_models.py
@@ -440,11 +440,6 @@ def _regressor_names(con_name, hrf_model, fir_delays=None):
     # Remove any non-word character
     names = [re.sub("[^a-zA-Z0-9_]+", "", str(name)) for name in names]
 
-    # Check that all names look like proper pandas.DataFrame column names
-    if not all([name.isidentifier() for name in names]):
-        raise ValueError("At least one regressor name can't be used "
-                         f"as a column identifier: {names}")
-
     return names
 
 

--- a/nilearn/glm/first_level/hemodynamic_models.py
+++ b/nilearn/glm/first_level/hemodynamic_models.py
@@ -435,11 +435,6 @@ def _regressor_names(con_name, hrf_model, fir_delays=None):
     if len(np.unique(names)) != len(names):
         raise ValueError(f"Computed regressor names are not unique: {names}")
 
-    # Replace spaces with underscores
-    names = [re.sub(" +", "_", str(name)) for name in names]
-    # Remove any non-word character
-    names = [re.sub("[^a-zA-Z0-9_]+", "", str(name)) for name in names]
-
     return names
 
 

--- a/nilearn/glm/tests/test_contrasts.py
+++ b/nilearn/glm/tests/test_contrasts.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from numpy.testing import assert_almost_equal
 from sklearn.datasets import make_regression
@@ -25,6 +26,13 @@ def test_expression_to_contrast_vector():
     cols = ["column_1"]
     contrast = expression_to_contrast_vector("column_1", cols)
     assert np.allclose(contrast, [1.])
+    cols = ['0', '1']
+    exp = '0-1'
+    with pytest.raises(
+            ValueError,
+            match='invalid python identifiers'
+    ):
+        expression_to_contrast_vector(exp, cols)
 
 
 def test_Tcontrast():

--- a/nilearn/glm/tests/test_dmtx.py
+++ b/nilearn/glm/tests/test_dmtx.py
@@ -247,32 +247,6 @@ def test_design_matrix6():
     assert len(names) == 10
 
 
-def test_design_matrix7():
-    """
-    idem test_design_matrix1, but odd experimental paradigm;
-    code should raise an exception as condition names are not valid
-    pandas.DataFrame column names (and hence the computed design matrix
-    won't be able to call pd.eval when computing contrasts for instance).
-    """
-    tr = 1.0
-    frame_times = np.linspace(0, 127 * tr, 128)
-    conditions = [0, 0, 0, 1, 1, 1, 3, 3, 3]
-    durations = 1 * np.ones(9)
-    # no condition 'c2'
-    onsets = [30, 70, 100, 10, 30, 90, 30, 40, 60]
-    events = pd.DataFrame({'trial_type': conditions,
-                           'onset': onsets,
-                           'duration': durations})
-    hrf_model = 'glover'
-
-    with pytest.raises(
-        ValueError,
-        match="At least one regressor name can't be used"
-    ):
-        design_matrix_light(frame_times, events, hrf_model=hrf_model,
-                            drift_model='polynomial', drift_order=3)
-
-
 def test_design_matrix8():
     # basic test based on basic_paradigm and FIR
     tr = 1.0

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -881,8 +881,9 @@ def test_first_level_hrf_model(hrf_model, spaces):
     Ensure that FirstLevelModel runs without raising errors
     for different values of hrf_model. In particular, one checks that it runs
     without raising errors when given a custom response function.
-    Also ensure that it computes contrasts without raising errors,
-    even when event (ie condition) names have spaces.
+    When :meth:`~nilearn.glm.first_level.FirstLevelModel.compute_contrast`
+    is used errors should be raised when event (ie condition) names are not
+    valid identifiers.
     """
     shapes, rk = [(10, 10, 10, 25)], 3
     mask, fmri_data, _ =\
@@ -897,7 +898,15 @@ def test_first_level_hrf_model(hrf_model, spaces):
     model.fit(fmri_data, events)
 
     columns = model.design_matrices_[0].columns
-    model.compute_contrast(f"{columns[0]}-{columns[1]}")
+    exp = f"{columns[0]}-{columns[1]}"
+    try:
+        model.compute_contrast(exp)
+    except Exception:
+        with pytest.raises(
+                ValueError,
+                match='invalid python identifiers'
+        ):
+            model.compute_contrast(exp)
 
 
 def test_glm_sample_mask():

--- a/nilearn/glm/tests/test_hemodynamic_models.py
+++ b/nilearn/glm/tests/test_hemodynamic_models.py
@@ -316,6 +316,13 @@ def test_make_regressor_3():
     assert_array_equal(reg, reg_)
 
 
+def test_regressor_names():
+    """ test that function allows invalid column identifier
+    """
+    reg_names = _regressor_names(['1_cond'], 'glover')
+    assert reg_names[0] == '1_cond'
+
+
 def test_design_warnings():
     """
     test that warnings are correctly raised upon weird design specification

--- a/nilearn/glm/tests/test_hemodynamic_models.py
+++ b/nilearn/glm/tests/test_hemodynamic_models.py
@@ -319,7 +319,7 @@ def test_make_regressor_3():
 def test__regressor_names():
     """ test that function allows invalid column identifier
     """
-    reg_names = _regressor_names(['1_cond'], 'glover')
+    reg_names = _regressor_names('1_cond', 'glover')
     assert reg_names[0] == '1_cond'
 
 

--- a/nilearn/glm/tests/test_hemodynamic_models.py
+++ b/nilearn/glm/tests/test_hemodynamic_models.py
@@ -316,7 +316,7 @@ def test_make_regressor_3():
     assert_array_equal(reg, reg_)
 
 
-def test_regressor_names():
+def test__regressor_names():
     """ test that function allows invalid column identifier
     """
     reg_names = _regressor_names(['1_cond'], 'glover')

--- a/nilearn/glm/tests/test_hemodynamic_models.py
+++ b/nilearn/glm/tests/test_hemodynamic_models.py
@@ -217,10 +217,6 @@ def test_names():
         [f"{name}_{custom_rf.__name__}"]
     assert _regressor_names(name, [custom_rf]) == \
         [f"{name}_{custom_rf.__name__}"]
-    assert _regressor_names(name, lambda tr, ov: np.ones(int(tr * ov))) == \
-        [f"{name}_lambda"]
-    assert _regressor_names(name, [lambda tr, ov: np.ones(int(tr * ov))]) == \
-        [f"{name}_lambda"]
 
     with pytest.raises(ValueError,
                        match="Computed regressor names are not unique"):


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3323.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Allow design matrix column name to be invalid identifier
