### PR TITLE
[WIP] ENH: Add draft coordinate image API as nilearn.coordimage

### DIFF
--- a/nilearn/coordimage/caretspec.py
+++ b/nilearn/coordimage/caretspec.py
@@ -1,0 +1,213 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+"""Read / write access to CaretSpecFile format
+
+The format of CaretSpecFiles does not seem to have any independent
+documentation.
+
+Code can be found here [0], and a DTD was worked out in this email thread [1].
+
+[0]: https://github.com/Washington-University/workbench/tree/master/src/Files
+[1]: https://groups.google.com/a/humanconnectome.org/g/hcp-users/c/EGuwdaTVFuw/m/tg7a_-7mAQAJ
+"""
+import xml.etree.ElementTree as et
+from urllib.parse import urlparse
+
+import nibabel as nib
+from nibabel import xmlutils as xml
+from nibabel.caret import CaretMetaData
+
+from nilearn.coordimage import pointset as ps
+
+
+class CaretSpecDataFile(xml.XmlSerializable):
+    """DataFile
+
+    * Attributes
+
+        * Structure - A string from the BrainStructure list to identify
+          what structure this element refers to (usually left cortex,
+          right cortex, or cerebellum).
+        * DataFileType - A string from the DataFileType list
+        * Selected - A boolean
+
+    * Child Elements: [NA]
+    * Text Content: A URI
+    * Parent Element - CaretSpecFile
+
+    Attributes
+    ----------
+    structure : str
+        Name of brain structure
+    data_file_type : str
+        Type of data file
+    selected : bool
+        Used for workbench internals
+    uri : str
+        URI of data file
+    """
+
+    def __init__(self, structure=None, data_file_type=None, selected=None, uri=None):
+        super().__init__()
+        self.structure = structure
+        self.data_file_type = data_file_type
+        self.selected = selected
+        self.uri = uri
+
+        if data_file_type == 'SURFACE':
+            self.__class__ = SurfaceDataFile
+
+    def _to_xml_element(self):
+        data_file = xml.Element('DataFile')
+        data_file.attrib['Structure'] = str(self.structure)
+        data_file.attrib['DataFileType'] = str(self.data_file_type)
+        data_file.attrib['Selected'] = 'true' if self.selected else 'false'
+        data_file.text = self.uri
+        return data_file
+
+    def __repr__(self):
+        return self.to_xml().decode()
+
+
+class SurfaceDataFile(ps.TriangularMesh, CaretSpecDataFile):
+    _gifti = None
+    _coords = None
+    _triangles = None
+
+    def _get_gifti(self):
+        if self._gifti is None:
+            parts = urlparse(self.uri)
+            if parts.scheme == 'file':
+                self._gifti = nib.GiftiImage.from_filename(parts.path)
+            elif parts.scheme == '':
+                self._gifti = nib.GiftiImage.from_filename(self.uri)
+            else:
+                # Note, this requires nibabel 5
+                self._gifti = nib.GiftiImage.from_url(self.uri)
+        return self._gifti
+
+    def get_triangles(self, name=None):
+        if self._triangles is None:
+            gifti = self._get_gifti()
+            self._triangles = gifti.agg_data('triangle')
+        return self._triangles
+
+    def get_coords(self, name=None):
+        if self._coords is None:
+            gifti = self._get_gifti()
+            self._coords = gifti.agg_data('pointset')
+        return self._coords
+
+
+class CaretSpecFile(xml.XmlSerializable):
+    """Class for CaretSpecFile XML documents
+
+    These are used to identify related surfaces and volumes for use with CIFTI-2
+    data files.
+    """
+
+    def __init__(self, metadata=None, data_files=(), version='1.0'):
+        super().__init__()
+        if metadata is not None:
+            metadata = CaretMetaData(metadata)
+        self.metadata = metadata
+        self.data_files = list(data_files)
+        self.version = version
+
+    def _to_xml_element(self):
+        caret_spec = xml.Element('CaretSpecFile')
+        caret_spec.attrib['Version'] = str(self.version)
+        if self.metadata is not None:
+            caret_spec.append(self.metadata._to_xml_element())
+        for data_file in self.data_files:
+            caret_spec.append(data_file._to_xml_element())
+        return caret_spec
+
+    def to_xml(self, enc='UTF-8', **kwargs):
+        ele = self._to_xml_element()
+        et.indent(ele, '    ')
+        return et.tostring(ele, enc, xml_declaration=True, short_empty_elements=False, **kwargs)
+
+    def __eq__(self, other):
+        return self.to_xml() == other.to_xml()
+
+    @classmethod
+    def from_filename(klass, fname, **kwargs):
+        parser = CaretSpecParser(**kwargs)
+        with open(fname, 'rb') as fobj:
+            parser.parse(fptr=fobj)
+        return parser.caret_spec
+
+
+class CaretSpecParser(xml.XmlParser):
+    def __init__(self, encoding=None, buffer_size=3500000, verbose=0):
+        super().__init__(encoding=encoding, buffer_size=buffer_size, verbose=verbose)
+        self.struct_state = []
+
+        self.caret_spec = None
+
+        # where to write CDATA:
+        self.write_to = None
+
+        # Collecting char buffer fragments
+        self._char_blocks = []
+
+    def StartElementHandler(self, name, attrs):
+        self.flush_chardata()
+        if name == 'CaretSpecFile':
+            self.caret_spec = CaretSpecFile(version=attrs['Version'])
+        elif name == 'MetaData':
+            self.caret_spec.metadata = CaretMetaData()
+        elif name == 'MD':
+            self.struct_state.append({})
+        elif name in ('Name', 'Value'):
+            self.write_to = name
+        elif name == 'DataFile':
+            selected_map = {'true': True, 'false': False}
+            data_file = CaretSpecDataFile(
+                structure=attrs['Structure'],
+                data_file_type=attrs['DataFileType'],
+                selected=selected_map[attrs['Selected']],
+            )
+            self.caret_spec.data_files.append(data_file)
+            self.struct_state.append(data_file)
+            self.write_to = 'DataFile'
+
+    def EndElementHandler(self, name):
+        self.flush_chardata()
+        if name == 'MD':
+            MD = self.struct_state.pop()
+            self.caret_spec.metadata[MD['Name']] = MD['Value']
+        elif name in ('Name', 'Value'):
+            self.write_to = None
+        elif name == 'DataFile':
+            self.struct_state.pop()
+            self.write_to = None
+
+    def CharacterDataHandler(self, data):
+        """Collect character data chunks pending collation
+
+        The parser breaks the data up into chunks of size depending on the
+        buffer_size of the parser.  A large bit of character data, with standard
+        parser buffer_size (such as 8K) can easily span many calls to this
+        function.  We thus collect the chunks and process them when we hit start
+        or end tags.
+        """
+        if self._char_blocks is None:
+            self._char_blocks = []
+        self._char_blocks.append(data)
+
+    def flush_chardata(self):
+        """Collate and process collected character data"""
+        if self._char_blocks is None:
+            return
+
+        data = ''.join(self._char_blocks).strip()
+        # Reset the char collector
+        self._char_blocks = None
+        # Process data
+        if self.write_to in ('Name', 'Value'):
+            self.struct_state[-1][self.write_to] = data
+
+        elif self.write_to == 'DataFile':
+            self.struct_state[-1].uri = data

