### PR TITLE
[FIX/ENH] signal interpolation for scrubbed volumes when applying butterworth filter in signal.clean

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -16,7 +16,7 @@ Fixes
 - Regressor names can now be invalid identifiers but will raise an error with :meth:`~glm.first_level.FirstLevelModel.compute_contrast` if combined to make an invalid expression (:gh:`3374` by `Yasmin Mzayek`_).
 - Fix :func:`~plotting.plot_connectome` which was raising a ``ValueError`` when ``vmax < 0`` (:gh:`3390` by `Paul Bogdan`_).
 - Change the order of applying ``sample_masks`` in :func:`~.signal.clean` based on different filtering options (:gh:`3385` by `Hao-Ting Wang`_). 
-- When using cosine filter and ``sample_masks`` is used, :func:`~.signal.clean` generates the cosine descrete regressors using the full time seiries (:gh:`3385` by `Hao-Ting Wang`_). 
+- When using cosine filter and ``sample_masks`` is used, :func:`~.signal.clean` generates the cosine discrete regressors using the full time seiries (:gh:`3385` by `Hao-Ting Wang`_). 
 
 Enhancements
 ------------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -15,13 +15,13 @@ Fixes
 
 - Regressor names can now be invalid identifiers but will raise an error with :meth:`~glm.first_level.FirstLevelModel.compute_contrast` if combined to make an invalid expression (:gh:`3374` by `Yasmin Mzayek`_).
 - Fix :func:`~plotting.plot_connectome` which was raising a ``ValueError`` when ``vmax < 0`` (:gh:`3390` by `Paul Bogdan`_).
-- Change the order of applying ``sample_masks`` in :func:`~.signal.clean` based on different filtering options (:gh:`3385` by `Hao-Ting Wang`_). 
-- When using cosine filter and ``sample_masks`` is used, :func:`~.signal.clean` generates the cosine discrete regressors using the full time seiries (:gh:`3385` by `Hao-Ting Wang`_). 
+- Change the order of applying ``sample_masks`` in :func:`~signal.clean` based on different filtering options (:gh:`3385` by `Hao-Ting Wang`_). 
+- When using cosine filter and ``sample_masks`` is used, :func:`~signal.clean` generates the cosine discrete regressors using the full time series (:gh:`3385` by `Hao-Ting Wang`_). 
 
 Enhancements
 ------------
 
-- :func:`nilearn.signal.clean` imputes scrubbed volumes (defined through ``sample_masks``) with cubic spline function before applying butterworth filter (:gh:`3385` by `Hao-Ting Wang`_). 
+- :func:`~signal.clean` imputes scrubbed volumes (defined through ``sample_masks``) with cubic spline function before applying butterworth filter (:gh:`3385` by `Hao-Ting Wang`_). 
 
 Changes
 -------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -11,8 +11,13 @@ NEW
 Fixes
 -----
 
+- Change the order of applying ``sample_masks`` in :func:`~.signal.clean` based on different filtering options (:gh:`3385` by `Hao-Ting Wang`). 
+- When using cosine filter and ``sample_masks`` is used, :func:`~.signal.clean` generates the cosine descrete regressors using the full time seiries (:gh:`3385` by `Hao-Ting Wang`). 
+
 Enhancements
 ------------
+
+- :func:`nilearn.signal.clean` imputes scrubbed volumes (defined through ``sample_masks``) with cubic spline function before applying butterworth filter (:gh:`3385` by `Hao-Ting Wang`). 
 
 Changes
 -------

--- a/nilearn/_utils/glm.py
+++ b/nilearn/_utils/glm.py
@@ -336,6 +336,7 @@ def positive_reciprocal(X):
 
 
 def _check_run_sample_masks(n_runs, sample_masks):
