### PR TITLE
[FIX] transparent vertices in `surf_plotting` function

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -272,6 +272,9 @@ authors:
   - given-names: Mathias
     family-names: Goncalves
     website: https://github.com/mgxd
+  - given-names: Mathieu
+    family-names: Dugré
+    website: https://mathdugre.me
   - given-names: Matthias
     family-names: Ekman
     website: https://github.com/mekman

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -10,7 +10,7 @@ NEW
 
 Fixes
 -----
-- Fix bug in :func:`nilearn.plotting.surf_plotting._plot_surf_matplotlib` that would make vertices transparent when saving in PDF or SVG format (:gh:`3860` by `Mathieu Dugré`_).
+- Fix bug in ``nilearn.plotting.surf_plotting._plot_surf_matplotlib`` that would make vertices transparent when saving in PDF or SVG format (:gh:`3860` by `Mathieu Dugré`_).
 
 - Fix bug that would prevent loading the confounds of a gifti file in actual fmriprep datasets (:gh:`3819` by `Rémi Gau`_).
 

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -10,6 +10,7 @@ NEW
 
 Fixes
 -----
+- Fix bug in :func:`nilearn.plotting.surf_plotting._plot_surf_matplotlib` that would make vertices transparent when saving in PDF or SVG format (:gh:`3860` by `Mathieu Dugré`_).
 
 - Fix bug that would prevent loading the confounds of a gifti file in actual fmriprep datasets (:gh:`3819` by `Rémi Gau`_).
 

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -550,7 +550,7 @@ def _plot_surf_matplotlib(coords, faces, surf_map=None, bg_map=None,
 
     # plot mesh without data
     p3dcollec = axes.plot_trisurf(coords[:, 0], coords[:, 1], coords[:, 2],
-                                  triangles=faces, linewidth=0.,
+                                  triangles=faces, linewidth=0.1,
                                   antialiased=False,
                                   color='white')
 
@@ -600,6 +600,7 @@ def _plot_surf_matplotlib(coords, faces, surf_map=None, bg_map=None,
                 format=cbar_tick_format, orientation='vertical')
 
         p3dcollec.set_facecolors(face_colors)
+        p3dcollec.set_edgecolors(face_colors)
 
     if title is not None:
         axes.set_title(title)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #3470 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Surface from `surf_plotting` with the matplotlib engine has transparent surfaces.

Changes proposed in this pull request:

- Add vertices width
- Apply surface color to the vertices