--- a/nilearn/coordimage/coordimage.py
+++ b/nilearn/coordimage/coordimage.py
@@ -1,0 +1,186 @@
+import numpy as np
+
+import nibabel as nib
+from nibabel.fileslice import fill_slicer
+
+import nilearn.coordimage.pointset as ps
+
+
+class CoordinateImage:
+    """
+    Attributes
+    ----------
+    header : a file-specific header
+    coordaxis : ``CoordinateAxis``
+    dataobj : array-like
+    """
+
+    def __init__(self, data, coordaxis, header=None):
+        self.data = data
+        self.coordaxis = coordaxis
+        self.header = header
+
+    @property
+    def shape(self):
+        return self.data.shape
+
+    def __getitem__(self, slicer):
+        if isinstance(slicer, str):
+            slicer = self.coordaxis.get_indices(slicer)
+        elif isinstance(slicer, list):
+            slicer = np.hstack([self.coordaxis.get_indices(sub) for sub in slicer])
+
+        if isinstance(slicer, range):
+            slicer = slice(slicer.start, slicer.stop, slicer.step)
+
+        data = self.data
+        if not isinstance(slicer, slice):
+            data = np.asanyarray(data)
+        return self.__class__(data[slicer], self.coordaxis[slicer], header=self.header.copy())
+
+    @classmethod
+    def from_image(klass, img):
+        coordaxis = CoordinateAxis.from_header(img.header)
+        if isinstance(img, nib.Cifti2Image):
+            if img.ndim != 2:
+                raise ValueError('Can only interpret 2D images')
+            for i in img.header.mapped_indices:
+                if isinstance(img.header.get_axis(i), nib.cifti2.BrainModelAxis):
+                    break
+            # Reinterpret data ordering based on location of coordinate axis
+            data = img.dataobj.copy()
+            data.order = ['F', 'C'][i]
+            if i == 1:
+                data._shape = data._shape[::-1]
+        return klass(data, coordaxis, img.header)
+
+
+class CoordinateAxis:
+    """
+    Attributes
+    ----------
+    parcels : list of ``Parcel`` objects
+    """
+
+    def __init__(self, parcels):
+        self.parcels = parcels
+
+    def load_structures(self, mapping):
+        """
+        Associate parcels to ``Pointset`` structures
+        """
+        raise NotImplementedError
+
+    def __getitem__(self, slicer):
+        """
+        Return a sub-sampled CoordinateAxis containing structures
+        matching the indices provided.
+        """
+        if slicer is Ellipsis or isinstance(slicer, slice) and slicer == slice(None):
+            return self
+        elif isinstance(slicer, slice):
+            slicer = fill_slicer(slicer, len(self))
+            start, stop, step = slicer.start, slicer.stop, slicer.step
+        else:
+            raise TypeError(f'Indexing type not supported: {type(slicer)}')
+
+        subparcels = []
+        pstop = 0
+        for parcel in self.parcels:
+            pstart, pstop = pstop, pstop + len(parcel)
+            if pstop < start:
+                continue
+            if pstart >= stop:
+                break
+            if start < pstart:
+                substart = (start - pstart) % step
+            else:
+                substart = start - pstart
+            subparcels.append(parcel[substart : stop - pstart : step])
+        return CoordinateAxis(subparcels)
+
+    def get_indices(self, parcel, indices=None):
+        """
+        Return the indices in the full axis that correspond to the
+        requested parcel. If indices are provided, further subsample
+        the requested parcel.
+        """
+        subseqs = []
+        idx = 0
+        for p in self.parcels:
+            if p.name == parcel:
+                subseqs.append(range(idx, idx + len(p)))
+            idx += len(p)
+        if not subseqs:
+            return ()
+        if indices:
+            return np.hstack(subseqs)[indices]
+        if len(subseqs) == 1:
+            return subseqs[0]
+        return np.hstack(subseqs)
+
+    def __len__(self):
+        return sum(len(parcel) for parcel in self.parcels)
+
+    # Hacky factory method for now
+    @classmethod
+    def from_header(klass, hdr):
+        parcels = []
+        if isinstance(hdr, nib.Cifti2Header):
+            axes = [hdr.get_axis(i) for i in hdr.mapped_indices]
+            for ax in axes:
+                if isinstance(ax, nib.cifti2.BrainModelAxis):
+                    break
+            else:
+                raise ValueError('No BrainModelAxis, cannot create CoordinateAxis')
+            for name, slicer, struct in ax.iter_structures():
+                if struct.volume_shape:
+                    substruct = ps.NdGrid(struct.volume_shape, struct.affine)
+                    indices = struct.voxel
+                else:
+                    substruct = None
+                    indices = struct.vertex
+                parcels.append(Parcel(name, substruct, indices))
+
+        return klass(parcels)
+
+
+class Parcel:
+    """
+    Attributes
+    ----------
+    name : str
+    structure : ``Pointset``
+    indices : object that selects a subset of coordinates in structure
+    """
+
+    def __init__(self, name, structure, indices):
+        self.name = name
+        self.structure = structure
+        self.indices = indices
+
+    def __repr__(self):
+        return f'<Parcel {self.name}({len(self.indices)})>'
+
+    def __len__(self):
+        return len(self.indices)
+
+    def __getitem__(self, slicer):
+        return self.__class__(self.name, self.structure, self.indices[slicer])
+
+
+class GeometryCollection:
+    """
+    Attributes
+    ----------
+    structures : dict
+        Mapping from structure names to ``Pointset``
+    """
+
+    def __init__(self, structures):
+        self.structures = structures
+
+    @classmethod
+    def from_spec(klass, pathlike):
+        """Load a collection of geometries from a specification."""
+        raise NotImplementedError