+    """Number of sample_mask matches number of runs."""
     if not isinstance(sample_masks, (list, tuple, np.ndarray)):
         raise TypeError(
             f"sample_mask has an unhandled type: {sample_masks.__class__}"

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -480,7 +480,8 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
     Butterworth filtering is only meaningful on evenly-sampled signals.
 
     When performing scrubbing (censoring high-motion volumes) with butterworth
-    filtering, the signal is processed in the following order:
+    filtering, the signal is processed in the following order, based on the
+    second recommendation in :footcite:`Lindquist2018`:
 
     - interpolate high motion volumes with cubic spline interpolation.
     - detrend
@@ -489,18 +490,20 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
     - remove confounds
     - standardize
 
+    According to :footcite:`Lindquist2018`, removal of confounds will be done
+    orthogonally to temporal filters (low- and/or high-pass filters), if both
+    are specified. The censored volumes should be removed in both signals and
+    confounds before the nuissance regression.
+
     When performing scrubbing with cosine drift term filtering, the signal is
-    processed in the following order:
+    processed in the following order, based on the first recommendation in
+    :footcite:`Lindquist2018`:
 
     - generate cosine drift term
-    - censor high motion volumes
+    - censor high motion volumes in both signal and confounds
     - detrend
     - remove confounds
     - standardize
-
-    According to :footcite:`Lindquist2018`, removal of confounds will be done
-    orthogonally to temporal filters (low- and/or high-pass filters), if both
-    are specified.
 
     Parameters
     ----------

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -483,7 +483,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
     filtering, the signal is processed in the following order, based on the
     second recommendation in :footcite:`Lindquist2018`:
 
-    - interpolate high motion volumes with cubic spline interpolation.
+    - interpolate high motion volumes with cubic spline interpolation
     - detrend
     - low- and high-pass butterworth filter
     - censor high motion volumes
@@ -577,7 +577,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
     -------
     cleaned_signals : :class:`numpy.ndarray`
         Input signals, cleaned. Same shape as `signals` unless `sample_mask`
-        applied.
+        is applied.
 
     Notes
     -----

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -650,7 +650,7 @@ def _filter_signal(signals, confounds, filter, low_pass,
     elif filter == 'cosine':
         from nilearn.glm.first_level.design_matrix import _cosine_drift
         frame_times = np.arange(signals.shape[0]) * t_r
-        # remove constant, as the signal is mean centred
+        # remove constant, as the signal is mean centered
         cosine_drift = _cosine_drift(high_pass, frame_times)[:, :-1]
         confounds = _check_cosine_by_user(confounds, cosine_drift)
     return signals, confounds
@@ -658,15 +658,15 @@ def _filter_signal(signals, confounds, filter, low_pass,
 
 def _check_cosine_by_user(confounds, cosine_drift):
     """Check if cosine term exists, based on correlation > 0.9. """
-    # stack consine drift terms if there's no cosine drift terms in data
+    # stack consine drift terms if there's no cosine drift term in data
     n_cosines = cosine_drift.shape[1]
     cosine_exists = False
     if confounds is None:
         return cosine_drift.copy()
 
-    # check if consie drift term is supplied by user  
-    # given the threshold and timeseries length, there can be no consine drift
-    # terms
+    # check if cosine drift term is supplied by user  
+    # given the threshold and timeseries length, there can be no cosine drift
+    # term
     if n_cosines > 0:
         corr_cosine = np.corrcoef(cosine_drift.T, confounds.T)
         np.fill_diagonal(corr_cosine, 0)
@@ -674,7 +674,7 @@ def _check_cosine_by_user(confounds, cosine_drift):
 
     if cosine_exists:
         warnings.warn(
-            "Consine filter exists in user supplied confounds."
+            "Cosine filter exists in user supplied confounds."
             "Use user supplied cosine regressors."
         )
     else:

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -593,7 +593,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
         if confounds is not None:
             confounds = confounds[sample_mask, :]
     # else:
-         # interpolate the scrubbed vols if butterworth filter is used
+        # interpolate the scrubbed vols if butterworth filter is used
 
     # Restrict the signal to the orthogonal of the confounds
     if runs is not None:

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -678,7 +678,8 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
     return signals
 
 
-def _handle_scrubbed_volumes(signals, confounds, sample_mask, filter_type, t_r):
+def _handle_scrubbed_volumes(signals, confounds, sample_mask, filter_type,
+                             t_r):
     """Interpolate or censor scrubbed volumes."""
     if sample_mask is None:
         return signals, confounds

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -644,8 +644,8 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
                                     low_pass=low_pass, high_pass=high_pass)
         # apply sample_mask to remove censored volumes after signal filtering
         if sample_mask is not None:
-            signals, confounds = _censor_signals(signals, confounds, sample_mask)
-
+            signals, confounds = _censor_signals(signals, confounds,
+                                                 sample_mask)
 
     # Remove confounds
     if confounds is not None:
@@ -693,10 +693,11 @@ def _handle_scrubbed_volumes(signals, confounds, sample_mask, filter_type,
 
 
 def _censor_signals(signals, confounds, sample_mask):
+    """Apply sample masks to data."""
     signals = signals[sample_mask, :]
     if confounds is not None:
         confounds = confounds[sample_mask, :]
-    return signals,confounds
+    return signals, confounds
 
 
 def _interpolate_volumes(volumes, sample_mask, t_r):

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -597,14 +597,14 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
                                 detrend=detrend)
     if use_filter:
         # check if filter parameters are satisfied and filter according to the strategy
-        signals, confounds = _filter_signal(signals, confounds, filter, 
+        signals, confounds = _filter_signal(signals, confounds, filter,
                                             low_pass, high_pass, t_r)
 
     # apply sample_mask to remove censored volumes
     if sample_mask is not None:
         signals = signals[sample_mask, :]
         if confounds is not None:
-            confounds = confounds[sample_mask, :]    
+            confounds = confounds[sample_mask, :]
 
     # Remove confounds
     if confounds is not None:
@@ -636,7 +636,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
     return signals
 
 
-def _filter_signal(signals, confounds, filter, low_pass, 
+def _filter_signal(signals, confounds, filter, low_pass,
                    high_pass, t_r):
     '''Filter signal based on provided strategy.'''
     if filter == 'butterworth':
@@ -664,7 +664,7 @@ def _check_cosine_by_user(confounds, cosine_drift):
     if confounds is None:
         return cosine_drift.copy()
 
-    # check if cosine drift term is supplied by user  
+    # check if cosine drift term is supplied by user
     # given the threshold and timeseries length, there can be no cosine drift
     # term
     if n_cosines > 0:

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -585,7 +585,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
 
     if filter_type == 'cosine':
         # create cosine regressors
-        signals, confounds = _filter_signal(signals, confounds, filter,
+        signals, confounds = _filter_signal(signals, confounds, filter_type,
                                             low_pass, high_pass, t_r)
 
     # censor volume if it's not butterworth
@@ -610,7 +610,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
                                      detrend=detrend)
 
     if filter_type == 'butterworth':
-        signals, confounds = _filter_signal(signals, confounds, filter,
+        signals, confounds = _filter_signal(signals, confounds, filter_type,
                                             low_pass, high_pass, t_r)
 
         # apply sample_mask to remove censored volumes

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -493,7 +493,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
     According to :footcite:`Lindquist2018`, removal of confounds will be done
     orthogonally to temporal filters (low- and/or high-pass filters), if both
     are specified. The censored volumes should be removed in both signals and
-    confounds before the nuissance regression.
+    confounds before the nuisance regression.
 
     When performing scrubbing with cosine drift term filtering, the signal is
     processed in the following order, based on the first recommendation in

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -693,7 +693,7 @@ def _check_cosine_by_user(confounds, cosine_drift):
 
     if cosine_exists:
         warnings.warn(
-            "Cosine filter exists in user supplied confounds."
+            "Cosine filter(s) exist in user supplied confounds."
             "Use user supplied regressors only."
         )
         return confounds

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -480,7 +480,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
     Butterworth filtering is only meaningful on evenly-sampled signals.
 
     When performing scrubbing (censoring high-motion volumes) with butterworth
-    filtering, the signal is proccessed in the following order:
+    filtering, the signal is processed in the following order:
 
     - interpolate high motion volumes with cubic spline interpolation.
     - detrend
@@ -490,7 +490,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
     - standardize
 
     When performing scrubbing with cosine drift term filtering, the signal is
-    proccessed in the following order:
+    processed in the following order:
 
     - generate cosine drift term
     - censor high motion volumes

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -676,8 +676,8 @@ def _check_cosine_by_user(confounds, cosine_drift):
 
     if n_cosines == 0:
         warnings.warn(
-            "Cosine filter was not created. The time series might be too short "
-            "or the high pass filter is not suitable for the data."
+            "Cosine filter was not created. The time series might be too "
+            "short or the high pass filter is not suitable for the data."
         )
         return confounds
 

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -676,7 +676,7 @@ def _check_cosine_by_user(confounds, cosine_drift):
 
     if n_cosines == 0:
         warnings.warn(
-            "Cosine filter was not create. The time series might be too short "
+            "Cosine filter was not created. The time series might be too short "
             "or the high pass filter is not suitable for the data."
         )
         return confounds
@@ -694,7 +694,7 @@ def _check_cosine_by_user(confounds, cosine_drift):
     if cosine_exists:
         warnings.warn(
             "Cosine filter exists in user supplied confounds."
-            "Use user supplied cosine regressors."
+            "Use user supplied regressors only."
         )
         return confounds
 

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -605,7 +605,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
     # Detrend
     # Detrend and filtering should apply to confounds, if confound presents
     # keep filters orthogonal (according to Lindquist et al. (2018))
-   # Restrict the signal to the orthogonal of the confounds
+    # Restrict the signal to the orthogonal of the confounds
     if detrend:
         mean_signals = signals.mean(axis=0)
         signals = _standardize(signals, standardize=False, detrend=detrend)
@@ -736,13 +736,14 @@ def _process_runs(signals, runs, detrend, standardize, confounds, sample_mask,
         if sample_mask is not None:
             run_sample_mask = sample_mask[i]
         run_signals = \
-            clean(signals[runs == run,],
+            clean(signals[runs == run],
                   detrend=detrend, standardize=standardize,
                   confounds=run_confounds, sample_mask=run_sample_mask,
                   filter=filter, low_pass=low_pass,
                   high_pass=high_pass, t_r=t_r)
         cleaned_signals.append(run_signals)
     return np.vstack(cleaned_signals)
+
 
 def _sanitize_inputs(signals, runs, confounds, sample_mask, ensure_finite):
     """Clean up signals and confounds before processing."""

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -606,7 +606,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
         mean_signals = signals.mean(axis=0)
         signals = _standardize(signals, standardize=False, detrend=detrend)
         if confounds is not None:
-            confounds = _standardize(confounds, standardize=False, 
+            confounds = _standardize(confounds, standardize=False,
                                      detrend=detrend)
 
     if filter_type == 'butterworth':
@@ -680,7 +680,7 @@ def _check_cosine_by_user(confounds, cosine_drift):
             "or the high pass filter is not suitable for the data."
         )
         return confounds
-    
+
     if confounds is None:
         return cosine_drift.copy()
 
@@ -697,7 +697,7 @@ def _check_cosine_by_user(confounds, cosine_drift):
             "Use user supplied cosine regressors."
         )
         return confounds
-        
+
     return np.hstack((confounds, cosine_drift))
 
 

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -760,7 +760,7 @@ def test_cosine_filter():
     high_pass_fail = 0.002
     with pytest.warns(UserWarning, match='Cosine filter was not create'):
         signals_unchanged, cosine_confounds = nisignal._filter_signal(
-            signals, confounds, filter, low_pass, high_pass_fail, 
+            signals, confounds, filter, low_pass, high_pass_fail,
             t_r)
     np.testing.assert_array_equal(signals_unchanged, signals)
     np.testing.assert_array_equal(cosine_confounds, confounds)

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -412,9 +412,9 @@ def test_clean_runs():
 
     # check the runs are individually cleaned
     x_run1 = nisignal.clean(x[0:n_samples // 2, :],
-        confounds=confounds[0:n_samples // 2, :],
-        standardize=False, detrend=True,
-        low_pass=None, high_pass=None)
+                            confounds=confounds[0:n_samples // 2, :],
+                            standardize=False, detrend=True,
+                            low_pass=None, high_pass=None)
     assert np.array_equal(x_run1, x_detrended[0:n_samples // 2, :])
 
 

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -562,22 +562,31 @@ def test_clean_frequencies_using_power_spectrum_density():
     _, _, confounds = generate_signals(
         n_features=10, n_confounds=10, length=100)
 
-    # Apply low- and high-pass filter (separately)
+    # Apply low- and high-pass filter with butterworth (separately)
     t_r = 1.0
     low_pass = 0.1
     high_pass = 0.4
-    res_low = clean(sx, detrend=False, standardize=False, low_pass=low_pass,
-                    high_pass=None, t_r=t_r)
-    res_high = clean(sx, detrend=False, standardize=False, low_pass=None,
-                     high_pass=high_pass, t_r=t_r)
+    res_low = clean(sx, detrend=False, standardize=False,
+                    filter='butterworth', low_pass=low_pass, high_pass=None,
+                    t_r=t_r)
+    res_high = clean(sx, detrend=False, standardize=False,
+                     filter='butterworth', low_pass=None, high_pass=high_pass,
+                     t_r=t_r)
+
+    # cosine high pass filter
+    res_cos = clean(sx, detrend=False, standardize=False,
+                    filter='cosine', low_pass=None, high_pass=high_pass,
+                    t_r=t_r)
 
     # Compute power spectrum density for both test
     f, Pxx_den_low = scipy.signal.welch(np.mean(res_low.T, axis=0), fs=t_r)
     f, Pxx_den_high = scipy.signal.welch(np.mean(res_high.T, axis=0), fs=t_r)
+    f, Pxx_den_cos = scipy.signal.welch(np.mean(res_cos.T, axis=0), fs=t_r)
 
     # Verify that the filtered frequencies are removed
     assert np.sum(Pxx_den_low[f >= low_pass * 2.]) <= 1e-4
     assert np.sum(Pxx_den_high[f <= high_pass / 2.]) <= 1e-4
+    assert np.sum(Pxx_den_cos[f <= high_pass / 2.]) <= 1e-4
 
 
 def test_clean_finite_no_inplace_mod():
@@ -764,6 +773,7 @@ def test_cosine_filter():
             t_r)
     np.testing.assert_array_equal(signals_unchanged, signals)
     np.testing.assert_array_equal(cosine_confounds, confounds)
+
 
 def test_sample_mask():
     """Test sample_mask related feature."""

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -727,14 +727,15 @@ def test_clean_zscore():
 def test_cosine_filter():
     '''Testing cosine filter interface and output.'''
     from nilearn.glm.first_level.design_matrix import _cosine_drift
-
-    t_r, high_pass, low_pass, filter = 2.5, 0.002, None, 'cosine'
-    signals, _, confounds = generate_signals(n_features=41,
-                                              n_confounds=5, length=45)
+    # fmriprep high pass cutoff is 128s, it's around 0.008 hz
+    t_r, high_pass, low_pass, filter = 2.5, 0.008, None, 'cosine'
+    signals, _, confounds = generate_signals(n_features=41, n_confounds=5, 
+                                             length=45)
 
     # Not passing confounds it will return drift terms only
     frame_times = np.arange(signals.shape[0]) * t_r
-    cosine_drift = _cosine_drift(high_pass, frame_times)
+    cosine_drift = _cosine_drift(high_pass, frame_times)[:, :-1]
+    confounds_with_drift = np.hstack((confounds, cosine_drift))
 
     signals_unchanged, cosine_confounds = nisignal._filter_signal(
         signals, confounds, filter, low_pass, high_pass, t_r)
@@ -747,6 +748,13 @@ def test_cosine_filter():
         signals, None, filter, low_pass, high_pass, t_r)
     np.testing.assert_array_equal(signals_unchanged, signals)
     np.testing.assert_almost_equal(drift_terms_only, cosine_drift)
+
+    # drift terms in confounds will create warning and no change to confounds
+    with pytest.warns(UserWarning, match='user supplied cosine regressors'):
+        signals_unchanged, cosine_confounds = nisignal._filter_signal(
+            signals, confounds_with_drift, filter, low_pass, high_pass, t_r)
+    np.testing.assert_array_equal(signals_unchanged, signals)
+    np.testing.assert_array_equal(cosine_confounds, confounds_with_drift)
 
 
 def test_sample_mask():

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -756,6 +756,14 @@ def test_cosine_filter():
     np.testing.assert_array_equal(signals_unchanged, signals)
     np.testing.assert_array_equal(cosine_confounds, confounds_with_drift)
 
+    # raise warning if cosine drift term is not created
+    high_pass_fail = 0.002
+    with pytest.warns(UserWarning, match='Cosine filter was not create'):
+        signals_unchanged, cosine_confounds = nisignal._filter_signal(
+            signals, confounds, filter, low_pass, high_pass_fail, 
+            t_r)
+    np.testing.assert_array_equal(signals_unchanged, signals)
+    np.testing.assert_array_equal(cosine_confounds, confounds)
 
 def test_sample_mask():
     """Test sample_mask related feature."""

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -729,7 +729,7 @@ def test_cosine_filter():
     from nilearn.glm.first_level.design_matrix import _cosine_drift
     # fmriprep high pass cutoff is 128s, it's around 0.008 hz
     t_r, high_pass, low_pass, filter = 2.5, 0.008, None, 'cosine'
-    signals, _, confounds = generate_signals(n_features=41, n_confounds=5, 
+    signals, _, confounds = generate_signals(n_features=41, n_confounds=5,
                                              length=45)
 
     # Not passing confounds it will return drift terms only

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -410,6 +410,13 @@ def test_clean_runs():
     # clean should not modify inputs
     assert np.array_equal(x_orig, x)
 
+    # check the runs are individually cleaned
+    x_run1 = nisignal.clean(x[0:n_samples // 2, :],
+        confounds=confounds[0:n_samples // 2, :],
+        standardize=False, detrend=True,
+        low_pass=None, high_pass=None)
+    assert np.array_equal(x_run1, x_detrended[0:n_samples // 2, :])
+
 
 def test_clean_confounds():
     signals, noises, confounds = generate_signals(n_features=41,

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -759,7 +759,7 @@ def test_cosine_filter():
     np.testing.assert_almost_equal(drift_terms_only, cosine_drift)
 
     # drift terms in confounds will create warning and no change to confounds
-    with pytest.warns(UserWarning, match='user supplied cosine regressors'):
+    with pytest.warns(UserWarning, match='user supplied confounds'):
         signals_unchanged, cosine_confounds = nisignal._filter_signal(
             signals, confounds_with_drift, filter, low_pass, high_pass, t_r)
     np.testing.assert_array_equal(signals_unchanged, signals)


### PR DESCRIPTION
Move volume censoring after signal filtering so the cosine drift term can be correctly generated.

Closes #3364.

I also took the chance to add a small feature - detect if cosine drift terms are already supplied in confounds, fix a void test etc.

- enh: check if confounds supplied by user contains cosine drift terms
- fix/test: change the high-pass filter in the test so the test data actually contains cosine drift term, rather than just a constant (oops)
- fix: remove constant from cosine drift term as this function works on mean centred data. Having the constant doesn't impact the performance (see `test_clean_confounds`)
- add: interpolation function and related documentation
- fix and refactor: processing runs independently, make the code work better for interpolation, and added relevant tests
