### PR TITLE
[FIX] Make load_confounds' confounds file selection more generic

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -15,6 +15,8 @@ Fixes
 
 - :bdg-dark:`Code` Fix bug where the `cv_params_` attribute of fitter Decoder objects sometimes had missing entries if `grid_param` is a sequence of dicts with different keys (:gh:`3733` by `Michelle Wang`_).
 
+- Make the :func:`~nilearn.interfaces.fmriprep.load_confounds` confounds file selection more generic (:gh:`3794` by `Taylor Salo`_).
+
 Enhancements
 ------------
 

--- a/nilearn/interfaces/fmriprep/load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_utils.py
@@ -97,6 +97,8 @@ def _get_file_name(nii_file):
 
     base_dir = os.path.dirname(nii_file)
 
+    # Build a list of potential confounds filenames using all combinations of the
+    # entities in the image file.
     entities = parse_bids_filename(nii_file)
     file_fields = entities["file_fields"]
     entities = {k: v for k, v in entities.items() if k in file_fields}
@@ -114,7 +116,8 @@ def _get_file_name(nii_file):
     unique_subsets = [subset for subset in unique_subsets if "desc" in subset]
 
     filenames = [
-        "_".join(["-".join([k, v]) for k, v in entities.items() if k in lst]) for lst in unique_subsets
+        "_".join(["-".join([k, v]) for k, v in entities.items() if k in lst])
+        for lst in unique_subsets
     ]
 
     # fmriprep has changed the file suffix between v20.1.1 and v20.2.0 with
@@ -128,10 +131,16 @@ def _get_file_name(nii_file):
     for suffix in suffixes:
         confounds_raw_candidates += [f + suffix for f in filenames]
 
+    # Sort the potential filenames by decreasing length,
+    # so earlier entries reflect more retained entities.
     # https://www.geeksforgeeks.org/python-sort-list-of-lists-by-the-size-of-sublists/
     confounds_raw_candidates = sorted(confounds_raw_candidates, key=len)[::-1]
-    confounds_raw_candidates = [os.path.join(base_dir, crc) for crc in confounds_raw_candidates]
-    found_candidates = [cr for cr in confounds_raw_candidates if os.path.isfile(cr)]
+    confounds_raw_candidates = [
+        os.path.join(base_dir, crc) for crc in confounds_raw_candidates
+    ]
+    found_candidates = [
+        cr for cr in confounds_raw_candidates if os.path.isfile(cr)
+    ]
 
     if not found_candidates:
         raise ValueError(

--- a/nilearn/interfaces/fmriprep/load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_utils.py
@@ -97,17 +97,22 @@ def _get_file_name(nii_file):
 
     base_dir = os.path.dirname(nii_file)
 
-    # Build a list of potential confounds filenames using all combinations of the
-    # entities in the image file.
+    # Build a list of potential confounds filenames using all combinations of
+    # the entities in the image file.
     entities = parse_bids_filename(nii_file)
     file_fields = entities["file_fields"]
     entities = {k: v for k, v in entities.items() if k in file_fields}
     entities["desc"] = "confounds"
+    if "desc" not in file_fields:
+        file_fields.append("desc")
 
     all_subsets = []
     for n_entities in range(1, len(file_fields) + 1):
-        all_subsets.append(itertools.combinations(file_fields, n_entities))
+        all_subsets.append(
+            list(itertools.combinations(file_fields, n_entities))
+        )
 
+    # Flatten the list of lists
     all_subsets = [item for sublist in all_subsets for item in sublist]
     # https://stackoverflow.com/a/3724558/2589328
     unique_subsets = [list(x) for x in set(tuple(x) for x in all_subsets)]
@@ -146,7 +151,8 @@ def _get_file_name(nii_file):
         raise ValueError(
             "Could not find associated confound file. "
             "The functional derivatives should exist under the same parent "
-            "directory."
+            "directory.\n"
+            f"{os.listdir(base_dir)}\n\n{confounds_raw_candidates}"
         )
     elif len(found_candidates) != 1:
         found_str = "\n\t".join(found_candidates)

--- a/nilearn/interfaces/fmriprep/load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_utils.py
@@ -113,7 +113,7 @@ def _get_file_name(nii_file):
         )
 
     # Flatten the list of lists
