### PR TITLE
Slight css enhacements on the documentation

### DIFF
--- a/doc/themes/custom.css
+++ b/doc/themes/custom.css
@@ -51,7 +51,7 @@ div[class^="highlight-"].sphx-glr-script-out {
 
 .sphx-glr-script-out .highlight {
   border-radius: 0px;
-  border-left: 4px solid var(--sd-color-primary);
+  background-color: var(--color-background-secondary);
 }
 
 .sphx-glr-script-out .highlight pre {
@@ -70,20 +70,15 @@ button.copybtn {
 /* Code snippets styling */
 .highlight {
   border-radius: 0px;
-  background-color: var(--color-background-secondary);
+  border-left: 4px solid var(--color-background-border);
 }
 
 .highlight-default .highlight {
-  border-left: 4px solid var(--color-background-border);
+  background-color: var(--color-background-secondary);
 }
 
 .highlight-primary .highlight {
   border-left: 4px solid var(--sd-color-primary);
-}
-
-/* Inline code */
-code.literal {
-  font-size: var(--font-size--normal);
 }
 
 table.plotting-table {
@@ -106,4 +101,10 @@ table.plotting-table img {
 
 .announcement-content {
   white-space: normal;
+}
+
+/* Wrap code blocks */
+pre {
+  white-space: pre-wrap !important;
+  word-break: break-all;
 }

--- a/doc/themes/custom.css
+++ b/doc/themes/custom.css
@@ -51,7 +51,7 @@ div[class^="highlight-"].sphx-glr-script-out {
 
 .sphx-glr-script-out .highlight {
   border-radius: 0px;
-  background-color: var(--color-background-secondary);
+  border-left: 4px solid var(--color-background-border);
 }
 
 .sphx-glr-script-out .highlight pre {
@@ -70,15 +70,15 @@ button.copybtn {
 /* Code snippets styling */
 .highlight {
   border-radius: 0px;
-  border-left: 4px solid var(--color-background-border);
-}
-
-.highlight-default .highlight {
   background-color: var(--color-background-secondary);
 }
 
-.highlight-primary .highlight {
+.highlight-default .highlight {
   border-left: 4px solid var(--sd-color-primary);
+}
+
+.highlight-primary .highlight {
+  border-left: 4px solid var(--color-background-border);
 }
 
 table.plotting-table {


### PR DESCRIPTION
This PR implements minor changes of the docs' CSS:
- [x] inline code blocks' font-size is a bit bigger than the rest of the text: use same text
- [x] border color of code blocks puts the emphasis on outputs instead of code blocks themselves: swap colors
- [x] output code blocks can have very long text: wrap this text

