### PR TITLE
[MAINT] Remove `FutureWarning`s due for release `0.10` and update related components

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -49,3 +49,4 @@ Changes
     * Joblib -- v1.0.0
 
   (:gh:`3440` by `Yasmin Mzayek`_).
+- In release ``0.10.0`` the default resolution for loaded MNI152 templates will be 1mm instead of 2mm (:gh:`3433` by `Yasmin Mzayek`_).

--- a/nilearn/datasets/struct.py
+++ b/nilearn/datasets/struct.py
@@ -196,8 +196,7 @@ def load_mni152_template(resolution=None):
 
     """
 
-    if resolution is None:
-        resolution = 1
+    resolution = resolution or 1
 
     brain_template = check_niimg(MNI152_FILE_PATH)
 
@@ -246,8 +245,7 @@ def load_mni152_gm_template(resolution=None):
 
     """
 
-    if resolution is None:
-        resolution = 1
+    resolution = resolution or 1
 
     gm_template = check_niimg(GM_MNI152_FILE_PATH)
 
@@ -296,8 +294,7 @@ def load_mni152_wm_template(resolution=None):
 
     """
 
-    if resolution is None:
-        resolution = 1
+    resolution = resolution or 1
 
     wm_template = check_niimg(WM_MNI152_FILE_PATH)
 
@@ -352,8 +349,7 @@ def load_mni152_brain_mask(resolution=None, threshold=0.2):
 
     """
 
-    if resolution is None:
-        resolution = 1
+    resolution = resolution or 1
 
     # Load MNI template
     target_img = load_mni152_template(resolution=resolution)
@@ -400,8 +396,7 @@ def load_mni152_gm_mask(resolution=None, threshold=0.2, n_iter=2):
 
     """
 
-    if resolution is None:
-        resolution = 1
+    resolution = resolution or 1
 
     # Load MNI template
     gm_target = load_mni152_gm_template(resolution=resolution)
@@ -453,8 +448,7 @@ def load_mni152_wm_mask(resolution=None, threshold=0.2, n_iter=2):
 
     """
 
-    if resolution is None:
-        resolution = 1
+    resolution = resolution or 1
 
     # Load MNI template
     wm_target = load_mni152_wm_template(resolution=resolution)

--- a/nilearn/datasets/struct.py
+++ b/nilearn/datasets/struct.py
@@ -37,10 +37,6 @@ _LEGACY_FORMAT_MSG = (
     "instead of recarrays."
 )
 
-# workaround for
-# https://github.com/nilearn/nilearn/pull/2738#issuecomment-869018842
-_MNI_RES_WARNING_ALREADY_SHOWN = False
-
 
 @fill_doc
 def fetch_icbm152_2009(data_dir=None, url=None, resume=True, verbose=1):
@@ -172,7 +168,7 @@ def load_mni152_template(resolution=None):
 
     Parameters
     ----------
-    resolution: int, optional, Default = 2
+    resolution: int, optional, Default = 1
         If resolution is different from 1, the template is re-sampled with the
         specified resolution.
 
@@ -200,14 +196,8 @@ def load_mni152_template(resolution=None):
 
     """
 
-    global _MNI_RES_WARNING_ALREADY_SHOWN
     if resolution is None:
-        if not _MNI_RES_WARNING_ALREADY_SHOWN:
-            warnings.warn("Default resolution of the MNI template will change "
-                          "from 2mm to 1mm in version 0.10.0", FutureWarning,
-                          stacklevel=2)
-            _MNI_RES_WARNING_ALREADY_SHOWN = True
-        resolution = 2
+        resolution = 1
 
     brain_template = check_niimg(MNI152_FILE_PATH)
 
@@ -237,7 +227,7 @@ def load_mni152_gm_template(resolution=None):
 
     Parameters
     ----------
-    resolution: int, optional, Default = 2
+    resolution: int, optional, Default = 1
         If resolution is different from 1, the template is re-sampled with the
         specified resolution.
 
@@ -256,13 +246,8 @@ def load_mni152_gm_template(resolution=None):
 
     """
 
-    global _MNI_RES_WARNING_ALREADY_SHOWN
     if resolution is None:
-        if not _MNI_RES_WARNING_ALREADY_SHOWN:
-            warnings.warn("Default resolution of the MNI template will change "
-                          "from 2mm to 1mm in version 0.10.0", FutureWarning)
-            _MNI_RES_WARNING_ALREADY_SHOWN = True
-        resolution = 2
+        resolution = 1
 
     gm_template = check_niimg(GM_MNI152_FILE_PATH)
 
@@ -292,7 +277,7 @@ def load_mni152_wm_template(resolution=None):
 
     Parameters
     ----------
-    resolution: int, optional, Default = 2
+    resolution: int, optional, Default = 1
         If resolution is different from 1, the template is re-sampled with the
         specified resolution.
 
@@ -311,13 +296,8 @@ def load_mni152_wm_template(resolution=None):
 
     """
 
-    global _MNI_RES_WARNING_ALREADY_SHOWN
     if resolution is None:
-        if not _MNI_RES_WARNING_ALREADY_SHOWN:
-            warnings.warn("Default resolution of the MNI template will change "
-                          "from 2mm to 1mm in version 0.10.0", FutureWarning)
-            _MNI_RES_WARNING_ALREADY_SHOWN = True
-        resolution = 2
+        resolution = 1
 
     wm_template = check_niimg(WM_MNI152_FILE_PATH)
 
@@ -346,7 +326,7 @@ def load_mni152_brain_mask(resolution=None, threshold=0.2):
 
     Parameters
     ----------
-    resolution: int, optional, Default = 2
+    resolution: int, optional, Default = 1
         If resolution is different from 1, the template loaded is first
         re-sampled with the specified resolution.
 
@@ -372,13 +352,8 @@ def load_mni152_brain_mask(resolution=None, threshold=0.2):
 
     """
 
-    global _MNI_RES_WARNING_ALREADY_SHOWN
     if resolution is None:
-        if not _MNI_RES_WARNING_ALREADY_SHOWN:
-            warnings.warn("Default resolution of the MNI template will change "
-                          "from 2mm to 1mm in version 0.10.0", FutureWarning)
-            _MNI_RES_WARNING_ALREADY_SHOWN = True
-        resolution = 2
+        resolution = 1
 
     # Load MNI template
     target_img = load_mni152_template(resolution=resolution)
@@ -397,7 +372,7 @@ def load_mni152_gm_mask(resolution=None, threshold=0.2, n_iter=2):
 
     Parameters
     ----------
-    resolution: int, optional, Default = 2
+    resolution: int, optional, Default = 1
         If resolution is different from 1, the template loaded is first
         re-sampled with the specified resolution.
 
@@ -425,13 +400,8 @@ def load_mni152_gm_mask(resolution=None, threshold=0.2, n_iter=2):
 
     """
 
-    global _MNI_RES_WARNING_ALREADY_SHOWN
     if resolution is None:
-        if not _MNI_RES_WARNING_ALREADY_SHOWN:
-            warnings.warn("Default resolution of the MNI template will change "
-                          "from 2mm to 1mm in version 0.10.0", FutureWarning)
-            _MNI_RES_WARNING_ALREADY_SHOWN = True
-        resolution = 2
+        resolution = 1
 
     # Load MNI template
     gm_target = load_mni152_gm_template(resolution=resolution)
@@ -455,7 +425,7 @@ def load_mni152_wm_mask(resolution=None, threshold=0.2, n_iter=2):
 
     Parameters
     ----------
-    resolution: int, optional, Default = 2
+    resolution: int, optional, Default = 1
         If resolution is different from 1, the template loaded is first
         re-sampled with the specified resolution.
 
@@ -483,13 +453,8 @@ def load_mni152_wm_mask(resolution=None, threshold=0.2, n_iter=2):
 
     """
 
-    global _MNI_RES_WARNING_ALREADY_SHOWN
     if resolution is None:
-        if not _MNI_RES_WARNING_ALREADY_SHOWN:
-            warnings.warn("Default resolution of the MNI template will change "
-                          "from 2mm to 1mm in version 0.10.0", FutureWarning)
-            _MNI_RES_WARNING_ALREADY_SHOWN = True
-        resolution = 2
+        resolution = 1
 
     # Load MNI template
     wm_target = load_mni152_wm_template(resolution=resolution)