-    all_subsets = [item for sublist in all_subsets for item in sublist]
+    all_subsets = [list(item) for sublist in all_subsets for item in sublist]
     # https://stackoverflow.com/a/3724558/2589328
     unique_subsets = [list(x) for x in set(tuple(x) for x in all_subsets)]
 
@@ -121,7 +121,7 @@ def _get_file_name(nii_file):
     unique_subsets = [subset for subset in unique_subsets if "desc" in subset]
 
     filenames = [
-        "_".join(["-".join([k, v]) for k, v in entities.items() if k in lst])
+        "_".join(["-".join([k, entities[k]]) for k in lst])
         for lst in unique_subsets
     ]
 
@@ -148,15 +148,17 @@ def _get_file_name(nii_file):
     ]
 
     if not found_candidates:
+        base_dir_str = "\n".join(os.listdir(base_dir))
+        candidates_str = "\n".join([os.path.basename(f) for f in confounds_raw_candidates])
         raise ValueError(
             "Could not find associated confound file. "
             "The functional derivatives should exist under the same parent "
             "directory.\n"
-            f"{os.listdir(base_dir)}\n\n{confounds_raw_candidates}"
+            f"{base_dir_str}\n\n{candidates_str}"
         )
     elif len(found_candidates) != 1:
         found_str = "\n\t".join(found_candidates)
-        raise ValueError(f"Found more than one confound file:\n\t{found_str}.")
+        raise ValueError(f"Found more than one confound file:\n\t{found_str}")
     else:
         return found_candidates[0]
 

--- a/nilearn/interfaces/fmriprep/load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_utils.py
@@ -148,13 +148,10 @@ def _get_file_name(nii_file):
     ]
 
     if not found_candidates:
-        base_dir_str = "\n".join(os.listdir(base_dir))
-        candidates_str = "\n".join([os.path.basename(f) for f in confounds_raw_candidates])
         raise ValueError(
             "Could not find associated confound file. "
             "The functional derivatives should exist under the same parent "
-            "directory.\n"
-            f"{base_dir_str}\n\n{candidates_str}"
+            "directory."
         )
     elif len(found_candidates) != 1:
         found_str = "\n\t".join(found_candidates)

--- a/nilearn/interfaces/fmriprep/load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_utils.py
@@ -140,9 +140,8 @@ def _get_file_name(nii_file):
             "directory."
         )
     elif len(found_candidates) != 1:
-        raise ValueError(
-            f"Found more than one confound file:\n\t{'\n\t'.join(found_candidates)}."
-        )
+        found_str = "\n\t".join(found_candidates)
+        raise ValueError(f"Found more than one confound file:\n\t{found_str}.")
     else:
         return found_candidates[0]
 

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
@@ -556,7 +556,16 @@ def test_sample_mask(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "image_type", ["regular", "native", "ica_aroma", "gifti", "cifti"]
+    "image_type", [
+        "regular",
+        "native",
+        "ica_aroma",
+        "gifti",
+        "cifti",
+        "res",
+        "den",
+        "part",
+    ],
 )
 def test_inputs(tmp_path, image_type):
     """Test multiple images as input."""

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
@@ -31,12 +31,17 @@ def test_sanitize_confounds(inputs, flag):
 
 
 @pytest.mark.parametrize("flag", [True, False])
