### PR TITLE
[DOC] remove the mention of intercept from `load_confounds`

### DIFF
--- a/nilearn/interfaces/fmriprep/load_confounds.py
+++ b/nilearn/interfaces/fmriprep/load_confounds.py
@@ -233,7 +233,6 @@ def load_confounds(img_files,
     confounds : pandas.DataFrame, or list of
         A reduced version of :term:`fMRIPrep` confounds based on selected
         strategy and flags.
-        An intercept is automatically added to the list of confounds.
         The columns contains the labels of the regressors.
 
     sample_mask : None, numpy.ndarray, or list of

--- a/nilearn/interfaces/fmriprep/load_confounds_strategy.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_strategy.py
@@ -122,7 +122,6 @@ def load_confounds_strategy(img_files, denoise_strategy="simple", **kwargs):
     confounds : pandas.DataFrame, or list of
         A reduced version of :term:`fMRIPrep` confounds based on selected
         strategy and flags.
-        An intercept is automatically added to the list of confounds.
         The columns contains the labels of the regressors.
 
     sample_mask : None, numpy.ndarray, or list of


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3356.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Remove the mention of intercept as this is no longer relevant as `signals.clean` standardize confounds by default and will raise warning when illogical combination of parameters are present. 