### PR TITLE
[FIX] Remove `_safe_cache` function that is outdated and error-prone

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -38,3 +38,4 @@ Changes
   since it has been deprecated and replaced by :func:`~masking.compute_multi_brain_mask` (:gh:`3427` by `Yasmin Mzayek`_).
 - :mod:`~nilearn.glm` will no longer warn that the module is experimental (:gh:`3424` by `Yasmin Mzayek`_).
 - Python ``3.6`` is no longer supported. Support for Python ``3.7`` is deprecated and will be removed in release ``0.12`` (:gh:`3429` by `Yasmin Mzayek`_).
+- The function ``_safe_cache`` is removed because it was deemed outdated and not necessary anymore (:gh:`3375` by `Yasmin Mzayek`_).

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -85,12 +85,6 @@ def _safe_cache(memory, func, **kwargs):
     number of nibabel has changed.
 
     """
-    ''' Workaround for
-     https://github.com/scikit-learn-contrib/imbalanced-learn/issues/482
-    joblib throws a spurious warning with newer scikit-learn.
-    This code uses the recommended method first and the deprecated one
-    if that fails, ensuring th warning is not generated in any case.
-    '''
     try:
         location = os.path.join(memory.location, 'joblib')
     except AttributeError:
@@ -108,9 +102,8 @@ def _safe_cache(memory, func, **kwargs):
         with open(version_file, 'r') as _version_file:
             versions = json.load(_version_file)
 
-    modules = (nibabel, )
     # Keep only the major + minor version numbers
-    my_versions = dict((m.__name__, m.__version__) for m in modules)
+    my_versions = {nibabel.__name__: nibabel.__version__}
     commons = set(versions.keys()).intersection(set(my_versions.keys()))
     try:
         collisions = [

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -141,7 +141,7 @@ def _safe_cache(memory, func, **kwargs):
         else:
             warnings.warn("Incompatible cache in %s: "
                           "old version of nibabel." % location)
-
+            return memory.cache(func, **kwargs)
     # Write json files if configuration is different
     if versions != my_versions:
         with open(version_file, 'w') as _version_file:

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -112,11 +112,14 @@ def _safe_cache(memory, func, **kwargs):
     # Keep only the major + minor version numbers
     my_versions = dict((m.__name__, m.__version__) for m in modules)
     commons = set(versions.keys()).intersection(set(my_versions.keys()))
-    collisions = [
-        m for m in commons if not _compare_version(
-            versions[m], '==', my_versions[m]
-        )
-    ]
+    try:
+        collisions = [
+            m for m in commons if not _compare_version(
+                versions[m], '==', my_versions[m]
+            )
+        ]
+    except TypeError:
+        collisions = ['']
     # Flush cache if version collision
     if len(collisions) > 0:
         if nilearn.CHECK_CACHE_VERSION:

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -112,7 +112,7 @@ def _safe_cache(memory, func, **kwargs):
             )
         ]
     except TypeError:
-        collisions = ['']
+        collisions = ['nibabel']
     # Flush cache if version collision
     if len(collisions) > 0:
         if nilearn.CHECK_CACHE_VERSION:

--- a/nilearn/tests/test_cache_mixin.py
+++ b/nilearn/tests/test_cache_mixin.py
@@ -45,59 +45,6 @@ def test_check_memory():
             assert memory, Memory
 
 
-def test__safe_cache_dir_creation():
-    # Test the _safe_cache function that is supposed to flush the
-    # cache if the nibabel version changes
-    with tempfile.TemporaryDirectory() as temp_dir:
-        mem = Memory(location=temp_dir)
-        version_file = os.path.join(temp_dir, 'joblib', 'module_versions.json')
-        assert not os.path.exists(version_file)
-        # First test that a version file get created
-        cache_mixin._safe_cache(mem, f)
-        assert os.path.exists(version_file)
-        # Test that it does not get recreated during the same session
-        os.unlink(version_file)
-        cache_mixin._safe_cache(mem, f)
-        assert not os.path.exists(version_file)
-
-
-def test__safe_cache_flush():
-    # Test the _safe_cache function that is supposed to flush the
-    # cache if the nibabel version changes
-    with tempfile.TemporaryDirectory() as temp_dir:
-        mem = Memory(location=temp_dir)
-        version_file = os.path.join(temp_dir, 'joblib', 'module_versions.json')
-        # Create an mock version_file with old module versions
-        with open(version_file, 'w') as f:
-            json.dump({"nibabel": "0.0"}, f)
-        # Create some store structure
-        nibabel_dir = os.path.join(temp_dir, 'joblib', 'nibabel_')
-        os.makedirs(nibabel_dir)
-
-        # First turn off version checking
-        nilearn.CHECK_CACHE_VERSION = False
-        cache_mixin._safe_cache(mem, f)
-        assert os.path.exists(nibabel_dir)
-
-        # Second turn on version checking
-        nilearn.CHECK_CACHE_VERSION = True
-        # Make sure that the check will run again
-        cache_mixin.__CACHE_CHECKED = {}
-        with open(version_file, 'w') as f:
-            json.dump({"nibabel": "0.0"}, f)
-        cache_mixin._safe_cache(mem, f)
-        assert os.path.exists(version_file)
-        assert not os.path.exists(nibabel_dir)
-
-        # Test handling of TypeError if version name is not str
-        cache_mixin.__CACHE_CHECKED = {}
-        with open(version_file, 'w') as f:
-            json.dump({"nibabel": [0.0]}, f)
-        cache_mixin._safe_cache(mem, f)
-        assert os.path.exists(version_file)
-        assert not os.path.exists(nibabel_dir)
-
-
 def test_cache_memory_level():
     with tempfile.TemporaryDirectory() as temp_dir:
         joblib_dir = Path(

--- a/nilearn/tests/test_cache_mixin.py
+++ b/nilearn/tests/test_cache_mixin.py
@@ -89,6 +89,14 @@ def test__safe_cache_flush():
         assert os.path.exists(version_file)
         assert not os.path.exists(nibabel_dir)
 
+        # Test handling of TypeError if version name is not str
+        cache_mixin.__CACHE_CHECKED = {}
+        with open(version_file, 'w') as f:
+            json.dump({"nibabel": [0.0]}, f)
+        cache_mixin._safe_cache(mem, f)
+        assert os.path.exists(version_file)
+        assert not os.path.exists(nibabel_dir)
+
 
 def test_cache_memory_level():
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3256.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- `_safe_cache` now handles if versions are different types by continuing to flush the cache as if the versions don't match
