### PR TITLE
[FIX] improve warnings in building glm from BIDS 

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -13,6 +13,8 @@ Fixes
 
 - Fix bug in :func:`~glm.first_level.first_level_from_bids` that returned no confound files if the corresponding bold files contained derivatives BIDS entities (:gh:`3742` by `Rémi Gau`_).
 
+- Fix bug in :func:`~glm.first_level.first_level_from_bids` that would throw a warning about ``slice_time_ref`` not being provided even when it was (:gh:`3811` by `Rémi Gau`_).
+
 - :bdg-dark:`Code` Fix bug where the `cv_params_` attribute of fitter Decoder objects sometimes had missing entries if `grid_param` is a sequence of dicts with different keys (:gh:`3733` by `Michelle Wang`_).
 
 Enhancements

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -990,7 +990,7 @@ def first_level_from_bids(dataset_path,
     if t_r is not None:
         _check_repetition_time(t_r)
     else:
-        warn("'t_r' not provided and cannot be inferred from BIDS metadata. "
+        warn("'t_r' not provided and cannot be inferred from BIDS metadata.\n"
              "It will need to be set manually in the list of models, "
              "otherwise their fit will throw an exception.")
 
@@ -1015,12 +1015,13 @@ def first_level_from_bids(dataset_path,
         assert (StartTime < t_r)
         inferred_slice_time_ref = StartTime / t_r
     else:
-        warn("'slice_time_ref' not provided "
-             "and cannot be inferred from metadata."
-             "It will be assumed that the slice timing reference "
-             "is 0.0 percent of the repetition time. "
-             "If it is not the case it will need to "
-             "be set manually in the generated list of models.")
+        if slice_time_ref is None:
+            warn("'slice_time_ref' not provided "
+                "and cannot be inferred from metadata.\n"
+                "It will be assumed that the slice timing reference "
+                "is 0.0 percent of the repetition time.\n"
+                "If it is not the case it will need to "
+                "be set manually in the generated list of models.")
         inferred_slice_time_ref = 0.0
 
     if slice_time_ref is None and inferred_slice_time_ref is not None:
@@ -1087,7 +1088,7 @@ def first_level_from_bids(dataset_path,
                          for c in confounds]
         models_confounds.append(confounds)
 
-    return models, models_run_imgs, models_events, models_confounds
+    return models, models_run_imgs, models_events, models_confounds 
 
 
 def _list_valid_subjects(derivatives_path,

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1088,7 +1088,7 @@ def first_level_from_bids(dataset_path,
                          for c in confounds]
         models_confounds.append(confounds)
 
-    return models, models_run_imgs, models_events, models_confounds 
+    return models, models_run_imgs, models_events, models_confounds
 
 
 def _list_valid_subjects(derivatives_path,

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1017,11 +1017,11 @@ def first_level_from_bids(dataset_path,
     else:
         if slice_time_ref is None:
             warn("'slice_time_ref' not provided "
-                "and cannot be inferred from metadata.\n"
-                "It will be assumed that the slice timing reference "
-                "is 0.0 percent of the repetition time.\n"
-                "If it is not the case it will need to "
-                "be set manually in the generated list of models.")
+                 "and cannot be inferred from metadata.\n"
+                 "It will be assumed that the slice timing reference "
+                 "is 0.0 percent of the repetition time.\n"
+                 "If it is not the case it will need to "
+                 "be set manually in the generated list of models.")
         inferred_slice_time_ref = 0.0
 
     if slice_time_ref is None and inferred_slice_time_ref is not None:

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -1420,10 +1420,12 @@ def test_first_level_from_bids_no_tr(tmp_path_factory):
         os.remove(f)
 
     with pytest.warns(
-         UserWarning,
-         match="t_r.* will need to be set manually in the list of models"):
+        UserWarning,
+        match="'t_r' not provided and cannot be inferred"):
         first_level_from_bids(
-            dataset_path=bids_dataset, task_label="main", space_label="MNI",
+            dataset_path=bids_dataset,
+            task_label="main",
+            space_label="MNI",
             slice_time_ref=None, t_r=None
         )
 
@@ -1578,3 +1580,20 @@ def test_first_level_from_bids_deprecated_slice_time_default(bids_dataset):
             img_filters=[("desc", "preproc")],
             slice_time_ref=0,
         )
+
+def test_slice_time_ref_warning_only_when_not_provided(bids_dataset):
+
+    # catch all warnings
+    with pytest.warns() as record:
+        models, m_imgs, m_events, m_confounds = first_level_from_bids(
+            dataset_path=bids_dataset,
+            task_label="main",
+            space_label="MNI",
+            img_filters=[("desc", "preproc")],
+            slice_time_ref=0.6,
+            verbose=0,
+        )
+
+    # check that no warnings were raised
+    for r in record:
+        assert "'slice_time_ref' not provided" not in r.message.args[0]

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -1420,8 +1420,8 @@ def test_first_level_from_bids_no_tr(tmp_path_factory):
         os.remove(f)
 
     with pytest.warns(
-        UserWarning,
-        match="'t_r' not provided and cannot be inferred"):
+            UserWarning,
+            match="'t_r' not provided and cannot be inferred"):
         first_level_from_bids(
             dataset_path=bids_dataset,
             task_label="main",
@@ -1580,6 +1580,7 @@ def test_first_level_from_bids_deprecated_slice_time_default(bids_dataset):
             img_filters=[("desc", "preproc")],
             slice_time_ref=0,
         )
+
 
 def test_slice_time_ref_warning_only_when_not_provided(bids_dataset):
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3735 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- make sure warnings is not raised when slice_time_ref is provided
- improve warnings readibility
