### PR TITLE
[INFRA] Reorganize some optional dependencies under doc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ dev = [
     "isort",
     "flynt",
     "black",
+    "flake8",
+    "flake8-docstrings",
     "flake8-use-fstring",
     "flake8-functions",
     'codespell',
@@ -58,9 +60,6 @@ dev = [
 # Requirements necessary for building the documentation
 doc = [
     "nilearn[plotly]",
-    "coverage",
-    "flake8",
-    "flake8-docstrings",
     "furo",
     "memory_profiler",  # measuring memory during docs building
     "myst-parser",


### PR DESCRIPTION
I moved the flake8 dependencies to the dev category and coverage is already listed in test. Any reason these need to stay in doc?
