### PR TITLE
[FIX] Change error string to match scikit-learn `InvalidParameterError` message

### DIFF
--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -22,6 +22,7 @@ import warnings
 
 import numpy as np
 import pytest
+import sklearn
 from numpy.testing import assert_array_almost_equal
 from sklearn.datasets import load_iris, make_classification, make_regression
 from sklearn.dummy import DummyClassifier, DummyRegressor
@@ -43,6 +44,7 @@ from sklearn.model_selection import KFold, LeaveOneGroupOut, ParameterGrid
 from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVR, LinearSVC
 
+from nilearn._utils import _compare_version
 from nilearn._utils.param_validation import check_feature_screening
 from nilearn.decoding.decoder import (
     Decoder,
@@ -681,12 +683,18 @@ def test_decoder_error_unknown_scoring_metrics(
 
     model = Decoder(estimator=dummy_classifier, mask=mask, scoring="foo")
 
-    with pytest.raises(
-        ValueError,
-        match="The 'scoring' parameter of check_scoring "
-        "must be a str among",
-    ):
-        model.fit(X, y)
+    if _compare_version(sklearn.__version__, ">", "1.2.2"):
+        with pytest.raises(
+            ValueError,
+            match="The 'scoring' parameter of check_scoring "
+            "must be a str among",
+        ):
+            model.fit(X, y)
+    else:
+        with pytest.raises(
+            ValueError, match="'foo' is not a valid scoring value"
+        ):
+            model.fit(X, y)
 
 
 def test_decoder_dummy_classifier_default_scoring():

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -681,7 +681,11 @@ def test_decoder_error_unknown_scoring_metrics(
 
     model = Decoder(estimator=dummy_classifier, mask=mask, scoring="foo")
 
-    with pytest.raises(ValueError, match="'foo' is not a valid scoring value"):
+    with pytest.raises(
+        ValueError,
+        match="The 'scoring' parameter of check_scoring "
+        "must be a str among",
+    ):
         model.fit(X, y)
 
 


### PR DESCRIPTION
See prerelease dependencies CI error: https://github.com/nilearn/nilearn/actions/runs/5290261152/jobs/9574189485?pr=3762