### PR TITLE
[FIX] Error when using plot_connectome(...) and edge_vmax < 0

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -14,6 +14,7 @@ Fixes
 -----
 
 - Regressor names can now be invalid identifiers but will raise an error with :meth:`~glm.first_level.FirstLevelModel.compute_contrast` if combined to make an invalid expression (:gh:`3374` by `Yasmin Mzayek`_).
+- Fix :func:`~plotting.plot_connectome` which was raising a ``ValueError`` when ``vmax < 0`` (:gh:`3390` by `Paul Bogdan`_).
 
 Enhancements
 ------------

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -168,6 +168,8 @@
 
 .. _Óscar Nájera: https://github.com/Titan-C
 
+.. _Paul Bogdan: https://github.com/paulcbogdan
+
 .. _Paula Sanz-Leon: https://github.com/pausz
 
 .. _Peer Herholz: https://peerherholz.github.io/

--- a/nilearn/plotting/displays/_axes.py
+++ b/nilearn/plotting/displays/_axes.py
@@ -523,7 +523,7 @@ class GlassBrainAxes(BaseAxes):
         norm = Normalize(vmin=vmin, vmax=vmax)
         # normalization useful for colorbar
         self.norm = norm
-        abs_norm = Normalize(vmin=0, vmax=vmax)
+        abs_norm = Normalize(vmin=0, vmax=max(abs(vmax), abs(vmin)))
         value_to_color = plt.cm.ScalarMappable(norm=norm, cmap=cmap).to_rgba
 
         # Allow lines only in their respective hemisphere when appropriate

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -66,8 +66,8 @@ def test_glass_brain_axes():
     """Tests for class ``GlassBrainAxes``."""
     from nilearn.plotting.displays import GlassBrainAxes
     ax = plt.subplot(111)
-    axes = GlassBrainAxes(ax, 'l', 2)
-    axes._add_markers(np.array([[0, 0, 0]]), 'r', [10])
+    axes = GlassBrainAxes(ax, 'r', 2)
+    axes._add_markers(np.array([[0, 0, 0]]), 'g', [10])
     line_coords = [np.array([[0, 0, 0],
                              [1, 1, 1]])]
     line_values = np.array([1, 0, 6])
@@ -79,7 +79,7 @@ def test_glass_brain_axes():
                        match="If vmin is set to a non-negative number "):
         axes._add_lines(line_coords, line_values, None, vmin=10, vmax=None)
     axes._add_lines(line_coords, line_values, None, vmin=-10, vmax=None)
-
+    axes._add_lines(line_coords, line_values, None, vmin=-10, vmax=-5)
 
 def test_get_index_from_direction_exception():
     """Tests that a ValueError is raised when an invalid direction


### PR DESCRIPTION
For `plotting.plot_connectome(...)`, I was interested in plotting a matrix with only negative edges. However, when you set the `edge_vmin` parameter to be less than zero, it raises an error. My PR is a fix. I provide details in #3389.

<!---



-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3389.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

I changed one line:

```Python
abs_norm = Normalize(vmin=0, vmax=vmax)
```

to

```Python
abs_norm = Normalize(vmin=0, vmax=max(abs(vmax), abs(vmin)))
```

From what I can tell, `abs_norm` is meant to essentially represent the magnitude of x relative to the highest magnitude specified by the user.  `abs_norm`  takes some x (a connectivity edge weight) and returns `(x - 0)/vmax` . 

My updated code does while accounting for cases where ` vmax < 0`  and ` abs(vmin) > abs(vmax)`, where you would likely be more interested in the magnitude of ` vmin` .