### PR TITLE
[FIX] Missing values in `Decoder.cv_params_` when `param_grid` is a list of dicts with different keys

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -11,6 +11,8 @@ NEW
 Fixes
 -----
 
+- :bdg-dark:`Code` Fix bug where the `cv_params_` attribute of fitter Decoder objects sometimes had missing entries if `grid_param` is a sequence of dicts with different keys (:gh:`3733` by `Michelle Wang`_).
+
 Enhancements
 ------------
 

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -304,10 +304,18 @@ def _parallel_fit(
         X_test = selector.transform(X_test)
 
     # If there is no parameter grid, then we use a suitable grid (by default)
-    param_grid = _check_param_grid(estimator, X_train, y_train, param_grid)
+    param_grid = ParameterGrid(
+        _check_param_grid(estimator, X_train, y_train, param_grid)
+    )
+
+    # collect all parameter names from the grid
+    all_params = set()
+    for params in param_grid:
+        all_params.update(params.keys())
+
     best_score = None
-    for param in ParameterGrid(param_grid):
-        estimator = clone(estimator).set_params(**param)
+    for params in param_grid:
+        estimator = clone(estimator).set_params(**params)
         estimator.fit(X_train, y_train)
 
         if is_classification:
@@ -332,8 +340,13 @@ def _parallel_fit(
                     dummy_output = estimator.constant_
 
             if isinstance(estimator, (RidgeCV, RidgeClassifierCV)):
-                param["best_alpha"] = estimator.alpha_
-            best_param = param
+                params["best_alpha"] = estimator.alpha_
+            best_params = params
+
+            # fill in any missing param from param_grid
+            for param in all_params:
+                if param not in best_params:
+                    best_params[param] = getattr(estimator, param)
 
     if best_coef is not None:
         if do_screening:
@@ -346,7 +359,7 @@ def _parallel_fit(
         class_index,
         best_coef,
         best_intercept,
-        best_param,
+        best_params,
         best_score,
         dummy_output,
     )

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -442,20 +442,19 @@ def test_parallel_fit_builtin_cv(
 
 
 def test_decoder_param_grid_sequence(binary_classification_data):
-
     X, y, _ = binary_classification_data
     n_cv_folds = 10
     param_grid = [
         {
             "penalty": ["l2"],
             "C": [100, 1000],
-            "random_state": [42], # fix the seed for consistent behaviour
+            "random_state": [42],  # fix the seed for consistent behaviour
         },
         {
             "penalty": ["l1"],
-            "dual": [False],    # "dual" is not in the first dict
+            "dual": [False],  # "dual" is not in the first dict
             "C": [100, 10],
-            "random_state": [42], # fix the seed for consistent behaviour
+            "random_state": [42],  # fix the seed for consistent behaviour
         },
     ]
 

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -441,6 +441,32 @@ def test_parallel_fit_builtin_cv(
     assert isinstance(best_param[fitted_param_name], (float, int))
 
 
+def test_decoder_param_grid_sequence(binary_classification_data):
+
+    X, y, _ = binary_classification_data
+    n_cv_folds = 10
+    param_grid = [
+        {
+            "penalty": ["l2"],
+            "C": [100, 1000],
+            "random_state": [42], # fix the seed for consistent behaviour
+        },
+        {
+            "penalty": ["l1"],
+            "dual": [False],    # "dual" is not in the first dict
+            "C": [100, 10],
+            "random_state": [42], # fix the seed for consistent behaviour
+        },
+    ]
+
+    model = Decoder(param_grid=param_grid, cv=n_cv_folds)
+    model.fit(X, y)
+
+    for best_params in model.cv_params_.values():
+        for param_list in best_params.values():
+            assert len(param_list) == n_cv_folds
+
+
 def test_decoder_binary_classification_with_masker_object(
     binary_classification_data,
 ):


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3715.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add test (`nilearn.decoding.decoder.tests.test_decoder.py`)
- In [nilearn.decoding.decoder._parallel_fit](https://github.com/nilearn/nilearn/blob/main/nilearn/decoding/decoder.py#L163), before looping over the hyperparameters, collect all the unique keys in `param_grid`
- Inside the loop, check if `best_param` is missing any keys, and add them if necessary
