### PR TITLE
[DOC] Workaround for sphinx warning reference target not found for 2 scikit-learn (v1.3) classes

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -372,6 +372,15 @@ extlinks = {
     "nipy": ("https://nipy.org/%s", None),
 }
 
+# Check intersphinx reference targets exist
+nitpicky = True
+# Temporary solution to nilearn/nilearn#3800
+# See also scikit-learn/scikit-learn#26761
+nitpick_ignore = [
+    ("py:class", "pipeline.Pipeline"),
+    ("py:class", "utils.metadata_routing.MetadataRequest"),
+]
+
 binder_branch = "main" if "dev" in current_version else current_version
 
 sphinx_gallery_conf = {


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
See #3800. See also https://github.com/scikit-learn/scikit-learn/issues/26761

This warning fails the full doc build

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add nitpicky option to conf.py
- Add reference targets to ignore
-
