### PR TITLE
[MAINT] No need to inherit `object` in Python 3

### DIFF
--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -156,7 +156,7 @@ def _safe_cache(memory, func, **kwargs):
     return memory.cache(func, **kwargs)
 
 
-class _ShelvedFunc(object):
+class _ShelvedFunc:
     """Work around for Python 2, for which pickle fails on instance method"""
     def __init__(self, func):
         self.func = func
@@ -246,7 +246,7 @@ def cache(func, memory, func_memory_level=None, memory_level=None,
     return cached_func
 
 
-class CacheMixin(object):
+class CacheMixin:
     """Mixin to add caching to a class.
 
     This class is a thin layer on top of joblib.Memory, that mainly adds a

--- a/nilearn/connectome/group_sparse_cov.py
+++ b/nilearn/connectome/group_sparse_cov.py
@@ -789,7 +789,7 @@ def group_sparse_covariance_path(train_subjs, alphas, test_subjs=None,
         return precisions_list
 
 
-class EarlyStopProbe(object):
+class EarlyStopProbe:
     """Callable probe for early stopping in GroupSparseCovarianceCV.
 
     Stop optimizing as soon as the score on the test set starts decreasing.

--- a/nilearn/connectome/tests/test_group_sparse_cov.py
+++ b/nilearn/connectome/tests/test_group_sparse_cov.py
@@ -26,7 +26,7 @@ def test_group_sparse_covariance():
 
     np.testing.assert_almost_equal(omega, omega2, decimal=4)
 
-    class Probe(object):
+    class Probe:
 
         def __init__(self):
             self.objective = []

--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -66,7 +66,7 @@ def _requests_session():
 
 # Helpers for filtering images and collections.
 
-class _SpecialValue(object):
+class _SpecialValue:
     """Base class for special values used to filter terms.
 
     Derived classes should override ``__eq__`` in order to create
@@ -677,7 +677,7 @@ def _empty_filter(arg):
     return True
 
 
-class ResultFilter(object):
+class ResultFilter:
     """Easily create callable (local) filters for ``fetch_neurovault``.
 
     Constructed from a mapping of key-value pairs (optional) and a
@@ -839,7 +839,7 @@ class ResultFilter(object):
 # Utilities for composing queries and interacting with
 # neurovault and neurosynth
 
-class _TemporaryDirectory(object):
+class _TemporaryDirectory:
     """Context manager that provides a temporary directory
 
     A temporary directory is created on __enter__

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -88,7 +88,7 @@ def search_light(X, y, estimator, A, groups=None, scoring=None,
 
 
 @fill_doc
-class GroupIterator(object):
+class GroupIterator:
     """Group iterator
 
     Provides group of features for search_light loop

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -203,7 +203,7 @@ def _space_net_alpha_grid(X, y, eps=1e-3, n_alphas=10, l1_ratio=1.,
                        num=n_alphas)[::-1]
 
 
-class _EarlyStoppingCallback(object):
+class _EarlyStoppingCallback:
     """Out-of-bag early stopping
 
         A callable that returns True when the test error starts

--- a/nilearn/externals/tempita/__init__.py
+++ b/nilearn/externals/tempita/__init__.py
@@ -86,7 +86,7 @@ def get_file_template(name, from_template):
         get_template=from_template.get_template)
 
 
-class Template(object):
+class Template:
 
     default_namespace = {
         'start_braces': '{{',
@@ -437,7 +437,7 @@ class bunch(dict):
 ############################################################
 
 
-class html(object):
+class html:
 
     def __init__(self, value):
         self.value = value
@@ -519,7 +519,7 @@ def sub_html(content, **kw):
     return tmpl.substitute(kw)
 
 
-class TemplateDef(object):
+class TemplateDef:
     def __init__(self, template, func_name, func_signature,
                  body, ns, pos, bound_self=None):
         self._template = template
@@ -596,7 +596,7 @@ class TemplateDef(object):
         return values
 
 
-class TemplateObject(object):
+class TemplateObject:
 
     def __init__(self, name):
         self.__name = name
@@ -606,7 +606,7 @@ class TemplateObject(object):
         return '<%s %s>' % (self.__class__.__name__, self.__name)
 
 
-class TemplateObjectGetter(object):
+class TemplateObjectGetter:
 
     def __init__(self, template_obj):
         self.__template_obj = template_obj
@@ -619,7 +619,7 @@ class TemplateObjectGetter(object):
             self.__class__.__name__, self.__template_obj)
 
 
-class _Empty(object):
+class _Empty:
     def __call__(self, *args, **kw):
         return self
 

--- a/nilearn/externals/tempita/_looper.py
+++ b/nilearn/externals/tempita/_looper.py
@@ -23,7 +23,7 @@ from .compat3 import basestring_
 __all__ = ['looper']
 
 
-class looper(object):
+class looper:
     """
     Helper for looping (particularly in templates)
 
@@ -45,7 +45,7 @@ class looper(object):
             self.__class__.__name__, self.seq)
 
 
-class looper_iter(object):
+class looper_iter:
 
     def __init__(self, seq):
         self.seq = list(seq)
@@ -65,7 +65,7 @@ class looper_iter(object):
         next = __next__
 
 
-class loop_pos(object):
+class loop_pos:
 
     def __init__(self, seq, pos):
         self.seq = seq

