### PR TITLE
[MAINT] add test for second level input as list of 3D image filenames

### DIFF
--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 from nibabel import Nifti1Image, load
 from nibabel.tmpdirs import InTemporaryDirectory
+from nilearn._utils import testing
 from nilearn._utils.data_gen import (
     generate_fake_fmri_data_and_design,
     write_fake_fmri_data_and_design,
@@ -14,14 +15,12 @@ from nilearn.glm.first_level import FirstLevelModel, run_glm
 from nilearn.glm.second_level import SecondLevelModel, non_parametric_inference
 from nilearn.image import concat_imgs, get_data, new_img_like, smooth_img
 from nilearn.maskers import NiftiMasker
-from nilearn._utils import testing                    
 from numpy.testing import (
     assert_almost_equal,
     assert_array_almost_equal,
     assert_array_equal,
 )
 from scipy import stats
-
 
 try:
     from nilearn.reporting import get_clusters_table
@@ -93,6 +92,7 @@ def test_sort_input_dataframe(input_df):
     assert (output_df['effects_map_path'].values.tolist()
             == ["bar.nii", "baz.nii", "foo.nii"])
 
+
 def test_second_level_input_as_3D_images():
     """Test second level model with a list 3D image filenames as input.
 
@@ -100,14 +100,13 @@ def test_second_level_input_as_3D_images():
     https://github.com/nilearn/nilearn/issues/3636
 
     """
-
     shape = (7, 8, 9)
     images = []
     nb_subjects = 10
     affine = np.eye(4)
     for _ in range(nb_subjects):
-        data= np.random.rand(*shape)
-        images.append( Nifti1Image(data, affine))
+        data = np.random.rand(*shape)
+        images.append(Nifti1Image(data, affine))
 
     with testing.write_tmp_imgs(*images, create_files=True) as filenames:
 
@@ -122,6 +121,7 @@ def test_second_level_input_as_3D_images():
             second_level_input,
             design_matrix=design_matrix,
         )
+
 
 def test_process_second_level_input_as_firstlevelmodels():
     """Unit tests for function

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -26,6 +26,7 @@ from nilearn.maskers import NiftiMasker
 from nilearn.glm.first_level import (FirstLevelModel, run_glm)
 from nilearn.glm.second_level import (SecondLevelModel,
                                       non_parametric_inference)
+from nilearn._utils import testing                    
 
 try:
     from nilearn.reporting import get_clusters_table
@@ -98,6 +99,37 @@ def test_sort_input_dataframe(input_df):
         == ["bar.nii", "baz.nii", "foo.nii"]
     )
 
+def test_second_level_input_as_3D_images():
+    """Test second level model with a list 3D image filenames as input.
+
+    Should act as a regression test for:
+    https://github.com/nilearn/nilearn/issues/3636
+
+    Adapted from examples: plot_second_level_one_sample_test.py
+
+    """
+
+    shape = (7, 8, 9)
+    images = []
+    nb_subjects = 10
+    affine = np.eye(4)
+    for _ in range(nb_subjects):
+        data= np.random.rand(*shape)
+        images.append( Nifti1Image(data, affine))
+
+    with testing.write_tmp_imgs(*images, create_files=True) as filenames:
+
+        second_level_input = filenames
+        design_matrix = pd.DataFrame(
+            [1] * len(second_level_input),
+            columns=["intercept"],
+        )
+
+        second_level_model = SecondLevelModel(smoothing_fwhm=8.0)
+        second_level_model = second_level_model.fit(
+            second_level_input,
+            design_matrix=design_matrix,
+        )
 
 def test_process_second_level_input_as_firstlevelmodels():
     """Unit tests for function

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -105,8 +105,6 @@ def test_second_level_input_as_3D_images():
     Should act as a regression test for:
     https://github.com/nilearn/nilearn/issues/3636
 
-    Adapted from examples: plot_second_level_one_sample_test.py
-
     """
 
     shape = (7, 8, 9)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3642
Act as regression test for #3636 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- add a test that pass but would fail if #3637 is reverted
- this checks that a second level model fit can accept a list of 3D image filenames as input
