### PR TITLE
[ENH] Use LogisticRegressionCV instead of LogisticRegression to improve Decoder performance

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -14,6 +14,8 @@ Fixes
 Enhancements
 ------------
 
+- Update Decoder objects to use the more efficient ``LogisticRegressionCV`` (:gh:`3736` by `Michelle Wang`_).
+
 Changes
 -------
 

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -118,17 +118,17 @@ dc = "Dummy classifier with stratified strategy"
 
 docdict['classifier_options'] = f"""
 
-        - `svc`: :class:`{svc} <sklearn.svm.SVC>` with L2 penalty.
+        - `svc`: :class:`{svc} <sklearn.svm.LinearSVC>` with L2 penalty.
             .. code-block:: python
 
                 svc = LinearSVC(penalty='l2',
                                 max_iter=1e4)
 
-        - `svc_l2`: :class:`{svc} <sklearn.svm.SVC>` with L2 penalty.
+        - `svc_l2`: :class:`{svc} <sklearn.svm.LinearSVC>` with L2 penalty.
             .. note::
                 Same as option `svc`.
 
-        - `svc_l1`: :class:`{svc} <sklearn.svm.SVC>` with L1 penalty.
+        - `svc_l1`: :class:`{svc} <sklearn.svm.LinearSVC>` with L1 penalty.
             .. code-block:: python
 
                 svc_l1 = LinearSVC(penalty='l1',

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -136,23 +136,23 @@ docdict['classifier_options'] = f"""
                                    max_iter=1e4)
 
         - `logistic`: \
-            :class:`{logistic} <sklearn.linear_model.LogisticRegression>` \
+            :class:`{logistic} <sklearn.linear_model.LogisticRegressionCV>` \
             with L2 penalty.
             .. code-block:: python
 
