### PR TITLE
[ENH] Make filter options available as kwargs in `signal.clean`

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -17,6 +17,7 @@ Enhancements
 ------------
 
 - Addition to docs to note that :meth:`~maskers.BaseMasker.inverse_transform` only performs spatial unmasking (:gh:`3445` by `Robert Williamson`_).
+- Give users control over Butterworth filter (:func:`~signal.butterworth`) parameters in :func:`~signal.clean` as kwargs (:gh:`3478` by `Taylor Salo`_).
 
 Changes
 -------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -17,7 +17,7 @@ Enhancements
 ------------
 
 - Addition to docs to note that :meth:`~maskers.BaseMasker.inverse_transform` only performs spatial unmasking (:gh:`3445` by `Robert Williamson`_).
-- Give users control over Butterworth filter (:func:`~signal.butterworth`) parameters in :func:`~signal.clean` as kwargs (:gh:`3478` by `Taylor Salo`_).
+- Give users control over Butterworth filter (:func:`~signal.butterworth`) parameters in :func:`~signal.clean` and Masker objects as kwargs (:gh:`3478` by `Taylor Salo`_).
 
 Changes
 -------

--- a/examples/03_connectivity/plot_sphere_based_connectome.py
+++ b/examples/03_connectivity/plot_sphere_based_connectome.py
@@ -65,9 +65,18 @@ labels = [
 from nilearn.maskers import NiftiSpheresMasker
 
 masker = NiftiSpheresMasker(
-    dmn_coords, radius=8, detrend=True, standardize=True,
-    low_pass=0.1, high_pass=0.01, t_r=2,
-    memory='nilearn_cache', memory_level=1, verbose=2)
+    dmn_coords,
+    radius=8,
+    detrend=True,
+    standardize=True,
+    low_pass=0.1,
+    high_pass=0.01,
+    t_r=2,
+    memory='nilearn_cache',
+    memory_level=1,
+    verbose=2,
+    clean__butterworth__padtype='even',  # kwarg to modify Butterworth filter
+)
 
 # Additionally, we pass confound information to ensure our extracted
 # signal is cleaned from confounds.

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -325,6 +325,17 @@ sample_mask : Any type compatible with numpy-array indexing, optional
     This parameter is passed to :func:`nilearn.signal.clean`.
 """
 
+# kwargs for Maskers
+docdict['masker_kwargs'] = """
+kwargs : dict
+    Keyword arguments to be passed to functions called within the masker.
+    Kwargs prefixed with ``'clean__'`` will be passed to
+    :func:`~nilearn.signal.clean`.
+    Within :func:`~nilearn.signal.clean`, kwargs prefixed with
+    ``'butterworth__'`` will be passed to the Butterworth filter
+    (i.e., ``clean__butterworth__``).
+"""
+
 # cut_coords
 docdict['cut_coords'] = """
 cut_coords : None, a :obj:`tuple` of :obj:`float`, or :obj:`int`, optional

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1176,7 +1176,7 @@ def clean_img(imgs, runs=None, detrend=True, standardize=True,
         See :ref:`extracting_data`.
 
     kwargs : dict
-        Keyword arguments to be passed to functions called within the masker.
+        Keyword arguments to be passed to functions called within this fucntion.
         Kwargs prefixed with ``'clean__'`` will be passed to
         :func:`~nilearn.signal.clean`.
         Within :func:`~nilearn.signal.clean`, kwargs prefixed with
@@ -1227,10 +1227,13 @@ def clean_img(imgs, runs=None, detrend=True, standardize=True,
         signals = get_data(imgs_).reshape(-1, imgs_.shape[-1]).T
 
     # Clean signal
+    clean_kwargs = {
+        k[7:]: v for k, v in kwargs.items() if k.startswith("clean__")
+    }
     data = signal.clean(
         signals, runs=runs, detrend=detrend, standardize=standardize,
         confounds=confounds, low_pass=low_pass, high_pass=high_pass, t_r=t_r,
-        ensure_finite=ensure_finite, **kwargs)
+        ensure_finite=ensure_finite, **clean_kwargs)
 
     # Put results back into Niimg-like object
     if mask_img is not None:

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1176,7 +1176,7 @@ def clean_img(imgs, runs=None, detrend=True, standardize=True,
         See :ref:`extracting_data`.
 
     kwargs : dict
-        Keyword arguments to be passed to functions called within this fucntion.
+        Keyword arguments to be passed to functions called within this function.
         Kwargs prefixed with ``'clean__'`` will be passed to
         :func:`~nilearn.signal.clean`.
         Within :func:`~nilearn.signal.clean`, kwargs prefixed with

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -123,18 +123,23 @@ def _filter_and_extract(
         print("[%s] Cleaning extracted signals" % class_name)
     runs = parameters.get('runs', None)
     region_signals = cache(
-        signal.clean, memory=memory, func_memory_level=2,
-        memory_level=memory_level)(
-            region_signals,
-            detrend=parameters['detrend'],
-            standardize=parameters['standardize'],
-            standardize_confounds=parameters['standardize_confounds'],
-            t_r=parameters['t_r'],
-            low_pass=parameters['low_pass'],
-            high_pass=parameters['high_pass'],
-            confounds=confounds,
-            sample_mask=sample_mask,
-            runs=runs)
+        signal.clean,
+        memory=memory,
+        func_memory_level=2,
+        memory_level=memory_level,
+    )(
+        region_signals,
+        detrend=parameters['detrend'],
+        standardize=parameters['standardize'],
+        standardize_confounds=parameters['standardize_confounds'],
+        t_r=parameters['t_r'],
+        low_pass=parameters['low_pass'],
+        high_pass=parameters['high_pass'],
+        confounds=confounds,
+        sample_mask=sample_mask,
+        runs=runs,
+        **parameters['clean_kwargs'],
+    )
 
     return region_signals, aux
 
@@ -310,7 +315,7 @@ class BaseMasker(BaseEstimator, TransformerMixin, CacheMixin):
 
         This step only performs spatial unmasking,
         without inverting any additional processing performed by ``transform``,
-        such as temporal filtering or smoothing. 
+        such as temporal filtering or smoothing.
 
         Parameters
         ----------

--- a/nilearn/maskers/multi_nifti_labels_masker.py
+++ b/nilearn/maskers/multi_nifti_labels_masker.py
@@ -91,8 +91,16 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
         standard_deviation. Default='mean'.
 
     reports : :obj:`bool`, optional
-         If set to True, data is saved in order to produce a report.
-         Default=True.
+        If set to True, data is saved in order to produce a report.
+        Default=True.
+
+    kwargs : dict
+        Keyword arguments to be passed to functions called within the masker.
+        Kwargs prefixed with ``'clean__'`` will be passed to
+        :func:`~nilearn.signal.clean`.
+        Within :func:`~nilearn.signal.clean`, kwargs prefixed with
+        ``'butterworth__'`` will be passed to the Butterworth filter
+        (i.e., ``clean__butterworth__``).
 
     See also
     --------
@@ -122,7 +130,8 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
         verbose=0,
         strategy='mean',
         reports=True,
-        n_jobs=1
+        n_jobs=1,
+        **kwargs,
     ):
         self.n_jobs = n_jobs
         super().__init__(
@@ -145,6 +154,7 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
             verbose=verbose,
             strategy=strategy,
             reports=reports,
+            **kwargs,
         )
 
     def transform_imgs(self, imgs_list, confounds=None, n_jobs=1,

--- a/nilearn/maskers/multi_nifti_labels_masker.py
+++ b/nilearn/maskers/multi_nifti_labels_masker.py
@@ -94,13 +94,7 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
         If set to True, data is saved in order to produce a report.
         Default=True.
 
-    kwargs : dict
-        Keyword arguments to be passed to functions called within the masker.
-        Kwargs prefixed with ``'clean__'`` will be passed to
-        :func:`~nilearn.signal.clean`.
-        Within :func:`~nilearn.signal.clean`, kwargs prefixed with
-        ``'butterworth__'`` will be passed to the Butterworth filter
-        (i.e., ``clean__butterworth__``).
+    %(masker_kwargs)s
 
     See also
     --------

--- a/nilearn/maskers/multi_nifti_maps_masker.py
+++ b/nilearn/maskers/multi_nifti_maps_masker.py
@@ -87,6 +87,14 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
         If set to True, data is saved in order to produce a report.
         Default=True.
 
+    kwargs : dict
+        Keyword arguments to be passed to functions called within the masker.
+        Kwargs prefixed with ``'clean__'`` will be passed to
+        :func:`~nilearn.signal.clean`.
+        Within :func:`~nilearn.signal.clean`, kwargs prefixed with
+        ``'butterworth__'`` will be passed to the Butterworth filter
+        (i.e., ``clean__butterworth__``).
+
     Notes
     -----
     If resampling_target is set to "maps", every 3D image processed by
@@ -121,7 +129,8 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
         memory_level=0,
         verbose=0,
         reports=True,
-        n_jobs=1
+        n_jobs=1,
+        **kwargs,
     ):
         self.n_jobs = n_jobs
         super().__init__(
@@ -142,6 +151,7 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
             memory_level=memory_level,
             verbose=verbose,
             reports=reports,
+            **kwargs,
         )
 
     def transform_imgs(self, imgs_list, confounds=None, n_jobs=1,

--- a/nilearn/maskers/multi_nifti_maps_masker.py
+++ b/nilearn/maskers/multi_nifti_maps_masker.py
@@ -87,13 +87,7 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
         If set to True, data is saved in order to produce a report.
         Default=True.
 
-    kwargs : dict
-        Keyword arguments to be passed to functions called within the masker.
-        Kwargs prefixed with ``'clean__'`` will be passed to
-        :func:`~nilearn.signal.clean`.
-        Within :func:`~nilearn.signal.clean`, kwargs prefixed with
-        ``'butterworth__'`` will be passed to the Butterworth filter
-        (i.e., ``clean__butterworth__``).
+    %(masker_kwargs)s
 
     Notes
     -----

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -147,6 +147,14 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
         Indicate the level of verbosity. By default, nothing is printed.
         Default=0.
 
+    kwargs : dict
+        Keyword arguments to be passed to functions called within the masker.
+        Kwargs prefixed with ``'clean__'`` will be passed to
+        :func:`~nilearn.signal.clean`.
+        Within :func:`~nilearn.signal.clean`, kwargs prefixed with
+        ``'butterworth__'`` will be passed to the Butterworth filter
+        (i.e., ``clean__butterworth__``).
+
     Attributes
     ----------
     mask_img_ : :obj:`nibabel.nifti1.Nifti1Image`
@@ -206,6 +214,9 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
         self.mask_strategy = mask_strategy
         self.mask_args = mask_args
         self.dtype = dtype
+        self.clean_kwargs = {
+            k[7:]: v for k, v in kwargs.items() if k.startswith("clean__")
+        }
 
         self.memory = memory
         self.memory_level = memory_level
@@ -386,6 +397,7 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
                 'copy',
             ],
         )
