### PR TITLE
[DOC] replace skipped doctests with default code-blocks

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -436,3 +436,7 @@ authors:
   - given-names: Óscar
     family-names: Nájera
     website: https://github.com/Titan-C
+  - given-names: Patrick
+    family-names: Sadil
+    website: https://psadil.github.io/psadil
+    affiliation: Department of Biostatistics, Johns Hopkins Bloomberg School of Public Health

--- a/doc/building_blocks/manual_pipeline.rst
+++ b/doc/building_blocks/manual_pipeline.rst
@@ -32,21 +32,27 @@ which downloads a dataset and returns a bunch of paths to the dataset
 files (more details in :ref:`loading_data`). We can then proceed
 loading them as if they were just any other files on our disk. For
 example, we can download the data from the
-`Haxby 2001 paper <http://dx.doi.org/10.1126/science.1063736>`_ ::
+`Haxby 2001 paper <http://dx.doi.org/10.1126/science.1063736>`_ :
 
-    >>> from nilearn import datasets
-    >>> dataset = datasets.fetch_haxby() # doctest: +SKIP
+.. code-block:: default
 
-`dataset.func` contains filenames referring to dataset files on the disk::
+     from nilearn import datasets
+     dataset = datasets.fetch_haxby()
 
-  >>> list(sorted(dataset.keys())) # doctest: +SKIP
-  ['anat', 'description', 'func', 'mask', 'mask_face', 'mask_face_little', 'mask_house', 'mask_house_little', 'mask_vt', 'session_target']
-  >>> dataset.func # doctest: +ELLIPSIS +SKIP
-  ['.../haxby2001/subj2/bold.nii.gz']
+`dataset.func` contains filenames referring to dataset files on the disk:
+
+.. code-block:: default
+
+     list(sorted(dataset.keys()))
+     # ['anat', 'description', 'func', 'mask', 'mask_face', 'mask_face_little', 'mask_house', 'mask_house_little', 'mask_vt', 'session_target']
+     dataset.func
+     # ['.../haxby2001/subj2/bold.nii.gz']
 
 Access supplementary information on the dataset:
 
-  >>> print(haxby_dataset['description']) # doctest: +SKIP
+.. code-block:: default
+
+     print(haxby_dataset['description'])
 
 The complete list of the data-downloading functions can be found in the
 :ref:`reference documentation for the datasets <datasets_ref>`.

--- a/doc/building_blocks/neurovault.rst
+++ b/doc/building_blocks/neurovault.rst
@@ -66,8 +66,7 @@ We can ask for :term:`BOLD` images only :
 
 .. code-block:: default
 
-  bold = fetch_neurovault(image_terms={'modality': 'fMRI-BOLD'},
-    ... max_images=7)
+  bold = fetch_neurovault(image_terms={'modality': 'fMRI-BOLD'}, max_images=7)
 
 Here we set the max_images parameter to 7, so that you can try this snippet
 without waiting for a long time. To get all the images which match your
@@ -100,25 +99,22 @@ provides ``IsIn`` which makes this easy :
 .. code-block:: default
 
   from nilearn.datasets import neurovault
-  fmri = fetch_neurovault(
-    ... modality=neurovault.IsIn('fMRI-BOLD', 'fMRI-CBF', 'fMRI-CBV'),
-    ... max_images=100)
+  fmri = fetch_neurovault(modality=neurovault.IsIn('fMRI-BOLD', 'fMRI-CBF', 'fMRI-CBV'),
+                          max_images=100)
 
 We could also have used ``Contains`` :
 
 .. code-block:: default
 
-  fmri = fetch_neurovault(
-    ... modality=neurovault.Contains('fMRI'),
-    ... max_images=7)
+  fmri = fetch_neurovault(modality=neurovault.Contains('fMRI'), max_images=7)
 
 If we need regular expressions, we can also use ``Pattern`` :
 
 .. code-block:: default
 
   fmri = fetch_neurovault(
-    ... modality=neurovault.Pattern('fmri(-.*)?', neurovault.re.IGNORECASE),
-    ... max_images=7)
+    modality=neurovault.Pattern('fmri(-.*)?', neurovault.re.IGNORECASE),
+    max_images=7)
 
 The complete list of such special values available in
 ``nilearn.datasets.neurovault`` is:
@@ -142,9 +138,8 @@ Using a filter rather than a dictionary, the first example becomes:
 
 .. code-block:: default
 
-  bold = fetch_neurovault(
-    ... image_filter=lambda meta: meta.get('modality') == 'fMRI-BOLD',
-    ... image_terms={}, max_images=7)
+  bold = fetch_neurovault(image_filter=lambda meta: meta.get('modality') == 'fMRI-BOLD',
+                          image_terms={}, max_images=7)
 
 .. note::
 
@@ -165,7 +160,7 @@ metadata dictionary to a required value, so we need to write our own filter:
 .. code-block:: default
 
   small_meta_images = fetch_neurovault(image_filter=lambda meta: len(meta) < 50,
-  ...                                      max_images=7)
+                                       max_images=7)
 
 
 Output

