### PR TITLE
[FIX] Add corrected standardize strategy to `signal.clean`

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -17,9 +17,11 @@ Fixes
 
 - :func:`~nilearn.interfaces.fmriprep.load_confounds` can support searching preprocessed data in native space. (:gh:`3531` by `Hao-Ting Wang`_)
 
+- Add correct "zscore_sample" strategy to ``signal._standardize`` which will replace the default "zscore" strategy in release 0.13  (:gh:`3474` by `Yasmin Mzayek`_).
 
 Enhancements
 ------------
+
 - Updated example :ref:`sphx_glr_auto_examples_02_decoding_plot_haxby_frem.py` to include section on plotting a confusion matrix from a decoder family object (:gh:`3483` by `Michelle Wang`_).
 
 - Surface plotting methods no longer automatically rescale background maps, which, among other things, allows to use curvature sign as a background map (:gh:`3173` by `Alexis Thual`_).

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -37,7 +37,7 @@ def _standardize(signals, detrend=False, standardize='zscore'):
         If detrending of timeseries is requested.
         Default=False.
 
-    standardize : {'zscore', 'psc', True, False}, optional
+    standardize : {'zscore_sample', 'zscore', 'psc', True, False}, optional
         Strategy to standardize the signal:
 
             - 'zscore_sample': The signal is z-scored. Timeseries are shifted
@@ -634,7 +634,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
 
     %(high_pass)s
     %(detrend)s
-    standardize : {'zscore', 'psc', False}, optional
+    standardize : {'zscore_sample', 'zscore', 'psc', True, False}, optional
         Strategy to standardize the signal:
 
             - 'zscore_sample': The signal is z-scored. Timeseries are shifted

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -40,8 +40,10 @@ def _standardize(signals, detrend=False, standardize='zscore'):
     standardize : {'zscore', 'psc', True, False}, optional
         Strategy to standardize the signal:
 
+            - 'zscore_sample': The signal is z-scored. Timeseries are shifted
+              to zero mean and scaled to unit variance. Uses sample std.
             - 'zscore': The signal is z-scored. Timeseries are shifted
-              to zero mean and scaled to unit variance.
+              to zero mean and scaled to unit variance. Uses population std.
             - 'psc':  Timeseries are shifted to zero mean value and scaled
               to percent signal change (as compared to original mean signal).
             - True: The signal is z-scored (same as option `zscore`).
@@ -69,6 +71,15 @@ def _standardize(signals, detrend=False, standardize='zscore'):
             warnings.warn('Standardization of 3D signal has been requested but '
                           'would lead to zero values. Skipping.')
             return signals
+
+        elif (standardize == 'zscore_sample'):
+            if not detrend:
+                # remove mean if not already detrended
+                signals = signals - signals.mean(axis=0)
+
+            std = signals.std(axis=0, ddof=1)
+            std[std < np.finfo(np.float64).eps] = 1.  # avoid numerical problems
+            signals /= std
 
         elif (standardize == 'zscore') or (standardize is True):
             if not detrend:
@@ -612,8 +623,10 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
     standardize : {'zscore', 'psc', False}, optional
         Strategy to standardize the signal:
 
+            - 'zscore_sample': The signal is z-scored. Timeseries are shifted
+              to zero mean and scaled to unit variance. Uses sample std.
             - 'zscore': The signal is z-scored. Timeseries are shifted
-              to zero mean and scaled to unit variance.
+              to zero mean and scaled to unit variance. Uses population std.
             - 'psc':  Timeseries are shifted to zero mean value and scaled
               to percent signal change (as compared to original mean signal).
             - True: The signal is z-scored (same as option `zscore`).

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -43,7 +43,8 @@ def _standardize(signals, detrend=False, standardize='zscore'):
             - 'zscore_sample': The signal is z-scored. Timeseries are shifted
               to zero mean and scaled to unit variance. Uses sample std.
             - 'zscore': The signal is z-scored. Timeseries are shifted
-              to zero mean and scaled to unit variance. Uses population std.
+              to zero mean and scaled to unit variance. Uses population std
+              by calling default :obj:`numpy.std` with N - ``ddof=0``.
             - 'psc':  Timeseries are shifted to zero mean value and scaled
               to percent signal change (as compared to original mean signal).
             - True: The signal is z-scored (same as option `zscore`).
@@ -640,7 +641,8 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
             - 'zscore_sample': The signal is z-scored. Timeseries are shifted
               to zero mean and scaled to unit variance. Uses sample std.
             - 'zscore': The signal is z-scored. Timeseries are shifted
-              to zero mean and scaled to unit variance. Uses population std.
+              to zero mean and scaled to unit variance. Uses population std
+              by calling default :obj:`numpy.std` with N - ``ddof=0``.
             - 'psc':  Timeseries are shifted to zero mean value and scaled
               to percent signal change (as compared to original mean signal).
             - True: The signal is z-scored (same as option `zscore`).

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -78,7 +78,8 @@ def _standardize(signals, detrend=False, standardize='zscore'):
                 signals = signals - signals.mean(axis=0)
 
             std = signals.std(axis=0, ddof=1)