+        params['clean_kwargs'] = self.clean_kwargs
 
         func = self._cache(
             _filter_and_mask,

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -147,13 +147,7 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
         Indicate the level of verbosity. By default, nothing is printed.
         Default=0.
 
-    kwargs : dict
-        Keyword arguments to be passed to functions called within the masker.
-        Kwargs prefixed with ``'clean__'`` will be passed to
-        :func:`~nilearn.signal.clean`.
-        Within :func:`~nilearn.signal.clean`, kwargs prefixed with
-        ``'butterworth__'`` will be passed to the Butterworth filter
-        (i.e., ``clean__butterworth__``).
+    %(masker_kwargs)s
 
     Attributes
     ----------

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -197,6 +197,7 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
         memory_level=0,
         n_jobs=1,
         verbose=0,
+        **kwargs,
     ):
         # Mask is provided or computed
         self.mask_img = mask_img

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -135,6 +135,14 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
         If set to True, data is saved in order to produce a report.
         Default=True.
 
+    kwargs : dict
+        Keyword arguments to be passed to functions called within the masker.
+        Kwargs prefixed with ``'clean__'`` will be passed to
+        :func:`~nilearn.signal.clean`.
+        Within :func:`~nilearn.signal.clean`, kwargs prefixed with
+        ``'butterworth__'`` will be passed to the Butterworth filter
+        (i.e., ``clean__butterworth__``).
+
     Attributes
     ----------
     mask_img_ : :obj:`nibabel.nifti1.Nifti1Image`
