### PR TITLE
[FIX] prevent extra line with spaces at the end of names.rst

### DIFF
--- a/maint_tools/citation_cff_maint.py
+++ b/maint_tools/citation_cff_maint.py
@@ -72,10 +72,9 @@ def write_names_rst(citation: list[dict[str, str]]) -> None:
         for author in citation["authors"]:
             line = (
                 f'.. _{author["given-names"]} {author["family-names"]}: '
-                f'{author["website"]}'
+                f'{author["website"]}\n'
             )
             print(line, file=f)
-            print("", file=f)
 
 
 def read_authors_file() -> list[str]:

--- a/maint_tools/citation_cff_maint.py
+++ b/maint_tools/citation_cff_maint.py
@@ -66,15 +66,17 @@ def write_names_rst(citation: list[dict[str, str]]) -> None:
     If you want to add to add yourself to the list of authors,
     please edit CITATION.cff and run maint_tools/citation_cff_maint.py.
 
-    """
+"""
         print(header, file=f)
 
-        for author in citation["authors"]:
+        for i, author in enumerate(citation["authors"]):
             line = (
                 f'.. _{author["given-names"]} {author["family-names"]}: '
-                f'{author["website"]}\n'
+                f'{author["website"]}'
             )
             print(line, file=f)
+            if i < len(citation["authors"]) - 1:
+                print("", file=f)
 
 
 def read_authors_file() -> list[str]:


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Supersedes #3806 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- update script that generates names.rst to prevent "tug of war" with pre-commit
