### PR TITLE
[MAINT] Catch warnings as errors on partial doc builds

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -73,13 +73,13 @@ html-strict:	sym_links
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 html-modified-examples-only: 	sym_links
-	BUILD_DEV_HTML=1 $(SPHINXBUILD) -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -D sphinx_gallery_conf.run_stale_examples=True -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	BUILD_DEV_HTML=1 $(SPHINXBUILD) -W --keep-going -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -D sphinx_gallery_conf.run_stale_examples=True -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	touch $(BUILDDIR)/html/.nojekyll
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 html-noplot:
-	BUILD_DEV_HTML=1 $(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	BUILD_DEV_HTML=1 $(SPHINXBUILD) -W --keep-going -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	touch $(BUILDDIR)/html/.nojekyll
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -157,6 +157,8 @@ pygments_dark_style = "stata-dark"
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
 
+# A list of warning types to suppress arbitrary warning messages
+suppress_warnings = ["image.not_readable"]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/examples/00_tutorials/plot_decoding_tutorial.py
+++ b/examples/00_tutorials/plot_decoding_tutorial.py
@@ -357,3 +357,5 @@ print(dummy_decoder.cv_scores_)
 # * :ref:`space_net`
 #
 # ______________
+
+# sphinx_gallery_dummy_images=1

--- a/examples/00_tutorials/plot_nilearn_101.py
+++ b/examples/00_tutorials/plot_nilearn_101.py
@@ -79,3 +79,5 @@ plotting.show()
 # To recap, all the nilearn tools can take data as filenames or in-memory
 # objects, and return brain volumes as in-memory objects. These can be
 # passed on to other nilearn tools, or saved to disk.
+
+# sphinx_gallery_dummy_images=1

--- a/examples/01_plotting/plot_3d_map_to_surface_projection.py
+++ b/examples/01_plotting/plot_3d_map_to_surface_projection.py
@@ -235,3 +235,5 @@ view = plotting.view_img_on_surf(
 
 # view.open_in_browser()
 view
+
+# sphinx_gallery_dummy_images=1

--- a/examples/01_plotting/plot_atlas.py
+++ b/examples/01_plotting/plot_atlas.py
@@ -51,3 +51,5 @@ plotting.plot_roi(
     atlas_ju_filename, view_type="contours", title="Juelich atlas in contours"
 )
 plotting.show()
+
+# sphinx_gallery_dummy_images=1

--- a/examples/01_plotting/plot_carpet.py
+++ b/examples/01_plotting/plot_carpet.py
@@ -78,3 +78,5 @@ display = plot_carpet(
 )
 
 fig.show()
+
+# sphinx_gallery_dummy_images=1

--- a/examples/01_plotting/plot_colormaps.py
+++ b/examples/01_plotting/plot_colormaps.py
@@ -51,3 +51,5 @@ for index, cmap in enumerate(m_cmaps):
     plt.title(cmap, fontsize=10, va="bottom", rotation=90)
 
 show()
+
+# sphinx_gallery_dummy_images=2

--- a/examples/01_plotting/plot_demo_glass_brain.py
+++ b/examples/01_plotting/plot_demo_glass_brain.py
@@ -39,3 +39,5 @@ plotting.plot_glass_brain(stat_img,
                           display_mode='lyrz', threshold=3)
 
 plotting.show()
+
+# sphinx_gallery_dummy_images=1

--- a/examples/01_plotting/plot_demo_glass_brain_extensive.py
+++ b/examples/01_plotting/plot_demo_glass_brain_extensive.py
@@ -293,3 +293,5 @@ display.add_contours(
 display.title('Now same plotting but with filled contours')
 # Finally, displaying them
 plotting.show()
+
+# sphinx_gallery_dummy_images=7

--- a/examples/01_plotting/plot_demo_more_plotting.py
+++ b/examples/01_plotting/plot_demo_more_plotting.py
@@ -375,3 +375,5 @@ display.savefig('plot_stat_map_from_display.png')
 display.close()
 
 plotting.show()
+
+# sphinx_gallery_dummy_images=17

--- a/examples/01_plotting/plot_demo_plotting.py
+++ b/examples/01_plotting/plot_demo_plotting.py
@@ -110,3 +110,5 @@ plotting.plot_epi(mean_haxby_img, title="plot_epi")
 # A call to plotting.show is needed to display the plots when running
 # in script mode (ie outside IPython)
 plotting.show()
+
+# sphinx_gallery_dummy_images=5

--- a/examples/01_plotting/plot_haxby_masks.py
+++ b/examples/01_plotting/plot_haxby_masks.py
@@ -59,3 +59,5 @@ p_f = Rectangle((0, 0), 1, 1, fc="limegreen")
 plt.legend([p_v, p_h, p_f], ["vt", "house", "face"])
 
 show()
+
+# sphinx_gallery_dummy_images=1

--- a/examples/01_plotting/plot_overlay.py
+++ b/examples/01_plotting/plot_overlay.py
@@ -76,3 +76,5 @@ display = plotting.plot_prob_atlas(
     dmn_nodes, cut_coords=(0, -55, 29), title="DMN nodes in MSDL atlas"
 )
 plotting.show()
+
+# sphinx_gallery_dummy_images=2

--- a/examples/01_plotting/plot_prob_atlas.py
+++ b/examples/01_plotting/plot_prob_atlas.py
@@ -96,3 +96,5 @@ plotting.plot_prob_atlas(
 )
 print("ready")
 plotting.show()
+
+# sphinx_gallery_dummy_images=3

--- a/examples/01_plotting/plot_surf_atlas.py
+++ b/examples/01_plotting/plot_surf_atlas.py
@@ -148,3 +148,5 @@ view = plotting.view_connectome(corr, coordinates, edge_threshold='90%')
 # uncomment this to open the plot in a web browser:
 # view.open_in_browser()
 view
+
+# sphinx_gallery_dummy_images=1

--- a/examples/01_plotting/plot_surf_stat_map.py
+++ b/examples/01_plotting/plot_surf_stat_map.py
@@ -193,3 +193,4 @@ plotting.plot_surf_stat_map(fsaverage['infl_left'], stat_map=stat_map,
 plotting.show()
 
 # sphinx_gallery_thumbnail_number = 2
+# sphinx_gallery_dummy_images=1

--- a/examples/01_plotting/plot_visualization.py
+++ b/examples/01_plotting/plot_visualization.py
@@ -68,3 +68,5 @@ plt.xlim(0, 150)
 plt.subplots_adjust(bottom=0.12, top=0.95, right=0.95, left=0.12)
 
 show()
+
+# sphinx_gallery_dummy_images=3

--- a/examples/02_decoding/plot_haxby_anova_svm.py
+++ b/examples/02_decoding/plot_haxby_anova_svm.py
@@ -119,3 +119,5 @@ view_img(weight_img, bg_img=haxby_dataset.anat[0], title="SVM weights", dim=-1)
 #############################################################################
 # Saving the results as a Nifti file may also be important
 weight_img.to_filename("haxby_face_vs_house.nii")
+
+# sphinx_gallery_dummy_images=1

--- a/examples/02_decoding/plot_haxby_different_estimators.py
+++ b/examples/02_decoding/plot_haxby_different_estimators.py
@@ -200,3 +200,5 @@ for classifier_name in sorted(classifiers):
     )
 
 show()
+
+# sphinx_gallery_dummy_images=6

--- a/examples/02_decoding/plot_haxby_frem.py
+++ b/examples/02_decoding/plot_haxby_frem.py
@@ -115,3 +115,5 @@ plotting.show()
 # even on heavier examples. Here we ensembled several instances of l2-SVC,
 # but FREMClassifier also works with ridge or logistic.
 # FREMRegressor object is also available to solve regression problems.
+
+# sphinx_gallery_dummy_images=1

--- a/examples/02_decoding/plot_haxby_full_analysis.py
+++ b/examples/02_decoding/plot_haxby_full_analysis.py
@@ -164,3 +164,5 @@ plt.tight_layout()
 
 
 show()
+
+# sphinx_gallery_dummy_images=1

--- a/examples/02_decoding/plot_haxby_grid_search.py
+++ b/examples/02_decoding/plot_haxby_grid_search.py
@@ -213,3 +213,5 @@ plt.axhline(
 
 plt.legend(loc="best", frameon=False)
 show()
+
+# sphinx_gallery_dummy_images=1

--- a/examples/02_decoding/plot_haxby_multiclass.py
+++ b/examples/02_decoding/plot_haxby_multiclass.py
@@ -141,3 +141,5 @@ plot_matrix(
 )
 
 show()
+
+# sphinx_gallery_dummy_images=3

--- a/examples/02_decoding/plot_haxby_searchlight.py
+++ b/examples/02_decoding/plot_haxby_searchlight.py
@@ -150,3 +150,5 @@ plot_stat_map(
 )
 
 show()
+
+# sphinx_gallery_dummy_images=2

--- a/examples/02_decoding/plot_haxby_stimuli.py
+++ b/examples/02_decoding/plot_haxby_stimuli.py
@@ -29,3 +29,5 @@ for stim_type in stimulus_information:
             ax.axis("off")
 
 show()
+
+# sphinx_gallery_dummy_images=7

--- a/examples/02_decoding/plot_mixed_gambles_frem.py
+++ b/examples/02_decoding/plot_mixed_gambles_frem.py
@@ -82,3 +82,5 @@ tv_l1 = SpaceNetRegressor(
 # tv_l1.fit(zmap_filenames, behavioral_target)
 # plot_stat_map(tv_l1.coef_img_, title="TV-L1", display_mode="yz",
 #               cut_coords=[20, -2])
+
+# sphinx_gallery_dummy_images=1

--- a/examples/02_decoding/plot_oasis_vbm.py
+++ b/examples/02_decoding/plot_oasis_vbm.py
@@ -220,3 +220,5 @@ n_detections = (get_data(signed_neg_log_pvals_unmasked) > threshold).sum()
 print(f"\n{int(n_detections)} detections")
 
 show()
+
+# sphinx_gallery_dummy_images=2

--- a/examples/03_connectivity/plot_compare_decomposition.py
+++ b/examples/03_connectivity/plot_compare_decomposition.py
@@ -180,3 +180,5 @@ show()
 #     created using :term:`Dictionary learning`, see :ref:`example Regions
 #     extraction using dictionary learning and functional connectomes
 #     <sphx_glr_auto_examples_03_connectivity_plot_extract_regions_dictlearning_maps.py>`.
+
+# sphinx_gallery_dummy_images=5

--- a/examples/03_connectivity/plot_data_driven_parcellations.py
+++ b/examples/03_connectivity/plot_data_driven_parcellations.py
@@ -429,3 +429,5 @@ plotting.plot_epi(
 # However, as said in the previous section, the computation time is
 # reduced which could still make ReNA more relevant than Ward in
 # some cases.
+
+# sphinx_gallery_dummy_images=3

--- a/examples/03_connectivity/plot_extract_regions_dictlearning_maps.py
+++ b/examples/03_connectivity/plot_extract_regions_dictlearning_maps.py
@@ -199,3 +199,5 @@ for each_index_of_map3, color in zip(regions_indices_of_map3[0], colors):
     )
 
 plotting.show()
+
+# sphinx_gallery_dummy_images=6

--- a/examples/03_connectivity/plot_inverse_covariance_connectome.py
+++ b/examples/03_connectivity/plot_inverse_covariance_connectome.py
@@ -132,3 +132,5 @@ view
 
 # uncomment this to open the plot in a web browser:
 # view.open_in_browser()
+
+# sphinx_gallery_dummy_images=4

--- a/examples/03_connectivity/plot_probabilistic_atlas_extraction.py
+++ b/examples/03_connectivity/plot_probabilistic_atlas_extraction.py
@@ -121,3 +121,5 @@ view
 
 # uncomment this to open the plot in a web browser:
 # view.open_in_browser()
+
+# sphinx_gallery_dummy_images=2

--- a/examples/03_connectivity/plot_signal_extraction.py
+++ b/examples/03_connectivity/plot_signal_extraction.py
@@ -317,3 +317,5 @@ plotting.show()
 # ----------
 #
 # .. footbibliography::
+
+# sphinx_gallery_dummy_images=2

--- a/examples/03_connectivity/plot_simulated_connectome.py
+++ b/examples/03_connectivity/plot_simulated_connectome.py
@@ -106,3 +106,5 @@ plotting.plot_matrix(
 plt.title(f"graph lasso, all subjects\n$\\alpha={gl.alpha_:.2f}$")
 
 show()
+
+# sphinx_gallery_dummy_images=1

--- a/examples/03_connectivity/plot_sphere_based_connectome.py
+++ b/examples/03_connectivity/plot_sphere_based_connectome.py
@@ -430,3 +430,5 @@ plotting.show()
 #   * :ref:`sphx_glr_auto_examples_03_connectivity_plot_atlas_comparison.py`
 #
 #   * :ref:`sphx_glr_auto_examples_03_connectivity_plot_multi_subject_connectome.py` # noqa
+
+# sphinx_gallery_dummy_images=7

--- a/examples/04_glm_first_level/plot_predictions_residuals.py
+++ b/examples/04_glm_first_level/plot_predictions_residuals.py
@@ -189,3 +189,5 @@ z_map_ftest = fmri_glm.compute_contrast(
 plotting.plot_stat_map(
     z_map_ftest, bg_img=mean_img, threshold=3.1, display_mode="z", cut_coords=7
 )
+
+# sphinx_gallery_dummy_images=2

--- a/examples/04_glm_first_level/plot_spm_multimodal_faces.py
+++ b/examples/04_glm_first_level/plot_spm_multimodal_faces.py
@@ -163,3 +163,5 @@ for contrast_id, contrast_val in contrasts.items():
 # conditions. By contrast, the differential effect between "faces" and
 # "scrambled" involves sparser, more anterior and lateral regions. It
 # also displays some responses in the frontal lobe.
+
+# sphinx_gallery_dummy_images=3

--- a/examples/06_manipulating_images/plot_affine_transformation.py
+++ b/examples/06_manipulating_images/plot_affine_transformation.py
@@ -147,3 +147,5 @@ plt.title(
 )
 
 show()
+
+# sphinx_gallery_dummy_images=4

--- a/examples/06_manipulating_images/plot_mask_computation.py
+++ b/examples/06_manipulating_images/plot_mask_computation.py
@@ -178,3 +178,5 @@ print(
 )
 
 show()
+
+# sphinx_gallery_dummy_images=2

--- a/examples/06_manipulating_images/plot_resample_to_template.py
+++ b/examples/06_manipulating_images/plot_resample_to_template.py
@@ -80,3 +80,5 @@ plotting.plot_stat_map(
     title="Resampled t-map",
 )
 plotting.show()
+
+# sphinx_gallery_dummy_images=2

--- a/examples/07_advanced/plot_haxby_mass_univariate.py
+++ b/examples/07_advanced/plot_haxby_mass_univariate.py
@@ -196,3 +196,5 @@ title = (
 display.title(title, y=1.1)
 
 show()
+
+# sphinx_gallery_dummy_images=1


### PR DESCRIPTION
I suppressed expected warnings related to partial sphinx builds and changed the calls for partial builds to treat warnings as errors. This will help catch warnings that fail the full build on main while having had passed on a given PR's partial build.  
