### PR TITLE
[FIX] Combine positive and negative cluster labels for two sided permutation tests 

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -21,6 +21,7 @@ Fixes
 - Description of the ``opening`` parameter added to ``compute_multi_epi_mask`` docs (:gh:`3412` by `Natasha Clarke`_).
 - Fix display of colorbar in matrix plots. Colorbar was overlapping in :func:`~matplotlib.pyplot.subplots` due to a hardcoded adjustment value in the subplot (:gh:`3403` by `Raphael Meudec`_).
 - Pass values with correct type to scikit-learn estimator parameters and remove deprecated parameter (:gh:`3430` by `Yasmin Mzayek`_).
+- Fix cluster labeling for two-sided cluster level permutation tests in :func:`~mass_univariate.permuted_least_squares.permuted_ols` and associated function test :func:`~mass_univariate.tests.test_permuted_least_squares.test_cluster_level_parameters_smoke` (:gh:`3436` by `Jelle Roelof Dalenberg`_).
 
 Enhancements
 ------------

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -102,6 +102,8 @@
 
 .. _Jean-Rémi King: https://github.com/kingjr
 
+.. _Jelle Roelof Dalenberg: https://github.com/jrdalenberg
+
 .. _Jeremy Lefort-Besnard: https://jlefortbesnard.github.io/
 
 .. _Jerome Dockes: https://jeromedockes.github.io/

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -908,7 +908,7 @@ def permuted_ols(
                     scores_original_data_3d < -threshold_t,
                     bin_struct,
                 )
-                n_negative_clusters = np.max(temp_labeled_arr3d) 
+                n_negative_clusters = np.max(temp_labeled_arr3d)
                 labeled_arr3d[labeled_arr3d > 0] += n_negative_clusters
                 labeled_arr3d = labeled_arr3d + temp_labeled_arr3d
                 del temp_labeled_arr3d

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -903,15 +903,13 @@ def permuted_ols(
             )
 
             if two_sided_test:
-                # Label positive and negative clusters separately
-                n_positive_clusters = np.max(labeled_arr3d)
+                # Add negative cluster labels
                 temp_labeled_arr3d, _ = label(
                     scores_original_data_3d < -threshold_t,
                     bin_struct,
                 )
-                temp_labeled_arr3d[
-                    temp_labeled_arr3d > threshold_t
-                ] += n_positive_clusters
+                n_negative_clusters = np.max(temp_labeled_arr3d) 
+                labeled_arr3d[labeled_arr3d > 0] += n_negative_clusters
                 labeled_arr3d = labeled_arr3d + temp_labeled_arr3d
                 del temp_labeled_arr3d
 

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -609,8 +609,10 @@ def test_cluster_level_parameters_smoke(random_state=0):
     ))
 
     columns = np.arange(0, voxel_vars.shape[1])
-    chosen_columns = np.random.choice(columns, size=125, p=[0.1, 0.1, 0.8]) # create 125 voxels
-    target_var = voxel_vars[:, chosen_columns]  # corresponds to 5 x 5 x 5 x 10 niimg
+    # create 125 voxels
+    chosen_columns = rng.choice(columns, size=125, p=[0.1, 0.1, 0.8])
+    # corresponds to 5 x 5 x 5 x 10 niimg
+    target_var = voxel_vars[:, chosen_columns]
     tested_var = np.arange(0, 20, 2)
 
     mask_img = nib.Nifti1Image(np.ones((5, 5, 5)), np.eye(4))

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -598,7 +598,7 @@ def test_cluster_level_parameters_smoke(random_state=0):
     import nibabel as nib
     from nilearn.maskers import NiftiMasker
 
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(random_state)
 
     # create design
     target_var1 = np.arange(0, 10).reshape((-1, 1))  # positive effect
@@ -609,7 +609,7 @@ def test_cluster_level_parameters_smoke(random_state=0):
     ))
 
     columns = np.arange(0, voxel_vars.shape[1])
