### PR TITLE
[INFRA] add a GH workflow to regularly update pre-commit hooks

### DIFF
--- a/.github/workflows/update_precommit_hooks.yml
+++ b/.github/workflows/update_precommit_hooks.yml
@@ -1,0 +1,54 @@
+---
+name: Update precommit hooks
+
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Uses the cron schedule for github actions
+#
+# https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events
+#
+#            ┌───────────── minute (0 - 59)
+#            │ ┌───────────── hour (0 - 23)
+#            │ │ ┌───────────── day of the month (1 - 31)
+#            │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+#            │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+#            │ │ │ │ │
+#            │ │ │ │ │
+#            │ │ │ │ │
+#            * * * * *
+  schedule:
+    - cron: "0 0 * * 1" # every monday
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  update_precommit_hooks:
+    # only run on upstream repo
+    if: github.repository_owner == 'nilearn'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Update pre-commit hooks
+        run: pre-commit autoupdate
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: pre-commit hooks autoupdate
+          base: master
+          token: ${{ secrets.GITHUB_TOKEN }}
+          delete-branch: true
+          title: '[BOT] update pre-commit hooks'
+          body: 'done via this [GitHub Action](https://github.com/nilearn/nilearn/blob/main/.github/workflows/update_precommit_hooks.yml)'

--- a/.github/workflows/update_precommit_hooks.yml
+++ b/.github/workflows/update_precommit_hooks.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   update_precommit_hooks:
     # only run on upstream repo
-    if: github.repository_owner == 'nilearn'
+    if: github.repository_owner == 'Remi-Gau'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/update_precommit_hooks.yml
+++ b/.github/workflows/update_precommit_hooks.yml
@@ -47,8 +47,8 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           commit-message: pre-commit hooks autoupdate
-          base: master
+          base: main
           token: ${{ secrets.GITHUB_TOKEN }}
           delete-branch: true
           title: '[BOT] update pre-commit hooks'
-          body: 'done via this [GitHub Action](https://github.com/nilearn/nilearn/blob/main/.github/workflows/update_precommit_hooks.yml)'
+          body: 'done via this [GitHub Action](https://github.com/${{ github.repository_owner }}/nilearn/blob/main/.github/workflows/update_precommit_hooks.yml)'

--- a/.github/workflows/update_precommit_hooks.yml
+++ b/.github/workflows/update_precommit_hooks.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          commit-message: pre-commit hooks autoupdate
+          commit-message: pre-commit hooks auto-update
           base: main
           token: ${{ secrets.GITHUB_TOKEN }}
           delete-branch: true

--- a/.github/workflows/update_precommit_hooks.yml
+++ b/.github/workflows/update_precommit_hooks.yml
@@ -3,11 +3,6 @@ name: Update precommit hooks
 
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-
 # Uses the cron schedule for github actions
 #
 # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events
@@ -29,8 +24,10 @@ on:
 
 jobs:
   update_precommit_hooks:
+  
     # only run on upstream repo
-    if: github.repository_owner == 'Remi-Gau'
+    if: github.repository_owner == 'nilearn'
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ files: "nilearn/decomposition"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.3.0
     hooks:
       - id: check-ast
       - id: check-case-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ files: "nilearn/decomposition"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-ast
       - id: check-case-conflict


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3490

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- add a github workflow to automatically to check for update of all the pre-commit hooks every monday
- if some hooks require to be updated then the pre-commit config is updated and a PR is opened against the main branch
- only the upstream repo should be affected to avoid extra noise on the 500 forks of nilearn
- this workflow is not trigger by pushes or PR but can be triggered manually by maintainers from the action tab.

I forced a this to trigger a PR on my fork to give an example:

https://github.com/Remi-Gau/nilearn/pull/7



