### PR TITLE
[FIX] Fix overlapping titles for `plot_matrix` function

### DIFF
--- a/nilearn/plotting/matrix_plotting.py
+++ b/nilearn/plotting/matrix_plotting.py
@@ -325,18 +325,9 @@ def plot_matrix(
         fig.tight_layout()
 
     if title is not None:
-        # Adjust the size
-        text_len = np.max([len(t) for t in title.split("\n")])
-        size = axes.bbox.size[0] / text_len
-        axes.text(
-            0.95,
-            0.95,
-            title,
-            horizontalalignment="right",
-            verticalalignment="top",
-            transform=axes.transAxes,
-            size=size,
-        )
+        axes.set_title(title, size=16)
+        fig.tight_layout()
+
     return display
 
 

--- a/nilearn/plotting/tests/test_matrix_plotting.py
+++ b/nilearn/plotting/tests/test_matrix_plotting.py
@@ -156,10 +156,10 @@ def test_matrix_plotting_labels(mat, lab):
 @pytest.mark.parametrize("title", ["foo", "foo bar", " ", None])
 def test_matrix_plotting_set_title(mat, labels, title):
     ax = plot_matrix(mat, labels=labels, title=title)
-    nb_txt = 0 if title is None else 1
-    assert len(ax._axes.texts) == nb_txt
+    nb_txt = 0 if title is None else len(title)
+    assert len(ax._axes.title.get_text()) == nb_txt
     if title is not None:
-        assert ax._axes.texts[0].get_text() == title
+        assert ax._axes.title.get_text() == title
     plt.close()
 
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Relates to #3728

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Simplify how title is added to matrix plots and make use of `tight_layout` for automatic adjustment
- Update relevant tests

Relevant to the following examples:
- https://nilearn.github.io/dev/auto_examples/03_connectivity/plot_sphere_based_connectome.html#
  - after fix: https://output.circle-artifacts.com/output/job/a9439351-08ed-476f-808e-6cb69147e4ce/artifacts/0/dev/auto_examples/03_connectivity/plot_sphere_based_connectome.html#connectome-extracted-from-dosenbach-s-atlas
- https://nilearn.github.io/dev/auto_examples/02_decoding/plot_haxby_multiclass.html#
  - after fix: https://output.circle-artifacts.com/output/job/a9439351-08ed-476f-808e-6cb69147e4ce/artifacts/0/dev/auto_examples/02_decoding/plot_haxby_multiclass.html#plot-a-confusion-matrix  
- https://nilearn.github.io/dev/auto_examples/03_connectivity/plot_inverse_covariance_connectome.html#
  - after fix: https://output.circle-artifacts.com/output/job/a9439351-08ed-476f-808e-6cb69147e4ce/artifacts/0/dev/auto_examples/03_connectivity/plot_inverse_covariance_connectome.html#display-the-connectome-matrix
- https://nilearn.github.io/dev/auto_examples/03_connectivity/plot_extract_regions_dictlearning_maps.html#
  - after fix: https://output.circle-artifacts.com/output/job/a9439351-08ed-476f-808e-6cb69147e4ce/artifacts/0/dev/auto_examples/03_connectivity/plot_extract_regions_dictlearning_maps.html#plot-resulting-connectomes 
- https://nilearn.github.io/dev/auto_examples/03_connectivity/plot_signal_extraction.html#
  - after fix: https://output.circle-artifacts.com/output/job/a9439351-08ed-476f-808e-6cb69147e4ce/artifacts/0/dev/auto_examples/03_connectivity/plot_signal_extraction.html#compute-and-display-a-correlation-matrix 
- https://nilearn.github.io/dev/auto_examples/03_connectivity/plot_multi_subject_connectome.html#
  - after fix: https://output.circle-artifacts.com/output/job/a9439351-08ed-476f-808e-6cb69147e4ce/artifacts/0/dev/auto_examples/03_connectivity/plot_multi_subject_connectome.html#displaying-results 
- https://nilearn.github.io/dev/auto_examples/01_plotting/plot_visualize_megatrawls_netmats.html#
  - After fix: https://output.circle-artifacts.com/output/job/a9439351-08ed-476f-808e-6cb69147e4ce/artifacts/0/dev/auto_examples/01_plotting/plot_visualize_megatrawls_netmats.html#visualization 