-    chosen_columns = random.choices(columns, k=125, weights=[1, 1, 5]) # create 125 voxels
+    chosen_columns = np.random.choice(columns, size=125, p=[0.1, 0.1, 0.8]) # create 125 voxels
     target_var = voxel_vars[:, chosen_columns]  # corresponds to 5 x 5 x 5 x 10 niimg
     tested_var = np.arange(0, 20, 2)
 

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -604,7 +604,7 @@ def test_cluster_level_parameters_smoke(random_state=0):
 
     # create design
     target_var1 = np.arange(0, 10).reshape((-1, 1))  # positive effect
-    voxel_vars = np.hstack(( 
+    voxel_vars = np.hstack((
         -target_var1, # negative effect
         target_var1, # positive effect
         np.random.random((10, 1)), # random voxel

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -595,7 +595,6 @@ def test_tfce_smoke(random_state=0):
 
 def test_cluster_level_parameters_smoke(random_state=0):
     """Test combinations of parameters related to cluster-level inference."""
-    import random
     import nibabel as nib
     from nilearn.maskers import NiftiMasker
 

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -603,9 +603,9 @@ def test_cluster_level_parameters_smoke(random_state=0):
     # create design
     target_var1 = np.arange(0, 10).reshape((-1, 1))  # positive effect
     voxel_vars = np.hstack((
-        -target_var1, # negative effect
-        target_var1, # positive effect
-        np.random.random((10, 1)), # random voxel
+        -target_var1,  # negative effect
+        target_var1,  # positive effect
+        rng.random((10, 1)),  # random voxel
     ))
 
     columns = np.arange(0, voxel_vars.shape[1])

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -598,8 +598,7 @@ def test_cluster_level_parameters_smoke(random_state=0):
     import nibabel as nib
     from nilearn.maskers import NiftiMasker
 
-    random.seed(random_state)
-    np.random.seed(random_state)
+    rng = np.random.RandomState(0)
 
     # create design
     target_var1 = np.arange(0, 10).reshape((-1, 1))  # positive effect

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -600,6 +600,7 @@ def test_cluster_level_parameters_smoke(random_state=0):
     from nilearn.maskers import NiftiMasker
 
     random.seed(random_state)
+    np.random.seed(random_state)
 
     # create design
     target_var1 = np.arange(0, 10).reshape((-1, 1))  # positive effect

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -595,19 +595,26 @@ def test_tfce_smoke(random_state=0):
 
 def test_cluster_level_parameters_smoke(random_state=0):
     """Test combinations of parameters related to cluster-level inference."""
+    import random
     import nibabel as nib
     from nilearn.maskers import NiftiMasker
 
+    random.seed(random_state)
+
     # create design
     target_var1 = np.arange(0, 10).reshape((-1, 1))  # positive effect
-    target_var = np.hstack((  # corresponds to 3 x 3 x 3 x 10 niimg
-        target_var1,  # voxel 1 has positive effect
-        - target_var1,  # voxel 2 has negative effect
-        np.random.random((10, 25)),  # 25 remaining voxels
+    voxel_vars = np.hstack(( 
+        -target_var1, # negative effect
+        target_var1, # positive effect
+        np.random.random((10, 1)), # random voxel
     ))
+
+    columns = np.arange(0, voxel_vars.shape[1])
+    chosen_columns = random.choices(columns, k=125, weights=[1, 1, 5]) # create 125 voxels
+    target_var = voxel_vars[:, chosen_columns]  # corresponds to 5 x 5 x 5 x 10 niimg
     tested_var = np.arange(0, 20, 2)
 
-    mask_img = nib.Nifti1Image(np.ones((3, 3, 3)), np.eye(4))
+    mask_img = nib.Nifti1Image(np.ones((5, 5, 5)), np.eye(4))
     masker = NiftiMasker(mask_img)
     masker.fit(mask_img)
 


### PR DESCRIPTION
This addresses the bug report in #3435. 