### PR TITLE
[DOC] Fix Sphinx reference to function due to spelling error 

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -22,7 +22,7 @@ Enhancements
 
 - Addition to docs to note that :meth:`~maskers.BaseMasker.inverse_transform` only performs spatial unmasking (:gh:`3445` by `Robert Williamson`_).
 - Give users control over Butterworth filter (:func:`~signal.butterworth`) parameters in :func:`~signal.clean` and Masker objects as kwargs (:gh:`3478` by `Taylor Salo`_).
-- Allow users to output label maps from :func:`~reporting.get_clusters_tables` (:gh:`3477` by `Steven Meisler`_).
+- Allow users to output label maps from :func:`~reporting.get_clusters_table` (:gh:`3477` by `Steven Meisler`_).
 
 Changes
 -------


### PR DESCRIPTION
Resolve doc build fail on main: https://github.com/nilearn/nilearn/actions/runs/4183070013/jobs/7246957945