--- a/doc/building_blocks/neurovault.rst
+++ b/doc/building_blocks/neurovault.rst
@@ -30,13 +30,17 @@ collection's webpage, you can click 'Details' to see its id
 (and more). You can then download it using
 :func:`nilearn.datasets.fetch_neurovault_ids` :
 
-    >>> from nilearn.datasets import fetch_neurovault_ids
-    >>> brainpedia = fetch_neurovault_ids(collection_ids=[1952]) # doctest: +SKIP
+.. code-block:: default
+
+  from nilearn.datasets import fetch_neurovault_ids
+  brainpedia = fetch_neurovault_ids(collection_ids=[1952])
 
 Or if you want some images in particular, rather than whole
 collections :
 
-    >>> brainpedia_subset = fetch_neurovault_ids(image_ids=[32015, 32016]) # doctest: +SKIP
+.. code-block:: default
+
+  brainpedia_subset = fetch_neurovault_ids(image_ids=[32015, 32016])
 
 Selection filters
 -----------------
@@ -60,8 +64,10 @@ For example, many images on Neurovault have a "modality" field in their
 metadata.  :term:`BOLD` images should have it set to "fMRI-BOLD".
 We can ask for :term:`BOLD` images only :
 
-    >>> bold = fetch_neurovault(image_terms={'modality': 'fMRI-BOLD'}, # doctest: +SKIP
-    ... max_images=7) # doctest: +SKIP
+.. code-block:: default
+
+  bold = fetch_neurovault(image_terms={'modality': 'fMRI-BOLD'},
+    ... max_images=7)
 
 Here we set the max_images parameter to 7, so that you can try this snippet
 without waiting for a long time. To get all the images which match your
@@ -82,30 +88,37 @@ Extra keyword arguments are treated as additional image filters, so if we want
 to keep the default filters, and add the requirement that the modality should
 be "fMRI-BOLD", we can write:
 
-    >>> bold = fetch_neurovault(modality='fMRI-BOLD', max_images=7) # doctest: +SKIP
+.. code-block:: default
 
+  bold = fetch_neurovault(modality='fMRI-BOLD', max_images=7)
 
 Sometimes the selection criteria are more complex than a simple
 comparison to a single value. For example, we may also be interested
 in CBF and CBV images. In ``nilearn``, the ``dataset.neurovault`` module
 provides ``IsIn`` which makes this easy :
 
-    >>> from nilearn.datasets import neurovault
-    >>> fmri = fetch_neurovault( # doctest: +SKIP
-    ... modality=neurovault.IsIn('fMRI-BOLD', 'fMRI-CBF', 'fMRI-CBV'), # doctest: +SKIP
-    ... max_images=100) # doctest: +SKIP
+.. code-block:: default
+
+  from nilearn.datasets import neurovault
+  fmri = fetch_neurovault(
+    ... modality=neurovault.IsIn('fMRI-BOLD', 'fMRI-CBF', 'fMRI-CBV'),
+    ... max_images=100)
 
 We could also have used ``Contains`` :
 
-    >>> fmri = fetch_neurovault( # doctest: +SKIP
-    ... modality=neurovault.Contains('fMRI'), # doctest: +SKIP
-    ... max_images=7) # doctest: +SKIP
+.. code-block:: default
+
+  fmri = fetch_neurovault(
+    ... modality=neurovault.Contains('fMRI'),
+    ... max_images=7)
 
 If we need regular expressions, we can also use ``Pattern`` :
 
-    >>> fmri = fetch_neurovault( # doctest: +SKIP
-    ... modality=neurovault.Pattern('fmri(-.*)?', neurovault.re.IGNORECASE), # doctest: +SKIP
-    ... max_images=7) # doctest: +SKIP
+.. code-block:: default
+
+  fmri = fetch_neurovault(
+    ... modality=neurovault.Pattern('fmri(-.*)?', neurovault.re.IGNORECASE),
+    ... max_images=7)
 
 The complete list of such special values available in
 ``nilearn.datasets.neurovault`` is:
@@ -127,9 +140,11 @@ job for images. The default values for these parameters don't filter out
 anything.
 Using a filter rather than a dictionary, the first example becomes:
 
-    >>> bold = fetch_neurovault( # doctest: +SKIP
-    ...     image_filter=lambda meta: meta.get('modality') == 'fMRI-BOLD', # doctest: +SKIP
-    ...     image_terms={}, max_images=7) # doctest: +SKIP
+.. code-block:: default
+
+  bold = fetch_neurovault(
+    ... image_filter=lambda meta: meta.get('modality') == 'fMRI-BOLD',
+    ... image_terms={}, max_images=7)
 
 .. note::
 
@@ -147,8 +162,10 @@ many metadata fields - say, an image should only be kept if its metadata has
 less than 50 fields.  This cannot be done by simply comparing each key in a
 metadata dictionary to a required value, so we need to write our own filter:
 
