### PR TITLE
remove unused pkg_resources import

### DIFF
--- a/nilearn/__init__.py
+++ b/nilearn/__init__.py
@@ -36,7 +36,6 @@ signal                  --- Set of preprocessing functions for time series
 import gzip
 import os
 import sys
-import pkg_resources
 import warnings
 
 from .version import (


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

The MNE-Python CIs are hitting a new `DeprecationWarning` today when we import nilearn. It appears to arise from the (unused) importing of `pkg_resources` in your `__init__.py`. Locally when I run `pytest nilearn` after this change, all tests pass, and `pip install -e .` into a clean environment also works, so I'm pretty sure that import was just cruft.

Here's the warning we've been hitting, FYI:

<details>

```
mne/viz/tests/test_3d_mpl.py:34: in <module>
    @requires_version('nilearn', '0.4')
mne/utils/_testing.py:94: in requires_version
    return pytest.mark.skipif(not check_version(library, min_version),
mne/utils/check.py:106: in check_version
    library = import_module(library)
/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1050: in _gcd_import
    ???
<frozen importlib._bootstrap>:1027: in _find_and_load
    ???
<frozen importlib._bootstrap>:1006: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:688: in _load_unlocked
    ???
<frozen importlib._bootstrap_external>:883: in exec_module
    ???
<frozen importlib._bootstrap>:241: in _call_with_frames_removed
    ???
/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/nilearn/__init__.py:39: in <module>
    import pkg_resources
/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/pkg_resources/__init__.py:3257: in <module>
    def _initialize_master_working_set():
/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/pkg_resources/__init__.py:3231: in _call_aside
    f(*args, **kwargs)
/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/pkg_resources/__init__.py:3282: in _initialize_master_working_set
    tuple(dist.activate(replace=False) for dist in working_set)
/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/pkg_resources/__init__.py:3282: in <genexpr>
    tuple(dist.activate(replace=False) for dist in working_set)
/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/pkg_resources/__init__.py:2803: in activate
    declare_namespace(pkg)
/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/pkg_resources/__init__.py:2297: in declare_namespace
    warnings.warn(msg, DeprecationWarning, stacklevel=2)
E   DeprecationWarning: Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
```

</details>

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- remove unused import of `pkg_resources` in `__init__.py`

*EDIT:* pasted wrong traceback the first time. fixed now.