### PR TITLE
[FIX] Allow preprocessed data in native space in `load_confounds`

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -36,6 +36,8 @@ Fixes
 
 - :func:`~nilearn.mass_univariate.permuted_ols` now checks if confounding variates contain a intercept and raises an warning when multiple intercepts are defined across target and confounding variates (:gh:`3465` by `Jelle Roelof Dalenberg`_).
 
+- :func:`~nilearn.interfaces.fmriprep.load_confounds` can support searching preprocessed data in native space. (:gh:`3531` by `Hao-Ting Wang`_)
+
 Enhancements
 ------------
 

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -11,6 +11,8 @@ NEW
 Fixes
 -----
 
+- :func:`~nilearn.interfaces.fmriprep.load_confounds` can support searching preprocessed data in native space. (:gh:`3531` by `Hao-Ting Wang`_)
+
 Enhancements
 ------------
 
@@ -36,7 +38,6 @@ Fixes
 
 - :func:`~nilearn.mass_univariate.permuted_ols` now checks if confounding variates contain a intercept and raises an warning when multiple intercepts are defined across target and confounding variates (:gh:`3465` by `Jelle Roelof Dalenberg`_).
 
-- :func:`~nilearn.interfaces.fmriprep.load_confounds` can support searching preprocessed data in native space. (:gh:`3531` by `Hao-Ting Wang`_)
 
 Enhancements
 ------------

--- a/nilearn/interfaces/fmriprep/load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_utils.py
@@ -26,7 +26,7 @@ img_file_error = {
         " strategy."
     ),    "nii.gz": "Invalid file type for the selected method.",
     "dtseries.nii": "Invalid file type for the selected method.",
-    "fnc.gii": "need fMRIprep output with extension func.gii",
+    "func.gii": "need fMRIprep output with extension func.gii",
 }
 
 def _check_params(confounds_raw, params):

