### PR TITLE
Fix typo in tutorial

### DIFF
--- a/examples/02_decoding/plot_haxby_searchlight.py
+++ b/examples/02_decoding/plot_haxby_searchlight.py
@@ -46,7 +46,7 @@ y, session = y[condition_mask], session[condition_mask]
 # -------------
 # - mask_img is the original mask
 # - process_mask_img is a subset of mask_img, it contains the voxels that
-#   should be processed (we only keep the slice z = 26 and the back of the
+#   should be processed (we only keep the slice z = 29 and the back of the
 #   brain to speed up computation)
 import numpy as np
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- I'm just fixing a tiny typo in the [tutorial](https://nilearn.github.io/stable/auto_examples/02_decoding/plot_haxby_searchlight.html#sphx-glr-auto-examples-02-decoding-plot-haxby-searchlight-py), where the text says "z = 26" but the example is about "z = 29". I didn't make any issue, since this is so minuscule.
