### PR TITLE
Run flake8 on .py files appearing in git diff

### DIFF
--- a/build_tools/flake8_diff.sh
+++ b/build_tools/flake8_diff.sh
@@ -76,5 +76,5 @@ echo '--------------------------------------------------------------------------
 
 # Conservative approach: diff without context so that code that was
 # not changed does not create failures
-git diff --unified=0 $COMMIT | flake8 --diff --show-source
+git diff --name-only $COMMIT | grep '\.py$' | xargs --delimiter='\n' --no-run-if-empty flake8 --show-source
 echo -e "No problem detected by flake8\n"


### PR DESCRIPTION
Closes #3431 .

Removes `--diff` flag that disappeared in `flake8==6.0.0`, which is currently failing all CI runs.