### PR TITLE
[MAINT] use tmp_path fixture in tests that do not depend on fake fmri data generation

### DIFF
--- a/nilearn/glm/tests/test_check_events_file_uses_tab_separators.py
+++ b/nilearn/glm/tests/test_check_events_file_uses_tab_separators.py
@@ -86,7 +86,7 @@ def test_for_pandas_dataframe():
     assert result is None
 
 
-def test_binary_opening_an_image(tmp_path):
+def test_binary_opening_an_image_error(tmp_path):
     img_data = bytearray(
         b"GIF87a\x01\x00\x01\x00\xe7*\x00\x00\x00\x00\x01\x01\x01\x02\x02"
         b"\x07\x08\x08\x08\x0b\x0b\x0b\x0c\x0c\x0c\r;"
@@ -98,35 +98,10 @@ def test_binary_opening_an_image(tmp_path):
         _check_events_file_uses_tab_separators(events_files=temp_img_file)
 
 
-def test_binary_bytearray_of_ints_data(tmp_path):
+def test_binary_bytearray_of_ints_data_error(tmp_path):
     temp_data_bytearray_from_ints = bytearray([0, 1, 0, 11, 10])
     temp_bin_file = tmp_path / "temp_bin.bin"
     with open(temp_bin_file, "wb") as temp_bin_obj:
         temp_bin_obj.write(temp_data_bytearray_from_ints)
     with pytest.raises(ValueError):
         _check_events_file_uses_tab_separators(events_files=temp_bin_file)
-
-
-if __name__ == "__main__":
-
-    def _run_tests_print_test_messages(test_func):
-        from pprint import pprint
-
-        pprint(["Running", test_func.__name__])
-        test_func()
-        pprint("... complete")
-
-    def run_test_suite():
-        tests = [
-            test_for_invalid_filepath,
-            test_with_2D_dataframe,
-            test_with_1D_dataframe,
-            test_for_invalid_filepath,
-            test_for_pandas_dataframe,
-            test_binary_opening_an_image,
-            test_binary_bytearray_of_ints_data,
-        ]
-        for test_ in tests:
-            _run_tests_print_test_messages(test_func=test_)
-
-    run_test_suite()

--- a/nilearn/glm/tests/test_check_events_file_uses_tab_separators.py
+++ b/nilearn/glm/tests/test_check_events_file_uses_tab_separators.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import pytest
-from nibabel.tmpdirs import InTemporaryDirectory
 
 from nilearn.glm._utils import _check_events_file_uses_tab_separators
 
@@ -38,19 +37,20 @@ def _run_test_for_invalid_separator(filepath, delimiter_name):
         assert result is None
 
 
-def test_for_invalid_separator():
+def test_for_invalid_separator(tmp_path):
     data_for_temp_datafile, delimiters = make_data_for_test_runs()
     for delimiter_name, delimiter_char in delimiters.items():
-        with InTemporaryDirectory():
-            temp_tsv_file = f"tempfile.{delimiter_name} separated values"
-            _create_test_file(
-                temp_csv=temp_tsv_file,
-                test_data=data_for_temp_datafile,
-                delimiter=delimiter_char,
-            )
-            _run_test_for_invalid_separator(
-                filepath=temp_tsv_file, delimiter_name=delimiter_name
-            )
+        temp_tsv_file = (
+            tmp_path / f"tempfile.{delimiter_name} separated values"
+        )
+        _create_test_file(
+            temp_csv=temp_tsv_file,
+            test_data=data_for_temp_datafile,
+            delimiter=delimiter_char,
+        )
+        _run_test_for_invalid_separator(
+            filepath=temp_tsv_file, delimiter_name=delimiter_name
+        )
 
 
 def test_with_2D_dataframe():
@@ -86,27 +86,25 @@ def test_for_pandas_dataframe():
     assert result is None
 
 
-def test_binary_opening_an_image():
+def test_binary_opening_an_image(tmp_path):
     img_data = bytearray(
         b"GIF87a\x01\x00\x01\x00\xe7*\x00\x00\x00\x00\x01\x01\x01\x02\x02"
         b"\x07\x08\x08\x08\x0b\x0b\x0b\x0c\x0c\x0c\r;"
     )
-    with InTemporaryDirectory():
-        temp_img_file = "temp_img.gif"
-        with open(temp_img_file, "wb") as temp_img_obj:
-            temp_img_obj.write(img_data)
-        with pytest.raises(ValueError):
-            _check_events_file_uses_tab_separators(events_files=temp_img_file)
+    temp_img_file = tmp_path / "temp_img.gif"
+    with open(temp_img_file, "wb") as temp_img_obj:
+        temp_img_obj.write(img_data)
+    with pytest.raises(ValueError):
+        _check_events_file_uses_tab_separators(events_files=temp_img_file)
 
 
-def test_binary_bytearray_of_ints_data():
+def test_binary_bytearray_of_ints_data(tmp_path):
     temp_data_bytearray_from_ints = bytearray([0, 1, 0, 11, 10])
-    with InTemporaryDirectory():
-        temp_bin_file = "temp_bin.bin"
-        with open(temp_bin_file, "wb") as temp_bin_obj:
-            temp_bin_obj.write(temp_data_bytearray_from_ints)
-        with pytest.raises(ValueError):
-            _check_events_file_uses_tab_separators(events_files=temp_bin_file)
+    temp_bin_file = tmp_path / "temp_bin.bin"
+    with open(temp_bin_file, "wb") as temp_bin_obj:
+        temp_bin_obj.write(temp_data_bytearray_from_ints)
+    with pytest.raises(ValueError):
+        _check_events_file_uses_tab_separators(events_files=temp_bin_file)
 
 
 if __name__ == "__main__":

--- a/nilearn/glm/tests/test_dmtx.py
+++ b/nilearn/glm/tests/test_dmtx.py
@@ -9,7 +9,6 @@ from os import path as osp
 import numpy as np
 import pandas as pd
 import pytest
-from nibabel.tmpdirs import InTemporaryDirectory
 from numpy.testing import (
     assert_almost_equal,
     assert_array_almost_equal,
@@ -611,7 +610,7 @@ def test_high_pass():
     assert X.shape[1] == n_frames
 
 
-def test_csv_io():
+def test_csv_io(tmp_path):
     # test the csv io on design matrices
     tr = 1.0
     frame_times = np.linspace(0, 127 * tr, 128)
@@ -623,10 +622,9 @@ def test_csv_io():
         drift_model="polynomial",
         drift_order=3,
     )
-    path = "design_matrix.csv"
-    with InTemporaryDirectory():
-        DM.to_csv(path)
-        DM2 = pd.read_csv(path, index_col=0)
+    path = tmp_path / "design_matrix.csv"
+    DM.to_csv(path)
+    DM2 = pd.read_csv(path, index_col=0)
 
     _, matrix, names = check_design_matrix(DM)
     _, matrix_, names_ = check_design_matrix(DM2)

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -1,8 +1,6 @@
 """Test image pre-processing functions"""
-import os
 import platform
 import sys
-import tempfile
 import warnings
 from pathlib import Path
 
@@ -173,7 +171,7 @@ def stat_img_test_data():
     return stat_img
 
 
-def test_get_data():
+def test_get_data(tmp_path):
     img, *_ = generate_fake_fmri(shape=SHAPE_3D)
 
     data = get_data(img)
@@ -187,18 +185,18 @@ def test_get_data():
     assert data.dtype == np.dtype("uint8")
 
     img_3d = index_img(img, 0)
-    with tempfile.TemporaryDirectory() as tempdir:
-        filename = os.path.join(tempdir, "img_{}.nii.gz")
-        img_3d.to_filename(filename.format("a"))
-        img_3d.to_filename(filename.format("b"))
 
-        data = get_data(filename.format("a"))
+    filename = str(tmp_path / "img_{}.nii.gz")
+    img_3d.to_filename(filename.format("a"))
+    img_3d.to_filename(filename.format("b"))
 
-        assert len(data.shape) == 3
+    data = get_data(filename.format("a"))
 
-        data = get_data(filename.format("*"))
+    assert len(data.shape) == 3
 
-        assert len(data.shape) == 4
+    data = get_data(filename.format("*"))
+
+    assert len(data.shape) == 4
 
 
 def test_high_variance_confounds():

--- a/nilearn/interfaces/tests/test_bids.py
+++ b/nilearn/interfaces/tests/test_bids.py
@@ -5,7 +5,6 @@ import os
 import numpy as np
 import pandas as pd
 import pytest
-from nibabel.tmpdirs import InTemporaryDirectory
 
 from nilearn._utils.data_gen import (
     _add_metadata_to_bids_dataset,
@@ -229,60 +228,63 @@ def test_get_bids_files_inheritance_principle_sub_folder(tmp_path, json_file):
     assert selection[0] == str(new_json_file)
 
 
-def test_get_bids_files():
-    with InTemporaryDirectory():
-        bids_path = create_fake_bids_dataset(
-            n_sub=10, n_ses=2, tasks=["localizer", "main"], n_runs=[1, 3]
-        )
-        # For each possible option of file selection we check that we
-        # recover the appropriate amount of files, as included in the
-        # fake bids dataset.
+def test_get_bids_files(tmp_path):
+    bids_path = create_fake_bids_dataset(
+        base_dir=tmp_path,
+        n_sub=10,
+        n_ses=2,
+        tasks=["localizer", "main"],
+        n_runs=[1, 3],
+    )
+    # For each possible option of file selection we check that we
+    # recover the appropriate amount of files, as included in the
+    # fake bids dataset.
 
-        # 250 files in total related to subject images. Top level files like
-        # README not included
-        selection = get_bids_files(bids_path)
-        assert len(selection) == 250
-        # 160 bold files expected. .nii and .json files
-        selection = get_bids_files(bids_path, file_tag="bold")
-        assert len(selection) == 160
-        # Only 90 files are nii.gz. Bold and T1w files.
-        selection = get_bids_files(bids_path, file_type="nii.gz")
-        assert len(selection) == 90
-        # Only 25 files correspond to subject 01
-        selection = get_bids_files(bids_path, sub_label="01")
-        assert len(selection) == 25
-        # There are only 10 files in anat folders. One T1w per subject.
-        selection = get_bids_files(bids_path, modality_folder="anat")
-        assert len(selection) == 10
-        # 20 files corresponding to run 1 of session 2 of main task.
-        # 10 bold.nii.gz and 10 bold.json files. (10 subjects)
-        filters = [("task", "main"), ("run", "01"), ("ses", "02")]
-        selection = get_bids_files(bids_path, file_tag="bold", filters=filters)
-        assert len(selection) == 20
-        # Get Top level folder files. Only 1 in this case, the README file.
-        selection = get_bids_files(bids_path, sub_folder=False)
-        assert len(selection) == 1
-        # 80 counfonds (4 runs per ses & sub), testing `fmriprep` >= 20.2 path
-        selection = get_bids_files(
-            os.path.join(bids_path, "derivatives"),
-            file_tag="desc-confounds_timeseries",
-        )
-        assert len(selection) == 80
+    # 250 files in total related to subject images. Top level files like
+    # README not included
+    selection = get_bids_files(bids_path)
+    assert len(selection) == 250
+    # 160 bold files expected. .nii and .json files
+    selection = get_bids_files(bids_path, file_tag="bold")
+    assert len(selection) == 160
+    # Only 90 files are nii.gz. Bold and T1w files.
+    selection = get_bids_files(bids_path, file_type="nii.gz")
+    assert len(selection) == 90
+    # Only 25 files correspond to subject 01
+    selection = get_bids_files(bids_path, sub_label="01")
+    assert len(selection) == 25
+    # There are only 10 files in anat folders. One T1w per subject.
+    selection = get_bids_files(bids_path, modality_folder="anat")
+    assert len(selection) == 10
+    # 20 files corresponding to run 1 of session 2 of main task.
+    # 10 bold.nii.gz and 10 bold.json files. (10 subjects)
+    filters = [("task", "main"), ("run", "01"), ("ses", "02")]
+    selection = get_bids_files(bids_path, file_tag="bold", filters=filters)
+    assert len(selection) == 20
+    # Get Top level folder files. Only 1 in this case, the README file.
+    selection = get_bids_files(bids_path, sub_folder=False)
+    assert len(selection) == 1
+    # 80 counfonds (4 runs per ses & sub), testing `fmriprep` >= 20.2 path
+    selection = get_bids_files(
+        os.path.join(bids_path, "derivatives"),
+        file_tag="desc-confounds_timeseries",
+    )
+    assert len(selection) == 80
 
-    with InTemporaryDirectory():
-        bids_path = create_fake_bids_dataset(
-            n_sub=10,
-            n_ses=2,
-            tasks=["localizer", "main"],
-            n_runs=[1, 3],
-            confounds_tag="desc-confounds_regressors",
-        )
-        # 80 counfonds (4 runs per ses & sub), testing `fmriprep` >= 20.2 path
-        selection = get_bids_files(
-            os.path.join(bids_path, "derivatives"),
-            file_tag="desc-confounds_regressors",
-        )
-        assert len(selection) == 80
+    bids_path = create_fake_bids_dataset(
+        base_dir=tmp_path,
+        n_sub=10,
+        n_ses=2,
+        tasks=["localizer", "main"],
+        n_runs=[1, 3],
+        confounds_tag="desc-confounds_regressors",
+    )
+    # 80 counfonds (4 runs per ses & sub), testing `fmriprep` >= 20.2 path
+    selection = get_bids_files(
+        os.path.join(bids_path, "derivatives"),
+        file_tag="desc-confounds_regressors",
+    )
+    assert len(selection) == 80
 
 
 def test_parse_bids_filename():

--- a/nilearn/plotting/tests/test_matrix_plotting.py
+++ b/nilearn/plotting/tests/test_matrix_plotting.py
@@ -1,11 +1,8 @@
-import os
-
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
-from nibabel.tmpdirs import InTemporaryDirectory
 
 from nilearn.glm.first_level.design_matrix import (
     make_first_level_design_matrix,
@@ -194,7 +191,7 @@ def test_matrix_plotting_reorder(mat, labels):
     plt.close()
 
 
-def test_show_design_matrix():
+def test_show_design_matrix(tmp_path):
     # test that the show code indeed (formally) runs
     frame_times = np.linspace(0, 127 * 1.0, 128)
     dmtx = make_first_level_design_matrix(
@@ -202,15 +199,15 @@ def test_show_design_matrix():
     )
     ax = plot_design_matrix(dmtx)
     assert ax is not None
-    with InTemporaryDirectory():
-        ax = plot_design_matrix(dmtx, output_file="dmtx.png")
-        assert os.path.exists("dmtx.png")
-        assert ax is None
-        plot_design_matrix(dmtx, output_file="dmtx.pdf")
-        assert os.path.exists("dmtx.pdf")
+
+    ax = plot_design_matrix(dmtx, output_file=tmp_path / "dmtx.png")
+    assert (tmp_path / "dmtx.png").exists()
+    assert ax is None
+    plot_design_matrix(dmtx, output_file=tmp_path / "dmtx.pdf")
+    assert (tmp_path / "dmtx.pdf").exists()
 
 
-def test_show_event_plot():
+def test_show_event_plot(tmp_path):
     # test that the show code indeed (formally) runs
     onset = np.linspace(0, 19.0, 20)
     duration = np.full(20, 0.5)
@@ -237,15 +234,14 @@ def test_show_event_plot():
         fig = plot_event(model_event, cmap="tab10")
 
     # Test save
-    with InTemporaryDirectory():
-        fig = plot_event(model_event, output_file="event.png")
-        assert os.path.exists("event.png")
-        assert fig is None
-        plot_event(model_event, output_file="event.pdf")
-        assert os.path.exists("event.pdf")
+    fig = plot_event(model_event, output_file=tmp_path / "event.png")
+    assert (tmp_path / "event.png").exists()
+    assert fig is None
+    plot_event(model_event, output_file=tmp_path / "event.pdf")
+    assert (tmp_path / "event.pdf").exists()
 
 
-def test_show_contrast_matrix():
+def test_show_contrast_matrix(tmp_path):
     # test that the show code indeed (formally) runs
     frame_times = np.linspace(0, 127 * 1.0, 128)
     dmtx = make_first_level_design_matrix(
@@ -254,9 +250,11 @@ def test_show_contrast_matrix():
     contrast = np.ones(4)
     ax = plot_contrast_matrix(contrast, dmtx)
     assert ax is not None
-    with InTemporaryDirectory():
-        ax = plot_contrast_matrix(contrast, dmtx, output_file="contrast.png")
-        assert os.path.exists("contrast.png")
-        assert ax is None
-        plot_contrast_matrix(contrast, dmtx, output_file="contrast.pdf")
-        assert os.path.exists("contrast.pdf")
+
+    ax = plot_contrast_matrix(
+        contrast, dmtx, output_file=tmp_path / "contrast.png"
+    )
+    assert (tmp_path / "contrast.png").exists()
+    assert ax is None
+    plot_contrast_matrix(contrast, dmtx, output_file=tmp_path / "contrast.pdf")
+    assert (tmp_path / "contrast.pdf").exists()

--- a/nilearn/reporting/tests/test_glm_reporter.py
+++ b/nilearn/reporting/tests/test_glm_reporter.py
@@ -239,53 +239,50 @@ def _generate_img():
 
 @pytest.mark.parametrize("cut_coords", [None, (5, 4, 3)])
 def test_stat_map_to_svg_slice_z(cut_coords):
-    with InTemporaryDirectory():
-        img = _generate_img()
-        table_details = pd.DataFrame.from_dict({"junk": 0}, orient="index")
-        glmr._stat_map_to_svg(
-            stat_img=img,
-            bg_img=None,
-            cut_coords=cut_coords,
-            display_mode="ortho",
-            plot_type="slice",
-            table_details=table_details,
-        )
+    img = _generate_img()
+    table_details = pd.DataFrame.from_dict({"junk": 0}, orient="index")
+    glmr._stat_map_to_svg(
+        stat_img=img,
+        bg_img=None,
+        cut_coords=cut_coords,
+        display_mode="ortho",
+        plot_type="slice",
+        table_details=table_details,
+    )
 
 
 @pytest.mark.parametrize("cut_coords", [None, (5, 4, 3)])
 def test_stat_map_to_svg_glass_z(cut_coords):
-    with InTemporaryDirectory():
-        img = _generate_img()
-        table_details = pd.DataFrame.from_dict({"junk": 0}, orient="index")
+    img = _generate_img()
+    table_details = pd.DataFrame.from_dict({"junk": 0}, orient="index")
+    glmr._stat_map_to_svg(
+        stat_img=img,
+        bg_img=None,
+        cut_coords=cut_coords,
+        display_mode="z",
+        plot_type="glass",
+        table_details=table_details,
+    )
+
+
+@pytest.mark.parametrize("cut_coords", [None, (5, 4, 3)])
+def test_stat_map_to_svg_invalid_plot_type(cut_coords):
+    img = _generate_img()
+    expected_error = ValueError(
+        "Invalid plot type provided. Acceptable options are"
+        "'slice' or 'glass'."
+    )
+    try:
         glmr._stat_map_to_svg(
             stat_img=img,
             bg_img=None,
             cut_coords=cut_coords,
             display_mode="z",
-            plot_type="glass",
-            table_details=table_details,
+            plot_type="junk",
+            table_details={"junk": 0},
         )
-
-
-@pytest.mark.parametrize("cut_coords", [None, (5, 4, 3)])
-def test_stat_map_to_svg_invalid_plot_type(cut_coords):
-    with InTemporaryDirectory():
-        img = _generate_img()
-        expected_error = ValueError(
-            "Invalid plot type provided. Acceptable options are"
-            "'slice' or 'glass'."
-        )
-        try:
-            glmr._stat_map_to_svg(
-                stat_img=img,
-                bg_img=None,
-                cut_coords=cut_coords,
-                display_mode="z",
-                plot_type="junk",
-                table_details={"junk": 0},
-            )
-        except ValueError as raised_exception:
-            assert str(raised_exception) == str(expected_error)
+    except ValueError as raised_exception:
+        assert str(raised_exception) == str(expected_error)
 
 
 def _make_dummy_contrasts_dmtx():


### PR DESCRIPTION
- relates to https://github.com/nilearn/nilearn/issues/3726
- extracted from [WIP] rely more on tmp_path in testing Do Not REVIEW  #3891