-            std[std < np.finfo(np.float64).eps] = 1.  # avoid numerical problems
+            # avoid numerical problems
+            std[std < np.finfo(np.float64).eps] = 1.
             signals /= std
 
         elif (standardize == 'zscore') or (standardize is True):
@@ -97,7 +98,8 @@ def _standardize(signals, detrend=False, standardize='zscore'):
                 signals = signals - signals.mean(axis=0)
 
             std = signals.std(axis=0)
-            std[std < np.finfo(np.float64).eps] = 1.  # avoid numerical problems
+            # avoid numerical problems
+            std[std < np.finfo(np.float64).eps] = 1.
             signals /= std
 
         elif standardize == 'psc':

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -82,6 +82,16 @@ def _standardize(signals, detrend=False, standardize='zscore'):
             signals /= std
 
         elif (standardize == 'zscore') or (standardize is True):
+            std_strategy_default = (
+                'The default strategy for standardize is currently \'zscore\' '
+                'which incorrectly uses population std to calculate sample '
+                'zscores. The new strategy \'zscore_sample\' corrects this '
+                'behavior by using the sample std. The default strategy will '
+                'be replaced by the new strategy in release 0.13.'
+            )
+            warnings.warn(category=FutureWarning,
+                          message=std_strategy_default,
+                          stacklevel=3)
             if not detrend:
                 # remove mean if not already detrended
                 signals = signals - signals.mean(axis=0)

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -85,13 +85,13 @@ def _standardize(signals, detrend=False, standardize='zscore'):
 
         elif (standardize == 'zscore') or (standardize is True):
             std_strategy_default = (
-                'The default strategy for standardize is currently \'zscore\' '
-                'which incorrectly uses population std to calculate sample '
-                'zscores. The new strategy \'zscore_sample\' corrects this '
-                'behavior by using the sample std. In release 0.13, the '
-                'default strategy will be replaced by the new strategy and '
-                'the \'zscore\' option will be removed. Please use '
-                '\'zscore_sample\' instead.'
+                "The default strategy for standardize is currently 'zscore' "
+                "which incorrectly uses population std to calculate sample "
+                "zscores. The new strategy 'zscore_sample' corrects this "
+                "behavior by using the sample std. In release 0.13, the "
+                "default strategy will be replaced by the new strategy and "
+                "the 'zscore' option will be removed. Please use "
+                "'zscore_sample' instead."
             )
             warnings.warn(category=FutureWarning,
                           message=std_strategy_default,

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -57,7 +57,7 @@ def _standardize(signals, detrend=False, standardize='zscore'):
     std_signals : :class:`numpy.ndarray`
         Copy of signals, standardized.
     """
-    if standardize not in [True, False, 'psc', 'zscore']:
+    if standardize not in [True, False, 'psc', 'zscore', 'zscore_sample']:
         raise ValueError('{} is no valid standardize strategy.'
                          .format(standardize))
 

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -87,8 +87,10 @@ def _standardize(signals, detrend=False, standardize='zscore'):
                 'The default strategy for standardize is currently \'zscore\' '
                 'which incorrectly uses population std to calculate sample '
                 'zscores. The new strategy \'zscore_sample\' corrects this '
-                'behavior by using the sample std. The default strategy will '
-                'be replaced by the new strategy in release 0.13.'
+                'behavior by using the sample std. In release 0.13, the '
+                'default strategy will be replaced by the new strategy and '
+                'the \'zscore\' option will be removed. Please use '
+                '\'zscore_sample\' instead.'
             )
             warnings.warn(category=FutureWarning,
                           message=std_strategy_default,

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -256,8 +256,8 @@ def test_standardize():
         nisignal._standardize(a, standardize="foo")
 
     # test warning for strategy that will be removed
-    with pytest.warns(FutureWarning, match='default strategy for standardize'):
-        nisignal._standardize(a, standardize='zscore')
+    with pytest.warns(FutureWarning, match="default strategy for standardize"):
+        nisignal._standardize(a, standardize="zscore")
 
     # transpose array to fit _standardize input.
     # Without trend removal
@@ -277,6 +277,9 @@ def test_standardize():
     b = nisignal._standardize(a, detrend=True, standardize=False)
     np.testing.assert_almost_equal(b, np.zeros(b.shape))
 
+    b = nisignal._standardize(a, detrend=True, standardize="zscore_sample")
+    np.testing.assert_almost_equal(b, np.zeros(b.shape))
+
     length_1_signal = np.atleast_2d(np.linspace(0, 2., n_features))
     np.testing.assert_array_equal(length_1_signal,
                                   nisignal._standardize(length_1_signal,
@@ -286,7 +289,7 @@ def test_standardize():
     length_1_signal = np.atleast_2d(np.linspace(0, 2., n_features))
     np.testing.assert_array_equal(
         length_1_signal,
-        nisignal._standardize(length_1_signal, standardize='zscore_sample')
+        nisignal._standardize(length_1_signal, standardize="zscore_sample")
     )
 
 

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -253,7 +253,8 @@ def test_standardize():
 
     # transpose array to fit _standardize input.
     # Without trend removal
-    b = nisignal._standardize(a, standardize='zscore')
+    with pytest.warns(FutureWarning, match='default strategy for standardize'):
+        b = nisignal._standardize(a, standardize='zscore')
     stds = np.std(b)
     np.testing.assert_almost_equal(stds, np.ones(n_features))
     np.testing.assert_almost_equal(b.sum(axis=0), np.zeros(n_features))

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -251,6 +251,10 @@ def test_standardize():
     a = rng.random_sample((n_samples, n_features))
     a += np.linspace(0, 2., n_features)
 
+    # Test raise error when strategy is not valid option
+    with pytest.raises(ValueError, match="no valid standardize strategy"):
+        nisignal._standardize(a, standardize="foo")
+
     # test warning for strategy that will be removed
     with pytest.warns(FutureWarning, match='default strategy for standardize'):
         nisignal._standardize(a, standardize='zscore')

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -251,10 +251,13 @@ def test_standardize():
     a = rng.random_sample((n_samples, n_features))
     a += np.linspace(0, 2., n_features)
 
+    # test warning for strategy that will be removed
+    with pytest.warns(FutureWarning, match='default strategy for standardize'):
+        nisignal._standardize(a, standardize='zscore')
+
     # transpose array to fit _standardize input.
     # Without trend removal
-    with pytest.warns(FutureWarning, match='default strategy for standardize'):
-        b = nisignal._standardize(a, standardize='zscore')
+    b = nisignal._standardize(a, standardize='zscore')
     stds = np.std(b)
     np.testing.assert_almost_equal(stds, np.ones(n_features))
     np.testing.assert_almost_equal(b.sum(axis=0), np.zeros(n_features))
@@ -841,14 +844,18 @@ def test_clean_zscore():
                                      length=n_samples)
 
     signals += rng.standard_normal(size=(1, n_features))
-    cleaned_signals = clean(signals, standardize='zscore')
-    np.testing.assert_almost_equal(cleaned_signals.mean(0), 0)
-    np.testing.assert_almost_equal(cleaned_signals.std(0), 1)
+    cleaned_signals_ = clean(signals, standardize='zscore')
+    np.testing.assert_almost_equal(cleaned_signals_.mean(0), 0)
+    np.testing.assert_almost_equal(cleaned_signals_.std(0), 1)
 
     # Repeating test above but for new correct strategy
     cleaned_signals = clean(signals, standardize='zscore_sample')
     np.testing.assert_almost_equal(cleaned_signals.mean(0), 0)
     np.testing.assert_almost_equal(cleaned_signals.std(0), 1, decimal=3)
+
+    # Show outcome from two zscore strategies is not equal
+    with pytest.raises(AssertionError):
+        np.testing.assert_array_equal(cleaned_signals_, cleaned_signals)
 
 
 def test_create_cosine_drift_terms():

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -259,6 +259,12 @@ def test_standardize():
     np.testing.assert_almost_equal(stds, np.ones(n_features))
     np.testing.assert_almost_equal(b.sum(axis=0), np.zeros(n_features))
 
+    # Repeating test above but for new correct strategy
+    b = nisignal._standardize(a, standardize='zscore_sample')
+    stds = np.std(b)
+    np.testing.assert_almost_equal(stds, np.ones(n_features), decimal=1)
+    np.testing.assert_almost_equal(b.sum(axis=0), np.zeros(n_features))
+
     # With trend removal
     a = np.atleast_2d(np.linspace(0, 2., n_features)).T
     b = nisignal._standardize(a, detrend=True, standardize=False)
@@ -268,6 +274,13 @@ def test_standardize():
     np.testing.assert_array_equal(length_1_signal,
                                   nisignal._standardize(length_1_signal,
                                                         standardize='zscore'))
+
+    # Repeating test above but for new correct strategy
+    length_1_signal = np.atleast_2d(np.linspace(0, 2., n_features))
+    np.testing.assert_array_equal(
+        length_1_signal,
+        nisignal._standardize(length_1_signal, standardize='zscore_sample')
+    )
 
 
 def test_detrend():
@@ -831,6 +844,11 @@ def test_clean_zscore():
     cleaned_signals = clean(signals, standardize='zscore')
     np.testing.assert_almost_equal(cleaned_signals.mean(0), 0)
     np.testing.assert_almost_equal(cleaned_signals.std(0), 1)
+
+    # Repeating test above but for new correct strategy
+    cleaned_signals = clean(signals, standardize='zscore_sample')
+    np.testing.assert_almost_equal(cleaned_signals.mean(0), 0)
+    np.testing.assert_almost_equal(cleaned_signals.std(0), 1, decimal=3)
 
 
 def test_create_cosine_drift_terms():


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3406 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add "zscore_sample" strategy as an option for `standardize` parameter (Suggestions welcome for a better strategy name)
- Add a `FutureWarning` about default behavior changing to this new strategy in release 0.13.
  - If current default should be removed entirely then add this to the warning
