### PR TITLE
[Fix] Fix pathlib.Path not being counted as Niimg-like in new_image_like

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -295,7 +295,7 @@ authors:
   - given-names: Matthieu
     family-names: Joulot
     website: https://github.com/MatthieuJoulot
-  - given-names: Maximilian
+  - given-names: Maximilian Cosmo
     family-names: Sitter
     website: https://github.com/mcsitter
   - given-names: Mehdi

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -295,6 +295,9 @@ authors:
   - given-names: Matthieu
     family-names: Joulot
     website: https://github.com/MatthieuJoulot
+  - given-names: Maximilian
+    family-names: Sitter
+    website: https://github.com/mcsitter
   - given-names: Mehdi
     family-names: Rahim
     website: https://github.com/mrahim

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -30,7 +30,7 @@ Fixes
 
 - Relax the :func:`~nilearn.interfaces.fmriprep.load_confounds` confounds selection on `cosine` as not all confound files contained the variables (:gh:`3816` by `Hao-Ting Wang`_).
 
-- Fix pathlib.Path not being counted as Niimg-like object in :func:`~image.image.new_img_like` and :func:`~image.image.mean_img` (:gh:`3723` by `Maximilian Cosmo Sitter`_).
+- Fix pathlib.Path not being counted as Niimg-like object in :func:`~image.new_img_like` (:gh:`3723` by `Maximilian Cosmo Sitter`_).
 
 
 Enhancements

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -30,6 +30,9 @@ Fixes
 
 - Relax the :func:`~nilearn.interfaces.fmriprep.load_confounds` confounds selection on `cosine` as not all confound files contained the variables (:gh:`3816` by `Hao-Ting Wang`_).
 
+- Fix pathlib.Path not being counted as Niimg-like object in :func:`~image.image.new_img_like` and :func:`~image.image.mean_img` (:gh:`3723` by `Maximilian Cosmo Sitter`_).
+
+
 Enhancements
 ------------
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -7,6 +7,7 @@ See also nilearn.signal.
 
 import collections.abc
 import copy
+import pathlib
 import warnings
 
 import nibabel
@@ -530,9 +531,9 @@ def mean_img(imgs, target_affine=None, target_shape=None, verbose=0, n_jobs=1):
 
     """
     imgs = stringify_path(imgs)
-    is_str = isinstance(imgs, str)
+    is_path = isinstance(imgs, str) or isinstance(imgs, pathlib.Path)
     is_iterable = isinstance(imgs, collections.abc.Iterable)
-    if is_str or not is_iterable:
+    if is_path or not is_iterable:
         imgs = [
             imgs,
         ]
@@ -751,19 +752,21 @@ def new_img_like(ref_niimg, data, affine=None, copy_header=False):
     """
     # Hand-written loading code to avoid too much memory consumption
     orig_ref_niimg = ref_niimg
-    is_str = isinstance(ref_niimg, str)
+    is_path = isinstance(ref_niimg, str) or isinstance(ref_niimg, pathlib.Path)
     has_get_data = hasattr(ref_niimg, "get_data")
     has_get_fdata = hasattr(ref_niimg, "get_fdata")
     has_iter = hasattr(ref_niimg, "__iter__")
     has_affine = hasattr(ref_niimg, "affine")
-    if has_iter and not any([is_str, has_get_data, has_get_fdata]):
+    if has_iter and not any([is_path, has_get_data, has_get_fdata]):
         ref_niimg = ref_niimg[0]
-        is_str = isinstance(ref_niimg, str)
+        is_path = isinstance(ref_niimg, str) or isinstance(
+            ref_niimg, pathlib.Path
+        )
         has_get_data = hasattr(ref_niimg, "get_data")
         has_get_fdata = hasattr(ref_niimg, "get_fdata")
         has_affine = hasattr(ref_niimg, "affine")
     if not ((has_get_data or has_get_fdata) and has_affine):