-@pytest.mark.parametrize(
-    "suffix", ["_desc-confounds_regressors", "_desc-confounds_timeseries"]
-)
-@pytest.mark.parametrize(
-    "image_type", ["regular", "native", "res", "cifti", "den", "part", "gifti"]
-)
+@pytest.mark.parametrize("suffix",
+                         ["_desc-confounds_regressors",
+                          "_desc-confounds_timeseries"])
+@pytest.mark.parametrize("image_type",
+                         ["regular",
+                          "native",
+                          "res",
+                          "cifti",
+                          "den",
+                          "part",
+                          "gifti"])
 def test_get_file_name(tmp_path, flag, suffix, image_type):
     """Test _get_file_name."""
     if image_type == "part":

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
@@ -25,10 +25,28 @@ def test_sanitize_confounds(inputs, flag):
     assert singleflag is flag
 
 
-@pytest.mark.parametrize("flag,suffix",
-                         [(True, "_desc-confounds_regressors"),
-                          (False, "_desc-confounds_timeseries")])
-def test_get_file_name(tmp_path, flag, suffix):
-    img, _ = create_tmp_filepath(tmp_path, old_derivative_suffix=flag)
+@pytest.mark.parametrize(
+    "flag,suffix,image_type",
+    [
+        (True, "_desc-confounds_regressors", "regular"),
+        (False, "_desc-confounds_timeseries", "regular"),
+        (True, "_desc-confounds_regressors", "native"),
+        (False, "_desc-confounds_timeseries", "native"),
+        (True, "_desc-confounds_regressors", "res"),
+        (False, "_desc-confounds_timeseries", "res"),
+        (True, "_desc-confounds_regressors", "cifti"),
+        (False, "_desc-confounds_timeseries", "cifti"),
+        (True, "_desc-confounds_regressors", "den"),
+        (False, "_desc-confounds_timeseries", "den"),
+        (True, "_desc-confounds_regressors", "gifti"),
+        (False, "_desc-confounds_timeseries", "gifti"),
+    ],
+)
+def test_get_file_name(tmp_path, flag, suffix, image_type):
+    img, _ = create_tmp_filepath(
+        tmp_path,
+        image_type=image_type,
+        old_derivative_suffix=flag,
+    )
     conf = _get_file_name(img)
     assert suffix in conf

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
@@ -38,6 +38,8 @@ def test_sanitize_confounds(inputs, flag):
         (False, "_desc-confounds_timeseries", "cifti"),
         (True, "_desc-confounds_regressors", "den"),
         (False, "_desc-confounds_timeseries", "den"),
+        (True, "_desc-confounds_regressors", "part"),
+        (False, "_desc-confounds_timeseries", "part"),
         (True, "_desc-confounds_regressors", "gifti"),
         (False, "_desc-confounds_timeseries", "gifti"),
     ],

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
@@ -49,17 +49,19 @@ def test_sanitize_confounds(inputs, flag):
             "part",
             {"suffix": "sub-test01_task-test_part-mag_run-01"},
         ),
-        (False, "_desc-confounds_timeseries", "part", {}),
+        (
+            False,
+            "_desc-confounds_timeseries",
+            "part",
+            {"suffix": "sub-test01_task-test_part-mag_run-01"},
+        ),
         (True, "_desc-confounds_regressors", "gifti", {}),
         (False, "_desc-confounds_timeseries", "gifti", {}),
     ],
 )
 def test_get_file_name(tmp_path, flag, suffix, image_type, kwargs):
     img, _ = create_tmp_filepath(
-        tmp_path,
-        image_type=image_type,
-        old_derivative_suffix=flag,
-        **kwargs
+        tmp_path, image_type=image_type, old_derivative_suffix=flag, **kwargs
     )
     conf = _get_file_name(img)
     assert suffix in conf

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
@@ -31,16 +31,24 @@ def test_sanitize_confounds(inputs, flag):
 
 
 @pytest.mark.parametrize("flag", [True, False])
-@pytest.mark.parametrize("suffix", ["_desc-confounds_regressors", "_desc-confounds_timeseries"])
-@pytest.mark.parametrize("image_type", ["regular", "native", "res", "cifti", "den", "part", "gifti"])
+@pytest.mark.parametrize(
+    "suffix", ["_desc-confounds_regressors", "_desc-confounds_timeseries"]
+)
+@pytest.mark.parametrize(
+    "image_type", ["regular", "native", "res", "cifti", "den", "part", "gifti"]
+)
 def test_get_file_name(tmp_path, flag, suffix, image_type):
