### PR TITLE
[FIX] Allow both vmin and threshold argument values to be used in plotting functions using `colorscale`

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -34,6 +34,8 @@ Fixes
 
 - Fix ``fit_transform`` behavior to match when ``fit`` method is passed image data (:gh:`3897` by `Yasmin Mzayek`_)
 
+- Allow using both vmin and threshold with  "plotly" engine to be consistent with "matplotlib" behavior (:gh:`3945` by `Yasmin Mzayek`_)
+
 Enhancements
 ------------
 

--- a/nilearn/plotting/js_plotting_utils.py
+++ b/nilearn/plotting/js_plotting_utils.py
@@ -80,11 +80,6 @@ def colorscale(cmap, values, threshold=None, symmetric_cmap=True,
     if symmetric_cmap and vmin is not None:
         warnings.warn('vmin cannot be chosen when cmap is symmetric')
         vmin = None
-    if threshold is not None:
-        if vmin is not None:
-            warnings.warn('choosing both vmin and a threshold is not allowed; '
-                          'setting vmin to 0')
-        vmin = 0
     if vmax is None:
         vmax = abs_values.max()
     # cast to float to avoid TypeError if vmax is a numpy boolean

--- a/nilearn/plotting/tests/test_js_plotting_utils.py
+++ b/nilearn/plotting/tests/test_js_plotting_utils.py
@@ -123,14 +123,11 @@ def test_colorscale_symmetric_cmap(vmin, vmax):
 @pytest.fixture
 def expected_vmin_vmax(values, vmax, vmin, threshold):
     """Returns expected vmin and vmax."""
-    if threshold is None:
-        if vmax is None:
-            return (min(values), max(values))
-        if min(values) < 0:
-            return (-vmax, vmax)
-        return (min(values), vmax) if vmin is None else (vmin, vmax)
-    else:
-        return (0, vmax)
+    if vmax is None:
+        return (min(values), max(values))
+    if min(values) < 0:
+        return (-vmax, vmax)
+    return (min(values), vmax) if vmin is None else (vmin, vmax)
 
 
 @pytest.mark.parametrize(

--- a/nilearn/plotting/tests/test_js_plotting_utils.py
+++ b/nilearn/plotting/tests/test_js_plotting_utils.py
@@ -121,7 +121,7 @@ def test_colorscale_symmetric_cmap(vmin, vmax):
 
 
 @pytest.fixture
-def expected_vmin_vmax(values, vmax, vmin, threshold):
+def expected_vmin_vmax(values, vmax, vmin):
     """Returns expected vmin and vmax."""
     if vmax is None:
         return (min(values), max(values))

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -815,6 +815,7 @@ def test_plot_surf_roi_error(engine):
     "kwargs", [{"vmin": 2}, {"vmin": 2, "threshold": 5}, {"threshold": 5}]
 )
 def test_plot_surf_roi_colorbar_vmin_equal_across_engines(kwargs):
+    """See issue https://github.com/nilearn/nilearn/issues/3944"""
     if not PLOTLY_INSTALLED:
         pytest.skip("Plotly is not installed; required for this test.")
     mesh = generate_surf()

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -811,6 +811,27 @@ def test_plot_surf_roi_error(engine):
         plot_surf_roi(mesh, roi_map=roi_idx, engine=engine)
 
 
+@pytest.mark.parametrize(
+    "kwargs", [{"vmin": 2}, {"vmin": 2, "threshold": 5}, {"threshold": 5}]
+)
+def test_plot_surf_roi_colorbar_vmin_equal_across_engines(kwargs):
+    if not PLOTLY_INSTALLED:
+        pytest.skip("Plotly is not installed; required for this test.")
+    mesh = generate_surf()
+    roi_map = np.arange(0, len(mesh[0]))
+
+    mpl_plot = plot_surf_roi(
+        mesh, roi_map=roi_map, colorbar=True, engine="matplotlib", **kwargs
+    )
+    plotly_plot = plot_surf_roi(
+        mesh, roi_map=roi_map, colorbar=True, engine="plotly", **kwargs
+    )
+    assert (
+        int(mpl_plot.axes[-1].get_yticklabels()[0].get_text())
+        == plotly_plot.figure.data[1]["cmin"]
+    )
+
+
 def test_plot_img_on_surf_hemispheres_and_orientations(img_3d_mni):
     nii = img_3d_mni
     # Check that all combinations of 1D or 2D hemis and orientations work.


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #3944
