### PR TITLE
[DOC] Note that Masker.inverse_transform only performs spatial unmasking in docstring

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -16,10 +16,7 @@ Fixes
 Enhancements
 ------------
 
-- :func:`~signal.clean` imputes scrubbed volumes (defined through ``sample_masks``) with cubic spline function before applying butterworth filter (:gh:`3385` by `Hao-Ting Wang`_). 
-- As part of making the User Guide more user-friendly, the introduction was reworked (:gh:`3380` by `Alexis Thual`_)
-- Added instructions for maintainers to make sure LaTeX dependencies are installed before building and deploying the stable docs (:gh:`3426` by `Yasmin Mzayek`_).
-- Addition to docs to note that :meth:`~maskers.BaseMasker.inverse_transform` only performs spatial unmasking (:gh: `3445` by `Robert Williamson`_).
+- Addition to docs to note that :meth:`~maskers.BaseMasker.inverse_transform` only performs spatial unmasking (:gh:`3445` by `Robert Williamson`_).
 
 Changes
 -------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -16,5 +16,10 @@ Fixes
 Enhancements
 ------------
 
+- :func:`~signal.clean` imputes scrubbed volumes (defined through ``sample_masks``) with cubic spline function before applying butterworth filter (:gh:`3385` by `Hao-Ting Wang`_). 
+- As part of making the User Guide more user-friendly, the introduction was reworked (:gh:`3380` by `Alexis Thual`_)
+- Added instructions for maintainers to make sure LaTeX dependencies are installed before building and deploying the stable docs (:gh:`3426` by `Yasmin Mzayek`_).
+- Addition to docs to note that Masker.inverse_transform only performs spatial unmasking (:gh: `3445` by `Robert Williamson`_).
+
 Changes
 -------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -19,7 +19,7 @@ Enhancements
 - :func:`~signal.clean` imputes scrubbed volumes (defined through ``sample_masks``) with cubic spline function before applying butterworth filter (:gh:`3385` by `Hao-Ting Wang`_). 
 - As part of making the User Guide more user-friendly, the introduction was reworked (:gh:`3380` by `Alexis Thual`_)
 - Added instructions for maintainers to make sure LaTeX dependencies are installed before building and deploying the stable docs (:gh:`3426` by `Yasmin Mzayek`_).
-- Addition to docs to note that Masker.inverse_transform only performs spatial unmasking (:gh: `3445` by `Robert Williamson`_).
+- Addition to docs to note that :meth:`~maskers.BaseMasker.inverse_transform` only performs spatial unmasking (:gh: `3445` by `Robert Williamson`_).
 
 Changes
 -------

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -327,7 +327,8 @@ Inverse transform: unmasking data
 
 .. note::
 
-  Inverse transform only performs spatial unmasking. 
+  Inverse transform only performs spatial unmasking.
+  The data is only brought back into either a 3D or 4D represnetaion.
 
 Once voxel signals have been processed, the result can be visualized as
 images after unmasking (masked-reduced data transformed back into

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -328,7 +328,7 @@ Inverse transform: unmasking data
 .. note::
 
   Inverse transform only performs spatial unmasking.
-  The data is only brought back into either a 3D or 4D represnetaion.
+  The data is only brought back into either a 3D or 4D represenetation.
 
 Once voxel signals have been processed, the result can be visualized as
 images after unmasking (masked-reduced data transformed back into

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -325,6 +325,10 @@ is explained in details in :ref:`resampling`.
 Inverse transform: unmasking data
 ---------------------------------
 
+.. note::
+
+  Inverse transform only performs spatial unmasking. 
+
 Once voxel signals have been processed, the result can be visualized as
 images after unmasking (masked-reduced data transformed back into
 the original whole-brain space). This step is present in many

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -328,7 +328,8 @@ Inverse transform: unmasking data
 .. note::
 
   Inverse transform only performs spatial unmasking.
-  The data is only brought back into either a 3D or 4D represenetation.
+  The data is only brought back into either a 3D or 4D represenetation,
+  without inverting any signal processing performed by 'transform'.
 
 Once voxel signals have been processed, the result can be visualized as
 images after unmasking (masked-reduced data transformed back into

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -329,7 +329,7 @@ Inverse transform: unmasking data
 
   Inverse transform only performs spatial unmasking.
   The data is only brought back into either a 3D or 4D represenetation,
-  without inverting any signal processing performed by 'transform'.
+  without inverting any signal processing performed by ``transform``.
 
 Once voxel signals have been processed, the result can be visualized as
 images after unmasking (masked-reduced data transformed back into

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -306,7 +306,9 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
                                                         )
 
     def inverse_transform(self, X):
-        """ Transform the 2D data matrix back to an image in brain space, only performs spatial unmasking.
+        """ Transform the 2D data matrix back to an image in brain space.
+
+        Only performs spatial unmasking.
 
         Parameters
         ----------

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -306,7 +306,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
                                                         )
 
     def inverse_transform(self, X):
-        """ Transform the 2D data matrix back to an image in brain space.
+        """ Transform the 2D data matrix back to an image in brain space, only performs spatial unmasking.
 
         Parameters
         ----------

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -308,7 +308,9 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
     def inverse_transform(self, X):
         """ Transform the 2D data matrix back to an image in brain space.
 
-        Only performs spatial unmasking.
+        This step only performs spatial unmasking,
+        without inverting any additional processing performed by ``transform``,
+        such as temporal filtering or smoothing. 
 
         Parameters
         ----------


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3416 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Adds a note to inverse transform section, stating that it only performs spatial unmasking
