### PR TITLE
[MAINT] remove codecov dependency and test with python 3.10 and 3.11 on windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,6 +38,8 @@ jobs:
       python -m pytest --pyargs nilearn --cov-report=xml --cov=nilearn --cov-append --junitxml=test-results.xml
     displayName: 'test'
 
+  # use the codecov uploader to upload the coverage report
+  # https://docs.codecov.com/docs/codecov-uploader
   - script: |
       Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
       .\codecov.exe -t ${CODECOV_TOKEN}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,9 +44,12 @@ jobs:
 
   # use the codecov uploader to upload the coverage report
   # https://docs.codecov.com/docs/codecov-uploader
-  - script: |
-      Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
-      .\codecov.exe -t ${CODECOV_TOKEN}
+  - task: PowerShell@2
+    inputs:
+      targetType: 'inline'
+      script: |
+        Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
+        .\codecov.exe -t ${CODECOV_TOKEN}
     displayName: 'codecov'
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,8 @@ jobs:
     displayName: 'test'
 
   - script: |
-      codecov -f coverage.xml -t %CODECOV_TOKEN%
+      Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
+      .\codecov.exe -t ${CODECOV_TOKEN}
     displayName: 'codecov'
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,10 @@ jobs:
         python.version: '3.8'
       Python39:
         python.version: '3.9'
+      Python310:
+        python.version: '3.10'
+      Python311:
+        python.version: '3.11'
     maxParallel: 4
 
   steps:

--- a/environment.yml
+++ b/environment.yml
@@ -12,4 +12,3 @@ dependencies:
     - pytest
     - pytest-cov
     - lxml
-    - codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ min = [
 ]
 # For running unit and docstring tests
 test = [
-	"codecov",
 	"coverage",
 	"pytest>=6.0.0",
 	"pytest-cov",


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3674
Closes #3676

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- removes the codecov dependency as the github action is used
- use the codecov uploader in azure
- test with python 3.10 and 3.11 in azure on windows
