### PR TITLE
[DOC] fix doc that mentioned `event_type` instead of `trial_type`

### DIFF
--- a/nilearn/plotting/matrix_plotting.py
+++ b/nilearn/plotting/matrix_plotting.py
@@ -475,7 +475,7 @@ def plot_event(model_event, cmap=None, output_file=None, **fig_kwargs):
     model_event : :class:`pandas.DataFrame` or :obj:`list`\
     of :class:`pandas.DataFrame`
         The :class:`pandas.DataFrame` must have three columns:
-        ``event_type`` with event name, ``onset`` and ``duration``.
+        ``trial_type`` with event name, ``onset`` and ``duration``.
 
         .. note::
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #3985

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
