### PR TITLE
[INFRA] Configure doc build CI to always host artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
                     if [[ "$STATUS" == "success" ]]; then
                         echo "Doc build is successful. Deploying docs..."
                     else
-                        echo "Failed to deploy because doc build status is failure"
+                        echo "Failed to deploy because doc build status is 'failure'"
                         exit 1
                     fi
         -   run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ parameters:
     GITHUB_RUN_URL:
         type: string
         default: none
+    STATUS:
+        type: string
+        default: failure
 
 jobs:
     host_docs:
@@ -34,12 +37,24 @@ jobs:
     deploy:
         docker:
         -   image: circleci/python:3.9
+        environment:
+            STATUS: << pipeline.parameters.STATUS >>
         steps:
         -   add_ssh_keys:
                 fingerprints:
                 -   19:56:86:2d:c6:df:02:f2:87:0e:59:a1:eb:b7:65:77
         -   attach_workspace:
                 at: /tmp/_build
+        -   run:
+                name: Check status
+                command: |
+                    echo $STATUS
+                    if [[ "$STATUS" == "success" ]]; then
+                        echo "Doc build is successful. Deploying docs..."
+                    else
+                        echo "Failed to deploy because doc build status is failure"
+                        exit 1
+                    fi
         -   run:
                 name: Fetch docs
                 command: |

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -304,11 +304,13 @@ jobs:
                 set -o pipefail;
                 PATTERN=$(cat ../pattern.txt) make $(cat ../build.txt) 2>&1 | tee log.txt;
         -   name: Upload documentation
+            if: always()
             uses: actions/upload-artifact@v3
             with:
                 name: doc
                 path: doc/_build/html
         -   name: Note about build
+            if: always()
             run: |
                 if [[ "$(cat build.txt)" != "html-strict" ]]; then
                     echo "Partial build : No data is downloaded or cached";

--- a/.github/workflows/trigger-hosting.yml
+++ b/.github/workflows/trigger-hosting.yml
@@ -29,3 +29,4 @@ jobs:
                 COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
                 REPO_NAME: ${{ github.event.workflow_run.head_repository.full_name }}
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                STATUS: ${{ github.event.workflow_run.conclusion }}

--- a/build_tools/github/trigger_hosting.sh
+++ b/build_tools/github/trigger_hosting.sh
@@ -37,4 +37,4 @@ curl --request POST \
      --header "content-type: application/json" \
      --header "x-attribution-actor-id: github_actions" \
      --header "x-attribution-login: github_actions" \
-     --data \{\"branch\":\"$BRANCH\",\"parameters\":\{\"GITHUB_RUN_URL\":\"$GITHUB_RUN_URL\",\"STATUS\":\"$STATUS\"\}\}q
+     --data \{\"branch\":\"$BRANCH\",\"parameters\":\{\"GITHUB_RUN_URL\":\"$GITHUB_RUN_URL\",\"STATUS\":\"$STATUS\"\}\}

--- a/build_tools/github/trigger_hosting.sh
+++ b/build_tools/github/trigger_hosting.sh
@@ -37,4 +37,4 @@ curl --request POST \
      --header "content-type: application/json" \
      --header "x-attribution-actor-id: github_actions" \
      --header "x-attribution-login: github_actions" \
-     --data \{\"branch\":\"$BRANCH\",\"parameters\":\{\"GITHUB_RUN_URL\":\"$GITHUB_RUN_URL\"\}\}
+     --data \{\"branch\":\"$BRANCH\",\"parameters\":\{\"GITHUB_RUN_URL\":\"$GITHUB_RUN_URL\",\"STATUS\":\"$STATUS\"\}\}q


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes None

With the current set up, a failure on the doc build prevents circleci from hosting the docs that have been built. This is annoying since the htmls exist but cannot be easily viewed (sometimes for very trivial errors) and thus hinders the review process. This PR changes the configuration so that the docs are always hosted if a build exists. Note that deploy will still only run on main only with a successful doc build.

I've tested this on my fork on [main](https://github.com/ymzayek/nilearn) and in a [PR](https://github.com/ymzayek/nilearn/pulls)
