### PR TITLE
[MAINT] update gitblame ignore and contributing

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -20,6 +20,26 @@
 # Most recently merged PRs are at the top
 #
 # ---------------------------------------------------------------------------- #
+# [FMT] apply black (#3836)
+1b8c6ed6028e3ecf880597539f1de0910eb8d230
+# [FMT] apply black to plotting - part 4 (#3833)
+34613ab01d219924a8ed34677f48779d5d0b0cd1
+# [FMT] apply black to plotting - part 3 (#3827)
+ea375e01b35208f26aae9e66183fab245dd9862e
+# [FMT] apply black to plotting - part 2 (#3810)
+787d662116a0808d074b0dd40c9b4c2498712819
+# [FMT] apply black to maskers - part 2 (#3803)
+3f2628ffd016c9504c62db8560c5c4cc06d024c8
+# [FMT] apply black to plotting - part 1 (#3802)
+90dd16e20afafd2f9628bd5e08d3db3fe50353f2
+# [FMT] apply black to maskers - part 1 (#3795)
+aece81bb22bff7ad84427bda8d777eb072ade0b0
+# [FMT] apply black nilearn.plotting.display (#3790)
+186845cc04cb8c13c2dd5aa50eff2b426ec2329c
+# apply black to interface (#3783)
+43ff123df9e3849019c12d1c4125ed5fc8d21328
+# [MAINT] Update config black and pre-commit (#3777)
+caa8da8172c2ea56929ef6ecd3b592b963384370
 # run isort and flake8 on the whole nilearn code base in CI (#3651)
 44933309ecd09add795ce1c3ea5edaab4294da87
 # Format nilearn/plotting: apply isort and fix flake8 errors (#3648)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -280,22 +280,12 @@ The main conventions we enforce are :
 You can check that any code you may have edited follows these conventions
 by running `flake8 <https://flake8.pycqa.org/en/latest/user/invocation.html#invoking-flake8>`__.
 
-Additionally, we recommend using:
+Additionally, we use:
 
 - `black <https://black.readthedocs.io/en/stable/getting_started.html#basic-usage>`_
-  to format your code,
+  to format our code,
 - `isort <https://pycqa.github.io/isort/index.html#using-isort>`_
   to organize the import statements.
-
-.. warning::
-
-      We are gradually transitioning to use `isort` and `black`
-      to format the codebase.
-      Only certain modules have been formatted so far,
-      and running `black` or `isort` may not affect the files you are working on,
-      because of how those formatter are currently configured.
-      See `issue #2528 <https://github.com/nilearn/nilearn/issues/2528>`_
-      for more details.
 
 Each function and class must come with a “docstring” at the top of the function code,
 using numpydoc_ formatting.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -182,7 +182,7 @@ with the tools we use for development and deployment.
 +--------------------+---------------+-----------------------------------------------------+
 |                    |               | - Variables, functions, arguments have clear names  |
 |                    |               | - Easy to read, PEP8_ compliant                     |
-|                    |               | - Code formatted with black_                         |
+|                    |               | - Code formatted with black_                        |
 |                    |               | - imports sorted with isort_                        |
 |                    |               | - Public functions have docstring (numpydoc_ format)|
 |                    |               | - Low redundancy                                    |

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -182,6 +182,8 @@ with the tools we use for development and deployment.
 +--------------------+---------------+-----------------------------------------------------+
 |                    |               | - Variables, functions, arguments have clear names  |
 |                    |               | - Easy to read, PEP8_ compliant                     |
+|                    |               | - Code formatted with black_                         |
+|                    |               | - imports sorted with isort_                        |
 |                    |               | - Public functions have docstring (numpydoc_ format)|
 |                    |               | - Low redundancy                                    |
 |   `Coding Style`_  |    Any        | - No new dependency                                 |
@@ -211,6 +213,8 @@ with the tools we use for development and deployment.
 
 .. _PEP8: https://www.python.org/dev/peps/pep-0008/
 .. _numpydoc: https://numpydoc.readthedocs.io/en/latest/format.html
+.. _black: https://black.readthedocs.io/en/stable/getting_started.html#basic-usage
+.. _isort: https://pycqa.github.io/isort/index.html#using-isort
 
 PR Structure
 ------------
@@ -282,10 +286,8 @@ by running `flake8 <https://flake8.pycqa.org/en/latest/user/invocation.html#invo
 
 Additionally, we use:
 
-- `black <https://black.readthedocs.io/en/stable/getting_started.html#basic-usage>`_
-  to format our code,
-- `isort <https://pycqa.github.io/isort/index.html#using-isort>`_
-  to organize the import statements.
+- black_ to format our code,
+- isort_  to organize the import statements.
 
 Each function and class must come with a “docstring” at the top of the function code,
 using numpydoc_ formatting.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -183,7 +183,7 @@ with the tools we use for development and deployment.
 |                    |               | - Variables, functions, arguments have clear names  |
 |                    |               | - Easy to read, PEP8_ compliant                     |
 |                    |               | - Code formatted with black_                        |
-|                    |               | - imports sorted with isort_                        |
+|                    |               | - Imports sorted with isort_                        |
 |                    |               | - Public functions have docstring (numpydoc_ format)|
 |                    |               | - Low redundancy                                    |
 |   `Coding Style`_  |    Any        | - No new dependency                                 |

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -35,6 +35,7 @@ Changes
 
 - Removed old files and test code from deprecated datasets COBRE and NYU resting state (:gh:`3743` by `Michelle Wang`_).
 - :bdg-secondary:`Maint` PEP8 and isort compliance extended to the whole nilearn codebase. (:gh:`3538`, :gh:`3566`, :gh:`3548`, :gh:`3556`, :gh:`3601`, :gh:`3609`, :gh:`3646`, :gh:`3650`, :gh:`3647`, :gh:`3640`, :gh:`3615`, :gh:`3614`, :gh:`3648`,  :gh:`#3651`  by `Rémi Gau`_).
+- :bdg-secondary:`Maint` Finish applying black formatting to most of the codebase. (:gh:`3836`, :gh:`3833`, :gh:`3827`, :gh:`3810`, :gh:`3803`, :gh:`3802`, :gh:`3795`, :gh:`3790`, :gh:`3783`, :gh:`3777` by `Rémi Gau`_).
 - :bdg-danger:`Deprecation` Empty region signals resulting from applying `mask_img` in :class:`~maskers.NiftiLabelsMasker` will no longer be kept in release 0.15. Meanwhile, use `keep_masked_labels` parameter when initializing the :class:`~maskers.NiftiLabelsMasker` object to enable/disable this behavior. (:gh:`3722` by `Mohammad Torabi`_).
 - :bdg-danger:`Deprecation` Empty region signals resulting from applying `mask_img` in :class:`~maskers.NiftiMapsMasker` will no longer be kept in release 0.15. Meanwhile, use `keep_masked_maps` parameter when initializing the :class:`~maskers.NiftiMapsMasker` object to enable/disable this behavior. (:gh:`3732` by `Mohammad Torabi`_).
 - Removed mention of license in "header" (:gh:`3838` by `Czarina Sy`_).


### PR DESCRIPTION
In my opinion this is the last PR for the formatting automation
and so this closes https://github.com/nilearn/nilearn/issues/2528

Changes proposed in this pull request:

- update contributing to say that we now use: black and isort
- update gitblame ignore 