### PR TITLE
[Fix] relabel `label_maps` to match the cluster IDs in the clusters table

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -38,6 +38,7 @@ Fixes
 
 - :func:`~nilearn.mass_univariate.permuted_ols` now checks if confounding variates contain a intercept and raises an warning when multiple intercepts are defined across target and confounding variates (:gh:`3465` by `Jelle Roelof Dalenberg`_).
 
+- The label of the clusters in the label maps returned by :func:`~nilearn.reporting.get_clusters_table` now matches the Cluster IDs in the clusters table (:gh:`3563` by `Julio A Peraza`_).
 
 Enhancements
 ------------

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -122,6 +122,8 @@
 
 .. _Julia Huntenburg: https://github.com/juhuntenburg
 
+.. _Julio A Peraza: https://github.com/JulioAPeraza
+
 .. _Kamalakar Reddy Daddy: https://github.com/KamalakerDadi
 
 .. _Koen Helwegen: https://github.com/koenhelwegen

--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -25,6 +25,7 @@ from nilearn._utils.niimg import _safe_get_data
 
 def _local_max(data, affine, min_distance):
     """Find all local maxima of the array, separated by at least min_distance.
+
     Adapted from https://stackoverflow.com/a/22631583/2589328
 
     Parameters
@@ -416,7 +417,4 @@ def get_clusters_table(
     else:
         df = pd.DataFrame(columns=cols, data=rows)
 
-    if return_label_maps:
-        return df, label_maps
-    else:
-        return df
+    return (df, label_maps) if return_label_maps else df

--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -311,7 +311,9 @@ def get_clusters_table(
     # If cluster threshold is used, there is chance that stat_map will be
     # modified, therefore copy is needed
     stat_map = _safe_get_data(
-        stat_img, ensure_finite=True, copy_data=(cluster_threshold is not None)
+        stat_img,
+        ensure_finite=True,
+        copy_data=(cluster_threshold is not None),
     )
 
     # Define array for 6-connectivity, aka NN1 or "faces"

--- a/nilearn/reporting/_get_clusters_table.py
+++ b/nilearn/reporting/_get_clusters_table.py
@@ -110,7 +110,7 @@ def _identify_subpeaks(data):
         ijk[subpeaks_outside_cluster] = _cluster_nearest_neighbor(
             ijk[subpeaks_outside_cluster],
             labels_index[subpeaks_outside_cluster],
-            labeled
+            labeled,
         )
     vals = data[ijk[:, 0], ijk[:, 1], ijk[:, 2]]
     return ijk, vals
@@ -205,9 +205,14 @@ def _pare_subpeaks(xyz, ijk, vals, min_distance):
     return ijk, vals
 
 
-def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
-                       two_sided=False, min_distance=8.,
-                       return_label_maps=False):
+def get_clusters_table(
+    stat_img,
+    stat_threshold,
+    cluster_threshold=None,
+    two_sided=False,
+    min_distance=8.0,
+    return_label_maps=False,
+):
     """Creates pandas dataframe with img cluster statistics.
 
     This function should work on any statistical maps where more extreme values
@@ -254,7 +259,7 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
     return_label_maps : :obj:`bool`, optional
         Whether or not to additionally output cluster label map images.
         Default=False.
-    
+
         .. versionadded:: 0.10.1.dev
 
     Returns
@@ -274,7 +279,7 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
                            Rows corresponding to subpeaks will not have a value
                            in this column.
         ================== ====================================================
-        
+
     label_maps : :obj:`list`
         Returned if return_label_maps=True
         List of Niimg-like objects of cluster label maps.