--- a/nilearn/datasets/tests/test_struct.py
+++ b/nilearn/datasets/tests/test_struct.py
@@ -148,8 +148,8 @@ def test_fetch_oasis_vbm(tmp_path, request_mocker, legacy_format):
 
 def test_load_mni152_template():
     # All subjects
-    template_nii_1mm = struct.load_mni152_template(resolution=1)
-    template_nii_2mm = struct.load_mni152_template()
+    template_nii_1mm = struct.load_mni152_template()
+    template_nii_2mm = struct.load_mni152_template(resolution=2)
     assert template_nii_1mm.shape == (197, 233, 189)
     assert template_nii_2mm.shape == (99, 117, 95)
     assert template_nii_1mm.header.get_zooms() == (1.0, 1.0, 1.0)
@@ -158,8 +158,8 @@ def test_load_mni152_template():
 
 def test_load_mni152_gm_template():
     # All subjects
-    gm_template_nii_1mm = struct.load_mni152_gm_template(resolution=1)
-    gm_template_nii_2mm = struct.load_mni152_gm_template()
+    gm_template_nii_1mm = struct.load_mni152_gm_template()
+    gm_template_nii_2mm = struct.load_mni152_gm_template(resolution=2)
     assert gm_template_nii_1mm.shape == (197, 233, 189)
     assert gm_template_nii_2mm.shape == (99, 117, 95)
     assert gm_template_nii_1mm.header.get_zooms() == (1.0, 1.0, 1.0)
@@ -168,8 +168,8 @@ def test_load_mni152_gm_template():
 
 def test_load_mni152_wm_template():
     # All subjects
-    wm_template_nii_1mm = struct.load_mni152_wm_template(resolution=1)
-    wm_template_nii_2mm = struct.load_mni152_wm_template()
+    wm_template_nii_1mm = struct.load_mni152_wm_template()
+    wm_template_nii_2mm = struct.load_mni152_wm_template(resolution=2)
     assert wm_template_nii_1mm.shape == (197, 233, 189)
     assert wm_template_nii_2mm.shape == (99, 117, 95)
     assert wm_template_nii_1mm.header.get_zooms() == (1.0, 1.0, 1.0)
@@ -177,8 +177,8 @@ def test_load_mni152_wm_template():
 
 
 def test_load_mni152_brain_mask():
-    brain_mask_1mm = struct.load_mni152_brain_mask(resolution=1)
-    brain_mask_2mm = struct.load_mni152_brain_mask()
+    brain_mask_1mm = struct.load_mni152_brain_mask()
+    brain_mask_2mm = struct.load_mni152_brain_mask(resolution=2)
     assert isinstance(brain_mask_1mm, nibabel.Nifti1Image)
     assert isinstance(brain_mask_2mm, nibabel.Nifti1Image)
     # standard MNI template shape
@@ -187,8 +187,8 @@ def test_load_mni152_brain_mask():
 
 
 def test_load_mni152_gm_mask():
-    gm_mask_1mm = struct.load_mni152_gm_mask(resolution=1)
-    gm_mask_2mm = struct.load_mni152_gm_mask()
+    gm_mask_1mm = struct.load_mni152_gm_mask()
+    gm_mask_2mm = struct.load_mni152_gm_mask(resolution=2)
     assert isinstance(gm_mask_1mm, nibabel.Nifti1Image)
     assert isinstance(gm_mask_2mm, nibabel.Nifti1Image)
     # standard MNI template shape
@@ -197,8 +197,8 @@ def test_load_mni152_gm_mask():
 
 
 def test_load_mni152_wm_mask():
-    wm_mask_1mm = struct.load_mni152_wm_mask(resolution=1)
-    wm_mask_2mm = struct.load_mni152_wm_mask()
+    wm_mask_1mm = struct.load_mni152_wm_mask()
+    wm_mask_2mm = struct.load_mni152_wm_mask(resolution=2)
     assert isinstance(wm_mask_1mm, nibabel.Nifti1Image)
     assert isinstance(wm_mask_2mm, nibabel.Nifti1Image)
     # standard MNI template shape

