### PR TITLE
FIX: `resample_img()` compatibility with non-NIfTI images

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -11,7 +11,7 @@ NEW
 Fixes
 -----
 
-- :func:`~image.resampling.resample_img` compatibility with non-NIfTI images (:gh:`3462` by `Mathias Goncalves`_).
+- :func:`~image.resample_img` compatibility with non-NIfTI images (:gh:`3462` by `Mathias Goncalves`_).
 
 Enhancements
 ------------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -11,7 +11,7 @@ NEW
 Fixes
 -----
 
-- :func:`~image.resample_img` compatibility with non-NIfTI images (:gh:`3462` by `Mathias Goncalves`_).
+- Restore :func:`~image.resample_img` compatibility with all :class:`nibabel.spatialimages.SpatialImage` objects (:gh:`3462` by `Mathias Goncalves`_).
 
 Enhancements
 ------------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -11,6 +11,8 @@ NEW
 Fixes
 -----
 
+- :func:`~image.resampling.resample_img` compatibility with non-NIfTI images (:gh:`3462` by `Mathias Goncalves`_).
+
 Enhancements
 ------------
 

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -142,6 +142,8 @@
 
 .. _Manon Pietrantoni: https://github.com/ManonP38
 
+.. _Mathias Goncalves: https://github.com/mgxd
+
 .. _Matthias Ekman: https://github.com/mekman
 
 .. _Matthieu Joulot: https://github.com/MatthieuJoulot

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -448,11 +448,12 @@ def resample_img(img, target_affine=None, target_shape=None,
 
     # If later on we want to impute sform using qform add this condition
     # see : https://github.com/nilearn/nilearn/issues/3168#issuecomment-1159447771 # noqa:E501
-    sform, sform_code = img.get_sform(coded=True)
-    if not sform_code:
-        warnings.warn("The provided image has no sform in its header. "
-                      "Please check the provided file. "
-                      "Results may not be as expected.")
+    if hasattr(img, 'get_sform'):  # NIfTI images only
+        _, sform_code = img.get_sform(coded=True)
+        if not sform_code:
+            warnings.warn("The provided image has no sform in its header. "
+                        "Please check the provided file. "
+                        "Results may not be as expected.")
 
     # noop cases
     if target_affine is None and target_shape is None:

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -13,6 +13,7 @@ import numpy as np
 import pytest
 
 from nibabel import Nifti1Image, Nifti1Header
+from nibabel.freesurfer import MGHImage
 
 from nilearn import _utils
 from nilearn.image.resampling import resample_img, resample_to_img, reorder_img
@@ -859,3 +860,14 @@ def test_resample_input():
     with testing.write_tmp_imgs(img, create_files=True) as filename:
         filename = Path(filename)
         resample_img(filename, target_affine=affine, interpolation='nearest')
+
+
+def test_smoke_resampling_non_nifti():
+    rng = np.random.RandomState(42)
+    shape = (3, 2, 5, 2)
+    affine = np.eye(4)
+    target_affine = 2 * affine
+    data = rng.randint(0, 10, shape, dtype="int32")
+    img = MGHImage(data, affine)
+
+    resample_img(img, target_affine=target_affine, interpolation='nearest')


### PR DESCRIPTION
Closes #3461

This adds a guard to ensure the input image has the `get_sform()` method prior to calling it, and a quick test.