### PR TITLE
Fix colorbar behaviour in subplots

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -19,7 +19,7 @@ Fixes
 - Change the order of applying ``sample_masks`` in :func:`~signal.clean` based on different filtering options (:gh:`3385` by `Hao-Ting Wang`_).
 - When using cosine filter and ``sample_masks`` is used, :func:`~signal.clean` generates the cosine discrete regressors using the full time series (:gh:`3385` by `Hao-Ting Wang`_).
 - Description of the ``opening`` parameter added to ``compute_multi_epi_mask`` docs (:gh:`3412` by `Natasha Clarke`_).
-- Fix display of colorbar in matrix plots which was overlapping in plt.subplots (:gh:`3403` by `Raphael Meudec`_).
+- Fix display of colorbar in matrix plots. Colorbar was overlapping in :func:`~matplotlib.pyplot.subplots` due to a hardcoded adjustment value in the subplot (:gh:`3403` by `Raphael Meudec`_).
 
 Enhancements
 ------------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -16,9 +16,10 @@ Fixes
 - Fix off-by-one error when setting ticks in :func:`~plotting.plot_surf` (:gh:`3105` by `Dimitri Papadopoulos Orfanos`_).
 - Regressor names can now be invalid identifiers but will raise an error with :meth:`~glm.first_level.FirstLevelModel.compute_contrast` if combined to make an invalid expression (:gh:`3374` by `Yasmin Mzayek`_).
 - Fix :func:`~plotting.plot_connectome` which was raising a ``ValueError`` when ``vmax < 0`` (:gh:`3390` by `Paul Bogdan`_).
-- Change the order of applying ``sample_masks`` in :func:`~signal.clean` based on different filtering options (:gh:`3385` by `Hao-Ting Wang`_). 
+- Change the order of applying ``sample_masks`` in :func:`~signal.clean` based on different filtering options (:gh:`3385` by `Hao-Ting Wang`_).
 - When using cosine filter and ``sample_masks`` is used, :func:`~signal.clean` generates the cosine discrete regressors using the full time series (:gh:`3385` by `Hao-Ting Wang`_).
 - Description of the ``opening`` parameter added to ``compute_multi_epi_mask`` docs (:gh:`3412` by `Natasha Clarke`_).
+- Fix display of colorbar in matrix plots which was overlapping in plt.subplots (:gh:`3403` by `Raphael Meudec`_).
 
 Enhancements
 ------------

--- a/nilearn/plotting/matrix_plotting.py
+++ b/nilearn/plotting/matrix_plotting.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
-from matplotlib.colorbar import make_axes
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 from .._utils import fill_doc
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", FutureWarning)
@@ -286,13 +286,10 @@ def plot_matrix(mat, title=None, labels=None, figure=None, axes=None,
                              rect=((0, 0, .95, 1) if colorbar
                                    else (0, 0, 1, 1)))
     if colorbar:
-        cax, kw = make_axes(axes, location='right', fraction=0.05, shrink=0.8,
-                            pad=.0)
-        fig.colorbar(mappable=display, cax=cax)
-        # make some room
-        fig.subplots_adjust(right=0.78)
-        # change current axis back to matrix
-        plt.sca(axes)
+        divider = make_axes_locatable(axes)
+        cax = divider.append_axes("right", size="5%", pad=.0)
+
+        plt.colorbar(display, cax=cax)
 
     if title is not None:
         # Adjust the size

--- a/nilearn/plotting/matrix_plotting.py
+++ b/nilearn/plotting/matrix_plotting.py
@@ -290,6 +290,7 @@ def plot_matrix(mat, title=None, labels=None, figure=None, axes=None,
         cax = divider.append_axes("right", size="5%", pad=.0)
 
         plt.colorbar(display, cax=cax)
+        fig.tight_layout()
 
     if title is not None:
         # Adjust the size


### PR DESCRIPTION
Fixes #3378

Revise how the colorbar is added to better handle subplots.

Before: 

![image](https://user-images.githubusercontent.com/12402673/198590175-a0eee7fb-ea52-42eb-9978-338f224b24dd.png)

After:

![image](https://user-images.githubusercontent.com/12402673/198589939-4cba9ab8-df95-45f3-a600-41e7a122c16d.png)

```python
from nilearn import datasets
from nilearn.maskers import NiftiMapsMasker
from nilearn.connectome import ConnectivityMeasure
from nilearn.plotting import plot_matrix

import numpy as np

import matplotlib.pyplot as plt


atlas = datasets.fetch_atlas_msdl()
atlas_filename = atlas['maps']
labels = atlas['labels']

data = datasets.fetch_development_fmri(n_subjects=1)
fmri_filenames = data.func[0]

masker = NiftiMapsMasker(maps_img=atlas_filename, standardize=True, detrend=True)
correlation_measure = ConnectivityMeasure(kind='correlation')

time_series = masker.fit_transform(fmri_filenames)
correlation_matrix = correlation_measure.fit_transform([time_series])[0]
np.fill_diagonal(correlation_matrix, 0)

# plot on subplot, with colorbar
fig = plt.figure()
axes = fig.subplots(1, 2)
for corr, ax in zip([correlation_matrix, correlation_matrix], axes):
    plot_matrix(corr, labels=labels, colorbar=True, axes=ax, vmax=0.7, vmin=-0.7)
```