--- a/nilearn/coordimage/pointset.py
+++ b/nilearn/coordimage/pointset.py
@@ -1,0 +1,128 @@
+import operator as op
+from functools import reduce
+
+import numpy as np
+
+from nibabel.affines import apply_affine
+
+
+class Pointset:
+    def __init__(self, coords):
+        self._coords = coords
+
+    @property
+    def n_coords(self):
+        """Number of coordinates
+
+        Subclasses should override with more efficient implementations.
+        """
+        return self.get_coords().shape[0]
+
+    def get_coords(self, name=None):
+        """Nx3 array of coordinates in RAS+ space"""
+        return self._coords
+
+
+class TriangularMesh(Pointset):
+    def __init__(self, mesh):
+        if isinstance(mesh, tuple) and len(mesh) == 2:
+            coords, self._triangles = mesh
+        elif hasattr(mesh, 'coords') and hasattr(mesh, 'triangles'):
+            coords = mesh.coords
+            self._triangles = mesh.triangles
+        elif hasattr(mesh, 'get_mesh'):
+            coords, self._triangles = mesh.get_mesh()
+        else:
+            raise ValueError('Cannot interpret input as triangular mesh')
+        super().__init__(coords)
+
+    @property
+    def n_triangles(self):
+        """Number of faces
+
+        Subclasses should override with more efficient implementations.
+        """
+        return self._triangles.shape[0]
+
+    def get_triangles(self):
+        """Mx3 array of indices into coordinate table"""
+        return self._triangles
+
+    def get_mesh(self, name=None):
+        return self.get_coords(name=name), self.get_triangles()
+
+    def get_names(self):
+        """List of surface names that can be passed to
+        ``get_{coords,triangles,mesh}``
+        """
+        raise NotImplementedError
+
+    ## This method is called for by the BIAP, but it now seems simpler to wait to
+    ## provide it until there are any proposed implementations
+    # def decimate(self, *, n_coords=None, ratio=None):
+    #     """ Return a TriangularMesh with a smaller number of vertices that
+    #     preserves the geometry of the original """
+    #     # To be overridden when a format provides optimization opportunities
+    #     raise NotImplementedError
+
+
+class TriMeshFamily(TriangularMesh):
+    def __init__(self, mapping, default=None):
+        self._triangles = None
+        self._coords = {}
+        for name, mesh in dict(mapping).items():
+            coords, triangles = TriangularMesh(mesh).get_mesh()
+            if self._triangles is None:
+                self._triangles = triangles
+            self._coords[name] = coords
+
+        if default is None:
+            default = next(iter(self._coords))
+        self._default = default
+
+    def get_names(self):
+        return list(self._coords)
+
+    def get_coords(self, name=None):
+        if name is None:
+            name = self._default
+        return self._coords[name]
+
+
+class NdGrid(Pointset):
+    """
+    Attributes
+    ----------
+    shape : 3-tuple
+        number of coordinates in each dimension of grid
+    """
+
+    def __init__(self, shape, affines):
+        self.shape = tuple(shape)
+        try:
+            self._affines = dict(affines)
+        except (TypeError, ValueError):
+            self._affines = {'world': np.array(affines)}
+        if 'voxels' not in self._affines:
+            self._affines['voxels'] = np.eye(4, dtype=np.uint8)
+
+    def get_affine(self, name=None):
+        """4x4 array"""
+        if name is None:
+            name = next(iter(self._affines))
+        return self._affines[name]
+
+    def get_coords(self, name=None):
+        if name is None:
+            name = next(iter(self._affines))
+        aff = self.get_affine(name)
+        dt = np.result_type(*(np.min_scalar_type(dim) for dim in self.shape))
+        # This is pretty wasteful; we almost certainly want instead an
+        # object that will retrieve a coordinate when indexed, but where
+        # np.array(obj) returns this
+        ijk_coords = np.array(list(np.ndindex(self.shape)), dtype=dt)
+        return apply_affine(aff, ijk_coords)
+
+    @property
+    def n_coords(self):
+        return reduce(op.mul, self.shape)

