### PR TITLE
[DOC] Fix Sphinx build error caused by changed pattern

### DIFF
--- a/doc/building_blocks/manual_pipeline.rst
+++ b/doc/building_blocks/manual_pipeline.rst
@@ -77,7 +77,7 @@ For example, we will now consider only the conditions *cat* and *face* from our 
 This can be done as follows:
 
 .. literalinclude:: ../../examples/00_tutorials/plot_decoding_tutorial.py
-    :start-after: # The input data will become much smaller (i.e. :term:`fmri<fMRI>` signal is shorter):
+    :start-after: # (i.e. :term:`fmri<fMRI>` signal is shorter):
     :end-before: ###########################################################################
 
 


### PR DESCRIPTION
Fixing build fail on main: https://github.com/nilearn/nilearn/actions/runs/4316077088/jobs/7531359830
In the reformatting process, a pattern for the Sphinx `:start-after:` directive was changed.
