### PR TITLE
[MAINT] check events before plotting them

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -12,7 +12,8 @@ NEW
 
 Fixes
 -----
-Fix bug in method ``transform_imgs`` of :class:`~maskers.MultiNiftiMapsMasker` and :class:`~maskers.MultiNiftiLabelsMasker` that would raise an error if a list of ``sample_mask`` was specified to ``fit_transform`` (:gh:`3971` by `Alexandre Cionca`_).
+
+- Fix bug in method ``transform_imgs`` of :class:`~maskers.MultiNiftiMapsMasker` and :class:`~maskers.MultiNiftiLabelsMasker` that would raise an error if a list of ``sample_mask`` was specified to ``fit_transform`` (:gh:`3971` by `Alexandre Cionca`_).
 
 - Fix bug in ``nilearn.plotting.surf_plotting._plot_surf_matplotlib`` that would make vertices transparent when saving in PDF or SVG format (:gh:`3860` by `Mathieu Dugré`_).
 
@@ -62,6 +63,7 @@ Enhancements
 Changes
 -------
 
+- Validate the content of events files before plotting them (:gh: `3994` by `Rémi Gau`_).
 - `nilearn.glm.first_level.experimental_paradigm.check_events` will now throw a warning if some events have a 0 second duration and will throw an error if an event has ``NaN`` onset or duration (:gh:`3943` by `Rémi Gau`_).
 - Removed old files and test code from deprecated datasets COBRE and NYU resting state (:gh:`3743` by `Michelle Wang`_).
 - :bdg-secondary:`Maint` PEP8 and isort compliance extended to the whole nilearn codebase. (:gh:`3538`, :gh:`3566`, :gh:`3548`, :gh:`3556`, :gh:`3601`, :gh:`3609`, :gh:`3646`, :gh:`3650`, :gh:`3647`, :gh:`3640`, :gh:`3615`, :gh:`3614`, :gh:`3648`,  :gh:`#3651`  by `Rémi Gau`_).

--- a/nilearn/glm/first_level/design_matrix.py
+++ b/nilearn/glm/first_level/design_matrix.py
@@ -40,7 +40,10 @@ import pandas as pd
 
 from nilearn._utils import fill_doc
 from nilearn.glm._utils import full_rank