--- a/nilearn/datasets/tests/test_struct.py
+++ b/nilearn/datasets/tests/test_struct.py
@@ -206,26 +206,6 @@ def test_load_mni152_wm_mask():
     assert wm_mask_2mm.shape == (99, 117, 95)
 
 
-@pytest.mark.parametrize("part", ["_brain", "_gm", "_wm"])
-@pytest.mark.parametrize("kind", ["template", "mask"])
-def test_mni152_resolution_warnings(part, kind):
-    struct._MNI_RES_WARNING_ALREADY_SHOWN = False
-    if kind == "template" and part == "_brain":
-        part = ""
-    loader = getattr(struct, f"load_mni152{part}_{kind}")
-    try:
-        loader.cache_clear()
-    except AttributeError:
-        pass
-    with warnings.catch_warnings(record=True) as w:
-        loader(resolution=1)
-    assert len(w) == 0
-    with warnings.catch_warnings(record=True) as w:
-        loader()
-        loader()
-    assert len(w) == 1
-
-
 def test_fetch_icbm152_brain_gm_mask(tmp_path, request_mocker):
     dataset = struct.fetch_icbm152_2009(data_dir=str(tmp_path), verbose=0)
     struct.load_mni152_template().to_filename(dataset.gm)

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -631,24 +631,24 @@ def index_img(imgs, index):
      >>> joint_mni_image = concat_imgs([datasets.load_mni152_template(),
      ...                                datasets.load_mni152_template()])
      >>> print(joint_mni_image.shape)
-     (99, 117, 95, 2)
+     (197, 233, 189, 2)
 
     We can now select one slice from the last dimension of this 4D-image::
 
      >>> single_mni_image = index_img(joint_mni_image, 1)
      >>> print(single_mni_image.shape)
-     (99, 117, 95)
+     (197, 233, 189)
 
     We can also select multiple frames using the `slice` constructor::
 
      >>> five_mni_images = concat_imgs([datasets.load_mni152_template()] * 5)
      >>> print(five_mni_images.shape)
-     (99, 117, 95, 5)
+     (197, 233, 189, 5)
 
      >>> first_three_images = index_img(five_mni_images,
      ...                                slice(0, 3))
      >>> print(first_three_images.shape)
-     (99, 117, 95, 3)
+     (197, 233, 189, 3)
 
     """
     imgs = check_niimg_4d(imgs)

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -131,7 +131,7 @@ def coord_transform(x, y, z, affine):
         >>> niimg = datasets.load_mni152_template()
         >>> # Find the MNI coordinates of the voxel (50, 50, 50)
         >>> image.coord_transform(50, 50, 50, niimg.affine)
-        (2.0, -34.0, 28.0)
+        (-48.0, -84.0, -22.0)
 
     """
     squeeze = (not hasattr(x, '__iter__'))

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -125,21 +125,6 @@ def test_butterworth():
     # single timeseries
     data = rng.standard_normal(size=n_samples)
     data_original = data.copy()
-    '''
-    May be only on py3.5:
-    Bug in scipy 1.1.0 generates an unavoidable FutureWarning.
-    (More info: https://github.com/scipy/scipy/issues/9086)
-    The number of warnings generated is overwhelming TravisCI's log limit,
-     causing it to fail tests.
-     This hack prevents that and will be removed in future.
-    '''
-    buggy_scipy = (
-        _compare_version(scipy.__version__, '<', '1.2')
-        and _compare_version(scipy.__version__, '>', '1.0')
-    )
-    if buggy_scipy:
-        warnings.simplefilter('ignore')
-    ''' END HACK '''
     out_single = nisignal.butterworth(data, sampling,
                                       low_pass=low_pass, high_pass=high_pass,
                                       copy=True)


### PR DESCRIPTION
This is to remove some future warnings that won't be relevant in v `0.10`.

Changes:

- Loading MNI152 templates now defaults to 1mm resolution
  - Updated tests and docs
- Removed old scipy bug hack that doesn't seem relevant anymore. We don't support the scipy version it checks for