### PR TITLE
[FIX] deal with test pollution in image modules

### DIFF
--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -774,21 +774,23 @@ def test_reorder_img_with_resample_arg(affine):
     assert_array_equal(get_data(reordered_img), get_data(resampled_img))
 
 
-def test_reorder_img_error_reorder_axis(affine):
+def test_reorder_img_error_reorder_axis():
     rng = np.random.RandomState(42)
 
     shape = (5, 5, 5, 2, 2)
     data = rng.uniform(size=shape)
 
-    # Create a non-diagonal affine, and check that we raise a sensible
-    # exception
-    affine[1, 0] = 0.1
-    ref_img = Nifti1Image(data, affine)
-    with pytest.raises(ValueError, match="Cannot reorder the axes"):
-        reorder_img(ref_img)
+    # Create a non-diagonal affine,
+    # and check that we raise a sensible exception
+    non_diagonal_affine = np.eye(4)
+    non_diagonal_affine[1, 0] = 0.1
+    ref_img = Nifti1Image(data, non_diagonal_affine)
 
     # Test that no exception is raised when resample='continuous'
     reorder_img(ref_img, resample="continuous")
+
+    with pytest.raises(ValueError, match="Cannot reorder the axes"):
+        reorder_img(ref_img)
 
 
 def test_reorder_img_flipping_axis():

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -65,7 +65,7 @@ def shape():
 
 @pytest.fixture
 def affine():
-    return AFFINE_EYE
+    return np.eye(4)
 
 
 def test_identity_resample(shape, affine):


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3658

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- make sure that tests do not change globals
