### PR TITLE
[FIX] allow using a list of `sample_mask` in `MultiNiftiMapsMasker.fit_transform`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -640,3 +640,8 @@ authors:
     family-names: Nájera
     website: https://github.com/Titan-C
     affiliation: Checkmk
+  - given-names: Alexandre
+    family-names: Cionca
+    website: https://github.com/acionca
+    affiliation: Centre Hospitalier Universitaire Vaudoise, Lausanne, Switzerland
+    orcid: https://orcid.org/0000-0002-1910-9650

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -12,6 +12,8 @@ NEW
 
 Fixes
 -----
+- Fix bug in :func:`~transform_imgs` of ``MultiNiftiMapsMasker`` and ``MultiNiftiLabelsMasker`` that would raise an error if a list of ``sample_mask`` was specified to :func:`~fit_transform` (:gh:`3971` by `Alexandre Cionca`_).
+
 - Fix bug in ``nilearn.plotting.surf_plotting._plot_surf_matplotlib`` that would make vertices transparent when saving in PDF or SVG format (:gh:`3860` by `Mathieu Dugré`_).
 
 - Fix bug that would prevent using `symmetric_cmap=True` or the `avg_method` argument with :func:`~plotting.plot_surf_roi` (:gh:`3942` by `Rémi Gau`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -12,7 +12,7 @@ NEW
 
 Fixes
 -----
-- Fix bug in :func:`~transform_imgs` of ``MultiNiftiMapsMasker`` and ``MultiNiftiLabelsMasker`` that would raise an error if a list of ``sample_mask`` was specified to :func:`~fit_transform` (:gh:`3971` by `Alexandre Cionca`_).
+Fix bug in method ``transform_imgs`` of :class:`~maskers.MultiNiftiMapsMasker` and :class:`~maskers.MultiNiftiLabelsMasker` that would raise an error if a list of ``sample_mask`` was specified to ``fit_transform`` (:gh:`3971` by `Alexandre Cionca`_).
 
 - Fix bug in ``nilearn.plotting.surf_plotting._plot_surf_matplotlib`` that would make vertices transparent when saving in PDF or SVG format (:gh:`3860` by `Mathieu Dugré`_).
 

--- a/nilearn/maskers/multi_nifti_labels_masker.py
+++ b/nilearn/maskers/multi_nifti_labels_masker.py
@@ -188,11 +188,14 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
         if confounds is None:
             confounds = itertools.repeat(None, len(imgs_list))
 
+        if sample_mask is None:
+            sample_mask = itertools.repeat(None, len(imgs_list))
+
         func = self._cache(self.transform_single_imgs)
 
         region_signals = Parallel(n_jobs=n_jobs)(
-            delayed(func)(imgs=imgs, confounds=cfs, sample_mask=sample_mask)
-            for imgs, cfs in zip(niimg_iter, confounds)
+            delayed(func)(imgs=imgs, confounds=cfs, sample_mask=sms)
+            for imgs, cfs, sms in zip(niimg_iter, confounds, sample_mask)
         )
         return region_signals
 

--- a/nilearn/maskers/multi_nifti_maps_masker.py
+++ b/nilearn/maskers/multi_nifti_maps_masker.py
@@ -182,11 +182,14 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
         if confounds is None:
             confounds = itertools.repeat(None, len(imgs_list))
 
+        if sample_mask is None:
+            sample_mask = itertools.repeat(None, len(imgs_list))
+
         func = self._cache(self.transform_single_imgs)
 
         region_signals = Parallel(n_jobs=n_jobs)(
-            delayed(func)(imgs=imgs, confounds=cfs, sample_mask=sample_mask)
-            for imgs, cfs in zip(niimg_iter, confounds)
+            delayed(func)(imgs=imgs, confounds=cfs, sample_mask=sms)
+            for imgs, cfs, sms in zip(niimg_iter, confounds, sample_mask)
         )
         return region_signals
 

--- a/nilearn/maskers/tests/test_multi_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_labels_masker.py
@@ -367,7 +367,8 @@ def test_multi_nifti_labels_masker_list_of_sample_mask():
 
     n_regions = 9
     length = 6
-    n_scrub = 3
+    n_scrub1 = 3
+    n_scrub2 = 2
 
     fmri11_img, mask11_img = data_gen.generate_fake_fmri(
         shape1, affine=affine1, length=length
@@ -376,12 +377,14 @@ def test_multi_nifti_labels_masker_list_of_sample_mask():
     labels11_img = data_gen.generate_labeled_regions(
         shape1, affine=affine1, n_regions=n_regions
     )
-    sample_mask = np.arange(length - n_scrub)
+    sample_mask1 = np.arange(length - n_scrub1)
+    sample_mask2 = np.arange(length - n_scrub2)
 
     masker = MultiNiftiLabelsMasker(labels11_img)
     ts_list = masker.fit_transform(
-        [fmri11_img, fmri11_img], sample_mask=[sample_mask, sample_mask]
+        [fmri11_img, fmri11_img], sample_mask=[sample_mask1, sample_mask2]
     )
 
     assert len(ts_list) == 2
-    assert ts_list[0].shape == (length - n_scrub, n_regions)
+    for ts, n_scrub in zip(ts_list, [n_scrub1, n_scrub2]):
+        assert ts.shape == (length - n_scrub, n_regions)

--- a/nilearn/maskers/tests/test_multi_nifti_maps_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_maps_masker.py
@@ -285,19 +285,22 @@ def test_multi_nifti_maps_masker_list_of_sample_mask():
 
     n_regions = 9
     length = 6
-    n_scrub = 3
+    n_scrub1 = 3
+    n_scrub2 = 2
 
     fmri11_img, mask11_img = data_gen.generate_fake_fmri(
         shape1, affine=affine1, length=length
     )
 
     maps11_img, _ = data_gen.generate_maps(shape1, n_regions, affine=affine1)
-    sample_mask = np.arange(length - n_scrub)
+    sample_mask1 = np.arange(length - n_scrub1)
+    sample_mask2 = np.arange(length - n_scrub2)
 
     masker = MultiNiftiMapsMasker(maps11_img)
     ts_list = masker.fit_transform(
-        [fmri11_img, fmri11_img], sample_mask=[sample_mask, sample_mask]
+        [fmri11_img, fmri11_img], sample_mask=[sample_mask1, sample_mask2]
     )
 
     assert len(ts_list) == 2
-    assert ts_list[0].shape == (length - n_scrub, n_regions)
+    for ts, n_scrub in zip(ts_list, [n_scrub1, n_scrub2]):
+        assert ts.shape == (length - n_scrub, n_regions)

--- a/nilearn/maskers/tests/test_multi_nifti_maps_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_maps_masker.py
@@ -129,12 +129,6 @@ def test_multi_nifti_maps_masker():
     masker.fit_transform(fmri22_img)
     np.testing.assert_array_equal(masker._resampled_maps_img_.affine, affine2)
 
-    # Test "MultiNiftiMapsMasker.fit_transform" with multiple "sample_mask"
-    sample_mask = np.arange(length - 2)
-    masker.fit_transform(
-        [fmri11_img, fmri11_img], sample_mask=[sample_mask, sample_mask]
-    )
-
 
 def test_multi_nifti_maps_masker_resampling():
     # Test resampling in MultiNiftiMapsMasker
@@ -277,3 +271,33 @@ def test_multi_nifti_maps_masker_resampling():
             fmri11_img_r.affine, masker.maps_img_.affine
         )
         assert fmri11_img_r.shape == (masker.maps_img_.shape[:3] + (length,))
+
+
+def test_multi_nifti_maps_masker_list_of_sample_mask():
+    """Tests MultiNiftiMapsMasker.fit_transform with a list of "sample_mask".
+
+    "sample_mask" was directly sent as input to the parallel calls of
+    "transform_single_imgs" instead of sending iterations.
+    See https://github.com/nilearn/nilearn/issues/3967 for more details.
+    """
+    shape1 = (13, 11, 12)
+    affine1 = np.eye(4)
+
+    n_regions = 9
+    length = 6
+    n_scrub = 3
+
+    fmri11_img, mask11_img = data_gen.generate_fake_fmri(
+        shape1, affine=affine1, length=length
+    )
+
+    maps11_img, _ = data_gen.generate_maps(shape1, n_regions, affine=affine1)
+    sample_mask = np.arange(length - n_scrub)
+
+    masker = MultiNiftiMapsMasker(maps11_img)
+    ts_list = masker.fit_transform(
+        [fmri11_img, fmri11_img], sample_mask=[sample_mask, sample_mask]
+    )
+
+    assert len(ts_list) == 2
+    assert ts_list[0].shape == (length - n_scrub, n_regions)

--- a/nilearn/maskers/tests/test_multi_nifti_maps_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_maps_masker.py
@@ -129,6 +129,12 @@ def test_multi_nifti_maps_masker():
     masker.fit_transform(fmri22_img)
     np.testing.assert_array_equal(masker._resampled_maps_img_.affine, affine2)
 
+    # Test "MultiNiftiMapsMasker.fit_transform" with multiple "sample_mask"
+    sample_mask = np.arange(length - 2)
+    masker.fit_transform(
+        [fmri11_img, fmri11_img], sample_mask=[sample_mask, sample_mask]
+    )
+
 
 def test_multi_nifti_maps_masker_resampling():
     # Test resampling in MultiNiftiMapsMasker


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #3967

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Iterate over the `sample_mask` in `MultiNiftiMapsMasker.transform_imgs` (mirroring the handling of `confounds`)