@@ -284,14 +289,14 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
         .. versionadded:: 0.10.1.dev
 
     """
-    cols = ['Cluster ID', 'X', 'Y', 'Z', 'Peak Stat', 'Cluster Size (mm3)']
+    cols = ["Cluster ID", "X", "Y", "Z", "Peak Stat", "Cluster Size (mm3)"]
     # Replace None with 0
     cluster_threshold = 0 if cluster_threshold is None else cluster_threshold
 
     # check that stat_img is niimg-like object and 3D
     stat_img = check_niimg_3d(stat_img)
     affine = stat_img.affine
-    
+
     # Apply threshold(s) to image
     stat_img = threshold_img(
         img=stat_img,
@@ -304,8 +309,9 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
 
     # If cluster threshold is used, there is chance that stat_map will be
     # modified, therefore copy is needed
-    stat_map = _safe_get_data(stat_img, ensure_finite=True,
-                              copy_data=(cluster_threshold is not None))
+    stat_map = _safe_get_data(
+        stat_img, ensure_finite=True, copy_data=(cluster_threshold is not None)
+    )
 
     # Define array for 6-connectivity, aka NN1 or "faces"
     bin_struct = generate_binary_structure(rank=3, connectivity=1)
@@ -327,8 +333,8 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
         # If the stat threshold is too high simply return an empty dataframe
         if np.sum(binarized) == 0:
             warnings.warn(
-                'Attention: No clusters with stat {0} than {1}'.format(
-                    'higher' if sign == 1 else 'lower',
+                "Attention: No clusters with stat {0} than {1}".format(
+                    "higher" if sign == 1 else "lower",
                     stat_threshold * sign,
                 )
             )
@@ -336,17 +342,20 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
 
         # Now re-label and create table
         label_map = label(binarized, bin_struct)[0]
-        # Save label maps as nifti objects
-        label_maps.append(new_img_like(stat_img, label_map, affine=affine))
         clust_ids = sorted(list(np.unique(label_map)[1:]))
         peak_vals = np.array(
-            [np.max(temp_stat_map * (label_map == c)) for c in clust_ids])
+            [np.max(temp_stat_map * (label_map == c)) for c in clust_ids]
+        )
         # Sort by descending max value
         clust_ids = [clust_ids[c] for c in (-peak_vals).argsort()]
 
+        re_label_map = np.zeros_like(label_map)
         for c_id, c_val in enumerate(clust_ids):
             cluster_mask = label_map == c_val
             masked_data = temp_stat_map * cluster_mask
+
+            # Relabel label_map
+            re_label_map[cluster_mask] = c_id + 1
 
             cluster_size_mm = int(np.sum(cluster_mask) * voxel_size)
 
@@ -382,7 +391,7 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
                 else:
                     # Subpeak naming convention is cluster num+letter:
                     # 1a, 1b, etc
-                    sp_id = '{0}{1}'.format(
+                    sp_id = "{0}{1}".format(
                         c_id + 1,
                         ascii_lowercase[subpeak - 1],
                     )
@@ -392,9 +401,12 @@ def get_clusters_table(stat_img, stat_threshold, cluster_threshold=None,
                         subpeak_xyz[subpeak, 1],
                         subpeak_xyz[subpeak, 2],
                         subpeak_vals[subpeak],
-                        '',
+                        "",
                     ]
                 rows += [row]
+
+        # Save label maps as nifti objects
+        label_maps.append(new_img_like(stat_img, re_label_map, affine=affine))
 
         # If we reach this point, there are clusters in this sign
         no_clusters_found = False

--- a/nilearn/reporting/tests/test_reporting.py
+++ b/nilearn/reporting/tests/test_reporting.py
@@ -6,8 +6,6 @@ import pytest
 from nilearn.plotting import _set_mpl_backend
 
 from nilearn.reporting import get_clusters_table
-    get_clusters_table,
-)
 from nilearn.image import get_data
 from nilearn.reporting._get_clusters_table import (
     _local_max,
@@ -148,7 +146,10 @@ def test_get_clusters_table(tmp_path):
     data_extra_dim = data[..., np.newaxis]
     stat_img_extra_dim = nib.Nifti1Image(data_extra_dim, np.eye(4))
     cluster_table = get_clusters_table(
-        stat_img_extra_dim, 4, 0, two_sided=True
+        stat_img_extra_dim,
+        4,
+        0,
+        two_sided=True,
     )
     assert len(cluster_table) == 2
 
@@ -160,6 +161,9 @@ def test_get_clusters_table(tmp_path):
 
 
 def test_get_clusters_table_relabel_label_maps():
+    """Check that the cluster's labels in label_maps match their corresponding
+    cluster IDs in the clusters table.
+    """
     shape = (9, 10, 11)
     data = np.zeros(shape)
     data[2:4, 5:7, 6:8] = 6.0
@@ -167,7 +171,10 @@ def test_get_clusters_table_relabel_label_maps():
     stat_img = nib.Nifti1Image(data, np.eye(4))
 
     cluster_table, label_maps = get_clusters_table(
-        stat_img, 4, 0, return_label_maps=True
+        stat_img,
+        4,
+        0,
+        return_label_maps=True,
     )
 
     # Get cluster ids from clusters table
@@ -191,7 +198,10 @@ def test_get_clusters_table_not_modifying_stat_image():
 
     # test one cluster should be removed
     clusters_table = get_clusters_table(
-        stat_img, 4, cluster_threshold=10, two_sided=True
+        stat_img,
+        4,
+        cluster_threshold=10,
+        two_sided=True,
     )
     assert np.allclose(data_orig, get_data(stat_img))
     assert len(clusters_table) == 1
@@ -199,7 +209,10 @@ def test_get_clusters_table_not_modifying_stat_image():
     # test no clusters should be removed
     stat_img = nib.Nifti1Image(data, np.eye(4))
     clusters_table = get_clusters_table(
-        stat_img, 4, cluster_threshold=7, two_sided=False
+        stat_img,
+        4,
+        cluster_threshold=7,
+        two_sided=False,
     )
     assert np.allclose(data_orig, get_data(stat_img))
     assert len(clusters_table) == 2
@@ -207,7 +220,10 @@ def test_get_clusters_table_not_modifying_stat_image():
     # test cluster threshold is None
     stat_img = nib.Nifti1Image(data, np.eye(4))
     clusters_table = get_clusters_table(
-        stat_img, 4, cluster_threshold=None, two_sided=False
+        stat_img,
+        4,
+        cluster_threshold=None,
+        two_sided=False,
     )
     assert np.allclose(data_orig, get_data(stat_img))
     assert len(clusters_table) == 2

--- a/nilearn/reporting/tests/test_reporting.py
+++ b/nilearn/reporting/tests/test_reporting.py
@@ -134,7 +134,11 @@ def test_get_clusters_table(tmp_path):
 
     # test with returning label maps
     cluster_table, label_maps = get_clusters_table(
-        stat_img, 4, 0, two_sided=True, return_label_maps=True
+        stat_img,
+        4,
+        0,
+        two_sided=True,
+        return_label_maps=True,
     )
     label_map_positive_data = label_maps[0].get_fdata()
     label_map_negative_data = label_maps[1].get_fdata()

--- a/nilearn/reporting/tests/test_reporting.py
+++ b/nilearn/reporting/tests/test_reporting.py
@@ -167,6 +167,7 @@ def test_get_clusters_table_relabel_label_maps():
     shape = (9, 10, 11)
     data = np.zeros(shape)
     data[2:4, 5:7, 6:8] = 6.0
+    data[5:7, 7:9, 7:9] = 5.5
     data[0:3, 0:3, 0:3] = 5.0
     stat_img = nib.Nifti1Image(data, np.eye(4))
 

--- a/nilearn/reporting/tests/test_reporting.py
+++ b/nilearn/reporting/tests/test_reporting.py
@@ -5,8 +5,9 @@ import pytest
 # Set backend to avoid DISPLAY problems
 from nilearn.plotting import _set_mpl_backend
 
-from nilearn.reporting import (get_clusters_table,
-                               )
+from nilearn.reporting import (
+    get_clusters_table,
+)
 from nilearn.image import get_data
 from nilearn.reporting._get_clusters_table import (
     _local_max,
@@ -17,6 +18,7 @@ from nilearn.reporting._get_clusters_table import (
 _set_mpl_backend
 try:
     import matplotlib.pyplot
+
     # Avoid making pyflakes unhappy
     matplotlib.pyplot
 except ImportError:
@@ -25,8 +27,9 @@ else:
     have_mpl = True
 
 
-@pytest.mark.skipif(not have_mpl,
-                    reason='Matplotlib not installed; required for this test')
+@pytest.mark.skipif(
+    not have_mpl, reason="Matplotlib not installed; required for this test"
+)
 def test_local_max():
     """Basic test of nilearn.reporting._get_clusters_table._local_max()"""
     shape = (9, 10, 11)
@@ -38,11 +41,11 @@ def test_local_max():
     affine = np.eye(4)
 
     ijk, vals = _local_max(data, affine, min_distance=9)
-    assert np.array_equal(ijk, np.array([[5., 5., 10.], [5., 5., 0.]]))
+    assert np.array_equal(ijk, np.array([[5.0, 5.0, 10.0], [5.0, 5.0, 0.0]]))
     assert np.array_equal(vals, np.array([6, 5]))
 
     ijk, vals = _local_max(data, affine, min_distance=11)
-    assert np.array_equal(ijk, np.array([[5., 5., 10.]]))
+    assert np.array_equal(ijk, np.array([[5.0, 5.0, 10.0]]))
     assert np.array_equal(vals, np.array([6]))
 
     # Two global (equal) maxima, 10 voxels apart.
@@ -53,11 +56,11 @@ def test_local_max():
     affine = np.eye(4)
 
     ijk, vals = _local_max(data, affine, min_distance=9)
-    assert np.array_equal(ijk, np.array([[5., 5., 0.], [5., 5., 10.]]))
+    assert np.array_equal(ijk, np.array([[5.0, 5.0, 0.0], [5.0, 5.0, 10.0]]))
     assert np.array_equal(vals, np.array([5, 5]))
 
     ijk, vals = _local_max(data, affine, min_distance=11)
-    assert np.array_equal(ijk, np.array([[5., 5., 0.]]))
+    assert np.array_equal(ijk, np.array([[5.0, 5.0, 0.0]]))
     assert np.array_equal(vals, np.array([5]))
 
     # A donut.
@@ -68,7 +71,7 @@ def test_local_max():
     affine = np.eye(4)
 
     ijk, vals = _local_max(data, affine, min_distance=9)
-    assert np.array_equal(ijk, np.array([[4., 5., 5.]]))
+    assert np.array_equal(ijk, np.array([[4.0, 5.0, 5.0]]))
     assert np.array_equal(vals, np.array([1]))
 
 
@@ -83,11 +86,13 @@ def test_cluster_nearest_neighbor():
     labeled[4, 2, 6] = 2
 
     labels_index = np.array([1, 1, 2])
-    ijk = np.array([
-        [4, 7, 5],  # inside cluster 1
-        [4, 2, 5],  # outside, close to 2
-        [4, 3, 6],  # outside, close to 2
-    ])
+    ijk = np.array(
+        [
+            [4, 7, 5],  # inside cluster 1
+            [4, 2, 5],  # outside, close to 2
+            [4, 3, 6],  # outside, close to 2
+        ]
+    )
     nbrs = _cluster_nearest_neighbor(ijk, labels_index, labeled)
     assert np.array_equal(nbrs, np.array([[4, 7, 5], [4, 5, 5], [4, 2, 6]]))
 
@@ -95,8 +100,8 @@ def test_cluster_nearest_neighbor():
 def test_get_clusters_table(tmp_path):
     shape = (9, 10, 11)
     data = np.zeros(shape)
-    data[2:4, 5:7, 6:8] = 5.
-    data[4:6, 7:9, 8:10] = -5.
+    data[2:4, 5:7, 6:8] = 5.0
+    data[4:6, 7:9, 8:10] = -5.0
     stat_img = nib.Nifti1Image(data, np.eye(4))
 
     # test one cluster extracted
@@ -128,10 +133,11 @@ def test_get_clusters_table(tmp_path):
     stat_img.to_filename(fname)
     cluster_table = get_clusters_table(fname, 4, 0, two_sided=True)
     assert len(cluster_table) == 2
-    
+
     # test with returning label maps
     cluster_table, label_maps = get_clusters_table(
-        stat_img, 4, 0, two_sided=True, return_label_maps=True)
+        stat_img, 4, 0, two_sided=True, return_label_maps=True
+    )
     label_map_positive_data = label_maps[0].get_fdata()
     label_map_negative_data = label_maps[1].get_fdata()
     # make sure positive and negative clusters are returned in the label maps
@@ -142,10 +148,7 @@ def test_get_clusters_table(tmp_path):
     data_extra_dim = data[..., np.newaxis]
     stat_img_extra_dim = nib.Nifti1Image(data_extra_dim, np.eye(4))
     cluster_table = get_clusters_table(
-        stat_img_extra_dim,
-        4,
-        0,
-        two_sided=True
+        stat_img_extra_dim, 4, 0, two_sided=True
     )
     assert len(cluster_table) == 2
 
@@ -156,21 +159,39 @@ def test_get_clusters_table(tmp_path):
     assert len(cluster_table) == 1
 
 
+def test_get_clusters_table_relabel_label_maps():
+    shape = (9, 10, 11)
+    data = np.zeros(shape)
+    data[2:4, 5:7, 6:8] = 6.0
+    data[0:3, 0:3, 0:3] = 5.0
+    stat_img = nib.Nifti1Image(data, np.eye(4))
+
+    cluster_table, label_maps = get_clusters_table(
+        stat_img, 4, 0, return_label_maps=True
+    )
+
+    # Get cluster ids from clusters table
+    cluster_ids = cluster_table["Cluster ID"].to_numpy()
+
+    # Find the cluster ids in the label map using the coords from the table.
+    coords = cluster_table[["X", "Y", "Z"]].to_numpy().astype(int)
+    lb_cluster_ids = label_maps[0].get_fdata()[tuple(coords.T)]
+
+    assert np.array_equal(cluster_ids, lb_cluster_ids)
+
+
 def test_get_clusters_table_not_modifying_stat_image():
     shape = (9, 10, 11)
     data = np.zeros(shape)
-    data[2:4, 5:7, 6:8] = 5.
-    data[0:3, 0:3, 0:3] = 6.
+    data[2:4, 5:7, 6:8] = 5.0
+    data[0:3, 0:3, 0:3] = 6.0
 
     stat_img = nib.Nifti1Image(data, np.eye(4))
     data_orig = get_data(stat_img).copy()
 
     # test one cluster should be removed
     clusters_table = get_clusters_table(
-        stat_img,
-        4,
-        cluster_threshold=10,
-        two_sided=True
+        stat_img, 4, cluster_threshold=10, two_sided=True
     )
     assert np.allclose(data_orig, get_data(stat_img))
     assert len(clusters_table) == 1
@@ -178,10 +199,7 @@ def test_get_clusters_table_not_modifying_stat_image():
     # test no clusters should be removed
     stat_img = nib.Nifti1Image(data, np.eye(4))
     clusters_table = get_clusters_table(
-        stat_img,
-        4,
-        cluster_threshold=7,
-        two_sided=False
+        stat_img, 4, cluster_threshold=7, two_sided=False
     )
     assert np.allclose(data_orig, get_data(stat_img))
     assert len(clusters_table) == 2
@@ -189,10 +207,7 @@ def test_get_clusters_table_not_modifying_stat_image():
     # test cluster threshold is None
     stat_img = nib.Nifti1Image(data, np.eye(4))
     clusters_table = get_clusters_table(
-        stat_img,
-        4,
-        cluster_threshold=None,
-        two_sided=False
+        stat_img, 4, cluster_threshold=None, two_sided=False
     )
     assert np.allclose(data_orig, get_data(stat_img))
     assert len(clusters_table) == 2

--- a/nilearn/reporting/tests/test_reporting.py
+++ b/nilearn/reporting/tests/test_reporting.py
@@ -5,7 +5,7 @@ import pytest
 # Set backend to avoid DISPLAY problems
 from nilearn.plotting import _set_mpl_backend
 
-from nilearn.reporting import (
+from nilearn.reporting import get_clusters_table
     get_clusters_table,
 )
 from nilearn.image import get_data

--- a/nilearn/reporting/tests/test_reporting.py
+++ b/nilearn/reporting/tests/test_reporting.py
@@ -163,6 +163,19 @@ def test_get_clusters_table(tmp_path):
     cluster_table = get_clusters_table(stat_img_nans, 1e-2, 0, two_sided=False)
     assert len(cluster_table) == 1
 
+    # Test that subpeaks are handled correctly for len(subpeak_vals) > 1
+    # 1 cluster and two subpeaks, 10 voxels apart.
+    data = np.zeros(shape)
+    data[4, 5, :] = [4, 3, 2, 1, 1, 1, 1, 1, 2, 3, 4]
+    data[5, 5, :] = [5, 4, 3, 2, 1, 1, 1, 2, 3, 4, 6]
+    data[6, 5, :] = [4, 3, 2, 1, 1, 1, 1, 1, 2, 3, 4]
+    stat_img = nib.Nifti1Image(data, np.eye(4))
+
+    cluster_table = get_clusters_table(stat_img, 0, 0, min_distance=9)
+    assert len(cluster_table) == 2
+    assert 1 in cluster_table["Cluster ID"].values
+    assert "1a" in cluster_table["Cluster ID"].values
+
 
 def test_get_clusters_table_relabel_label_maps():
     """Check that the cluster's labels in label_maps match their corresponding


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3561.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Relabel the clusters in `label_maps` to match their corresponding cluster IDs in the clusters table.
