### PR TITLE
[MAINT] Remove data extension from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 *.nt.bz2
 *.swp
 *.swo
-*.tar.gz
 *.tgz
 *.zip
 *#

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@
 *.nt.bz2
 *.swp
 *.swo
-*.tgz
-*.zip
 *#
 
 .mypy_cache


### PR DESCRIPTION
Related to #3660 

The extension .tar.gz in .gitigore should not be ignored. It leads to test data being left out when building the distribution because hatchling uses .gitignore by default to exclude files during build. 