@@ -177,6 +185,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
         verbose=0,
         strategy='mean',
         reports=True,
+        **kwargs,
     ):
         self.labels_img = labels_img
         self.labels = labels
@@ -195,6 +204,9 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
         self.high_pass = high_pass
         self.t_r = t_r
         self.dtype = dtype
+        self.clean_kwargs = {
+            k[7:]: v for k, v in kwargs.items() if k.startswith("clean__")
+        }
 
         # Parameters for resampling
         self.resampling_target = resampling_target

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -135,13 +135,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
         If set to True, data is saved in order to produce a report.
         Default=True.
 
-    kwargs : dict
-        Keyword arguments to be passed to functions called within the masker.
-        Kwargs prefixed with ``'clean__'`` will be passed to
-        :func:`~nilearn.signal.clean`.
-        Within :func:`~nilearn.signal.clean`, kwargs prefixed with
-        ``'butterworth__'`` will be passed to the Butterworth filter
-        (i.e., ``clean__butterworth__``).
+    %(masker_kwargs)s
 
     Attributes
     ----------

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -625,6 +625,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
         )
         params['target_shape'] = target_shape
         params['target_affine'] = target_affine
+        params['clean_kwargs'] = self.clean_kwargs
 
         region_signals, labels_ = self._cache(
             _filter_and_extract,

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -120,13 +120,7 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
         If set to True, data is saved in order to produce a report.
         Default=True.
 
-    kwargs : dict
-        Keyword arguments to be passed to functions called within the masker.
-        Kwargs prefixed with ``'clean__'`` will be passed to
-        :func:`~nilearn.signal.clean`.
-        Within :func:`~nilearn.signal.clean`, kwargs prefixed with
-        ``'butterworth__'`` will be passed to the Butterworth filter
-        (i.e., ``clean__butterworth__``).
+    %(masker_kwargs)s
 
     Attributes
     ----------

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -120,6 +120,14 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
         If set to True, data is saved in order to produce a report.
         Default=True.
 
+    kwargs : dict
+        Keyword arguments to be passed to functions called within the masker.
+        Kwargs prefixed with ``'clean__'`` will be passed to
+        :func:`~nilearn.signal.clean`.
+        Within :func:`~nilearn.signal.clean`, kwargs prefixed with
+        ``'butterworth__'`` will be passed to the Butterworth filter
+        (i.e., ``clean__butterworth__``).
+
     Attributes
     ----------
     maps_img_ : :obj:`nibabel.nifti1.Nifti1Image`
@@ -164,6 +172,7 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
         memory_level=0,
         verbose=0,
         reports=True,
+        **kwargs,
     ):
         self.maps_img = maps_img
         self.mask_img = mask_img
