### PR TITLE
[MAINT] update label in bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -8,7 +8,7 @@ description: Fill in this template to report a bug
 
 title: '[BUG] '
 
-labels: ['bug']
+labels: ['Bug']
 
 body:
 


### PR DESCRIPTION
Closes none

Otherwise the bug label is not automatically added to new issues


