### PR TITLE
[FIX] Pass correct type to scikit-learn estimators parameter

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -20,6 +20,7 @@ Fixes
 - When using cosine filter and ``sample_masks`` is used, :func:`~signal.clean` generates the cosine discrete regressors using the full time series (:gh:`3385` by `Hao-Ting Wang`_).
 - Description of the ``opening`` parameter added to ``compute_multi_epi_mask`` docs (:gh:`3412` by `Natasha Clarke`_).
 - Fix display of colorbar in matrix plots. Colorbar was overlapping in :func:`~matplotlib.pyplot.subplots` due to a hardcoded adjustment value in the subplot (:gh:`3403` by `Raphael Meudec`_).
+- Pass values with correct type to scikit-learn estimator parameters and remove deprecated parameter (:gh:`3430` by `Yasmin Mzayek`_).
 
 Enhancements
 ------------

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -54,7 +54,7 @@ SUPPORTED_ESTIMATORS = dict(
     ridge_classifier=RidgeClassifierCV(),
     ridge_regressor=RidgeCV(),
     ridge=RidgeCV(),
-    svr=SVR(kernel='linear', max_iter=1000),
+    svr=SVR(kernel='linear', max_iter=10000),
     dummy_classifier=DummyClassifier(strategy='stratified',
                                      random_state=0),
     dummy_regressor=DummyRegressor(strategy='mean'),

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -45,16 +45,16 @@ except ImportError:
 
 
 SUPPORTED_ESTIMATORS = dict(
-    svc_l1=LinearSVC(penalty='l1', dual=False, max_iter=1e4),
-    svc_l2=LinearSVC(penalty='l2', max_iter=1e4),
-    svc=LinearSVC(penalty='l2', max_iter=1e4),
+    svc_l1=LinearSVC(penalty='l1', dual=False, max_iter=10000),
+    svc_l2=LinearSVC(penalty='l2', max_iter=10000),
+    svc=LinearSVC(penalty='l2', max_iter=10000),
     logistic_l1=LogisticRegression(penalty='l1', solver='liblinear'),
     logistic_l2=LogisticRegression(penalty='l2', solver='liblinear'),
     logistic=LogisticRegression(penalty='l2', solver='liblinear'),
     ridge_classifier=RidgeClassifierCV(),
     ridge_regressor=RidgeCV(),
     ridge=RidgeCV(),
-    svr=SVR(kernel='linear', max_iter=1e4),
+    svr=SVR(kernel='linear', max_iter=1000),
     dummy_classifier=DummyClassifier(strategy='stratified',
                                      random_state=0),
     dummy_regressor=DummyRegressor(strategy='mean'),

--- a/nilearn/decoding/tests/test_space_net.py
+++ b/nilearn/decoding/tests/test_space_net.py
@@ -236,7 +236,7 @@ def test_lasso_vs_graph_net():
     # Test for one of the extreme cases of Graph-Net: That is, with
     # l1_ratio = 1 (pure Lasso), we compare Graph-Net's performance with
     # Scikit-Learn lasso
-    lasso = Lasso(max_iter=100, tol=1e-8, normalize=False)
+    lasso = Lasso(max_iter=100, tol=1e-8)
     graph_net = BaseSpaceNet(mask=mask, alphas=1. * X_.shape[0],
                              l1_ratios=1, is_classif=False,
                              penalty="graph-net", max_iter=100)

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -23,7 +23,7 @@ sparse_encode_args = {'check_input': False}
 
 
 def _compute_loadings(components, data):
-    ridge = Ridge(fit_intercept=None, alpha=1e-8)
+    ridge = Ridge(fit_intercept=False, alpha=1e-8)
     ridge.fit(components.T, np.asarray(data.T))
     loadings = ridge.coef_.T
 


### PR DESCRIPTION
Pre-release of scikit-learn enforces correct behavior of:
 - Passing `int` to the `max_iter` parameter used by some estimators
 - Deletion of deprecated parameter
 - `fit_intercept` only accepts booleans
 
See failing test: https://github.com/nilearn/nilearn/actions/runs/3574331280/jobs/6009470192