### PR TITLE
[FIX] Change URL for fetching fiac fMRI dataset

### DIFF
--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -2557,7 +2557,7 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
 
     # No. Download the data
     print('Data absent, downloading...')
-    url = 'http://nipy.sourceforge.net/data-packages/nipy-data-0.2.tar.gz'
+    url = 'https://nipy.org/data-packages/nipy-data-0.2.tar.gz'
 
     archive_path = os.path.join(data_dir, os.path.basename(url))
     _fetch_file(url, data_dir)


### PR DESCRIPTION
Downloading fiac dataset from http://nipy.sourceforge.net/data-packages/nipy-data-0.2.tar.gz throws a 404 error.
See line 140 in https://github.com/nilearn/nilearn/actions/runs/3343296692/jobs/5536366621