--- a/nilearn/glm/contrasts.py
+++ b/nilearn/glm/contrasts.py
@@ -149,7 +149,7 @@ def _compute_fixed_effect_contrast(labels, results, con_vals,
     return contrast * (1. / n_contrasts)
 
 
-class Contrast(object):
+class Contrast:
     """ The contrast class handles the estimation of statistical contrasts
     on a given model: student (t) or Fisher (F).
     The important feature is that it supports addition,

--- a/nilearn/glm/model.py
+++ b/nilearn/glm/model.py
@@ -15,7 +15,7 @@ from nilearn._utils.glm import positive_reciprocal
 inv_t_cdf = t_distribution.ppf
 
 
-class LikelihoodModelResults(object):
+class LikelihoodModelResults:
     """ Class to contain results from likelihood models.
 
     This is the class in which things like AIC, BIC, llf
@@ -343,7 +343,7 @@ class LikelihoodModelResults(object):
         return np.asarray(list(zip(lower, upper)))
 
 
-class TContrastResults(object):
+class TContrastResults:
     """Results from a t contrast of coefficients in a parametric model.
 
     The class does nothing.
@@ -367,7 +367,7 @@ class TContrastResults(object):
                 (self.effect, self.sd, self.t, self.df_den))
 
 
-class FContrastResults(object):
+class FContrastResults:
     """Results from an F contrast of coefficients in a parametric model.
 
     The class does nothing.

--- a/nilearn/glm/regression.py
+++ b/nilearn/glm/regression.py
@@ -53,7 +53,7 @@ def _deprecation_warning(old_param,
     return _warned_func
 
 
-class OLSModel(object):
+class OLSModel:
     """ A simple ordinary least squares model.
 
     Parameters

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -11,7 +11,7 @@ from nilearn import _utils, image, masking
 from nilearn.maskers.base_masker import _filter_and_extract, BaseMasker
 
 
-class _ExtractionFunctor(object):
+class _ExtractionFunctor:
 
     func_name = 'nifti_labels_masker_extractor'
 

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -10,7 +10,7 @@ from nilearn import _utils, image
 from nilearn.maskers.base_masker import _filter_and_extract, BaseMasker
 
 
-class _ExtractionFunctor(object):
+class _ExtractionFunctor:
 
     func_name = 'nifti_maps_masker_extractor'
 

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -14,7 +14,7 @@ from nilearn.maskers.base_masker import BaseMasker, _filter_and_extract
 from nilearn import _utils, image, masking
 
 
-class _ExtractionFunctor(object):
+class _ExtractionFunctor:
     func_name = 'nifti_masker_extractor'
 
     def __init__(self, mask_img_):

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -184,7 +184,7 @@ def _iter_signals_from_spheres(seeds, niimg, radius, allow_overlap,
         yield X[:, row]
 
 
-class _ExtractionFunctor(object):
+class _ExtractionFunctor:
 
     func_name = 'nifti_spheres_masker_extractor'
 

--- a/nilearn/maskers/tests/test_masker_validation.py
+++ b/nilearn/maskers/tests/test_masker_validation.py
@@ -37,7 +37,8 @@ class OwningClass(BaseEstimator):
         self.verbose = verbose
         self.dummy = dummy
 
-class DummyEstimator(object):
+
+class DummyEstimator:
 
     def __init__(self, **kwargs):
         for k, v in kwargs.items():

--- a/nilearn/plotting/displays/_axes.py
+++ b/nilearn/plotting/displays/_axes.py
@@ -15,7 +15,7 @@ from nilearn.plotting.glass_brain import plot_brain_schematics
 
 
 @fill_doc
-class BaseAxes(object):
+class BaseAxes:
     """An MPL axis-like object that displays a 2D view of 3D volumes.
 
     Parameters

--- a/nilearn/plotting/displays/_slicers.py
+++ b/nilearn/plotting/displays/_slicers.py
@@ -21,7 +21,7 @@ from nilearn._utils.niimg import _is_binary_niimg, _safe_get_data
 from nilearn.plotting.displays._axes import _coords_3d_to_2d
 
 
-class BaseSlicer(object):
+class BaseSlicer:
     """BaseSlicer implementation which main purpose is to auto adjust
     the axes size to the data with different layout of cuts. It create
     3 linked axes for plotting orthogonal cuts.

--- a/nilearn/plotting/glass_brain_files/svg_to_json_converter.py
+++ b/nilearn/plotting/glass_brain_files/svg_to_json_converter.py
@@ -9,7 +9,7 @@ import sys
 import json
 
 
-class SVGToJSONConverter(object):
+class SVGToJSONConverter:
     """Reads an svg file and exports paths to a JSON format
 
     Only segments and Bezier curves are supported

--- a/nilearn/plotting/html_document.py
+++ b/nilearn/plotting/html_document.py
@@ -26,7 +26,7 @@ def _remove_after_n_seconds(file_name, n_seconds):
     return proc
 
 
-class HTMLDocument(object):
+class HTMLDocument:
     """Embeds a plot in a web page.
 
     If you are running a Jupyter notebook, the plot will be displayed

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -33,7 +33,7 @@ currdir = os.path.dirname(os.path.abspath(__file__))
 datadir = os.path.join(currdir, 'data')
 
 
-class MeshLikeObject(object):
+class MeshLikeObject:
     """Class with attributes coordinates and
     faces to be used for testing purposes.
     """
@@ -47,7 +47,8 @@ class MeshLikeObject(object):
     def faces(self):
         return self._faces
 
-class SurfaceLikeObject(object):
+
+class SurfaceLikeObject:
     """Class with attributes mesh and
     data to be used for testing purposes.
     """

--- a/nilearn/tests/test_logger.py
+++ b/nilearn/tests/test_logger.py
@@ -36,7 +36,7 @@ def other_run():
     log("function other_run()", stack_level=100)
 
 
-class Run3(object):
+class Run3:
 
     def run3(self):
         log("method Test3")


### PR DESCRIPTION
Classes inherit from `object` implicitly.