### PR TITLE
[INFRA] Add timeout setting in Azure Pipelines CI 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ jobs:
 
 
 - job: 'run_tests_on_windows'
+  timeoutInMinutes: 0
   pool:
     vmImage: 'windows-latest'
   strategy:


### PR DESCRIPTION
Related to #3718 

I'm implementing a solution given to me by Microsoft support which is to set the parameter timeoutInMinutes to 0. This allows for the maximum limit which for public projects is 6 hours. It doesn't really answer the question of why the tests are taking so long to run but for now it's enough to make sure our tests run fully.