-  >>> small_meta_images = fetch_neurovault(image_filter=lambda meta: len(meta) < 50, # doctest: +SKIP
-  ...                                      max_images=7) # doctest: +SKIP
+.. code-block:: default
+
+  small_meta_images = fetch_neurovault(image_filter=lambda meta: len(meta) < 50,
+  ...                                      max_images=7)
 
 
 Output

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -42,3 +42,4 @@ Changes
 - :bdg-danger:`Deprecation` Empty region signals resulting from applying `mask_img` in :class:`~maskers.NiftiMapsMasker` will no longer be kept in release 0.15. Meanwhile, use `keep_masked_maps` parameter when initializing the :class:`~maskers.NiftiMapsMasker` object to enable/disable this behavior. (:gh:`3732` by `Mohammad Torabi`_).
 - Removed mention of license in "header" (:gh:`3838` by `Czarina Sy`_).
 - Configure plots in example gallery for better rendering  (:gh:`3753` by `Yasmin Mzayek`_)
+- :bdg-secondary:`Doc` Replace skipped doctests with default code-blocks (:gh:`3681` in by `Patrick Sadil`_)

--- a/doc/connectivity/connectome_extraction.rst
+++ b/doc/connectivity/connectome_extraction.rst
@@ -47,22 +47,28 @@ conditioned on all the others.
 To recover well the interaction structure, a **sparse inverse covariance
 estimator** is necessary. The GraphicalLasso, implemented in scikit-learn's
 estimator :class:`sklearn.covariance.GraphicalLassoCV` is a good, simple
-solution. To use it, you need to create an estimator object::
+solution. To use it, you need to create an estimator object:
 
-    >>> from sklearn.covariance import GraphicalLassoCV
-    >>> estimator = GraphicalLassoCV()
+.. code-block:: default
+
+     from sklearn.covariance import GraphicalLassoCV
+     estimator = GraphicalLassoCV()
 
 And then you can fit it on the activation time series, for instance
-extracted in :ref:`the previous section <functional_connectomes>`::
+extracted in :ref:`the previous section <functional_connectomes>`:
 
-    >>> estimator.fit(time_series)  # doctest: +SKIP
+.. code-block:: default
+
+     estimator.fit(time_series)
 
 The covariance matrix and inverse-covariance matrix (precision matrix)
 can be found respectively in the `covariance_` and `precision_` attribute
-of the estimator::
+of the estimator:
 
-    >>> estimator.covariance_  # doctest: +SKIP
-    >>> estimator.precision_  # doctest: +SKIP
+.. code-block:: default
+
+     estimator.covariance_
+     estimator.precision_
 
 
 .. |covariance| image:: ../auto_examples/03_connectivity/images/sphx_glr_plot_inverse_covariance_connectome_001.png
@@ -123,15 +129,20 @@ differing connection values across subjects.
 For this, nilearn provides the
 :class:`nilearn.connectome.GroupSparseCovarianceCV`
 estimator. Its usage is similar to the GraphicalLassoCV object, but it takes
-a list of time series::
+a list of time series:
 
-    >>> estimator.fit([time_series_1, time_series_2, ...])  # doctest: +SKIP
+.. code-block:: default
+
+     estimator.fit([time_series_1, time_series_2, ...])
 
 And it provides one estimated covariance and inverse-covariance
-(precision) matrix per time-series: for the first one::
+(precision) matrix per time-series: for the first one:
 
-    >>> estimator.covariances_[0]  # doctest: +SKIP
-    >>> estimator.precisions_[0]  # doctest: +SKIP
+.. code-block:: default
+
+     estimator.covariances_[0]
+     estimator.precisions_[0]
+
 
 |
 
@@ -233,14 +244,19 @@ Individual connectivity patterns reflect both on covariances and inverse covaria
 We can go one step further by coupling the information from total (pairwise) and direct interactions in a unique group connectome. This can be done through a geometrical framework allowing to measure interactions in a common space called **tangent space** `[Varoquaux et al, MICCAI 2010] <https://hal.inria.fr/inria-00512417/>`_.
 
 In nilearn, this is implemented in
-:class:`nilearn.connectome.ConnectivityMeasure`::
+:class:`nilearn.connectome.ConnectivityMeasure`:
 
-    >>> measure = ConnectivityMeasure(kind='tangent')  # doctest: +SKIP
+.. code-block:: default
 
-The group connectivity is computed using all the subjects timeseries.::
+     measure = ConnectivityMeasure(kind='tangent')
 
-    >>> connectivities = measure.fit([time_series_1, time_series_2, ...])  # doctest: +SKIP
-    >>> group_connectivity = measure.mean_  # doctest: +SKIP
+The group connectivity is computed using all the subjects timeseries.:
+
+
+.. code-block:: default
+
+     connectivities = measure.fit([time_series_1, time_series_2, ...])
+     group_connectivity = measure.mean_
 
 Deviations from this mean in the tangent space are provided in the connectivities array and can be used to compare different groups/sessions. In practice, the tangent measure can outperform the correlation and partial correlation measures, especially for noisy or heterogeneous data.
 

