### PR TITLE
[FIX/ENH] Improve generate_report method to work with fit_transform for the maskers

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -32,6 +32,7 @@ Fixes
 
 - Fix pathlib.Path not being counted as Niimg-like object in :func:`~image.new_img_like` (:gh:`3723` by `Maximilian Cosmo Sitter`_).
 
+- Fix ``fit_transform`` behavior to match when ``fit`` method is passed image data (:gh:`3897` by `Yasmin Mzayek`_)
 
 Enhancements
 ------------
@@ -47,6 +48,8 @@ Enhancements
 - Add ``LassoCV`` as a new estimator option for Decoder objects (:gh: `3781` by `Michelle Wang`_)
 
 - Add ``vmin`` and ``symmetric_cbar`` arguments to :func:`~nilearn.plotting.plot_img_on_surf` (:gh:`3873` by `Michelle Wang`_).
+
+- Improve ``generate_report`` method of maskers by allowing users to pass a cmap argument for plotting image (:gh:`3897` by `Yasmin Mzayek`_)
 
 Changes
 -------

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -4,6 +4,7 @@ import warnings
 
 import numpy as np
 from joblib import Memory
+import matplotlib as mpl
 
 from nilearn import _utils, image, masking
 from nilearn.maskers.base_masker import BaseMasker, _filter_and_extract
@@ -299,7 +300,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
                 display = plotting.plot_img(
                     img,
                     black_bg=False,
-                    cmap='CMRmap_r',
+                    cmap='RdBu',
                 )
                 plt.close()
                 display.add_contours(labels_image, filled=False, linewidths=3)

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -292,10 +292,6 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
             img = self._reporting_data['img']
             # If we have a func image to show in the report, use it
             if img is not None:
