### PR TITLE
[MAINT] Drop support for python 3.6 and deprecate 3.7

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,7 +27,7 @@ jobs:
     needs: check_skip
     if: ${{ needs.check_skip.outputs.skip == 'false' }}
     runs-on: "ubuntu-20.04"
-    name: Python 3.6, minimal requirements without Matplotlib
+    name: Python 3.7, minimal requirements without Matplotlib
     defaults:
       run:
         shell: bash
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.6"
+          python-version: "3.7"
         name: 'Setup python'
       - shell: bash -l {0}
         name: 'Display Python version'
@@ -59,7 +59,7 @@ jobs:
     needs: check_skip
     if: ${{ needs.check_skip.outputs.skip == 'false' }}
     runs-on: "ubuntu-20.04"
-    name: Python 3.6, minimal requirements with Matplotlib
+    name: Python 3.7, minimal requirements with Matplotlib
     defaults:
       run:
         shell: bash
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.6"
+          python-version: "3.7"
         name: 'Setup python'
       - shell: bash -l {0}
         name: 'Display Python version'
@@ -93,7 +93,7 @@ jobs:
         fail-fast: false
         matrix:
             os: ["ubuntu-latest", "macos-latest"]
-            python-version: ["3.7", "3.8", "3.9", "3.10"]
+            python-version: ["3.8", "3.9", "3.10"]
     name: ${{ matrix.os }} with Python ${{ matrix.python-version }} and latest package versions
     defaults:
       run:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,10 +14,10 @@ jobs:
     vmImage: 'windows-latest'
   strategy:
     matrix:
-      Python37:
-        python.version: '3.7'
       Python38:
         python.version: '3.8'
+      Python39:
+        python.version: '3.9'
     maxParallel: 4
 
   steps:
@@ -56,8 +56,8 @@ jobs:
     vmImage: 'ubuntu-18.04'
   strategy:
     matrix:
-      Python37:
-        python.version: '3.7'
+      Python38:
+        python.version: '3.8'
     maxParallel: 4
 
   steps:
@@ -94,8 +94,8 @@ jobs:
     vmImage: 'macOS-latest'
   strategy:
     matrix:
-      Python37:
-        python.version: '3.7'
+      Python38:
+        python.version: '3.8'
     maxParallel: 4
 
   steps:
@@ -132,8 +132,8 @@ jobs:
     vmImage: 'windows-latest'
   strategy:
     matrix:
-      Python37:
-        python.version: '3.7'
+      Python38:
+        python.version: '3.8'
     maxParallel: 4
 
   steps:

--- a/build_tools/github/build_docs_dependencies.sh
+++ b/build_tools/github/build_docs_dependencies.sh
@@ -3,7 +3,7 @@
 conda init bash
 echo "conda version = $(conda --version)"
 conda create -n testenv
-conda install -n testenv -yq python=3.8
+conda install -n testenv -yq python=3.9
 source activate testenv
 python -m pip install --user --upgrade --progress-bar off pip setuptools
 # Install the local version of the library, along with both standard and testing-related dependencies

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -34,4 +34,4 @@ Changes
 - Function ``nilearn.masking.compute_multi_gray_matter_mask`` has been removed
   since it has been deprecated and replaced by :func:`~masking.compute_multi_brain_mask` (:gh:`3427` by `Yasmin Mzayek`_).
 - :mod:`~nilearn.glm` will no longer warn that the module is experimental (:gh:`3424` by `Yasmin Mzayek`_).
