### PR TITLE
[ENH][DOC] Fix inconsistent description of return keys for fetch_atlas_surf_destrieux

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -20,6 +20,8 @@ Enhancements
 
 - Update Decoder objects to use the more efficient ``LogisticRegressionCV`` (:gh:`3736` by `Michelle Wang`_).
 
+- [DOC] Inconsistent description of return keys for fetch_atlas_surf_destrieux (:gh:`3774` bt `Tarun Samanta`_).
+
 Changes
 -------
 

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -20,7 +20,7 @@ Enhancements
 
 - Update Decoder objects to use the more efficient ``LogisticRegressionCV`` (:gh:`3736` by `Michelle Wang`_).
 
-- [DOC] Inconsistent description of return keys for fetch_atlas_surf_destrieux (:gh:`3774` bt `Tarun Samanta`_).
+- Make return key names in the description file of destrieux surface consistent with :func:`~datasets.fetch_atlas_surf_destrieux` (:gh:`3774` by `Tarun Samanta`_).
 
 Changes
 -------

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -236,6 +236,8 @@
 
 .. _Sylvain Takerkart: https://github.com/SylvainTakerkart
 
+.. _Tarun Samanta: https://github.com/tarunsamanta2k20
+
 .. _Taylor Salo: https://tsalo.github.io/
 
 .. _Thomas Bazeille: https://github.com/thomasbazeille
@@ -253,5 +255,3 @@
 .. _Yasmin Mzayek: https://github.com/ymzayek
 
 .. _Zvi Baratz: https://github.com/ZviBaratz
-
-.. _Tarun Samanta: https://github.com/tarunsamanta2k20

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -253,3 +253,5 @@
 .. _Yasmin Mzayek: https://github.com/ymzayek
 
 .. _Zvi Baratz: https://github.com/ZviBaratz
+
+.. _Tarun Samanta: https://github.com/tarunsamanta2k20

--- a/nilearn/datasets/description/destrieux_surface.rst
+++ b/nilearn/datasets/description/destrieux_surface.rst
@@ -9,8 +9,8 @@ Fischl et al, 1999) in fsaverage5 standard surface space.
 
 Content
 -------
-    :'annot_left': parcellation on left hemisphere in freesurfer annot format
-    :'annot_right': parcellation on right hemisphere in freesurfer annot format
+    :'map_left': parcellation on left hemisphere in freesurfer annot format
+    :'map_right': parcellation on right hemisphere in freesurfer annot format
 
 
 References


### PR DESCRIPTION
Closes #3773 

**Describe your proposed suggestion in detail.**

The function fetch_atlas_surf_destrieux returns a dictionary with the keys 'labels', 'map_left', 'map_right', and 'description'. However, in the description, 'map_left' and 'map_right' are called 'annot_left' and 'annot_right'. These should be changed to be consistent with the API. The change should be made in [nilearn/datasets/description/destrieux_surface.rst](https://github.com/nilearn/nilearn/blob/main/nilearn/datasets/description/destrieux_surface.rst).
List any pages that would be impacted.

No response