### PR TITLE
[FIX] Nibabel Nifti1Image class now requires `header` or `dtype` arguments for int64 data

### DIFF
--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -521,7 +521,7 @@ def test_new_img_like_int64():
     assert image.get_data(new_img).dtype == "int32"
     data[:] = 2**40
     with pytest.warns(UserWarning, match=r".*64.*too large.*"):
-        new_img = new_img_like(img, data)
+        new_img = new_img_like(img, data, copy_header=True)
     assert image.get_data(new_img).dtype == "int64"
 
 

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -835,7 +835,7 @@ def test_resampling_with_int_types_no_crash(dtype):
     resample_img(img, target_affine=2. * affine)
 
 
-@pytest.mark.parametrize("dtype", ["int64", "uint64", "<i8", ">i8", int])
+@pytest.mark.parametrize("dtype", ["int64", "uint64", "<i8", ">i8"])
 @pytest.mark.parametrize("no_int64_nifti", ["allow for this test"])
 def test_resampling_with_int64_types_no_crash(dtype):
     affine = np.eye(4)
@@ -843,6 +843,7 @@ def test_resampling_with_int64_types_no_crash(dtype):
     # Passing dtype or header is required when using int64
     # https://nipy.org/nibabel/changelog.html#api-changes-and-deprecations
     hdr = Nifti1Header()
+    hdr.set_data_dtype(dtype)
     img = Nifti1Image(data.astype(dtype), affine, header=hdr)
     resample_img(img, target_affine=2. * affine)
 

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -835,12 +835,12 @@ def test_resampling_with_int_types_no_crash(dtype):
     resample_img(img, target_affine=2. * affine)
 
 
-@pytest.mark.parametrize("dtype", ["int64", "uint64", "<i8", ">i8", int])
+@pytest.mark.parametrize("dtype", ["int64", "uint64", "<i8", ">i8"])
 @pytest.mark.parametrize("no_int64_nifti", ["allow for this test"])
 def test_resampling_with_int64_types_no_crash(dtype):
     affine = np.eye(4)
     data = np.zeros((2, 2, 2))
-    img = Nifti1Image(data.astype(dtype), affine)
+    img = Nifti1Image(data.astype(dtype), affine, dtype=dtype)
     resample_img(img, target_affine=2. * affine)
 
 

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -12,7 +12,7 @@ from numpy.testing import (assert_almost_equal,
 import numpy as np
 import pytest
 
-from nibabel import Nifti1Image
+from nibabel import Nifti1Image, Nifti1Header
 
 from nilearn import _utils
 from nilearn.image.resampling import resample_img, resample_to_img, reorder_img
@@ -835,12 +835,15 @@ def test_resampling_with_int_types_no_crash(dtype):
     resample_img(img, target_affine=2. * affine)
 
 
-@pytest.mark.parametrize("dtype", ["int64", "uint64", "<i8", ">i8"])
+@pytest.mark.parametrize("dtype", ["int64", "uint64", "<i8", ">i8", int])
 @pytest.mark.parametrize("no_int64_nifti", ["allow for this test"])
 def test_resampling_with_int64_types_no_crash(dtype):
     affine = np.eye(4)
     data = np.zeros((2, 2, 2))
-    img = Nifti1Image(data.astype(dtype), affine, dtype=dtype)
+    # Passing dtype or header is required when using int64
+    # https://nipy.org/nibabel/reference/nibabel.nifti1.html#nibabel.nifti1.Nifti1Header.set_data_dtype
+    hdr = Nifti1Header()
+    img = Nifti1Image(data.astype(dtype), affine, header=hdr)
     resample_img(img, target_affine=2. * affine)
 
 

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -841,7 +841,7 @@ def test_resampling_with_int64_types_no_crash(dtype):
     affine = np.eye(4)
     data = np.zeros((2, 2, 2))
     # Passing dtype or header is required when using int64
-    # https://nipy.org/nibabel/reference/nibabel.nifti1.html#nibabel.nifti1.Nifti1Header.set_data_dtype
+    # https://nipy.org/nibabel/changelog.html#api-changes-and-deprecations
     hdr = Nifti1Header()
     img = Nifti1Image(data.astype(dtype), affine, header=hdr)
     resample_img(img, target_affine=2. * affine)

--- a/nilearn/tests/test_niimg.py
+++ b/nilearn/tests/test_niimg.py
@@ -52,7 +52,7 @@ def test_get_target_dtype():
 
     hdr = Nifti1Header()
     data = np.ones((2, 2, 2), dtype=np.int64)
-    img2 = Nifti1Image(data, dtype=np.int64, affine=np.eye(4), header=hdr)
+    img2 = Nifti1Image(data, affine=np.eye(4), header=hdr)
     assert get_data(img2).dtype.kind == 'i'
     dtype_kind_int = niimg._get_target_dtype(get_data(img2).dtype,
                                              target_dtype='auto')

--- a/nilearn/tests/test_niimg.py
+++ b/nilearn/tests/test_niimg.py
@@ -55,7 +55,7 @@ def test_get_target_dtype():
     hdr.set_data_dtype(np.int64)
     data = np.ones((2, 2, 2), dtype=np.int64)
     img2 = Nifti1Image(data, affine=np.eye(4), header=hdr)
-    assert get_data(img2).dtype.kind == 'i'
+    assert get_data(img2).dtype.kind == img2.get_data_dtype().kind == 'i'
     dtype_kind_int = niimg._get_target_dtype(get_data(img2).dtype,
                                              target_dtype='auto')
     assert dtype_kind_int == np.int32

--- a/nilearn/tests/test_niimg.py
+++ b/nilearn/tests/test_niimg.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import joblib
 import nibabel as nb
 import pytest
-from nibabel import Nifti1Image
+from nibabel import Nifti1Image, Nifti1Header
 from nibabel.tmpdirs import InTemporaryDirectory
 
 from nilearn.image import new_img_like
@@ -50,8 +50,9 @@ def test_get_target_dtype():
                                                target_dtype='auto')
     assert dtype_kind_float == np.float32
 
