### PR TITLE
[ENH] Deprecate and replace `plot_epi` function name with `plot_fmri`

### DIFF
--- a/nilearn/plotting/__init__.py
+++ b/nilearn/plotting/__init__.py
@@ -46,7 +46,7 @@ _set_mpl_backend()
 ###############################################################################
 from . import cm
 from .img_plotting import (
-    plot_img, plot_anat, plot_epi, plot_roi, plot_stat_map,
+    plot_img, plot_anat, plot_fmri, plot_roi, plot_stat_map,
     plot_glass_brain, plot_connectome, plot_markers, plot_prob_atlas,
     plot_carpet, plot_img_comparison, show)
 from .find_cuts import find_xyz_cut_coords, find_cut_slices, \
@@ -59,7 +59,10 @@ from .html_connectome import view_connectome, view_markers
 from .surf_plotting import (plot_surf, plot_surf_stat_map, plot_surf_roi,
                             plot_img_on_surf, plot_surf_contours)
 
-__all__ = ['cm', 'plot_img', 'plot_anat', 'plot_epi',
+# alias for renamed function for backwards compatibility
+plot_epi = plot_fmri
+
+__all__ = ['cm', 'plot_img', 'plot_anat', 'plot_epi', 'plot_fmri',
            'plot_roi', 'plot_stat_map', 'plot_glass_brain',
            'plot_markers', 'plot_connectome', 'plot_prob_atlas',
            'find_xyz_cut_coords', 'find_cut_slices',

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -480,7 +480,7 @@ def plot_anat(anat_img=MNI152TEMPLATE, cut_coords=None,
 
 
 @fill_doc
-def plot_epi(epi_img=None, cut_coords=None, output_file=None,
+def plot_fmri(epi_img=None, cut_coords=None, output_file=None,
              display_mode='ortho', figure=None, axes=None, title=None,
              annotate=True, draw_cross=True, black_bg=True,
              colorbar=False, cbar_tick_format="%.2g",


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3388 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Change name of `plot_epi` function to `plot_fmri`

TODO: 
- [ ] Add deprecation warning
- [ ] Add versionchanged directive
- [ ] Replace name where function is used
- [ ] Change parameter `epi_img` name?
- [ ] Adapt docstring