### PR TITLE
MAINT: Pandas deprecation

### DIFF
--- a/nilearn/glm/first_level/experimental_paradigm.py
+++ b/nilearn/glm/first_level/experimental_paradigm.py
@@ -107,7 +107,7 @@ def check_events(events):
 
     # Duplicate handling strategy
     # Sum the modulation values of duplicate events
-    STRATEGY = {"modulation": np.sum}
+    STRATEGY = {"modulation": "sum"}
 
     cleaned_events = (
         events_copy.groupby(COLUMN_DEFINING_EVENT_IDENTITY, sort=False)

--- a/nilearn/glm/first_level/experimental_paradigm.py
+++ b/nilearn/glm/first_level/experimental_paradigm.py
@@ -14,7 +14,6 @@ Author: Bertrand Thirion, 2015
 """
 import warnings
 
-import numpy as np
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 


### PR DESCRIPTION
Fixes:
```
...
../nilearn/nilearn/glm/first_level/design_matrix.py:236: in _convolve_regressors
    trial_type, onset, duration, modulation = check_events(events)
../nilearn/nilearn/glm/first_level/experimental_paradigm.py:114: in check_events
    .agg(STRATEGY)
...
../virtualenvs/base/lib/python3.11/site-packages/pandas/core/apply.py:1828: in warn_alias_replacement
    warnings.warn(
E   FutureWarning: The provided callable <function sum at 0x7fa1a230afc0> is currently using SeriesGroupBy.sum. In a future version of pandas, the provided callable will be used directly. To keep current behavior pass 'sum' instead.

```
Seems like it was available at least back to Pandas 1.4 (Jan 2022) so maybe good enough... couldn't find docs for earlier versions despite them having a drop-down :man_shrugging: 