@@ -183,6 +192,9 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
         self.high_pass = high_pass
         self.t_r = t_r
         self.dtype = dtype
+        self.clean_kwargs = {
+            k[7:]: v for k, v in kwargs.items() if k.startswith("clean__")
+        }
 
         # Parameters for resampling
         self.resampling_target = resampling_target

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -594,6 +594,7 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
         )
         params['target_shape'] = target_shape
         params['target_affine'] = target_affine
+        params['clean_kwargs'] = self.clean_kwargs
 
         region_signals, labels_ = self._cache(
             _filter_and_extract,

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -233,6 +233,14 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         If set to True, data is saved in order to produce a report.
         Default=True.
 
+    kwargs : dict
+        Keyword arguments to be passed to functions called within the masker.
+        Kwargs prefixed with ``'clean__'`` will be passed to
+        :func:`~nilearn.signal.clean`.
+        Within :func:`~nilearn.signal.clean`, kwargs prefixed with
+        ``'butterworth__'`` will be passed to the Butterworth filter
+        (i.e., ``clean__butterworth__``).
+
     Attributes
     ----------
     mask_img_ : :obj:`nibabel.nifti1.Nifti1Image`
@@ -277,6 +285,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         memory=Memory(location=None),
         verbose=0,
         reports=True,
+        **kwargs,
     ):
         # Mask is provided or computed
         self.mask_img = mask_img
