### PR TITLE
[MAINT] Update deprecated parameter name for Pandas `DataFrame.to_csv` method

### DIFF
--- a/nilearn/interfaces/bids/glm.py
+++ b/nilearn/interfaces/bids/glm.py
@@ -143,7 +143,6 @@ def save_glm_to_bids(
         design_matrix.to_csv(
             dm_file,
             sep='\t',
-            lineterminator='\n',
             index=False,
         )
 

--- a/nilearn/interfaces/bids/glm.py
+++ b/nilearn/interfaces/bids/glm.py
@@ -143,7 +143,7 @@ def save_glm_to_bids(
         design_matrix.to_csv(
             dm_file,
             sep='\t',
-            line_terminator='\n',
+            lineterminator='\n',
             index=False,
         )
 


### PR DESCRIPTION
Pandas pre-release 2.0.0rc0 deprecates parameter `line_terminator` for `lineterminator` in method `to_csv` causing some tests to fail on pre-release workflow (e.g. https://github.com/nilearn/nilearn/actions/runs/4233168828/jobs/7353781075#step:8:16674)

Edit: Closes #3530

Edit: Or remove it alltogether if not needed (new parameter name doesn't meet minimum supported requirements )