### PR TITLE
[MAINT] make test_percentile_range for canica less brittle

### DIFF
--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -169,16 +169,14 @@ def test_percentile_range():
     canica = CanICA(n_components=edge_case, threshold=float(edge_case))
     with warnings.catch_warnings(record=True) as warning:
         canica.fit(data)
-        # Filter out deprecation warnings
-        not_deprecation_warning = [
-            not issubclass(w.category, (DeprecationWarning, FutureWarning))
+        # ensure a single warning is raised
+        # filter out deprecation warnings
+        warning_messages = [
+            "obtained a critical threshold" in str(w.message)
             for w in warning
+            if not issubclass(w.category, (DeprecationWarning, FutureWarning))
         ]
-        assert sum(not_deprecation_warning) == 1  # ensure single warning
-        idx_critical_warning = not_deprecation_warning.index(True)
-        assert "critical threshold" in str(
-            warning[idx_critical_warning].message
-        )
+        assert sum(warning_messages) == 1
 
 
 def test_masker_attributes_with_fit():


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3546 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- simplify test by making sure that only one warning with the expected message is thrown

### Unrelated

tidy up gitignore