+    """Test _get_file_name."""
     if image_type == "part":
         kwargs = {"suffix": "sub-test01_task-test_part-mag_run-01"}
     else:
         kwargs = {}
 
-   img, _ = create_tmp_filepath(
-        tmp_path, image_type=image_type, old_derivative_suffix=flag, **kwargs
+    img, _ = create_tmp_filepath(
+        tmp_path,
+        image_type=image_type,
+        old_derivative_suffix=flag,
+        **kwargs,
     )
 
     conf = _get_file_name(img)

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
@@ -31,14 +31,9 @@ def test_sanitize_confounds(inputs, flag):
 
 
 @pytest.mark.parametrize("flag", [True, False])
-@pytest.mark.parametrize("image_type",
-                         ["regular",
-                          "native",
-                          "res",
-                          "cifti",
-                          "den",
-                          "part",
-                          "gifti"])
+@pytest.mark.parametrize(
+    "image_type", ["regular", "native", "res", "cifti", "den", "part", "gifti"]
+)
 def test_get_file_name(tmp_path, flag, image_type):
     """Test _get_file_name."""
     if flag:

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
@@ -15,8 +15,13 @@ from nilearn.interfaces.fmriprep.tests.utils import create_tmp_filepath
         (["image1.nii.gz", "image2.nii.gz"], False),
         (["image_L.func.gii", "image_R.func.gii"], True),
         ([["image_L.func.gii", "image_R.func.gii"]], True),
-        ([["image1_L.func.gii", "image1_R.func.gii"],
-          ["image2_L.func.gii", "image2_R.func.gii"]], False),
+        (
+            [
+                ["image1_L.func.gii", "image1_R.func.gii"],
+                ["image2_L.func.gii", "image2_R.func.gii"],
+            ],
+            False,
+        ),
     ],
 )
 def test_sanitize_confounds(inputs, flag):
@@ -26,29 +31,35 @@ def test_sanitize_confounds(inputs, flag):
 
 
 @pytest.mark.parametrize(
-    "flag,suffix,image_type",
+    "flag,suffix,image_type,kwargs",
     [
-        (True, "_desc-confounds_regressors", "regular"),
-        (False, "_desc-confounds_timeseries", "regular"),
-        (True, "_desc-confounds_regressors", "native"),
-        (False, "_desc-confounds_timeseries", "native"),
-        (True, "_desc-confounds_regressors", "res"),
-        (False, "_desc-confounds_timeseries", "res"),
-        (True, "_desc-confounds_regressors", "cifti"),
-        (False, "_desc-confounds_timeseries", "cifti"),
-        (True, "_desc-confounds_regressors", "den"),
-        (False, "_desc-confounds_timeseries", "den"),
-        (True, "_desc-confounds_regressors", "part"),
-        (False, "_desc-confounds_timeseries", "part"),
-        (True, "_desc-confounds_regressors", "gifti"),
-        (False, "_desc-confounds_timeseries", "gifti"),
+        (True, "_desc-confounds_regressors", "regular", {}),
+        (False, "_desc-confounds_timeseries", "regular", {}),
+        (True, "_desc-confounds_regressors", "native", {}),
+        (False, "_desc-confounds_timeseries", "native", {}),
+        (True, "_desc-confounds_regressors", "res", {}),
+        (False, "_desc-confounds_timeseries", "res", {}),
+        (True, "_desc-confounds_regressors", "cifti", {}),
+        (False, "_desc-confounds_timeseries", "cifti", {}),
+        (True, "_desc-confounds_regressors", "den", {}),
+        (False, "_desc-confounds_timeseries", "den", {}),
+        (
+            True,
+            "_desc-confounds_regressors",
+            "part",
+            {"suffix": "sub-test01_task-test_part-mag_run-01"},
+        ),
+        (False, "_desc-confounds_timeseries", "part", {}),
+        (True, "_desc-confounds_regressors", "gifti", {}),
+        (False, "_desc-confounds_timeseries", "gifti", {}),
     ],
 )