@@ -312,6 +321,9 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
             'hover over the displayed image.'
         )
         self._shelving = False
+        self.clean_kwargs = {
+            k[7:]: v for k, v in kwargs.items() if k.startswith("clean__")
+        }
 
     def generate_report(self):
         from nilearn.reporting.html_report import generate_report
@@ -566,6 +578,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
                 'sample_mask',
             ],
         )
+        params['clean_kwargs'] = self.clean_kwargs
 
         data = self._cache(
             _filter_and_mask,

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -233,13 +233,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         If set to True, data is saved in order to produce a report.
         Default=True.
 
-    kwargs : dict
-        Keyword arguments to be passed to functions called within the masker.
-        Kwargs prefixed with ``'clean__'`` will be passed to
-        :func:`~nilearn.signal.clean`.
-        Within :func:`~nilearn.signal.clean`, kwargs prefixed with
-        ``'butterworth__'`` will be passed to the Butterworth filter
-        (i.e., ``clean__butterworth__``).
+    %(masker_kwargs)s
 
     Attributes
     ----------

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -292,6 +292,14 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         Indicate the level of verbosity. By default, nothing is printed.
         Default=0.
 
+    kwargs : dict
+        Keyword arguments to be passed to functions called within the masker.
+        Kwargs prefixed with ``'clean__'`` will be passed to
+        :func:`~nilearn.signal.clean`.
+        Within :func:`~nilearn.signal.clean`, kwargs prefixed with
+        ``'butterworth__'`` will be passed to the Butterworth filter
+        (i.e., ``clean__butterworth__``).
+
     Attributes
     ----------
     n_elements_ : :obj:`int`
@@ -327,6 +335,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         memory=Memory(location=None, verbose=0),
         memory_level=1,
         verbose=0,
+        **kwargs,
     ):
         self.seeds = seeds
         self.mask_img = mask_img
@@ -345,6 +354,9 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         self.high_pass = high_pass
         self.t_r = t_r
         self.dtype = dtype
+        self.clean_kwargs = {
+            k[7:]: v for k, v in kwargs.items() if k.startswith("clean__")
+        }
 
         # Parameters for joblib
         self.memory = memory

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -494,6 +494,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         self._check_fitted()
 
         params = get_params(NiftiSpheresMasker, self)
