### PR TITLE
[INFRA][FIX] Actions setup-python for v3.6 does not work with Ubuntu-latest runner

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,7 +26,7 @@ jobs:
   min_requirements:
     needs: check_skip
     if: ${{ needs.check_skip.outputs.skip == 'false' }}
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     name: Python 3.6, minimal requirements without Matplotlib
     defaults:
       run:
@@ -58,7 +58,7 @@ jobs:
   min_requirements_matplotlib:
     needs: check_skip
     if: ${{ needs.check_skip.outputs.skip == 'false' }}
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     name: Python 3.6, minimal requirements with Matplotlib
     defaults:
       run:


### PR DESCRIPTION
GitHub Actions now fails with tests that use some python versions such as 3.6 if runner is set to `Ubuntu-latest` (which is now ubuntu-22.04). It should work with ubuntu-20.04.

See failure: https://github.com/nilearn/nilearn/actions/runs/3498548522/jobs/5859058796
More details at similar issue: https://github.com/actions/setup-python/issues/543 