-def test_get_file_name(tmp_path, flag, suffix, image_type):
+def test_get_file_name(tmp_path, flag, suffix, image_type, kwargs):
     img, _ = create_tmp_filepath(
         tmp_path,
         image_type=image_type,
         old_derivative_suffix=flag,
+        **kwargs
     )
     conf = _get_file_name(img)
     assert suffix in conf

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
@@ -30,38 +30,18 @@ def test_sanitize_confounds(inputs, flag):
     assert singleflag is flag
 
 
-@pytest.mark.parametrize(
-    "flag,suffix,image_type,kwargs",
-    [
-        (True, "_desc-confounds_regressors", "regular", {}),
-        (False, "_desc-confounds_timeseries", "regular", {}),
-        (True, "_desc-confounds_regressors", "native", {}),
-        (False, "_desc-confounds_timeseries", "native", {}),
-        (True, "_desc-confounds_regressors", "res", {}),
-        (False, "_desc-confounds_timeseries", "res", {}),
-        (True, "_desc-confounds_regressors", "cifti", {}),
-        (False, "_desc-confounds_timeseries", "cifti", {}),
-        (True, "_desc-confounds_regressors", "den", {}),
-        (False, "_desc-confounds_timeseries", "den", {}),
-        (
-            True,
-            "_desc-confounds_regressors",
-            "part",
-            {"suffix": "sub-test01_task-test_part-mag_run-01"},
-        ),
-        (
-            False,
-            "_desc-confounds_timeseries",
-            "part",
-            {"suffix": "sub-test01_task-test_part-mag_run-01"},
-        ),
-        (True, "_desc-confounds_regressors", "gifti", {}),
-        (False, "_desc-confounds_timeseries", "gifti", {}),
-    ],
-)
-def test_get_file_name(tmp_path, flag, suffix, image_type, kwargs):
-    img, _ = create_tmp_filepath(
+@pytest.mark.parametrize("flag", [True, False])
+@pytest.mark.parametrize("suffix", ["_desc-confounds_regressors", "_desc-confounds_timeseries"])
+@pytest.mark.parametrize("image_type", ["regular", "native", "res", "cifti", "den", "part", "gifti"])
+def test_get_file_name(tmp_path, flag, suffix, image_type):
+    if image_type == "part":
+        kwargs = {"suffix": "sub-test01_task-test_part-mag_run-01"}
+    else:
+        kwargs = {}
+
+   img, _ = create_tmp_filepath(
         tmp_path, image_type=image_type, old_derivative_suffix=flag, **kwargs
     )
+
     conf = _get_file_name(img)
     assert suffix in conf

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds_utils.py
@@ -31,9 +31,6 @@ def test_sanitize_confounds(inputs, flag):
 
 
 @pytest.mark.parametrize("flag", [True, False])
-@pytest.mark.parametrize("suffix",
-                         ["_desc-confounds_regressors",
-                          "_desc-confounds_timeseries"])
 @pytest.mark.parametrize("image_type",
                          ["regular",
                           "native",
@@ -42,8 +39,13 @@ def test_sanitize_confounds(inputs, flag):
                           "den",
                           "part",
                           "gifti"])
-def test_get_file_name(tmp_path, flag, suffix, image_type):
+def test_get_file_name(tmp_path, flag, image_type):
     """Test _get_file_name."""
+    if flag:
+        suffix = "_desc-confounds_regressors"
+    else:
+        suffix = "_desc-confounds_timeseries"
+
     if image_type == "part":
         kwargs = {"suffix": "sub-test01_task-test_part-mag_run-01"}
     else:

--- a/nilearn/interfaces/fmriprep/tests/utils.py
+++ b/nilearn/interfaces/fmriprep/tests/utils.py
@@ -15,7 +15,7 @@ img_file_patterns = {
     "cifti": "_space-fsLR_den-91k_bold.dtseries.nii",
     "den": "_space-fsLR_den-32k_desc-preproc_bold.nii.gz",
     "part": (
-        "_dir-ap_run-1_part-mag_space-MNI152NLin2009cAsym_"
+        "_part-mag_space-MNI152NLin2009cAsym_"
         "desc-preproc_bold.nii.gz"
     ),
     "gifti": (

--- a/nilearn/interfaces/fmriprep/tests/utils.py
+++ b/nilearn/interfaces/fmriprep/tests/utils.py
@@ -14,7 +14,10 @@ img_file_patterns = {
     "native": "_desc-preproc_bold.nii.gz",
     "cifti": "_space-fsLR_den-91k_bold.dtseries.nii",
     "den": "_space-fsLR_den-32k_desc-preproc_bold.nii.gz",
-    "part": "_part-mag_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz",
+    "part": (
+        "_dir-ap_run-1_part-mag_space-MNI152NLin2009cAsym_"
+        "desc-preproc_bold.nii.gz"
+    ),
     "gifti": (
         "_space-fsaverage5_hemi-L_bold.func.gii",
         "_space-fsaverage5_hemi-R_bold.func.gii",

--- a/nilearn/interfaces/fmriprep/tests/utils.py
+++ b/nilearn/interfaces/fmriprep/tests/utils.py
@@ -11,10 +11,14 @@ img_file_patterns = {
         "_space-MNI152NLin2009cAsym_desc-smoothAROMAnonaggr_bold.nii.gz",
     "regular":
         "_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz",
+    "res":
+        "_space-MNI152NLin2009cAsym_res-2_desc-preproc_bold.nii.gz",
     "native":
         "_desc-preproc_bold.nii.gz",
     "cifti":
         "_space-fsLR_den-91k_bold.dtseries.nii",
+    "den":
+        "_space-fsLR_den-32k_desc-preproc_bold.nii.gz",
     "gifti": (
         "_space-fsaverage5_hemi-L_bold.func.gii",
         "_space-fsaverage5_hemi-R_bold.func.gii",

--- a/nilearn/interfaces/fmriprep/tests/utils.py
+++ b/nilearn/interfaces/fmriprep/tests/utils.py
@@ -9,16 +9,12 @@ from nilearn.interfaces.fmriprep import load_confounds_utils
 img_file_patterns = {
     "ica_aroma":
         "_space-MNI152NLin2009cAsym_desc-smoothAROMAnonaggr_bold.nii.gz",
-    "regular":
-        "_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz",
-    "res":
-        "_space-MNI152NLin2009cAsym_res-2_desc-preproc_bold.nii.gz",
-    "native":
-        "_desc-preproc_bold.nii.gz",
-    "cifti":
-        "_space-fsLR_den-91k_bold.dtseries.nii",
-    "den":
-        "_space-fsLR_den-32k_desc-preproc_bold.nii.gz",
+    "regular": "_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz",
+    "res": "_space-MNI152NLin2009cAsym_res-2_desc-preproc_bold.nii.gz",
+    "native": "_desc-preproc_bold.nii.gz",
+    "cifti": "_space-fsLR_den-91k_bold.dtseries.nii",
+    "den": "_space-fsLR_den-32k_desc-preproc_bold.nii.gz",
+    "part": "_part-mag_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz",
     "gifti": (
         "_space-fsaverage5_hemi-L_bold.func.gii",
         "_space-fsaverage5_hemi-R_bold.func.gii",


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3792.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Build candidate confounds filenames from entities in the image files. The only value that is hardcoded is "desc-confounds".
- Update tests to cover more cases.
    - The tests that would have failed before are `test_get_file_name[True-_desc-confounds_regressors-part]` and `test_get_file_name[False-_desc-confounds_timeseries-part]`.