-                logistic = LogisticRegression(penalty='l2',
+                logistic = LogisticRegressionCV(penalty='l2',
                                               solver='liblinear')
 
         - `logistic_l1`: \
-            :class:`{logistic} <sklearn.linear_model.LogisticRegression>` \
+            :class:`{logistic} <sklearn.linear_model.LogisticRegressionCV>` \
             with L1 penalty.
             .. code-block:: python
 
-                logistic_l1 = LogisticRegression(penalty='l1',
+                logistic_l1 = LogisticRegressionCV(penalty='l1',
                                                  solver='liblinear')
 
         - `logistic_l2`: \
-            :class:`{logistic} <sklearn.linear_model.LogisticRegression>` \
+            :class:`{logistic} <sklearn.linear_model.LogisticRegressionCV>` \
             with L2 penalty
             .. note::
                 Same as option `logistic`.

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -179,8 +179,15 @@ def _default_param_grid(estimator, X, y):
     if isinstance(estimator, (RidgeCV, RidgeClassifierCV)):
         param_grid["alphas"] = [np.geomspace(1e-3, 1e4, 8)]
     elif isinstance(estimator, LogisticRegressionCV):
+        # min_c value is set to 0.5 unless the estimator uses L1 penalty,
+        # in which case min_c is computed with sklearn.svm.l1_min_c(),
+        # so for L2 penalty, param_grid["Cs"] is either 1e-3, ..., 1e4, and
+        # for L1 penalty the values are obtained in a more data-driven way
         param_grid["Cs"] = [np.geomspace(2e-3, 2e4, 8) * min_c]
     elif isinstance(estimator, (LinearSVC, SVR)):
+        # similar logic as above:
+        # - for L2 penalty this is [1, 10, 100]
+        # - for L1 penalty the values depend on the data
         param_grid["C"] = np.array([2, 20, 200]) * min_c
     else:
         param_grid = {}

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -589,8 +589,9 @@ class _BaseDecoder(LinearRegression, CacheMixin):
             when Dummy estimators are provided. Note: if the estimator used its
             built-in cross-validation, this will include an additional key for
             the single best value estimated by the built-in cross-validation
-            ('best_C' for LogisticRegressionCV and 'best_alpha' for 
-            RidgeCV/RidgeClassifierCV), in addition to the input list of values.
+            ('best_C' for LogisticRegressionCV and 'best_alpha' for
+            RidgeCV/RidgeClassifierCV), in addition to the input list of
+            values.
 
         'scorer_' : function
             Scorer function used on the held out data to choose the best

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -41,7 +41,11 @@ from sklearn.datasets import load_iris, make_classification, make_regression
 from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.exceptions import NotFittedError
-from sklearn.linear_model import LogisticRegression, RidgeClassifierCV, RidgeCV
+from sklearn.linear_model import (
+    LogisticRegressionCV,
+    RidgeClassifierCV, 
+    RidgeCV,
+)
 from sklearn.metrics import (
     accuracy_score,
     check_scoring,
@@ -153,8 +157,8 @@ def test_check_param_grid_regression(regressor, param):
 @pytest.mark.parametrize(
     "classifier, param",
     [
-        (LogisticRegression(penalty="l1"), "C"),
-        (LogisticRegression(penalty="l2"), "C"),
+        (LogisticRegressionCV(penalty="l1"), ["Cs"]),
+        (LogisticRegressionCV(penalty="l2"), ["Cs"]),
         (RidgeClassifierCV(), ["alphas"]),
     ],
 )
@@ -383,6 +387,7 @@ def test_parallel_fit(rand_X_Y):
     [
         (RidgeCV(), "alphas", "best_alpha", False),
         (RidgeClassifierCV(), "alphas", "best_alpha", True),
+        (LogisticRegressionCV(), "Cs", "best_C", True),
     ],
 )
 def test_parallel_fit_builtin_cv(
@@ -438,7 +443,7 @@ def test_parallel_fit_builtin_cv(
         clustering_percentile=100,
     )
 
-    assert isinstance(best_param[fitted_param_name], (float, int))
+    assert isinstance(best_param[fitted_param_name], numbers.Number)
 
 
 def test_decoder_binary_classification_with_masker_object(

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -43,7 +43,7 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import (
     LogisticRegressionCV,
-    RidgeClassifierCV, 
+    RidgeClassifierCV,
     RidgeCV,
 )
 from sklearn.metrics import (

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -174,6 +174,30 @@ def test_check_param_grid_classification(rand_X_Y, classifier, param):
     assert list(param_grid.keys()) == list(param)
 
 
+@pytest.mark.parametrize(
+    "param_grid_input",
+    [
+        {"C": [1, 10, 100]},
+        {"Cs": [1, 10, 100]},
+        [{"C": [1, 10, 100]}, {"fit_intercept": [False]}],
+    ],
+)
+def test_check_param_grid_replacement(rand_X_Y, param_grid_input):
+    X, Y = rand_X_Y
+    param_to_replace = "C"
+    param_replaced = "Cs"
+    param_grid_output = _check_param_grid(
+        LogisticRegressionCV(),
+        X,
+        Y,
+        param_grid_input,
+    )
+    for params in ParameterGrid(param_grid_output):
+        assert param_to_replace not in params
+        if param_replaced not in params:
+            assert params in ParameterGrid(param_grid_input)
+
+
 @pytest.mark.parametrize("estimator", ["log_l1", RandomForestClassifier()])
 def test_non_supported_estimator_error(rand_X_Y, estimator):
     """Raise the error when using a non supported estimator."""


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #2200.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Replace [`LogisticRegression`](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html) with [`LogisticRegressionCV`](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegressionCV.html) in `nilearn.decoding.decoder`
  - Note that the `param_grid` should now contain `Cs` instead of `C`, meaning that any code that explicitly provides a `param_grid = {'C': [...]}` would now break. Does this mean this needs a deprecation cycle? If so how is this usually done?
    - Another option could be to change `C` to `Cs` when processing the `param_grid` (with maybe a warning)
  - I used `LogisticRegressionCV` for both `"logistic_l1"` and `"logistic_l2"`. `sklearn` also has a [`LassoCV`](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LassoCV.html) class, but its hyperparameters are different (`alphas` instead of `Cs`), so it seems like it would be better to use `LogisticRegressionCV` for both the L1 and L2 regularization cases (to be consistent)
- Fix incorrect links to sklearn documentation in Decoder docstring (should be `LinearSVC`, not `SVC`)
