### PR TITLE
[FIX] force ordered output of _sanitize_reorder to match regex in test

### DIFF
--- a/nilearn/plotting/matrix_plotting.py
+++ b/nilearn/plotting/matrix_plotting.py
@@ -101,7 +101,8 @@ def _sanitize_reorder(reorder):
     VALID_REORDER_ARGS = {True, False, 'single', 'complete', 'average'}
     if reorder not in VALID_REORDER_ARGS:
         raise ValueError(
-            f"Parameter reorder needs to be one of {VALID_REORDER_ARGS}.")
+            f"Parameter reorder needs to be one of {list(VALID_REORDER_ARGS)}."
+        )
     reorder = 'average' if reorder is True else reorder
     return reorder
 

--- a/nilearn/plotting/tests/test_matrix_plotting.py
+++ b/nilearn/plotting/tests/test_matrix_plotting.py
@@ -90,9 +90,16 @@ def test_sanitize_reorder_error(reorder):
     from ..matrix_plotting import _sanitize_reorder
     with pytest.raises(ValueError,
                        match=("Parameter reorder needs to be "
-                              f"one of {VALID_REORDER_VALUES}")):
+                              f"one of {list(VALID_REORDER_VALUES)}")):
         _sanitize_reorder(reorder)
 
+@pytest.mark.parametrize("reorder", [None, "foo", 2])
+def test_sanitize_reorder_error_should_fail_with_311(reorder):
+    from ..matrix_plotting import _sanitize_reorder
+    with pytest.raises(ValueError,
+                       match=("Parameter reorder needs to be "
+                              f"one of {VALID_REORDER_VALUES}")):
+        _sanitize_reorder(reorder)
 
 @pytest.fixture
 def mat():


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3750

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- force to print VALID_REORDER_VALUES in an ordered way