--- a/nilearn/interfaces/fmriprep/load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_utils.py
@@ -104,8 +104,14 @@ def _get_file_name(nii_file):
     # Check file with new naming scheme exists or replace,
     # for backward compatibility.
     confounds_raw_candidates = [
-        nii_file.replace(img_filename, f"{subject_label}_{specifiers}_desc-confounds_timeseries.tsv"),
-        nii_file.replace(img_filename, f"{subject_label}_{specifiers}_desc-confounds_regressors.tsv"),
+~         nii_file.replace(
+~             img_filename,
++             f"{subject_label}_{specifiers}_desc-confounds_timeseries.tsv"
++         ),
++         nii_file.replace(
++             img_filename,
++             f"{subject_label}_{specifiers}_desc-confounds_regressors.tsv"
++         ),
     ]
 
     confounds_raw = [

--- a/nilearn/interfaces/fmriprep/load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_utils.py
@@ -15,9 +15,9 @@ from nilearn.interfaces.bids import parse_bids_filename
 
 img_file_patterns = {
     "aroma": "_desc-smoothAROMAnonaggr_bold",
-    "nii.gz": "(_space-.*)?_desc-preproc_bold\.nii\.gz",
-    "dtseries.nii": "(_space-.*)?_bold.dtseries\.nii",
-    "func.gii": "(_space-.*)?_hemi-[LR]_bold\.func\.gii",
+    "nii.gz": "(_space-.*)?_desc-preproc_bold.nii.gz",
+    "dtseries.nii": "(_space-.*)?_bold.dtseries.nii",
+    "func.gii": "(_space-.*)?_hemi-[LR]_bold.func.gii",
 }
 
 img_file_error = {

--- a/nilearn/interfaces/fmriprep/load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_utils.py
@@ -10,7 +10,7 @@ from .load_confounds_scrub import _extract_outlier_regressors
 from nilearn._utils.fmriprep_confounds import (
     _flag_single_gifti, _is_camel_case
 )
-
+from nilearn.interfaces.bids import parse_bids_filename
 
 img_file_patterns = {
     "aroma": "_desc-smoothAROMAnonaggr_bold",
@@ -89,15 +89,22 @@ def _get_file_name(nii_file):
     """Construct the raw confound file name from processed functional data."""
     if isinstance(nii_file, list):  # catch gifti
         nii_file = nii_file[0]
-    suffix = "_space-" + nii_file.split("space-")[1]
+    entities = parse_bids_filename(nii_file)
+    subject_label = f"sub-{entities['sub']}"
+    if "session" in entities:
+        subject_label = f"{subject_label}_ses-{entities['ses']}"
+    specifiers = f"task-{entities['task']}"
+    if "run" in entities:
+        specifiers = f"{specifiers}_run-{entities['run']}"
+    img_filename = nii_file.split(os.sep)[-1]
     # fmriprep has changed the file suffix between v20.1.1 and v20.2.0 with
     # respect to BEP 012.
     # cf. https://neurostars.org/t/naming-change-confounds-regressors-to-confounds-timeseries/17637 # noqa
     # Check file with new naming scheme exists or replace,
     # for backward compatibility.
     confounds_raw_candidates = [
-        nii_file.replace(suffix, "_desc-confounds_timeseries.tsv"),
-        nii_file.replace(suffix, "_desc-confounds_regressors.tsv"),
+        nii_file.replace(img_filename, f"{subject_label}_{specifiers}_desc-confounds_timeseries.tsv"),
+        nii_file.replace(img_filename, f"{subject_label}_{specifiers}_desc-confounds_regressors.tsv"),
     ]
 
     confounds_raw = [

--- a/nilearn/interfaces/fmriprep/load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_utils.py
@@ -12,6 +12,7 @@ from nilearn._utils.fmriprep_confounds import (
 )
 from nilearn.interfaces.bids import parse_bids_filename
 
+
 img_file_patterns = {
     "aroma": "_desc-smoothAROMAnonaggr_bold",
     "nii.gz": "(_space-.*)?_desc-preproc_bold\.nii\.gz",
@@ -91,7 +92,7 @@ def _get_file_name(nii_file):
         nii_file = nii_file[0]
     entities = parse_bids_filename(nii_file)
     subject_label = f"sub-{entities['sub']}"
-    if "session" in entities:
+    if "ses" in entities:
         subject_label = f"{subject_label}_ses-{entities['ses']}"
     specifiers = f"task-{entities['task']}"
     if "run" in entities:

--- a/nilearn/interfaces/fmriprep/load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_utils.py
@@ -22,14 +22,12 @@ img_file_patterns = {
 
 img_file_error = {
     "aroma": (
-        "Input must be ~desc-smoothAROMAnonaggr_bold for full ICA-AROMA"
+        "Input must be desc-smoothAROMAnonaggr_bold for full ICA-AROMA"
         " strategy."
-    ),
-    "nii.gz": "Invalid file type for the selected method.",
+    ),    "nii.gz": "Invalid file type for the selected method.",
     "dtseries.nii": "Invalid file type for the selected method.",
-    "func.gii": "need fMRIprep output with extension func.gii",
+    "fnc.gii": "need fMRIprep output with extension func.gii",
 }
-
 
 def _check_params(confounds_raw, params):
     """Check that specified parameters can be found in the confounds."""
@@ -104,14 +102,14 @@ def _get_file_name(nii_file):
     # Check file with new naming scheme exists or replace,
     # for backward compatibility.
     confounds_raw_candidates = [
-~         nii_file.replace(
-~             img_filename,
-+             f"{subject_label}_{specifiers}_desc-confounds_timeseries.tsv"
-+         ),
-+         nii_file.replace(
-+             img_filename,
-+             f"{subject_label}_{specifiers}_desc-confounds_regressors.tsv"
-+         ),
+        nii_file.replace(
+            img_filename,
+            f"{subject_label}_{specifiers}_desc-confounds_timeseries.tsv"
+        ),
+        nii_file.replace(
+            img_filename,
+            f"{subject_label}_{specifiers}_desc-confounds_regressors.tsv"
+        ),
     ]
 
     confounds_raw = [

--- a/nilearn/interfaces/fmriprep/load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_utils.py
@@ -14,9 +14,9 @@ from nilearn.interfaces.bids import parse_bids_filename
 
 img_file_patterns = {
     "aroma": "_desc-smoothAROMAnonaggr_bold",
-    "nii.gz": "_space-.*_desc-preproc_bold.nii.gz",
-    "dtseries.nii": "_space-.*_bold.dtseries.nii",
-    "func.gii": "_space-.*_hemi-[LR]_bold.func.gii",
+    "nii.gz": "(_space-.*)?_desc-preproc_bold\.nii\.gz",
+    "dtseries.nii": "(_space-.*)?_bold.dtseries\.nii",
+    "func.gii": "(_space-.*)?_hemi-[LR]_bold\.func\.gii",
 }
 
 img_file_error = {

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
@@ -551,7 +551,7 @@ def test_sample_mask(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "image_type", ["regular", "ica_aroma", "gifti", "cifti"]
+    "image_type", ["regular", "native", "ica_aroma", "gifti", "cifti"]
 )
 def test_inputs(tmp_path, image_type):
     """Test multiple images as input."""
@@ -560,7 +560,7 @@ def test_inputs(tmp_path, image_type):
     for i in range(2):  # gifti edge case
         nii, _ = create_tmp_filepath(
             tmp_path,
-            suffix=f"img{i+1}",
+            suffix=f"sub-test{i+1}_task-testimg",
             image_type=image_type,
             copy_confounds=True,
             copy_json=True,

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
@@ -450,7 +450,6 @@ def test_invalid_filetype(tmp_path):
                                             suffix="sub-test01_task-test",
                                             copy_confounds=True,
                                             old_derivative_suffix=False)
-    print(bad_nii)
     conf, _ = load_confounds(bad_nii)
 
     # more than one legal filename for confounds
@@ -563,7 +562,7 @@ def test_inputs(tmp_path, image_type):
     for i in range(2):  # gifti edge case
         nii, _ = create_tmp_filepath(
             tmp_path,
-            suffix=f"sub-test{i+1}_task-testimg",
+            suffix=f"sub-test{i+1}_ses-test_task-testimg_run-01",
             image_type=image_type,
             copy_confounds=True,
             copy_json=True,

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
@@ -446,12 +446,15 @@ def test_load_non_nifti(tmp_path):
 
 def test_invalid_filetype(tmp_path):
     """Invalid file types/associated files for load method."""
-    bad_nii, bad_conf = create_tmp_filepath(tmp_path, copy_confounds=True,
+    bad_nii, bad_conf = create_tmp_filepath(tmp_path,
+                                            suffix="sub-test01_task-test",
+                                            copy_confounds=True,
                                             old_derivative_suffix=False)
+    print(bad_nii)
     conf, _ = load_confounds(bad_nii)
 
     # more than one legal filename for confounds
-    add_conf = "test_desc-confounds_regressors.tsv"
+    add_conf = "sub-test01_task-test_desc-confounds_regressors.tsv"
     leagal_confounds, _ = get_leagal_confound()
     leagal_confounds.to_csv(tmp_path / add_conf, sep="\t", index=False)
     with pytest.raises(ValueError) as info:

--- a/nilearn/interfaces/fmriprep/tests/utils.py
+++ b/nilearn/interfaces/fmriprep/tests/utils.py
@@ -10,6 +10,8 @@ img_file_patterns = {
         "_space-MNI152NLin2009cAsym_desc-smoothAROMAnonaggr_bold.nii.gz",
     "regular":
         "_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz",
+    "native":
+        "_desc-preproc_bold.nii.gz",
     "cifti":
         "_space-fsLR_den-91k_bold.dtseries.nii",
     "gifti": (
@@ -45,7 +47,7 @@ def get_testdata_path(non_steady_state=True):
 def create_tmp_filepath(
     base_path,
     image_type="regular",
-    suffix="test",
+    suffix="sub-test01_task-test",
     copy_confounds=False,
     copy_json=False,
     old_derivative_suffix=False


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the 
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3479.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Use `nilearn.interfaces.bids.parse_bids_filename` to parse and construct file names that fits fMRIPrep doc better
- Adapt BIDS compatible test file name  