-        if is_str:
+        if is_path:
             ref_niimg = nibabel.load(ref_niimg)
         else:
             raise TypeError(

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -531,9 +531,9 @@ def mean_img(imgs, target_affine=None, target_shape=None, verbose=0, n_jobs=1):
 
     """
     imgs = stringify_path(imgs)
-    is_path = isinstance(imgs, str) or isinstance(imgs, pathlib.Path)
+    is_str = isinstance(imgs, str)
     is_iterable = isinstance(imgs, collections.abc.Iterable)
-    if is_path or not is_iterable:
+    if is_str or not is_iterable:
         imgs = [
             imgs,
         ]

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -7,7 +7,6 @@ See also nilearn.signal.
 
 import collections.abc
 import copy
-import pathlib
 import warnings
 
 import nibabel
@@ -752,21 +751,21 @@ def new_img_like(ref_niimg, data, affine=None, copy_header=False):
     """
     # Hand-written loading code to avoid too much memory consumption
     orig_ref_niimg = ref_niimg
-    is_path = isinstance(ref_niimg, str) or isinstance(ref_niimg, pathlib.Path)
+    ref_niimg = stringify_path(ref_niimg)
+    is_str = isinstance(ref_niimg, str)
     has_get_data = hasattr(ref_niimg, "get_data")
     has_get_fdata = hasattr(ref_niimg, "get_fdata")
     has_iter = hasattr(ref_niimg, "__iter__")
     has_affine = hasattr(ref_niimg, "affine")
-    if has_iter and not any([is_path, has_get_data, has_get_fdata]):
+    if has_iter and not any([is_str, has_get_data, has_get_fdata]):
         ref_niimg = ref_niimg[0]
-        is_path = isinstance(ref_niimg, str) or isinstance(
-            ref_niimg, pathlib.Path
-        )
+        ref_niimg = stringify_path(ref_niimg)
+        is_str = isinstance(ref_niimg, str)
         has_get_data = hasattr(ref_niimg, "get_data")
         has_get_fdata = hasattr(ref_niimg, "get_fdata")
         has_affine = hasattr(ref_niimg, "affine")
     if not ((has_get_data or has_get_fdata) and has_affine):
-        if is_path:
+        if is_str:
             ref_niimg = nibabel.load(ref_niimg)
         else:
             raise TypeError(

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -666,7 +666,7 @@ def test_new_img_like_accepts_paths(tmp_path):
     new_data = np.random.rand(10, 10, 10)
     new_img = new_img_like(nifti_path, new_data)
     assert new_img.shape == (10, 10, 10)
-    
+
     # Check that list of pathlib.Path also accepted
     new_img = new_img_like([nifti_path], new_data)
     assert new_img.shape == (10, 10, 10)

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -654,6 +654,20 @@ def test_new_img_like():
     assert_array_equal(get_data(img_nifti2), get_data(img2_nifti2))
 
 
+def test_new_img_like_accepts_paths(tmp_path):
+    """Check that new_img_like can accept instances of pathlib.Path."""
+    nifti_path = tmp_path / "sample.nii"
+    assert isinstance(nifti_path, Path)
+
+    data = np.random.rand(10, 10, 10)
+    img = Nifti1Image(data, np.eye(4))
+    nibabel.save(img, nifti_path)
+
+    new_data = np.random.rand(10, 10, 10)
+    new_img = new_img_like(nifti_path, new_data)
+    assert new_img.shape == (10, 10, 10)
+
+
 def test_new_img_like_non_iterable_header():
     """
     Tests that when an niimg's header is not iterable

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -666,6 +666,10 @@ def test_new_img_like_accepts_paths(tmp_path):
     new_data = np.random.rand(10, 10, 10)
     new_img = new_img_like(nifti_path, new_data)
     assert new_img.shape == (10, 10, 10)
+    
+    # Check that list of pathlib.Path also accepted
+    new_img = new_img_like([nifti_path], new_data)
+    assert new_img.shape == (10, 10, 10)
 
 
 def test_new_img_like_non_iterable_header():


### PR DESCRIPTION
I received `TypeError: The reference image should be a niimg` when putting a `pathlib.Path` as an argument into `nilearn.image.new_image_like`. I fixed it to properly accept Niimg-like objects, which include `pathlib.Path` in its definition.

Changes proposed in this pull request:
- Check for `isinstance` of `pathlib.Path` as well as `str`