-- Python `3.6` is no longer supported. Support for Python `3.7` is deprecated and will be removed in release `0.12` (:gh:`3429` by `Yasmin Mzayek`_).
+- Python ``3.6`` is no longer supported. Support for Python ``3.7`` is deprecated and will be removed in release ``0.12`` (:gh:`3429` by `Yasmin Mzayek`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -34,3 +34,4 @@ Changes
 - Function ``nilearn.masking.compute_multi_gray_matter_mask`` has been removed
   since it has been deprecated and replaced by :func:`~masking.compute_multi_brain_mask` (:gh:`3427` by `Yasmin Mzayek`_).
 - :mod:`~nilearn.glm` will no longer warn that the module is experimental (:gh:`3424` by `Yasmin Mzayek`_).
+- Python `3.6` is no longer supported. Support for Python `3.7` is deprecated and will be removed in release `0.12` (:gh:`3429` by `Yasmin Mzayek`_).

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -341,7 +341,7 @@ latex_show_urls = 'footnote'
 
 trim_doctests_flags = True
 
-_python_doc_base = 'https://docs.python.org/3.8'
+_python_doc_base = 'https://docs.python.org/3.9'
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {

--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -53,7 +53,7 @@ os.environ.setdefault("KMP_INIT_AT_FORK", "FALSE")
 def _py37_deprecation_warning():
     py37_warning = ("Python 3.7 support is deprecated and will be removed in "
                     "release 0.12 of Nilearn. Consider switching to "
-                    "Python 3.8 or 3.9.")
+                    "Python 3.9 or 3.10.")
     warnings.filterwarnings('once', message=py37_warning)
     warnings.warn(message=py37_warning,
                   category=FutureWarning,

--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -61,7 +61,7 @@ def _py37_deprecation_warning():
 
 
 def _python_deprecation_warnings():
-    if sys.version_info.major == 3 and sys.version_info.minor == 6:
+    if sys.version_info.major == 3 and sys.version_info.minor == 7:
         _py37_deprecation_warning()
 
 

--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -50,19 +50,19 @@ from .version import (
 os.environ.setdefault("KMP_INIT_AT_FORK", "FALSE")
 
 
-def _py36_deprecation_warning():
-    py36_warning = ("Python 3.6 support is deprecated and will be removed in "
-                    "release 0.10 of Nilearn. Consider switching to "
+def _py37_deprecation_warning():
+    py37_warning = ("Python 3.7 support is deprecated and will be removed in "
+                    "release 0.12 of Nilearn. Consider switching to "
                     "Python 3.8 or 3.9.")
-    warnings.filterwarnings('once', message=py36_warning)
-    warnings.warn(message=py36_warning,
+    warnings.filterwarnings('once', message=py37_warning)
+    warnings.warn(message=py37_warning,
                   category=FutureWarning,
                   stacklevel=3)
 
 
 def _python_deprecation_warnings():
     if sys.version_info.major == 3 and sys.version_info.minor == 6:
-        _py36_deprecation_warning()
+        _py37_deprecation_warning()
 
 
 _check_module_dependencies()

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1581,16 +1581,11 @@ def _separate_talairach_levels(atlas_img, labels, output_dir, verbose):
                 get_data(atlas_img) == region_nb] = level_labels[region_name]
         new_img_like(atlas_img, level_data).to_filename(
             str(output_dir.joinpath(f"{level_name}.nii.gz")))
-        # order the labels so that image values are indices in the list of
-        # labels for each level
-        # (TODO can be removed when dropping python 3.6 support)
-        sorted_level_labels = [
-            k for (k, v) in sorted(level_labels.items(), key=lambda t: t[1])
-        ]
+        level_labels = list(level_labels.keys())
         # rename '*' -> 'Background'
-        sorted_level_labels[0] = 'Background'
+        level_labels[0] = 'Background'
         output_dir.joinpath(f"{level_name}-labels.json").write_text(
-            json.dumps(sorted_level_labels), "utf-8")
+            json.dumps(level_labels), "utf-8")
 
 
 def _download_talairach(talairach_dir, verbose):

--- a/nilearn/tests/test_init.py
+++ b/nilearn/tests/test_init.py
@@ -5,14 +5,14 @@ import pytest
 
 with warnings.catch_warnings(record=True):
     from nilearn import (
-        _py36_deprecation_warning, _python_deprecation_warnings
+        _py37_deprecation_warning, _python_deprecation_warnings
     )
 
 
-def test_py36_deprecation_warning():
+def test_py37_deprecation_warning():
     with pytest.warns(FutureWarning,
-                      match="Python 3.6 support is deprecated"):
-        _py36_deprecation_warning()
+                      match="Python 3.7 support is deprecated"):
+        _py37_deprecation_warning()
 
 
 def test_python_deprecation_warnings():

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 doc-files = doc
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
 	joblib>=0.15
 	lxml

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ if __name__ == "__main__":
               'Operating System :: POSIX',
               'Operating System :: Unix',
               'Operating System :: MacOS',
-              'Programming Language :: Python :: 3.6',
               'Programming Language :: Python :: 3.7',
               'Programming Language :: Python :: 3.8',
               'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
Even though we initially agreed to extend support for python 3.6 due to many machines still using it, it was then discussed in #3423 that it is more reasonable to drop its support since dependencies such as scikit-learn do not support it anymore and it has been EOL since Dec2021.