+    hdr = Nifti1Header()
     data = np.ones((2, 2, 2), dtype=np.int64)
-    img2 = Nifti1Image(data, dtype=np.int64, affine=np.eye(4))
+    img2 = Nifti1Image(data, dtype=np.int64, affine=np.eye(4), header=hdr)
     assert get_data(img2).dtype.kind == 'i'
     dtype_kind_int = niimg._get_target_dtype(get_data(img2).dtype,
                                              target_dtype='auto')
@@ -66,12 +67,13 @@ def test_img_data_dtype():
         np.int8, np.int16, np.int32,
         np.float32, np.float64)
     dtype_matches = []
+    hdr = Nifti1Header()
     with InTemporaryDirectory():
         rng = np.random.RandomState(42)
         for logical_dtype in nifti1_dtypes:
             dataobj = rng.uniform(0, 255, (2, 2, 2)).astype(logical_dtype)
             for on_disk_dtype in nifti1_dtypes:
-                img = Nifti1Image(dataobj, np.eye(4), dtype=on_disk_dtype)
+                img = Nifti1Image(dataobj, np.eye(4), header=hdr)
                 img.set_data_dtype(on_disk_dtype)
                 img.to_filename('test.nii')
                 loaded = nb.load('test.nii')

--- a/nilearn/tests/test_niimg.py
+++ b/nilearn/tests/test_niimg.py
@@ -50,7 +50,8 @@ def test_get_target_dtype():
                                                target_dtype='auto')
     assert dtype_kind_float == np.float32
 
-    img2 = Nifti1Image(np.ones((2, 2, 2), dtype=np.int64), affine=np.eye(4))
+    data = np.ones((2, 2, 2), dtype=np.int64)
+    img2 = Nifti1Image(data, dtype=np.int64, affine=np.eye(4))
     assert get_data(img2).dtype.kind == 'i'
     dtype_kind_int = niimg._get_target_dtype(get_data(img2).dtype,
                                              target_dtype='auto')
@@ -70,7 +71,7 @@ def test_img_data_dtype():
         for logical_dtype in nifti1_dtypes:
             dataobj = rng.uniform(0, 255, (2, 2, 2)).astype(logical_dtype)
             for on_disk_dtype in nifti1_dtypes:
-                img = Nifti1Image(dataobj, np.eye(4))
+                img = Nifti1Image(dataobj, np.eye(4), dtype=on_disk_dtype)
                 img.set_data_dtype(on_disk_dtype)
                 img.to_filename('test.nii')
                 loaded = nb.load('test.nii')

--- a/nilearn/tests/test_niimg.py
+++ b/nilearn/tests/test_niimg.py
@@ -49,7 +49,8 @@ def test_get_target_dtype():
     dtype_kind_float = niimg._get_target_dtype(get_data(img).dtype,
                                                target_dtype='auto')
     assert dtype_kind_float == np.float32
-
+    # Passing dtype or header is required when using int64
+    # https://nipy.org/nibabel/changelog.html#api-changes-and-deprecations
     hdr = Nifti1Header()
     data = np.ones((2, 2, 2), dtype=np.int64)
     img2 = Nifti1Image(data, affine=np.eye(4), header=hdr)
@@ -67,6 +68,8 @@ def test_img_data_dtype():
         np.int8, np.int16, np.int32,
         np.float32, np.float64)
     dtype_matches = []
+    # Passing dtype or header is required when using int64
+    # https://nipy.org/nibabel/changelog.html#api-changes-and-deprecations
     hdr = Nifti1Header()
     with InTemporaryDirectory():
         rng = np.random.RandomState(42)

--- a/nilearn/tests/test_niimg.py
+++ b/nilearn/tests/test_niimg.py
@@ -52,6 +52,7 @@ def test_get_target_dtype():
     # Passing dtype or header is required when using int64
     # https://nipy.org/nibabel/changelog.html#api-changes-and-deprecations
     hdr = Nifti1Header()
+    hdr.set_data_dtype(np.int64)
     data = np.ones((2, 2, 2), dtype=np.int64)
     img2 = Nifti1Image(data, affine=np.eye(4), header=hdr)
     assert get_data(img2).dtype.kind == 'i'
@@ -76,8 +77,8 @@ def test_img_data_dtype():
         for logical_dtype in nifti1_dtypes:
             dataobj = rng.uniform(0, 255, (2, 2, 2)).astype(logical_dtype)
             for on_disk_dtype in nifti1_dtypes:
+                hdr.set_data_dtype(on_disk_dtype)
                 img = Nifti1Image(dataobj, np.eye(4), header=hdr)
-                img.set_data_dtype(on_disk_dtype)
                 img.to_filename('test.nii')
                 loaded = nb.load('test.nii')
                 # To verify later that sometimes these differ meaningfully


### PR DESCRIPTION
Resolves failures on tests using dtype int64 data arrays. See https://github.com/nilearn/nilearn/actions/runs/3881843135/
From nibabel changelog: Passing an int64 array to [Nifti1Image](https://nipy.org/nibabel/reference/nibabel.nifti1.html#nibabel.nifti1.Nifti1Image) without a header or dtype argument will raise a `ValueError`
