### PR TITLE
[FIX] Flake8 latest release raises error and includes backwards incompatilble change

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -363,16 +363,16 @@ Here are the key steps you need to go through to contribute code to `nilearn`:
 .. admonition:: Recommendation
 
     To lint your code and verify PEP8 compliance, you can run
-    `flake8 <https://flake8.pycqa.org/en/latest/>`_ locally on the
-    changes you have made in your branch compared to the main branch.
+    `flake8 <https://flake8.pycqa.org/en/latest/>`_ locally on changed files
+    based on changes you have made in your branch compared to the main branch.
     To do this, find the latest common ancestor (commit) of your branch with
-    main and then get the diff between your working directory and this commit
-    and pipe it to flake8 by running:
+    main and then get the files with a diff between your working directory and
+    this commit and pipe it to flake8 by running:
 
     .. code-block:: bash
 
         COMMIT=$(git merge-base main @)
-        git diff $COMMIT | flake8 --diff
+        git diff $COMMIT --name-only -z --diff-filter=d -- '*.py' | xargs -0 flake8
 
 4. commit your changes on this branch (don't forget to write tests!)
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -372,7 +372,7 @@ Here are the key steps you need to go through to contribute code to `nilearn`:
     .. code-block:: bash
 
         COMMIT=$(git merge-base main @)
-        git diff $COMMIT --name-only -z --diff-filter=d -- '*.py' | xargs -0 flake8
+        git diff $COMMIT --name-only -z --diff-filter=d -- '*.py' | xargs -0 -r flake8
 
 4. commit your changes on this branch (don't forget to write tests!)
 

--- a/build_tools/flake8_diff.sh
+++ b/build_tools/flake8_diff.sh
@@ -74,7 +74,8 @@ echo -e '\nRunning flake8 on the diff in the range'\
      "($(git rev-list $COMMIT.. | wc -l) commit(s)):"
 echo '--------------------------------------------------------------------------------'
 
-# Conservative approach: diff without context so that code that was
-# not changed does not create failures
-git diff --unified=0 $COMMIT | flake8 --diff --show-source
+# The --diff argument has been removed from flake8:
+# https://github.com/PyCQA/flake8/issues/1760
+# Now flake8 will be run on entire files but only files that have been changed.
+git diff $COMMIT --name-only -z --diff-filter=d -- '*.py' | xargs -0 flake8
 echo -e "No problem detected by flake8\n"

--- a/build_tools/flake8_diff.sh
+++ b/build_tools/flake8_diff.sh
@@ -77,5 +77,5 @@ echo '--------------------------------------------------------------------------
 # The --diff argument has been removed from flake8:
 # https://github.com/PyCQA/flake8/issues/1760
 # Now flake8 will be run on entire files but only files that have been changed.
-git diff $COMMIT --name-only -z --diff-filter=d -- '*.py' | xargs -0 flake8
+git diff $COMMIT --name-only -z --diff-filter=d -- '*.py' | xargs -0 -r flake8
 echo -e "No problem detected by flake8\n"

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ dev =
 # E402: module level import not at top of file
 # W503: line break before binary operator
 # W504: line break after binary operator
-ignore=E402, W503, W504. W605
+ignore=E402, W503, W504, W605
 
 [tool:pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS


### PR DESCRIPTION
Closes #3431. Flake8 just released a new version that raises a PEP8 failure in our CI check. Also the --diff option is now removed so we have to handle differently how we pipe changes for flake8 to check.
See: https://flake8.pycqa.org/en/latest/release-notes/6.0.0.html#backwards-incompatible-changes
