### PR TITLE
[MAINT] Remove deprecated function `compute_multi_gray_matter_mask`

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -30,3 +30,5 @@ Changes
 
 - Private functions ``nilearn.regions.rena_clustering.weighted_connectivity_graph`` and ``nilearn.regions.rena_clustering.nearest_neighbor_grouping`` have been renamed with a leading "_", while function :func:`~regions.recursive_neighbor_agglomeration` has been added to the public API (:gh:`3347` by `Ahmad Chamma`_).
 - Numpy deprecated type aliases are replaced by equivalent builtin types (:gh:`3422` by `Yasmin Mzayek`_).
+- Function ``nilearn.masking.compute_multi_gray_matter_mask`` has been removed
+  since it has been deprecated and replaced by :func:`~masking.compute_multi_brain_mask` (:gh:`3427` by `Yasmin Mzayek`_).

--- a/nilearn/maskers/tests/test_multi_nifti_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_masker.py
@@ -193,25 +193,6 @@ def test_mask_strategy_errors():
         mask.fit(imgs)
 
 
-@pytest.mark.parametrize('strategy',
-                         [f'{p}-template' for p in
-                          ['whole-brain', 'gm', 'wm']])
-def test_compute_multi_gray_matter_mask(strategy):
-    imgs = _get_random_imgs((9, 9, 5), 2)
-    masker = MultiNiftiMasker(mask_strategy=strategy,
-                              mask_args={'opening': 1})
-    masker.fit(imgs)
-    # Check that the order of the images does not change the output
-    masker2 = MultiNiftiMasker(mask_strategy=strategy,
-                               mask_args={'opening': 1})
-    masker2.fit(imgs[::-1])
-    mask_ref = np.zeros((9, 9, 5), dtype='int8')
-    np.testing.assert_array_equal(get_data(masker.mask_img_),
-                                  mask_ref)
-    np.testing.assert_array_equal(get_data(masker2.mask_img_),
-                                  mask_ref)
-
-
 def test_dtype():
     data = np.zeros((9, 9, 9), dtype=np.float64)
     data[2:-2, 2:-2, 2:-2] = 10

--- a/nilearn/maskers/tests/test_multi_nifti_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_masker.py
@@ -193,6 +193,25 @@ def test_mask_strategy_errors():
         mask.fit(imgs)
 
 
+@pytest.mark.parametrize('strategy',
+                         [f'{p}-template' for p in
+                          ['whole-brain', 'gm', 'wm']])
+def test_compute_mask_strategy(strategy):
+    imgs = _get_random_imgs((9, 9, 5), 2)
+    masker = MultiNiftiMasker(mask_strategy=strategy,
+                              mask_args={'opening': 1})
+    masker.fit(imgs)
+    # Check that the order of the images does not change the output
+    masker2 = MultiNiftiMasker(mask_strategy=strategy,
+                               mask_args={'opening': 1})
+    masker2.fit(imgs[::-1])
+    mask_ref = np.zeros((9, 9, 5), dtype='int8')
+    np.testing.assert_array_equal(get_data(masker.mask_img_),
+                                  mask_ref)
+    np.testing.assert_array_equal(get_data(masker2.mask_img_),
+                                  mask_ref)
+
+
 def test_dtype():
     data = np.zeros((9, 9, 9), dtype=np.float64)
     data[2:-2, 2:-2, 2:-2] = 10

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -579,66 +579,6 @@ def compute_brain_mask(target_img, threshold=.5, connected=True, opening=2,
     return new_img_like(target_img, mask, affine)
 
 
-@deprecated("Function 'compute_multi_gray_matter_mask' has been renamed to "
-            "'compute_multi_brain_mask' and 'compute_multi_gray_matter_mask' "
-            "will be removed in release 0.10.0")
-@_utils.fill_doc
-def compute_multi_gray_matter_mask(target_imgs, threshold=.5,
-                                   connected=True, opening=2,
-                                   memory=None, verbose=0, n_jobs=1, **kwargs):
-    """Compute a mask corresponding to the gray matter part of the brain for
-    a list of images.
-
-    The gray matter part is calculated through the resampling of MNI152
-    template gray matter mask onto the target image
-
-    Parameters
-    ----------
-    target_imgs : :obj:`list` of Niimg-like object
-        See :ref:`extracting_data`.
-        Images used to compute the mask. 3D and 4D images are accepted.
-
-        .. note::
-            The images in this list must be of same shape and affine.
-            The mask is calculated with the first element of the list
-            for only the shape/affine of the image is used for this
-            masking strategy.
-
-    threshold : :obj:`float`, optional
-        The value under which the :term:`MNI` template is cut off.
-        Default=0.5.
-    %(connected)s
-        Default=True.
-    %(opening)s
-        Default=2.
-    %(memory)s
-    %(verbose0)s
-    %(n_jobs)s
-
-        .. note::
-            Argument not used but kept to fit the API.
-
-    **kwargs : optional arguments
-        arguments such as 'target_affine' are used in the call of other
-        masking strategies, which then would raise an error for this function
-        which does not need such arguments.
-
-    Returns
-    -------
-    mask : :class:`nibabel.nifti1.Nifti1Image`
-        The brain mask (3D image).
-
-    See also
-    --------
-    nilearn.masking.compute_brain_mask
-    """
-    return compute_multi_brain_mask(target_imgs=target_imgs,
-                                    threshold=threshold, connected=connected,
-                                    opening=opening, memory=memory,
-                                    verbose=verbose, n_jobs=n_jobs,
-                                    mask_type='whole-brain', **kwargs)
-
-
 @_utils.fill_doc
 def compute_multi_brain_mask(target_imgs, threshold=.5, connected=True,
                              opening=2, memory=None, verbose=0, n_jobs=1,

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -527,18 +527,6 @@ def test_compute_multi_brain_mask():
     assert_array_equal(get_data(mask1), get_data(mask2))
 
 
-def test_deprecation_warning_compute_multi_gray_matter_mask():
-    imgs = [Nifti1Image(np.ones((9, 9, 9)), np.eye(4)),
-            Nifti1Image(np.ones((9, 9, 9)), np.eye(4))]
-    if _compare_version(sklearn.__version__, '<', '0.22'):
-        with pytest.deprecated_call():
-            masking.compute_multi_gray_matter_mask(imgs)
-    else:
-        with pytest.warns(FutureWarning,
-                          match="renamed to 'compute_multi_brain_mask'"):
-            masking.compute_multi_gray_matter_mask(imgs)
-
-
 def test_error_shape(random_state=42, shape=(3, 5, 7, 11)):
     # open-ended `if .. elif` in masking.unmask
 


### PR DESCRIPTION
Remove `masking.compute_multi_gray_matter_mask` which has been deprecated and replaced by `masking.compute_multi_brain_mask` in version 0.8.1