--- a/nilearn/coordimage/tests/data/fsLR.wb.spec
+++ b/nilearn/coordimage/tests/data/fsLR.wb.spec
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CaretSpecFile Version="1.0">
+   <MetaData>
+   </MetaData>
+   <DataFile Structure="CortexLeft"
+             DataFileType="SURFACE"
+             Selected="true">
+      https://raw.githubusercontent.com/mgxd/brainplot/master/brainplot/Conte69_Atlas/Conte69.L.midthickness.32k_fs_LR.surf.gii
+   </DataFile>
+   <DataFile Structure="CortexRight"
+             DataFileType="SURFACE"
+             Selected="true">
+      https://raw.githubusercontent.com/mgxd/brainplot/master/brainplot/Conte69_Atlas/Conte69.R.midthickness.32k_fs_LR.surf.gii
+   </DataFile>
+   <DataFile Structure="CortexLeft"
+             DataFileType="SURFACE"
+             Selected="false">
+      https://raw.githubusercontent.com/mgxd/brainplot/master/brainplot/Conte69_Atlas/Conte69.L.very_inflated.32k_fs_LR.surf.gii
+   </DataFile>
+   <DataFile Structure="CortexRight"
+             DataFileType="SURFACE"
+             Selected="false">
+      https://raw.githubusercontent.com/mgxd/brainplot/master/brainplot/Conte69_Atlas/Conte69.R.very_inflated.32k_fs_LR.surf.gii
+   </DataFile>
+   <DataFile Structure="Invalid"
+             DataFileType="VOLUME"
+             Selected="true">
+      https://templateflow.s3.amazonaws.com/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_res-02_T1w.nii.gz
+   </DataFile>
+</CaretSpecFile>