-                dim = image.load_img(img).shape
-                if len(dim) == 4:
-                    # compute middle image from 4D series for plotting
-                    img = image.index_img(img, dim[-1] // 2)
                 display = plotting.plot_img(
                     img,
                     black_bg=False,
@@ -410,6 +406,11 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
             self._resampled_labels_img_ = self.labels_img_
 
         if self.reports:
+            if imgs is not None:
+                dim = image.load_img(imgs).shape
+                if len(dim) == 4:
+                    # compute middle image from 4D series for plotting
+                    imgs = image.index_img(imgs, dim[-1] // 2)
             self._reporting_data = {
                 'labels_image': self._resampled_labels_img_,
                 'mask': self.mask_img_,

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -335,8 +335,15 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
     def fit(self, imgs=None, y=None):
         """Prepare signal extraction from regions.
 
-        All parameters are unused, they are for scikit-learn compatibility.
+        Parameters
+        ----------
+        imgs : :obj:`list` of Niimg-like objects
+            See :ref:`extracting_data`.
+            Image data passed to the reporter.
 
+        y : None
+            This parameter is unused. It is solely included for scikit-learn
+            compatibility.
         """
         repr = _utils._repr_niimgs(self.labels_img,
                                    shorten=(not self.verbose))

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -4,7 +4,6 @@ import warnings
 
 import numpy as np
 from joblib import Memory
-import matplotlib as mpl
 
 from nilearn import _utils, image, masking
 from nilearn.maskers.base_masker import BaseMasker, _filter_and_extract

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -292,6 +292,10 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
             img = self._reporting_data['img']
             # If we have a func image to show in the report, use it
             if img is not None:
+                dim = image.load_img(img).shape
+                if len(dim) == 4:
+                    # compute middle image from 4D series for plotting
+                    img = image.index_img(img, dim[-1] // 2)
                 display = plotting.plot_img(
                     img,
                     black_bg=False,
@@ -406,11 +410,6 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
             self._resampled_labels_img_ = self.labels_img_
 
         if self.reports:
-            if imgs is not None:
-                dim = image.load_img(imgs).shape
-                if len(dim) == 4:
-                    # compute middle image from 4D series for plotting
-                    imgs = image.index_img(imgs, dim[-1] // 2)
             self._reporting_data = {
                 'labels_image': self._resampled_labels_img_,
                 'mask': self.mask_img_,

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -451,8 +451,9 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
             shape: (number of scans, number of labels)
 
         """
-        return self.fit().transform(imgs, confounds=confounds,
-                                    sample_mask=sample_mask)
+        return self.fit(imgs).transform(
+            imgs, confounds=confounds, sample_mask=sample_mask
+        )
 
     def _check_fitted(self):
         if not hasattr(self, 'labels_img_'):

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -203,6 +203,8 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
 
         self.keep_masked_labels = keep_masked_labels
 
+        self.cmap = kwargs.get("cmap", "CMRmap_r")
+
     def generate_report(self):
         """Generate a report."""
         from nilearn.reporting.html_report import generate_report
@@ -299,7 +301,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
                 display = plotting.plot_img(
                     img,
                     black_bg=False,
-                    cmap='RdBu',
+                    cmap=self.cmap,
                 )
                 plt.close()
                 display.add_contours(labels_image, filled=False, linewidths=3)

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -356,8 +356,15 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
     def fit(self, imgs=None, y=None):
         """Prepare signal extraction from regions.
 
-        All parameters are unused, they are for scikit-learn compatibility.
+        Parameters
+        ----------
+        imgs : :obj:`list` of Niimg-like objects
+            See :ref:`extracting_data`.
+            Image data passed to the reporter.
 
+        y : None
+            This parameter is unused. It is solely included for scikit-learn
+            compatibility.
         """
         # Load images
         repr = _utils._repr_niimgs(self.mask_img, shorten=(not self.verbose))

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -327,11 +327,6 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
                 display.close()
             return embeded_images
 
-        dim = image.load_img(img).shape
-        if len(dim) == 4:
-            # compute middle image from 4D series for plotting
-            img = image.index_img(img, dim[-1] // 2)
-
         # Find the cut coordinates
         cut_coords = [
             plotting.find_xyz_cut_coords(image.index_img(maps_image, i))
@@ -423,6 +418,11 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
             )
 
         if self.reports:
+            if imgs is not None:
+                dim = image.load_img(imgs).shape
+                if len(dim) == 4:
+                    # compute middle image from 4D series for plotting
+                    imgs = image.index_img(imgs, dim[-1] // 2)
             self._reporting_data = {
                 "maps_image": self.maps_img_,
                 "mask": self.mask_img_,

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -439,7 +439,7 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
 
     def fit_transform(self, imgs, confounds=None, sample_mask=None):
         """Prepare and perform signal extraction."""
-        return self.fit().transform(
+        return self.fit(imgs).transform(
             imgs, confounds=confounds, sample_mask=sample_mask
         )
 

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -343,7 +343,7 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
                 img,
                 cut_coords=cut_coords[idx],
                 black_bg=False,
-                cmap="CMRmap_r",
+                cmap="RdBu",
             )
             display.add_overlay(
                 image.index_img(maps_image, idx),

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -190,6 +190,8 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
 
         self.keep_masked_maps = keep_masked_maps
 
+        self.cmap = kwargs.get("cmap", "CMRmap_r")
+
     def generate_report(self, displayed_maps=10):
         """Generate an HTML report for the current ``NiftiMapsMasker`` object.
 
@@ -343,7 +345,7 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
                 img,
                 cut_coords=cut_coords[idx],
                 black_bg=False,
-                cmap="RdBu",
+                cmap=self.cmap,
             )
             display.add_overlay(
                 image.index_img(maps_image, idx),

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -327,6 +327,11 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
                 display.close()
             return embeded_images
 
+        dim = image.load_img(img).shape
+        if len(dim) == 4:
+            # compute middle image from 4D series for plotting
+            img = image.index_img(img, dim[-1] // 2)
+
         # Find the cut coordinates
         cut_coords = [
             plotting.find_xyz_cut_coords(image.index_img(maps_image, i))
@@ -418,11 +423,6 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
             )
 
         if self.reports:
-            if imgs is not None:
-                dim = image.load_img(imgs).shape
-                if len(dim) == 4:
-                    # compute middle image from 4D series for plotting
-                    imgs = image.index_img(imgs, dim[-1] // 2)
             self._reporting_data = {
                 "maps_image": self.maps_img_,
                 "mask": self.mask_img_,

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -337,7 +337,13 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         img = self._reporting_data["images"]
         mask = self._reporting_data["mask"]
 
-        if img is None:  # images were not provided to fit
+        if img is not None:
+            dim = image.load_img(img).shape
+            if len(dim) == 4:
+                # compute middle image from 4D series for plotting
+                img = image.index_img(img, dim[-1] // 2)
+
+        else:  # images were not provided to fit
             msg = (
                 "No image provided to fit in NiftiMasker. "
                 "Setting image to mask for reporting."
@@ -371,7 +377,6 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         # create display of resampled NiftiImage and mask
         # assuming that resampl_img has same dim as img
         resampl_img, resampl_mask = self._reporting_data["transform"]
-        dim = self._reporting_data["dim"]
         if resampl_img is None:  # images were not provided to fit
             resampl_img = resampl_mask
         elif len(dim) == 4:
@@ -436,14 +441,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
             self.mask_img_ = _utils.check_niimg_3d(self.mask_img)
 
         if self.reports:  # save inputs for reporting
-            self._reporting_data = {"mask": self.mask_img_}
-            if imgs is not None:
-                dim = image.load_img(imgs).shape
-                if len(dim) == 4:
-                    # compute middle image from 4D series for plotting
-                    imgs = image.index_img(imgs, dim[-1] // 2)
-                self._reporting_data["dim"] = dim
-            self._reporting_data["images"] = imgs
+            self._reporting_data = {"images": imgs, "mask": self.mask_img_}
         else:
             self._reporting_data = None
 

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -386,7 +386,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         final_display = plotting.plot_img(
             resampl_img,
             black_bg=False,
-            cmap="CMRmap_r",
+            cmap="RdBu",
         )
         plt.close()
         final_display.add_contours(

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -296,6 +296,8 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
             k[7:]: v for k, v in kwargs.items() if k.startswith("clean__")
         }
 
+        self.cmap = kwargs.get("cmap", "CMRmap_r")
+
     def generate_report(self):
         """Generate a report of the masker."""
         from nilearn.reporting.html_report import generate_report
@@ -357,7 +359,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         init_display = plotting.plot_img(
             img,
             black_bg=False,
-            cmap="CMRmap_r",
+            cmap=self.cmap,
         )
         plt.close()
         if mask is not None:
@@ -386,7 +388,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         final_display = plotting.plot_img(
             resampl_img,
             black_bg=False,
-            cmap="RdBu",
+            cmap=self.cmap,
         )
         plt.close()
         final_display.add_contours(

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -337,13 +337,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         img = self._reporting_data["images"]
         mask = self._reporting_data["mask"]
 
-        if img is not None:
-            dim = image.load_img(img).shape
-            if len(dim) == 4:
-                # compute middle image from 4D series for plotting
-                img = image.index_img(img, dim[-1] // 2)
-
-        else:  # images were not provided to fit
+        if img is None:  # images were not provided to fit
             msg = (
                 "No image provided to fit in NiftiMasker. "
                 "Setting image to mask for reporting."
@@ -377,6 +371,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         # create display of resampled NiftiImage and mask
         # assuming that resampl_img has same dim as img
         resampl_img, resampl_mask = self._reporting_data["transform"]
+        dim = self._reporting_data["dim"]
         if resampl_img is None:  # images were not provided to fit
             resampl_img = resampl_mask
         elif len(dim) == 4:
@@ -441,7 +436,14 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
             self.mask_img_ = _utils.check_niimg_3d(self.mask_img)
 
         if self.reports:  # save inputs for reporting
-            self._reporting_data = {"images": imgs, "mask": self.mask_img_}
+            self._reporting_data = {"mask": self.mask_img_}
+            if imgs is not None:
+                dim = image.load_img(imgs).shape
+                if len(dim) == 4:
+                    # compute middle image from 4D series for plotting
+                    imgs = image.index_img(imgs, dim[-1] // 2)
+                self._reporting_data["dim"] = dim
+            self._reporting_data["images"] = imgs
         else:
             self._reporting_data = None
 

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -398,8 +398,9 @@ class NiftiSpheresMasker(BaseMasker, CacheMixin):
             shape: (number of scans, number of spheres)
 
         """
-        return self.fit().transform(imgs, confounds=confounds,
-                                    sample_mask=sample_mask)
+        return self.fit(imgs).transform(
+            imgs, confounds=confounds, sample_mask=sample_mask
+        )
 
     def _check_fitted(self):
         if not hasattr(self, "seeds_"):


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Deals with most of #3709

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- [x] Pass image data to fit() in fit_transform()
- [x] Use better colormap or instead allow users to pass colormap
- [x] Improve docstrings to explain image data being passed to reporter
- [ ] Store 1 time point for reporting using 4D images (will handle in a separate PR)