-from nilearn.glm.first_level.experimental_paradigm import check_events
+from nilearn.glm.first_level.experimental_paradigm import (
+    check_events,
+    sum_modulation_of_duplicate_events,
+)
 from nilearn.glm.first_level.hemodynamic_models import (
     _orthogonalize,
     compute_regressor,
@@ -233,7 +236,15 @@ def _convolve_regressors(
     """
     regressor_names = []
     regressor_matrix = None
-    trial_type, onset, duration, modulation = check_events(events)
+
+    events_copy = check_events(events)
+    cleaned_events = sum_modulation_of_duplicate_events(events_copy)
+
+    trial_type = cleaned_events["trial_type"].values
+    onset = cleaned_events["onset"].values
+    duration = cleaned_events["duration"].values
+    modulation = cleaned_events["modulation"].values
+
     for condition in np.unique(trial_type):
         condition_mask = trial_type == condition
         exp_condition = (

--- a/nilearn/glm/first_level/design_matrix.py
+++ b/nilearn/glm/first_level/design_matrix.py
@@ -42,7 +42,7 @@ from nilearn._utils import fill_doc
 from nilearn.glm._utils import full_rank
 from nilearn.glm.first_level.experimental_paradigm import (
     check_events,
-    sum_modulation_of_duplicate_events,
+    handle_modulation_of_duplicate_events,
 )
 from nilearn.glm.first_level.hemodynamic_models import (
     _orthogonalize,
@@ -238,7 +238,7 @@ def _convolve_regressors(
     regressor_matrix = None
 
     events_copy = check_events(events)
-    cleaned_events = sum_modulation_of_duplicate_events(events_copy)
+    cleaned_events = handle_modulation_of_duplicate_events(events_copy)
 
     trial_type = cleaned_events["trial_type"].values
     onset = cleaned_events["onset"].values

--- a/nilearn/glm/first_level/experimental_paradigm.py
+++ b/nilearn/glm/first_level/experimental_paradigm.py
@@ -24,9 +24,6 @@ def check_events(events):
     It is valid if the events data has ``'onset'`` and ``'duration'`` keys
     with numeric non NaN values.
 
-    This function also handles duplicate events
-    by summing their modulation if they have one.
-
     Parameters
     ----------
     events : pandas DataFrame
@@ -34,6 +31,11 @@ def check_events(events):
 
     Returns
     -------
+    events : pandas DataFrame
+        Events data that describes a functional experimental paradigm.
+
+    The dataframe has the following columns:
+
     trial_type : array of shape (n_events,), dtype='s'
         Per-event experimental conditions identifier.
         Defaults to np.repeat('dummy', len(onsets)).
@@ -95,15 +97,7 @@ def check_events(events):
 
     _check_unexpected_columns(events_copy)
 
-    events_copy = _handle_modulation(events_copy)
-
-    cleaned_events = _handle_duplicate_events(events_copy)
-
-    trial_type = cleaned_events["trial_type"].values
-    onset = cleaned_events["onset"].values
-    duration = cleaned_events["duration"].values
-    modulation = cleaned_events["modulation"].values
-    return trial_type, onset, duration, modulation
+    return _handle_modulation(events_copy)
 
 
 def _check_columns(events):
@@ -185,7 +179,8 @@ COLUMN_DEFINING_EVENT_IDENTITY = ["trial_type", "onset", "duration"]
 STRATEGY = {"modulation": "sum"}
 
 
-def _handle_duplicate_events(events):
+def sum_modulation_of_duplicate_events(events):
+    """Sum modulation of duplicate events if they have one."""
     cleaned_events = (
         events.groupby(COLUMN_DEFINING_EVENT_IDENTITY, sort=False)
         .agg(STRATEGY)

--- a/nilearn/glm/first_level/experimental_paradigm.py
+++ b/nilearn/glm/first_level/experimental_paradigm.py
@@ -182,7 +182,7 @@ STRATEGY = {"modulation": "sum"}
 
 
 def handle_modulation_of_duplicate_events(events):
-    """Deal modulation of duplicate events if they have one.
+    """Deal with modulation of duplicate events if they have one.
 
     Currently the strategy is to sum the modulation values of duplicate events.
     """

--- a/nilearn/glm/first_level/experimental_paradigm.py
+++ b/nilearn/glm/first_level/experimental_paradigm.py
@@ -101,7 +101,7 @@ def check_events(events):
 
 
 def _check_columns(events):
-    # Column checks
+    """Check events has onset and duration numeric columns with no NaN."""
     for col_name in ["onset", "duration"]:
         if col_name not in events.columns:
             raise ValueError(
@@ -123,6 +123,7 @@ def _check_columns(events):
 
 
 def _handle_missing_trial_types(events):
+    """Create 'dummy' events trial_type if the column is not present."""
     if "trial_type" not in events.columns:
         warnings.warn(
             "'trial_type' column not found in the given events data."
@@ -132,6 +133,7 @@ def _handle_missing_trial_types(events):
 
 
 def _check_null_duration(events):
+    """Warn if there are events with null duration."""
     conditions_with_null_duration = events["trial_type"][
         events["duration"] == 0
     ].unique()
@@ -143,6 +145,7 @@ def _check_null_duration(events):
 
 
 def _handle_modulation(events):
+    """Set the modulation column to 1 if it is not present."""
     if "modulation" in events.columns:
         print(
             "A 'modulation' column was found in "
@@ -157,8 +160,7 @@ VALID_FIELDS = {"onset", "duration", "trial_type", "modulation"}
 
 
 def _check_unexpected_columns(events):
-    # Warn for each unexpected column that will
-    # not be used afterwards
+    """Warn for each unexpected column that will not be used afterwards."""
     unexpected_columns = list(set(events.columns).difference(VALID_FIELDS))
     if unexpected_columns:
         warnings.warn(
@@ -179,8 +181,11 @@ COLUMN_DEFINING_EVENT_IDENTITY = ["trial_type", "onset", "duration"]
 STRATEGY = {"modulation": "sum"}
 
 
-def sum_modulation_of_duplicate_events(events):
-    """Sum modulation of duplicate events if they have one."""
+def handle_modulation_of_duplicate_events(events):
+    """Deal modulation of duplicate events if they have one.
+
+    Currently the strategy is to sum the modulation values of duplicate events.
+    """
     cleaned_events = (
         events.groupby(COLUMN_DEFINING_EVENT_IDENTITY, sort=False)
         .agg(STRATEGY)

--- a/nilearn/glm/tests/test_paradigm.py
+++ b/nilearn/glm/tests/test_paradigm.py
@@ -15,7 +15,7 @@ from numpy.testing import assert_array_equal
 from nilearn._utils.data_gen import basic_paradigm
 from nilearn.glm.first_level import check_events
 from nilearn.glm.first_level.experimental_paradigm import (
-    sum_modulation_of_duplicate_events,
+    handle_modulation_of_duplicate_events,
 )
 
 from ._utils import (
@@ -172,7 +172,7 @@ def test_sum_modulation_of_duplicate_events():
 
     # Check that a warning is given to the user
     with pytest.warns(UserWarning, match="Duplicated events were detected."):
-        events_copy = sum_modulation_of_duplicate_events(events)
+        events_copy = handle_modulation_of_duplicate_events(events)
     assert_array_equal(
         events_copy["trial_type"], ["c0", "c0", "c0", "c1", "c1"]
     )

--- a/nilearn/plotting/matrix_plotting.py
+++ b/nilearn/plotting/matrix_plotting.py
@@ -8,6 +8,8 @@ import pandas as pd
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from scipy.cluster.hierarchy import leaves_list, linkage, optimal_leaf_ordering
 
+from nilearn.glm.first_level.experimental_paradigm import check_events
+
 from .._utils import fill_doc
 
 with warnings.catch_warnings():
@@ -495,6 +497,10 @@ def plot_event(model_event, cmap=None, output_file=None, **fig_kwargs):
     """
     if isinstance(model_event, pd.DataFrame):
         model_event = [model_event]
+
+    for i, event in enumerate(model_event):
+        event_copy = check_events(event)
+        model_event[i] = event_copy
 
     n_runs = len(model_event)
     figure, ax = plt.subplots(1, 1, **fig_kwargs)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #3948

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- run check_events on inputs of plot_events to ensure that they get the same treatment as before design matrix generation
- extract summation of modulation of duplicated events in a separate function