+        params['clean_kwargs'] = self.clean_kwargs
 
         signals, _ = self._cache(
             _filter_and_extract,

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -292,13 +292,7 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
         Indicate the level of verbosity. By default, nothing is printed.
         Default=0.
 
-    kwargs : dict
-        Keyword arguments to be passed to functions called within the masker.
-        Kwargs prefixed with ``'clean__'`` will be passed to
-        :func:`~nilearn.signal.clean`.
-        Within :func:`~nilearn.signal.clean`, kwargs prefixed with
-        ``'butterworth__'`` will be passed to the Butterworth filter
-        (i.e., ``clean__butterworth__``).
+    %(masker_kwargs)s
 
     Attributes
     ----------

--- a/nilearn/maskers/tests/test_base_masker.py
+++ b/nilearn/maskers/tests/test_base_masker.py
@@ -32,19 +32,19 @@ def test_cropping_code_paths():
 
     cropped_mask_img = image.crop_img(mask_img)
 
-    parameters = {"smoothing_fwhm": None,
-                  "high_pass": None,
-                  "low_pass": None,
-                  "t_r": None,
-                  "detrend": None,
-                  "standardize": 'zscore',
-                  "standardize_confounds": True,
-                  }
+    parameters = {
+        "smoothing_fwhm": None,
+        "high_pass": None,
+        "low_pass": None,
+        "t_r": None,
+        "detrend": None,
+        "standardize": 'zscore',
+        "standardize_confounds": True,
+        "clean_kwargs": {},
+    }
 
     # Now do the two maskings
-    out_data_uncropped = _filter_and_mask(
-        img, mask_img, parameters)
-    out_data_cropped = _filter_and_mask(
-        img, cropped_mask_img, parameters)
+    out_data_uncropped = _filter_and_mask(img, mask_img, parameters)
+    out_data_cropped = _filter_and_mask(img, cropped_mask_img, parameters)
 
     assert_array_almost_equal(out_data_cropped, out_data_uncropped)

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -405,6 +405,7 @@ def test_filter_and_mask():
 
     masker = NiftiMasker()
     params = get_params(NiftiMasker, masker)
+    params["clean_kwargs"] = {}
 
     # Test return_affine = False
     data = _filter_and_mask(data_img, mask_img, params)

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -625,7 +625,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
     %(ensure_finite)s
         Default=False.
 
-    kwargs
+    kwargs : dict
         Keyword arguments to be passed to functions called within ``clean``.
         Kwargs prefixed with ``'butterworth__'`` will be passed to
         :func:`~nilearn.signal.butterworth`.

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -254,29 +254,28 @@ def _detrend(signals, inplace=False, type="linear", n_batches=10):
 
 
 def _check_wn(btype, freq, nyq):
-    wn = freq / float(nyq)
-    if wn >= 1.:
+    if freq >= nyq:
         # results looked unstable when the critical frequencies are
         # exactly at the Nyquist frequency. See issue at SciPy
         # https://github.com/scipy/scipy/issues/6265. Before, SciPy 1.0.0 ("wn
         # should be btw 0 and 1"). But, after ("0 < wn < 1"). Due to unstable
         # results as pointed in the issue above. Hence, we forced the
         # critical frequencies to be slightly less than 1. but not 1.
-        wn = 1 - 10 * np.finfo(1.).eps
+        freq = nyq - 10 * np.finfo(1.).eps
         warnings.warn(
-            'The frequency specified for the %s pass filter is '
+            f'The frequency specified for the {btype} pass filter is '
             'too high to be handled by a digital filter (superior to '
-            'nyquist frequency). It has been lowered to %.2f (nyquist '
-            'frequency).' % (btype, wn))
+            f'nyquist frequency). It has been lowered to {freq} (nyquist '
+            'frequency).')
 
-    if wn < 0.0: # equal to 0.0 is okay
-        wn = np.finfo(1.).eps
+    if freq < 0.0:  # equal to 0.0 is okay
+        freq = np.finfo(1.).eps
         warnings.warn(
-            'The frequency specified for the %s pass filter is '
-            'too low to be handled by a digital filter (must be non-negative).'
-            ' It has been set to eps: %.5e' % (btype, wn))
+            f'The frequency specified for the {btype} pass filter is too '
+            'low to be handled by a digital filter (must be non-negative). '
+            f'It has been set to eps: {freq}')
 
-    return wn
+    return freq
 
 
 @fill_doc