--- a/nilearn/coordimage/tests/test_coordimage.py
+++ b/nilearn/coordimage/tests/test_coordimage.py
@@ -1,0 +1,80 @@
+import os
+from pathlib import Path
+
+import nibabel as nb
+from nibabel.tests.nibabel_data import get_nibabel_data
+
+from nilearn.coordimage import coordimage as ci
+from nilearn.coordimage import pointset as ps
+from .test_pointset import FreeSurferHemisphere
+
+CIFTI2_DATA = Path(get_nibabel_data()) / 'nitest-cifti2'
+
+
+class FreeSurferSubject(ci.GeometryCollection):
+    @classmethod
+    def from_subject(klass, subject_id, subjects_dir=None):
+        """Load a FreeSurfer subject by ID"""
+        if subjects_dir is None:
+            subjects_dir = os.environ['SUBJECTS_DIR']
+        return klass.from_spec(Path(subjects_dir) / subject_id)
+
+    @classmethod
+    def from_spec(klass, pathlike):
+        """Load a FreeSurfer subject from its directory structure"""
+        subject_dir = Path(pathlike)
+        surfs = subject_dir / 'surf'
+        structures = {
+            'lh': FreeSurferHemisphere.from_filename(surfs / 'lh.white'),
+            'rh': FreeSurferHemisphere.from_filename(surfs / 'rh.white'),
+        }
+        subject = klass(structures)
+        subject._subject_dir = subject_dir
+        return subject
+
+
+class CaretSpec(ci.GeometryCollection):
+    @classmethod
+    def from_spec(klass, pathlike):
+        from nilearn.coordimage.caretspec import CaretSpecFile
+
+        csf = CaretSpecFile.from_filename(pathlike)
+        structures = {
+            df.structure: df.uri
+            for df in csf.data_files
+            if df.selected  # Use selected to avoid overloading for now
+        }
+        wbspec = klass(structures)
+        wbspec._specfile = csf
+        return wbspec
+
+
+def test_Cifti2Image_as_CoordImage():
+    ones = nb.load(CIFTI2_DATA / 'ones.dscalar.nii')
+    assert ones.shape == (1, 91282)
+    cimg = ci.CoordinateImage.from_image(ones)
+    assert cimg.shape == (91282, 1)
+
+    caxis = cimg.coordaxis
+    assert len(caxis) == 91282
+    assert caxis[...] is caxis
+    assert caxis[:] is caxis
+
+    subaxis = caxis[:100]
+    assert len(subaxis) == 100
+    assert len(subaxis.parcels) == 1
+    subaxis = caxis[100:]
+    assert len(subaxis) == len(caxis) - 100
+    assert len(subaxis.parcels) == len(caxis.parcels)
+    subaxis = caxis[100:-100]
+    assert len(subaxis) == len(caxis) - 200
+    assert len(subaxis.parcels) == len(caxis.parcels)
+
+    lh_img = cimg['CIFTI_STRUCTURE_CORTEX_LEFT']
+    assert len(lh_img.coordaxis.parcels) == 1
+    assert lh_img.shape == (29696, 1)
+
+    # # Not working yet.
+    # cortex_img = cimg[["CIFTI_STRUCTURE_CORTEX_LEFT", "CIFTI_STRUCTURE_CORTEX_RIGHT"]]
+    # assert len(cortex_img.coordaxis.parcels) == 2
+    # assert cortex_img.shape == (59412, 1)

