### PR TITLE
[FIX] Fix syntax error that prevents flake8 v6.0.0 from running on files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ dev =
 # E402: module level import not at top of file
 # W503: line break before binary operator
 # W504: line break after binary operator
-ignore=E402, W503, W504. W605
+ignore=E402, W503, W504, W605
 
 [tool:pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS


### PR DESCRIPTION
Related to #3420 

Right now if you try to run flake8 locally on a file with flake8 version 6.0.0 you will get the following error:
`ValueError: Error code 'W504.' supplied to 'ignore' option does not match '^[A-Z]{1,3}[0-9]{0,3}$'`
This is a fix for that. Note that this does not fix our broken PEP8 check.