@@ -303,7 +302,7 @@ def butterworth(
         of `signals`.
 
     sampling_rate : :obj:`float`
-        Number of samples per time unit (sample frequency).
+        Number of samples per second (sample frequency, in Hertz).
     %(low_pass)s
     %(high_pass)s
     order : :obj:`int`, optional

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -697,7 +697,7 @@ def clean(signals, runs=None, detrend=True, standardize='zscore',
     # Butterworth filtering
     if filter_type == 'butterworth':
         butterworth_kwargs = {
-            k.replace("butterworth__", ""): v for k, v in kwargs if
+            k.replace("butterworth__", ""): v for k, v in kwargs.items() if
             k.startswith("butterworth__")
         }
         signals = butterworth(

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -261,7 +261,7 @@ def _check_wn(btype, freq, nyq):
         # should be btw 0 and 1"). But, after ("0 < wn < 1"). Due to unstable
         # results as pointed in the issue above. Hence, we forced the
         # critical frequencies to be slightly less than 1. but not 1.
-        freq = nyq - 10 * np.finfo(1.).eps
+        freq = nyq - (nyq * 10 * np.finfo(1.).eps)
         warnings.warn(
             f'The frequency specified for the {btype} pass filter is '
             'too high to be handled by a digital filter (superior to '
@@ -269,7 +269,7 @@ def _check_wn(btype, freq, nyq):
             'frequency).')
 
     if freq < 0.0:  # equal to 0.0 is okay
-        freq = np.finfo(1.).eps
+        freq = nyq * np.finfo(1.).eps
         warnings.warn(
             f'The frequency specified for the {btype} pass filter is too '
             'low to be handled by a digital filter (must be non-negative). '

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -167,15 +167,59 @@ def test_butterworth():
     sampling = 1
     low_pass = 2
     high_pass = 1
-    with pytest.warns(UserWarning,
-                      match='Signals are returned unfiltered because '
-                      'band-pass critical frequencies are equal. '
-                      'Please check that inputs for sampling_rate, '
-                      'low_pass, and high_pass are valid.'):
-        out = nisignal.butterworth(data, sampling,
-                                   low_pass=low_pass, high_pass=high_pass,
-                                   copy=True)
+    with pytest.warns(
+        UserWarning,
+        match=(
+            'Signals are returned unfiltered because '
+            'band-pass critical frequencies are equal. '
+            'Please check that inputs for sampling_rate, '
+            'low_pass, and high_pass are valid.'
+        ),
+    ):
+        out = nisignal.butterworth(
+            data,
+            sampling,
+            low_pass=low_pass,
+            high_pass=high_pass,
+            copy=True,
+        )
     assert (out == data).all()
+
+    # Test check for frequency higher than allowed (>=Nyquist).
+    # The frequency should be modified and the filter should be run.
+    sampling = 1
+    high_pass = 0.01
+    low_pass = 0.5
+    with pytest.warns(
+        UserWarning,
+        match='The frequency specified for the low pass filter is too high',
+    ):
+        out = nisignal.butterworth(
+            data,
+            sampling,
+            low_pass=low_pass,
+            high_pass=high_pass,
+            copy=True,
+        )
+    assert not np.array_equal(data, out)
+
+    # Test check for frequency lower than allowed (<0).
+    # The frequency should be modified and the filter should be run.
+    sampling = 1
+    high_pass = 0.01
+    low_pass = -1
+    with pytest.warns(
+        UserWarning,
+        match='The frequency specified for the high pass filter is too low',
+    ):
+        out = nisignal.butterworth(
+            data,
+            sampling,
+            low_pass=low_pass,
+            high_pass=high_pass,
+            copy=True,
+        )
+    assert not np.array_equal(data, out)
 
 
 def test_standardize():

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -369,13 +369,13 @@ def test_clean_kwargs():
     kwargs = [
         {
             "butterworth__padtype": "even",
-            "butterworth__padlen": 100,
+            "butterworth__padlen": 10,
             "butterworth__order": 3,
         },
         {
             "butterworth__padtype": None,
             "butterworth__padlen": None,
-            "butterworth__order": 0,
+            "butterworth__order": 1,
         },
         {
             "butterworth__padtype": "constant",

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -386,7 +386,7 @@ def test_clean_kwargs():
     # Base result
     t_r, high_pass, low_pass = 0.8, 0.01, 0.08
     base_filtered = nisignal.clean(
-        x_orig, t_r=t_r, low_pass=low_cutoff, high_pass=high_cutoff
+        x_orig, t_r=t_r, low_pass=low_pass, high_pass=high_pass
     )
     for kwarg_set in kwargs:
         test_filtered = nisignal.clean(
@@ -396,6 +396,7 @@ def test_clean_kwargs():
             high_pass=high_pass,
             **kwarg_set,
         )
+        # Check that results are **not** the same.
         np.testing.assert_(np.any(np.not_equal(
             base_filtered, test_filtered
         )))

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -384,7 +384,7 @@ def test_clean_kwargs():
         },
     ]
     # Base result
-    t_r, low_cutoff, high_cutoff = 0.8, 0.01, 0.08
+    t_r, high_pass, low_pass = 0.8, 0.01, 0.08
     base_filtered = nisignal.clean(
         x_orig, t_r=t_r, low_pass=low_cutoff, high_pass=high_cutoff
     )
@@ -392,8 +392,8 @@ def test_clean_kwargs():
         test_filtered = nisignal.clean(
             x_orig,
             t_r=t_r,
-            low_pass=low_cutoff,
-            high_pass=high_cutoff,
+            low_pass=low_pass,
+            high_pass=high_pass,
             **kwarg_set,
         )
         np.testing.assert_(np.any(np.not_equal(

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -359,6 +359,48 @@ def test_clean_t_r():
                 del det_one_tr, det_diff_tr
 
 
+def test_clean_kwargs():
+    """Providing kwargs to clean should change the filtered results."""
+    n_samples = 34
+    n_features = 501
+    x_orig = generate_signals_plus_trends(
+        n_features=n_features, n_samples=n_samples
+    )
+    kwargs = [
+        {
+            "butterworth__padtype": "even",
+            "butterworth__padlen": 100,
+            "butterworth__order": 3,
+        },
+        {
+            "butterworth__padtype": None,
+            "butterworth__padlen": None,
+            "butterworth__order": 0,
+        },
+        {
+            "butterworth__padtype": "constant",
+            "butterworth__padlen": 20,
+            "butterworth__order": 10,
+        },
+    ]
+    # Base result
+    t_r, low_cutoff, high_cutoff = 0.8, 0.01, 0.08
+    base_filtered = nisignal.clean(
+        x_orig, t_r=t_r, low_pass=low_cutoff, high_pass=high_cutoff
+    )
+    for kwarg_set in kwargs:
+        test_filtered = nisignal.clean(
+            x_orig,
+            t_r=t_r,
+            low_pass=low_cutoff,
+            high_pass=high_cutoff,
+            **kwarg_set,
+        )
+        np.testing.assert_(np.any(np.not_equal(
+            base_filtered, test_filtered
+        )))
+
+
 def test_clean_frequencies():
     '''Using butterworth method.'''
     sx1 = np.sin(np.linspace(0, 100, 2000))

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -221,8 +221,8 @@ def test_butterworth():
         )
     assert not np.array_equal(data, out)
 
-    # Test check for frequency lower than allowed (<0).
-    # The frequency should be modified and the filter should be run.
+    # Test check for high-pass frequency higher than low-pass frequency.
+    # An error should be raised.
     sampling = 1
     high_pass = 0.2
     low_pass = 0.1

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -206,8 +206,8 @@ def test_butterworth():
     # Test check for frequency lower than allowed (<0).
     # The frequency should be modified and the filter should be run.
     sampling = 1
-    high_pass = 0.01
-    low_pass = -1
+    high_pass = -1
+    low_pass = 0.4
     with pytest.warns(
         UserWarning,
         match='The frequency specified for the high pass filter is too low',
@@ -220,6 +220,26 @@ def test_butterworth():
             copy=True,
         )
     assert not np.array_equal(data, out)
+
+    # Test check for frequency lower than allowed (<0).
+    # The frequency should be modified and the filter should be run.
+    sampling = 1
+    high_pass = 0.2
+    low_pass = 0.1
+    with pytest.raises(
+        ValueError,
+        match=(
+            'High pass cutoff frequency \([0-9.]+\) is greater than or '
+            'equal to low pass filter frequency \([0-9.]+\)\.'
+        ),
+    ):
+        nisignal.butterworth(
+            data,
+            sampling,
+            low_pass=low_pass,
+            high_pass=high_pass,
+            copy=True,
+        )
 
 
 def test_standardize():


### PR DESCRIPTION
Closes #3475.

I haven't thought about testing or examples yet, but I can start on that if folks feel like this is a good direction.

I also don't know if I should make these kwargs available in the maskers as well. This kwargs approach could be useful for #3437.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add `padtype` and `padlen` as parameters in `nilearn.signal.butterworth`.
- Add `**kwargs` to `nilearn.signal.clean`. Kwargs prefixed with `butterworth__` will be fed into `nilearn.signal.butterworth`. This will allow users to set `padtype`, `padlen`, `order`, and `copy`.