--- a/nilearn/coordimage/tests/test_pointset.py
+++ b/nilearn/coordimage/tests/test_pointset.py
@@ -1,0 +1,167 @@
+from pathlib import Path
+from unittest import skipUnless
+
+import numpy as np
+
+from nibabel.arrayproxy import ArrayProxy
+from nibabel.onetime import auto_attr
+from nibabel.optpkg import optional_package
+from nibabel.tests.nibabel_data import get_nibabel_data
+
+from nilearn.coordimage import pointset as ps
+
+h5, has_h5py, _ = optional_package('h5py')
+
+FS_DATA = Path(get_nibabel_data()) / 'nitest-freesurfer'
+
+
+class H5ArrayProxy:
+    def __init__(self, file_like, dataset_name):
+        self.file_like = file_like
+        self.dataset_name = dataset_name
+        with h5.File(file_like, 'r') as h5f:
+            arr = h5f[dataset_name]
+            self._shape = arr.shape
+            self._dtype = arr.dtype
+
+    @property
+    def is_proxy(self):
+        return True
+
+    @property
+    def shape(self):
+        return self._shape
+
+    @property
+    def ndim(self):
+        return len(self.shape)
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    def __array__(self, dtype=None):
+        with h5.File(self.file_like, 'r') as h5f:
+            return np.asanyarray(h5f[self.dataset_name], dtype)
+
+    def __getitem__(self, slicer):
+        with h5.File(self.file_like, 'r') as h5f:
+            return h5f[self.dataset_name][slicer]
+
+
+class H5Geometry(ps.TriMeshFamily):
+    """Simple Geometry file structure that combines a single topology
+    with one or more coordinate sets
+    """
+
+    @classmethod
+    def from_filename(klass, pathlike):
+        meshes = {}
+        with h5.File(pathlike, 'r') as h5f:
+            triangles = H5ArrayProxy(pathlike, '/topology')
+            for name in h5f['coordinates']:
+                meshes[name] = (H5ArrayProxy(pathlike, f'/coordinates/{name}'), triangles)
+        return klass(meshes)
+
+    def to_filename(self, pathlike):
+        with h5.File(pathlike, 'w') as h5f:
+            h5f.create_dataset('/topology', data=self.get_triangles())
+            for name, coord in self._coords.items():
+                h5f.create_dataset(f'/coordinates/{name}', data=coord)
+
+
+class FSGeometryProxy:
+    def __init__(self, pathlike):
+        self._file_like = str(Path(pathlike))
+        self._offset = None
+        self._vnum = None
+        self._fnum = None
+
+    def _peek(self):
+        from nibabel.freesurfer.io import _fread3
+
+        with open(self._file_like, 'rb') as fobj:
+            magic = _fread3(fobj)
+            if magic != 16777214:
+                raise NotImplementedError('Triangle files only!')
+            fobj.readline()
+            fobj.readline()
+            self._vnum = np.fromfile(fobj, '>i4', 1)[0]
+            self._fnum = np.fromfile(fobj, '>i4', 1)[0]
+            self._offset = fobj.tell()
+
+    @property
+    def vnum(self):
+        if self._vnum is None:
+            self._peek()
+        return self._vnum
+
+    @property
+    def fnum(self):
+        if self._fnum is None:
+            self._peek()
+        return self._fnum
+
+    @property
+    def offset(self):
+        if self._offset is None:
+            self._peek()
+        return self._offset
+
+    @auto_attr
+    def coords(self):
+        ap = ArrayProxy(self._file_like, ((self.vnum, 3), '>f4', self.offset))
+        ap.order = 'C'
+        return ap
+
+    @auto_attr
+    def triangles(self):
+        offset = self.offset + 12 * self.vnum
+        ap = ArrayProxy(self._file_like, ((self.fnum, 3), '>i4', offset))
+        ap.order = 'C'
+        return ap
+
+
+class FreeSurferHemisphere(ps.TriMeshFamily):
+    @classmethod
+    def from_filename(klass, pathlike):
+        path = Path(pathlike)
+        hemi, default = path.name.split('.')
+        mesh_names = (
+            'orig',
+            'white',
+            'smoothwm',
+            'pial',
+            'inflated',
+            'sphere',
+            'midthickness',
+            'graymid',
+        )  # Often created
+        if default not in mesh_names:
+            mesh_names.append(default)
+        meshes = {}
+        for mesh in mesh_names:
+            fpath = path.parent / f'{hemi}.{mesh}'
+            if fpath.exists():
+                meshes[mesh] = FSGeometryProxy(fpath)
+        hemi = klass(meshes)
+        hemi._default = default
+        return hemi
+
+
+def test_FreeSurferHemisphere():
+    lh = FreeSurferHemisphere.from_filename(FS_DATA / 'fsaverage/surf/lh.white')
+    assert lh.n_coords == 163842
+    assert lh.n_triangles == 327680
+
+
+@skipUnless(has_h5py, reason='Test requires h5py')
+def test_make_H5Geometry(tmp_path):
+    lh = FreeSurferHemisphere.from_filename(FS_DATA / 'fsaverage/surf/lh.white')
+    h5geo = H5Geometry({name: lh.get_mesh(name) for name in ('white', 'pial')})
+    h5geo.to_filename(tmp_path / 'geometry.h5')
+
+    rt_h5geo = H5Geometry.from_filename(tmp_path / 'geometry.h5')
+    assert set(h5geo._coords) == set(rt_h5geo._coords)
+    assert np.array_equal(lh.get_coords('white'), rt_h5geo.get_coords('white'))
+    assert np.array_equal(lh.get_triangles(), rt_h5geo.get_triangles())


### PR DESCRIPTION
I've done some very cursory edits to adjust imports, but this is more-or-less the significant portions of https://github.com/nipy/nibabel/pull/1090.

I don't have full test coverage, and I'm quite sure that the parts that depend on nibabel test directories will need to be changed, but let's see how broken it is...

Touches on:
* #2171
* #2388
* #2423
* #2681 
* and probably others...

Changes proposed in this pull request:

- Adds `coordimage.pointset` to encode descriptions of geometry
  - Triangular meshes and ND grids are implemented
  - `TriMeshFamily` is intended as a drop-in replacement for `TriangularMesh` that adds a "name" parameter to most functions to make it easy to shift to alternative coordinates in the same mesh.
- Adds `coordimage.coordimage`
  - `CoordinateImage`'s `(data, coordaxis, header)` model is intended to mirror `SpatialImage`'s `(data, affine, header)`
  - A coordinate axis is a series of parcels
  - A parcel is a (subsampled) geometry
- Adds `CaretSpecFile` to encode Connectome Workbench `wbspec` files, which associate CIFTI-2 files with geometry files