### PR TITLE
[MAINT] Use lower resolution MNI152 templates for tests and examples

### DIFF
--- a/examples/06_manipulating_images/plot_resample_to_template.py
+++ b/examples/06_manipulating_images/plot_resample_to_template.py
@@ -13,7 +13,7 @@ Function :func:`nilearn.image.resample_img` could also be used to achieve this.
 from nilearn.datasets import fetch_neurovault_motor_task
 from nilearn.datasets import load_mni152_template
 
-template = load_mni152_template()
+template = load_mni152_template(resolution=2)
 
 motor_images = fetch_neurovault_motor_task()
 stat_img = motor_images.images[0]

--- a/examples/07_advanced/plot_ica_neurovault.py
+++ b/examples/07_advanced/plot_ica_neurovault.py
@@ -71,7 +71,7 @@ with warnings.catch_warnings():
     warnings.simplefilter('ignore', UserWarning)
     warnings.simplefilter('ignore', DeprecationWarning)
 
-    mask_img = load_mni152_brain_mask()
+    mask_img = load_mni152_brain_mask(resolution=2)
     masker = NiftiMasker(
         mask_img=mask_img, memory='nilearn_cache', memory_level=1)
     masker = masker.fit()

--- a/nilearn/_utils/data_gen.py
+++ b/nilearn/_utils/data_gen.py
@@ -50,10 +50,7 @@ def generate_mni_space_img(n_scans=1, res=30, random_state=0, mask_dilation=2):
 
     """
     rand_gen = check_random_state(random_state)
-    mni = datasets.load_mni152_brain_mask()
-    target_affine = np.eye(3) * res
-    mask_img = image.resample_img(
-        mni, target_affine=target_affine, interpolation="nearest")
+    mask_img = datasets.load_mni152_brain_mask(resolution=res)
     masker = maskers.NiftiMasker(mask_img).fit()
     n_voxels = image.get_data(mask_img).sum()
     data = rand_gen.randn(n_scans, n_voxels)

--- a/nilearn/datasets/tests/test_struct.py
+++ b/nilearn/datasets/tests/test_struct.py
@@ -208,7 +208,7 @@ def test_load_mni152_wm_mask():
 
 def test_fetch_icbm152_brain_gm_mask(tmp_path, request_mocker):
     dataset = struct.fetch_icbm152_2009(data_dir=str(tmp_path), verbose=0)
-    struct.load_mni152_template().to_filename(dataset.gm)
+    struct.load_mni152_template(resolution=2).to_filename(dataset.gm)
     grey_matter_img = struct.fetch_icbm152_brain_gm_mask(
         data_dir=str(tmp_path), verbose=0)
     assert isinstance(grey_matter_img, nibabel.Nifti1Image)

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -216,7 +216,7 @@ def _load_bg_img(stat_map_img, bg_img='MNI152', black_bg='auto', dim='auto'):
         bg_min, bg_max = 0, 0
     else:
         if isinstance(bg_img, str) and bg_img == "MNI152":
-            bg_img = load_mni152_template()
+            bg_img = load_mni152_template(resolution=2)
         else:
             bg_img = check_niimg_3d(bg_img)
         masked_data = np.ma.masked_inside(

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -297,7 +297,7 @@ class _MNI152Template(SpatialImage):
 
     def load(self):
         if self.data is None:
-            anat_img = load_mni152_template()
+            anat_img = load_mni152_template(resolution=2)
             anat_img = reorder_img(anat_img)
             data = get_data(anat_img)
             data = data.astype(np.float64)

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -94,7 +94,7 @@ def test_get_index_from_direction_exception():
 @pytest.fixture
 def img():
     """Image used for testing."""
-    return load_mni152_template()
+    return load_mni152_template(resolution=2)
 
 
 @pytest.fixture

--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -325,7 +325,7 @@ def test_get_cut_slices():
 
 
 def test_view_img():
-    mni = datasets.load_mni152_template()
+    mni = datasets.load_mni152_template(resolution=2)
     with warnings.catch_warnings(record=True) as w:
         # Create a fake functional image by resample the template
         img = image.resample_img(mni, target_affine=3 * np.eye(3))

--- a/nilearn/plotting/tests/test_html_surface.py
+++ b/nilearn/plotting/tests/test_html_surface.py
@@ -14,7 +14,7 @@ from .test_js_plotting_utils import check_colors, check_html
 
 
 def _get_img():
-    return datasets.load_mni152_template()
+    return datasets.load_mni152_template(resolution=2)
 
 
 def test_get_vertexcolor():

--- a/nilearn/plotting/tests/test_img_plotting/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_img_plotting.py
@@ -36,7 +36,7 @@ def _test_data_with_nans(img):
 
 def test_mni152template_is_reordered():
     """See issue #2550."""
-    reordered_mni = reorder_img(load_mni152_template())
+    reordered_mni = reorder_img(load_mni152_template(resolution=2))
     assert np.allclose(get_data(reordered_mni), get_data(MNI152TEMPLATE))
     assert np.allclose(reordered_mni.affine, MNI152TEMPLATE.affine)
     assert np.allclose(reordered_mni.shape, MNI152TEMPLATE.shape)
@@ -156,7 +156,7 @@ def test_plot_with_nans(plot_func, testdata_3d):  # noqa:F811
 @pytest.mark.parametrize("cmap", ['Paired', 'Set1', 'Set2', 'Set3', 'viridis'])
 def test_plotting_functions_with_cmaps(plot_func, cmap):
     """Some test for plotting functions with different cmaps."""
-    plot_func(load_mni152_template(), cmap=cmap, colorbar=True)
+    plot_func(load_mni152_template(resolution=2), cmap=cmap, colorbar=True)
     plt.close()
 
 

--- a/nilearn/plotting/tests/test_img_plotting/test_plot_stat_map.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_plot_stat_map.py
@@ -130,7 +130,7 @@ def test_plot_stat_map_singleton_ax_dim(shape, direction):
 
 def test_outlier_cut_coords():
     """Test to plot a subset of a large set of cuts found for a small area."""
-    bg_img = load_mni152_template()
+    bg_img = load_mni152_template(resolution=2)
     data = np.zeros((79, 95, 79))
     affine = np.array([[-2., 0., 0., 78.],
                        [0., 2., 0., -112.],


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3482.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Lower resolution of loaded templates for tests from 1mm to 2mm
- Change some examples to load lower resolution templates
- Simplify mni space data generator by passing resolution argument directly into `load_mni152_brain_mask`