### PR TITLE
[MAINT] Fix failing tests in prerelease job due to deprecation and bug in matplotlib 3.8.0rc1

### DIFF
--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -1513,7 +1513,8 @@ def plot_carpet(img, mask_img=None, mask_labels=None, t_r=None,
             ax0.set_yticks([])
 
         # Carpet plot
-        axes = plt.subplot(gs[1])  # overwrite axes
+        axes.remove()
+        axes = plt.subplot(gs[1])
         axes.imshow(
             data.T,
             interpolation='nearest',

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -31,7 +31,7 @@ from nilearn.maskers import NiftiMasker
 from nilearn.plotting.displays import get_projector, get_slicer
 
 from .. import _utils
-from .._utils import fill_doc
+from .._utils import fill_doc, _compare_version
 from .._utils.extmath import fast_abs_percentile
 from .._utils.ndimage import get_border_data
 from .._utils.niimg import _safe_get_data
@@ -1513,8 +1513,9 @@ def plot_carpet(img, mask_img=None, mask_labels=None, t_r=None,
             ax0.set_yticks([])
 
         # Carpet plot
-        axes.remove()
-        axes = plt.subplot(gs[1])
+        if _compare_version(matplotlib.__version__, ">", "3.7.2"):
+            axes.remove()  # remove axes for newer versions of mpl
+        axes = plt.subplot(gs[1])  # overwrites axes with older versions of mpl
         axes.imshow(
             data.T,
             interpolation='nearest',

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -31,7 +31,7 @@ from nilearn.maskers import NiftiMasker
 from nilearn.plotting.displays import get_projector, get_slicer
 
 from .. import _utils
-from .._utils import fill_doc, _compare_version
+from .._utils import _compare_version, fill_doc
 from .._utils.extmath import fast_abs_percentile
 from .._utils.ndimage import get_border_data
 from .._utils.niimg import _safe_get_data

--- a/nilearn/plotting/tests/test_displays.py
+++ b/nilearn/plotting/tests/test_displays.py
@@ -299,7 +299,9 @@ def test_contour_fillings_levels_in_add_contours(img):
     oslicer.add_contours(img, filled=True, levels=[0.0, 0.2])
 
     # levels with only one value
-    oslicer.add_contours(img, filled=True, levels=[0.0])
+    # vmin argument is not needed but added because of matplotlib 3.8.0rc1 bug
+    # see https://github.com/matplotlib/matplotlib/issues/26531
+    oslicer.add_contours(img, filled=True, levels=[0.0], vmin=0.0)
 
     # without passing levels, should work with default levels from
     # matplotlib


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- In matplotlib > 3.7.2 axes have to be explicitly removed using `ax.remove()` instead of being automatically overwritten
- Adjust failing test in `test_displays.py` to get around matplotlib bug https://github.com/matplotlib/matplotlib/issues/26531