--- a/doc/connectivity/functional_connectomes.rst
+++ b/doc/connectivity/functional_connectomes.rst
@@ -223,11 +223,6 @@ with :term:`MNI` coordinates for each region (see for instance example:
 .. image:: ../auto_examples/03_connectivity/images/sphx_glr_plot_probabilistic_atlas_extraction_002.png
    :target: ../auto_examples/03_connectivity/plot_probabilistic_atlas_extraction.html
 
-..
-    For doctesting
-
-    >>> from nilearn import datasets
-    >>> atlas_filename = datasets.fetch_atlas_msdl().maps # doctest: +SKIP
 
 As you can see, the correlation matrix gives a very "full" graph: every
 node is connected to every other one. This is because it also captures
@@ -246,11 +241,12 @@ can be computed for each region on hard parcellation or probabilistic atlases.
 
  * For probabilistic atlases (eg. :func:`nilearn.datasets.fetch_atlas_msdl`), use the
    :func:`nilearn.plotting.find_probabilistic_atlas_cut_coords` function.
-   See example: :ref:`sphx_glr_auto_examples_03_connectivity_plot_multi_subject_connectome.py`::
+   See example: :ref:`sphx_glr_auto_examples_03_connectivity_plot_multi_subject_connectome.py`:
 
-        >>> from nilearn import plotting
-        >>> atlas_region_coords = plotting.find_probabilistic_atlas_cut_coords(atlas_filename) # doctest: +SKIP
+   .. code-block:: default
 
+           from nilearn import plotting
+           atlas_region_coords = plotting.find_probabilistic_atlas_cut_coords(atlas_filename)
 
 |
 

--- a/doc/decoding/decoding_intro.rst
+++ b/doc/decoding/decoding_intro.rst
@@ -1,6 +1,3 @@
-.. Remove doctest: +SKIP at LDA while dropping support for sklearn older than
-    versions 0.17
-
 .. _decoding_intro:
 
 
@@ -190,12 +187,16 @@ two lines. The additional `standardize=True` argument adds a normalization
 of images signal to a zero mean and unit variance, which will improve
 performance of most estimators.
 
-    >>> from nilearn.decoding import Decoder # doctest: +SKIP
-    >>> decoder = Decoder(estimator='svc', mask=mask_filename) # doctest: +SKIP
+.. code-block:: default
+
+     from nilearn.decoding import Decoder
+     decoder = Decoder(estimator='svc', mask=mask_filename)
 
 Then we can fit it on the images and the conditions we chose before.
 
-    >>> decoder.fit(fmri_niimgs, conditions) # doctest: +SKIP
+.. code-block:: default
+
+     decoder.fit(fmri_niimgs, conditions)
 
 This decoder can now be used to predict conditions for new images !
 Be careful though, as we warned you, predicting on images that were used to
@@ -231,7 +232,9 @@ During the `fit`, :class:`nilearn.decoding.Decoder` object implicitly used a
 cross-validation: Stratified K-fold by default. You can easily inspect
 the prediction "score" it got in each fold.
 
-    >>> print(decoder.cv_scores_) # doctest: +SKIP
+.. code-block:: default
+
+     print(decoder.cv_scores_)
 
 
 Choosing a good cross-validation strategy

--- a/doc/manipulating_images/input_output.rst
+++ b/doc/manipulating_images/input_output.rst
@@ -16,10 +16,12 @@ Inputing data: file names or image objects
 File names and objects, 3D and 4D images
 -----------------------------------------
 
-All Nilearn functions accept file names as arguments::
+All Nilearn functions accept file names as arguments:
 
-    >>> from nilearn import image
-    >>> smoothed_img = image.smooth_img('/home/user/t_map001.nii')  # doctest: +SKIP
+.. code-block:: default
+
+     from nilearn import image
+     smoothed_img = image.smooth_img('/home/user/t_map001.nii')
 
 Nilearn can operate on either file names or `NiftiImage objects
 <http://nipy.org/nibabel/nibabel_images.html>`_. The later represent the
@@ -33,11 +35,13 @@ either a file name or a `NiftiImage object
 
 Niimgs can be 3D or 4D. A 4D niimg may for instance represent a time
 series of 3D images. It can be **a list of file names**, if these contain
-3D information::
+3D information:
 
-    >>> # dataset folder contains subject1.nii and subject2.nii
-    >>> from nilearn.image import smooth_img
-    >>> result_img = smooth_img(['dataset/subject1.nii', 'dataset/subject2.nii']) # doctest: +SKIP
+.. code-block:: default
+
+     # dataset folder contains subject1.nii and subject2.nii
+     from nilearn.image import smooth_img
+     result_img = smooth_img(['dataset/subject1.nii', 'dataset/subject2.nii'])
 
 ``result_img`` is a 4D in-memory image, containing the data of both
 subjects.
@@ -53,18 +57,22 @@ shell):
 
  * **Matching multiple files**: suppose the dataset folder contains
    subject_01.nii, subject_03.nii, and subject_03.nii;
-   ``dataset/subject_*.nii`` is a glob expression matching all filenames::
+   ``dataset/subject_*.nii`` is a glob expression matching all filenames:
 
-    >>> # Example with a smoothing process:
-    >>> from nilearn.image import smooth_img
-    >>> result_img = smooth_img("dataset/subject_*.nii") # doctest: +SKIP
+.. code-block:: default
+
+     # Example with a smoothing process:
+     from nilearn.image import smooth_img
+     result_img = smooth_img("dataset/subject_*.nii")
 
    Note that the resulting is a 4D image.
 
  * **Expanding the home directory** ``~`` is expanded to your home
-   directory::
+   directory:
 
-    >>> result_img = smooth_img("~/dataset/subject_01.nii") # doctest: +SKIP
+.. code-block:: default
+
+     result_img = smooth_img("~/dataset/subject_01.nii")
 
    Using ``~`` rather than specifying the details of the path is good
    practice, as it will make it more likely that your script work on
@@ -97,33 +105,39 @@ Fetching open datasets from Internet
 Nilearn provides dataset fetching function that
 automatically downloads reference
 datasets and atlases. They can be imported from
-:mod:`nilearn.datasets`::
+:mod:`nilearn.datasets`:
 
-    >>> from nilearn import datasets
-    >>> haxby_dataset = datasets.fetch_haxby()  # doctest: +SKIP
+.. code-block:: default
+
+     from nilearn import datasets
+     haxby_dataset = datasets.fetch_haxby()
 
 They return a data structure that contains different pieces of
 information on the retrieved dataset, including the
-file names on hard disk::
+file names on hard disk:
 
-    >>> # The different files
-    >>> print(sorted(list(haxby_dataset.keys())))  # doctest: +SKIP
-    ['anat', 'description', 'func', 'mask', 'mask_face', 'mask_face_little',
-    'mask_house', 'mask_house_little', 'mask_vt', 'session_target']
-    >>> # Path to first functional file
-    >>> print(haxby_dataset.func[0])  # doctest: +SKIP
-    /.../nilearn_data/haxby2001/subj1/bold.nii.gz
+.. code-block:: default
+
+     # The different files
+     print(sorted(list(haxby_dataset.keys())))
+     # ['anat', 'description', 'func', 'mask', 'mask_face',
+     # ... 'mask_face_little', 'mask_house', 'mask_house_little', 'mask_vt', 'session_target']
+     # Path to first functional file
+     print(haxby_dataset.func[0])
+     # /.../nilearn_data/haxby2001/subj1/bold.nii.gz
 
 Explanation and further resources of the dataset at hand can be retrieved as
-follows::
+follows:
 
-    >>> print(haxby_dataset.description)  # doctest: +SKIP
-    Haxby 2001 results
+.. code-block:: default
+
+     print(haxby_dataset.description)
+     # Haxby 2001 results
 
 
-    Notes
-    -----
-    Results from a classical fMRI study that...
+     # Notes
+     # -----
+     # Results from a classical fMRI study that...
 
 |
 
@@ -258,16 +272,17 @@ can be loaded with `pd.read_csv` but you may have to specify some options
 (typically `sep` if fields aren't delimited with a comma).
 
 For the Haxby datasets, we can load the categories of the images
-presented to the subject::
+presented to the subject:
 
-    >>> from nilearn import datasets
-    >>> haxby_dataset = datasets.fetch_haxby()  # doctest: +SKIP
-    >>> import pandas as pd  # doctest: +SKIP
-    >>> labels = pd.read_csv(haxby_dataset.session_target[0], sep=" ")  # doctest: +SKIP
-    >>> stimuli = labels['labels']  # doctest: +SKIP
-    >>> print(stimuli.unique())  # doctest: +SKIP
-    ['bottle' 'cat' 'chair' 'face' 'house' 'rest' 'scissors' 'scrambledpix'
-     'shoe']
+.. code-block:: default
+
+     from nilearn import datasets
+     haxby_dataset = datasets.fetch_haxby()
+     import pandas as pd
+     labels = pd.read_csv(haxby_dataset.session_target[0], sep=" ")
+     stimuli = labels['labels']
+     print(stimuli.unique())
+     # ['bottle' 'cat' 'chair' 'face' 'house' 'rest' 'scissors' 'scrambledpix' 'shoe']
 
 .. topic:: **Reading CSV with pandas**
 

--- a/doc/manipulating_images/input_output.rst
+++ b/doc/manipulating_images/input_output.rst
@@ -59,24 +59,24 @@ shell):
    subject_01.nii, subject_03.nii, and subject_03.nii;
    ``dataset/subject_*.nii`` is a glob expression matching all filenames:
 
-.. code-block:: default
+ .. code-block:: default
 
-     # Example with a smoothing process:
-     from nilearn.image import smooth_img
-     result_img = smooth_img("dataset/subject_*.nii")
+    # Example with a smoothing process:
+    from nilearn.image import smooth_img
+    result_img = smooth_img("dataset/subject_*.nii")
 
-   Note that the resulting is a 4D image.
+ Note that the resulting is a 4D image.
 
  * **Expanding the home directory** ``~`` is expanded to your home
    directory:
 
-.. code-block:: default
+ .. code-block:: default
 
-     result_img = smooth_img("~/dataset/subject_01.nii")
+    result_img = smooth_img("~/dataset/subject_01.nii")
 
-   Using ``~`` rather than specifying the details of the path is good
-   practice, as it will make it more likely that your script work on
-   different computers.
+ Using ``~`` rather than specifying the details of the path is good
+ practice, as it will make it more likely that your script work on
+ different computers.
 
 
 .. topic:: **Python globbing**
@@ -120,8 +120,8 @@ file names on hard disk:
 
      # The different files
      print(sorted(list(haxby_dataset.keys())))
-     # ['anat', 'description', 'func', 'mask', 'mask_face',
-     # ... 'mask_face_little', 'mask_house', 'mask_house_little', 'mask_vt', 'session_target']
+     # ['anat', 'description', 'func', 'mask', 'mask_face', 'mask_face_little',
+     # 'mask_house', 'mask_house_little', 'mask_vt', 'session_target']
      # Path to first functional file
      print(haxby_dataset.func[0])
      # /.../nilearn_data/haxby2001/subj1/bold.nii.gz

--- a/doc/plotting/index.rst
+++ b/doc/plotting/index.rst
@@ -138,13 +138,14 @@ different heuristics to find cutting coordinates.
    are not displayed, but still accumulate and eventually lead to slowing
    the execution and running out of memory.
 
-   To avoid this, you must close the plot as follow::
+   To avoid this, you must close the plot as follow:
 
-    >>> from nilearn import plotting
-    >>> display = plotting.plot_stat_map(img)     # doctest: +SKIP
-    >>> display.close()     # doctest: +SKIP
+     .. code-block:: default
 
-|
+          from nilearn import plotting
+          display = plotting.plot_stat_map(img)
+          display.close()
+
 
 .. seealso::
 
@@ -295,7 +296,9 @@ Adding overlays, edges, contours, contour fillings, markers, scale bar
 To add overlays, contours, or edges, use the return value of the plotting
 functions. Indeed, these return a display object, such as the
 :class:`nilearn.plotting.displays.OrthoSlicer`. This object represents the
-plot, and has methods to add overlays, contours or edge maps::
+plot, and has methods to add overlays, contours or edge maps:
+
+.. code-block:: default
 
         display = plotting.plot_epi(...)
 
@@ -376,17 +379,21 @@ Displaying or saving to an image file
 =====================================
 
 To display the figure when running a script, you need to call
-:func:`nilearn.plotting.show`: (this is just an alias to
-:func:`matplotlib.pyplot.show`)::
+:func:`nilearn.plotting.show` (this is just an alias to
+:func:`matplotlib.pyplot.show`):
 
-    >>> from nilearn import plotting
-    >>> plotting.show() # doctest: +SKIP
+.. code-block:: default
+
+     from nilearn import plotting
+     plotting.show()
 
 The simplest way to output an image file from the plotting functions is
-to specify the `output_file` argument::
+to specify the `output_file` argument:
 
-    >>> from nilearn import plotting
-    >>> plotting.plot_stat_map(img, output_file='pretty_brain.png')     # doctest: +SKIP
+.. code-block:: default
+
+     from nilearn import plotting
+     plotting.plot_stat_map(img, output_file='pretty_brain.png')
 
 In this case, the display is closed automatically and the plotting
 function returns None.
@@ -394,13 +401,15 @@ function returns None.
 |
 
 The display object returned by the plotting function has a savefig method
-that can be used to save the plot to an image file::
+that can be used to save the plot to an image file:
 
-    >>> from nilearn import plotting
-    >>> display = plotting.plot_stat_map(img)     # doctest: +SKIP
-    >>> display.savefig('pretty_brain.png')     # doctest: +SKIP
-    # Don't forget to close the display
-    >>> display.close()     # doctest: +SKIP
+.. code-block:: default
+
+     from nilearn import plotting
+     display = plotting.plot_stat_map(img)
+     display.savefig('pretty_brain.png')
+     # Remember to close the display
+     display.close()
 
 .. _surface-plotting:
 
@@ -501,11 +510,13 @@ depending on what you want to do and the packages you have installed.
 .................................................................
 
 You can use :func:`view_img_on_surf` to display a 3D statistical map projected on the
-cortical surface::
+cortical surface:
 
-    >>> from nilearn import plotting, datasets     # doctest: +SKIP
-    >>> img = datasets.fetch_localizer_button_task()['tmap']     # doctest: +SKIP
-    >>> view = plotting.view_img_on_surf(img, threshold='90%', surf_mesh='fsaverage')     # doctest: +SKIP
+.. code-block:: default
+
+     from nilearn import plotting, datasets
+     img = datasets.fetch_localizer_button_task()['tmap']
+     view = plotting.view_img_on_surf(img, threshold='90%', surf_mesh='fsaverage')
 
 If you are running a notebook, displaying ``view`` will embed an interactive
 plot (this is the case for all interactive plots produced by nilearn's "view"
@@ -513,33 +524,39 @@ functions):
 
 .. image:: ../images/plotly_surface_plot_notebook_screenshot.png
 
-If you are not using a notebook, you can open the plot in a browser like this::
+If you are not using a notebook, you can open the plot in a browser like this:
 
-    >>> view.open_in_browser()     # doctest: +SKIP
+.. code-block:: default
+
+     view.open_in_browser()
 
 This will open this 3D plot in your web browser:
 
 .. image:: ../images/plotly_surface_plot.png
 
 
-Or you can save it to an html file::
+Or you can save it to an html file:
 
-    >>> view.save_as_html("surface_plot.html")     # doctest: +SKIP
+.. code-block:: default
+
+     view.save_as_html("surface_plot.html")
 
 
 :func:`view_surf`: Surface plot using a surface map and a cortical mesh
 .......................................................................
 
 You can use :func:`view_surf` to display a 3D surface statistical map over
-a cortical mesh::
+a cortical mesh:
 
-    >>> from nilearn import plotting, datasets     # doctest: +SKIP
-    >>> destrieux = datasets.fetch_atlas_surf_destrieux()     # doctest: +SKIP
-    >>> fsaverage = datasets.fetch_surf_fsaverage()     # doctest: +SKIP
-    >>> view = plotting.view_surf(fsaverage['infl_left'], destrieux['map_left'],     # doctest: +SKIP
-    ...                           cmap='gist_ncar', symmetric_cmap=False)     # doctest: +SKIP
-    ...
-    >>> view.open_in_browser()     # doctest: +SKIP
+.. code-block:: default
+
+     from nilearn import plotting, datasets
+     destrieux = datasets.fetch_atlas_surf_destrieux()
+     fsaverage = datasets.fetch_surf_fsaverage()
+     view = plotting.view_surf(fsaverage['infl_left'], destrieux['map_left'],
+     ...                           cmap='gist_ncar', symmetric_cmap=False)
+     ...
+     view.open_in_browser()
 
 
 .. image:: ../images/plotly_surface_atlas_plot.png
@@ -550,17 +567,19 @@ a cortical mesh::
 
 If you have `plotly`_ installed, you can also use :func:`plot_surf_stat_map` with
 the ``engine`` parameter set to "plotly" to display a statistical map over a
-cortical mesh::
+cortical mesh:
 
-    >>> from nilearn import plotting, datasets, surface  # doctest: +SKIP
-    >>> fsaverage = datasets.fetch_surf_fsaverage()  # doctest: +SKIP
-    >>> motor_images = datasets.fetch_neurovault_motor_task()  # doctest: +SKIP
-    >>> mesh = surface.load_surf_mesh(fsaverage.pial_right)  # doctest: +SKIP
-    >>> map = surface.vol_to_surf(motor_images.images[0], mesh)  # doctest: +SKIP
-    >>> fig = plotting.plot_surf_stat_map(mesh, map, hemi='right',  # doctest: +SKIP
-    ...     view='lateral', colorbar=True, threshold=1.2,  # doctest: +SKIP
-    ...     bg_map=fsaverage.sulc_right, engine='plotly')  # doctest: +SKIP
-    >>> fig.show()  # doctest: +SKIP
+.. code-block:: default
+
+     from nilearn import plotting, datasets, surface
+     fsaverage = datasets.fetch_surf_fsaverage()
+     motor_images = datasets.fetch_neurovault_motor_task()
+     mesh = surface.load_surf_mesh(fsaverage.pial_right)
+     map = surface.vol_to_surf(motor_images.images[0], mesh)
+     fig = plotting.plot_surf_stat_map(mesh, map, hemi='right',
+     ...     view='lateral', colorbar=True, threshold=1.2,
+     ...     bg_map=fsaverage.sulc_right, engine='plotly')
+     fig.show()
 
 .. image:: ../images/plotly_plot_surf_stat_map.png
 
@@ -572,10 +591,12 @@ cortical mesh::
 For 3D plots of a connectome, use :func:`view_connectome`. To see only markers,
 use :func:`view_markers`.
 
-:func:`view_connectome`: 3D plot of a connectome::
+:func:`view_connectome`: 3D plot of a connectome:
 
-      >>> view = plotting.view_connectome(correlation_matrix, coords, edge_threshold='90%')    # doctest: +SKIP
-      >>> view.open_in_browser() # doctest: +SKIP
+.. code-block:: default
+
+     view = plotting.view_connectome(correlation_matrix, coords, edge_threshold='90%')
+     view.open_in_browser()
 
 
 .. image:: ../images/plotly_connectome_plot.png
@@ -586,14 +607,15 @@ use :func:`view_markers`.
 3D Plots of markers
 -------------------
 
-:func:`view_markers`: showing markers (e.g. seed locations) in 3D::
+:func:`view_markers`: showing markers (e.g. seed locations) in 3D:
 
-    >>> from nilearn import plotting  # doctest: +SKIP
-    >>> dmn_coords = [(0, -52, 18), (-46, -68, 32), (46, -68, 32), (1, 50, -5)] # doctest: +SKIP
-    >>> view = plotting.view_markers( # doctest: +SKIP
-    >>>       dmn_coords, ['red', 'cyan', 'magenta', 'orange'], marker_size=10) # doctest: +SKIP
-    >>> view.open_in_browser() # doctest: +SKIP
+.. code-block:: default
 
+     from nilearn import plotting
+     dmn_coords = [(0, -52, 18), (-46, -68, 32), (46, -68, 32), (1, 50, -5)]
+     view = plotting.view_markers(
+          dmn_coords, ['red', 'cyan', 'magenta', 'orange'], marker_size=10)
+     view.open_in_browser()
 
 
 .. image:: ../images/plotly_markers_plot.png
@@ -604,12 +626,14 @@ use :func:`view_markers`.
 Interactive visualization of statistical map slices
 ---------------------------------------------------
 
-:func:`view_img`: open stat map in a Brainsprite viewer (https://github.com/simexp/brainsprite.js)::
+:func:`view_img`: open stat map in a Brainsprite viewer (https://github.com/simexp/brainsprite.js):
 
-    >>> from nilearn import plotting, datasets     # doctest: +SKIP
-    >>> img = datasets.fetch_localizer_button_task()['tmap']     # doctest: +SKIP
-    >>> html_view = plotting.view_img(img, threshold=2, vmax=4, cut_coords=[-42, -16, 52],
-    ...                                     title="Motor contrast")     # doctest: +SKIP
+.. code-block:: default
+
+     from nilearn import plotting, datasets
+     img = datasets.fetch_localizer_button_task()['tmap']
+     html_view = plotting.view_img(img, threshold=2, vmax=4, cut_coords=[-42, -16, 52],
+     ...                                     title="Motor contrast")
 
 in a Jupyter notebook, if `html_view` is not requested, the viewer will be inserted in the notebook:
 
@@ -617,11 +641,11 @@ in a Jupyter notebook, if `html_view` is not requested, the viewer will be inser
 
 Or you can open a viewer in your web browser if you are not in a notebook::
 
-    >>> html_view.open_in_browser()   # doctest: +SKIP
+     html_view.open_in_browser()
 
 Finally, you can also save the viewer as a stand-alone html file::
 
-    >>> html_view.save_as_html('viewer.html') # doctest: +SKIP
+     html_view.save_as_html('viewer.html')
 
 .. _`kaleido`:
     https://pypi.org/project/kaleido/

--- a/doc/plotting/index.rst
+++ b/doc/plotting/index.rst
@@ -140,11 +140,11 @@ different heuristics to find cutting coordinates.
 
    To avoid this, you must close the plot as follow:
 
-     .. code-block:: default
+   .. code-block:: default
 
-          from nilearn import plotting
-          display = plotting.plot_stat_map(img)
-          display.close()
+     from nilearn import plotting
+     display = plotting.plot_stat_map(img)
+     display.close()
 
 
 .. seealso::
@@ -554,8 +554,7 @@ a cortical mesh:
      destrieux = datasets.fetch_atlas_surf_destrieux()
      fsaverage = datasets.fetch_surf_fsaverage()
      view = plotting.view_surf(fsaverage['infl_left'], destrieux['map_left'],
-     ...                           cmap='gist_ncar', symmetric_cmap=False)
-     ...
+                               cmap='gist_ncar', symmetric_cmap=False)
      view.open_in_browser()
 
 
@@ -577,8 +576,10 @@ cortical mesh:
      mesh = surface.load_surf_mesh(fsaverage.pial_right)
      map = surface.vol_to_surf(motor_images.images[0], mesh)
      fig = plotting.plot_surf_stat_map(mesh, map, hemi='right',
-     ...     view='lateral', colorbar=True, threshold=1.2,
-     ...     bg_map=fsaverage.sulc_right, engine='plotly')
+                                       view='lateral', colorbar=True,
+                                       threshold=1.2,
+                                       bg_map=fsaverage.sulc_right,
+                                       engine='plotly')
      fig.show()
 
 .. image:: ../images/plotly_plot_surf_stat_map.png
@@ -613,8 +614,8 @@ use :func:`view_markers`.
 
      from nilearn import plotting
      dmn_coords = [(0, -52, 18), (-46, -68, 32), (46, -68, 32), (1, 50, -5)]
-     view = plotting.view_markers(
-          dmn_coords, ['red', 'cyan', 'magenta', 'orange'], marker_size=10)
+     view = plotting.view_markers(dmn_coords, ['red', 'cyan', 'magenta', 'orange'],
+                                  marker_size=10)
      view.open_in_browser()
 
 
@@ -632,8 +633,9 @@ Interactive visualization of statistical map slices
 
      from nilearn import plotting, datasets
      img = datasets.fetch_localizer_button_task()['tmap']
-     html_view = plotting.view_img(img, threshold=2, vmax=4, cut_coords=[-42, -16, 52],
-     ...                                     title="Motor contrast")
+     html_view = plotting.view_img(img, threshold=2, vmax=4,
+                                   cut_coords=[-42, -16, 52],
+                                   title="Motor contrast")
 
 in a Jupyter notebook, if `html_view` is not requested, the viewer will be inserted in the notebook:
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3681.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- doctest blocks that had skipped lines were converted to (default) code-blocks
- output that could have been tested against via a doctest ([e.g.](https://github.com/psadil/nilearn/blob/6fb7df5c7af3ec9bcc447e2b3ee274df7273e370/doc/manipulating_images/input_output.rst?plain=1#L121-L127)) were converted into comments
