### PR TITLE
[MAINT] Source encoding is UTF-8 by default

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # nilearn documentation build configuration file, created by
 # sphinx-quickstart on Fri Jan  8 09:13:42 2010.
 #

--- a/doc/sphinxext/gh_substitutions.py
+++ b/doc/sphinxext/gh_substitutions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from docutils.nodes import reference
 from docutils.parsers.rst.roles import set_classes
 

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Functions related to the documentation.
 
 docdict contains the standard documentation entries

--- a/nilearn/reporting/glm_reporter.py
+++ b/nilearn/reporting/glm_reporter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Functionality to create an HTML report using a fitted GLM & contrasts.
 

--- a/nilearn/reporting/tests/test_glm_reporter.py
+++ b/nilearn/reporting/tests/test_glm_reporter.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import warnings
 
 import nibabel as nib

--- a/nilearn/version.py
+++ b/nilearn/version.py
@@ -1,4 +1,3 @@
-# *- encoding: utf-8 -*-
 """
 nilearn version, required package versions, and utilities for checking
 """


### PR DESCRIPTION
In Python 3, not need to  declare it explictly.