### PR TITLE
[DOC] Fix documentation build failure on main

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -80,7 +80,7 @@ source_suffix = [".rst", ".md"]
 # source_encoding = 'utf-8'
 
 # Generate the plots for the gallery
-plot_gallery = True
+plot_gallery = "True"
 
 # The master toctree document.
 master_doc = "index"


### PR DESCRIPTION
It seems that the doc build is broken due to a recent release of sphinx-gallery.

This first failed on a scheduled build after a successful build on a merge: https://github.com/nilearn/nilearn/actions/runs/4371630220
