### PR TITLE
[MAINT] remove long decription from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ description = "Statistical learning for neuroimaging in Python"
 # Version from setuptools_scm
 dynamic = ["version"]
 license = {text = "new BSD"}
-long_description = {file = "README.rst"}
 maintainers = [{name = "Bertrand Thirion", email = "bertrand.thirion@inria.fr"}]
 name = "nilearn"
 readme = "README.rst"


### PR DESCRIPTION
closes none

`long_description` are replaced by the `readme` (that we do specify) metadata in pyproject.toml:

https://peps.python.org/pep-0621/#readme