### PR TITLE
[FIX] Allow `MultiNiftiMasker` to use `generate_report` method

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -14,6 +14,8 @@ NEW
 Fixes
 -----
 
+- :bdg-success:`API` :class:`~maskers.MultiNiftiMasker` can now call :meth:`~maskers.NiftiMasker.generate_report` which will generate a report for the first subject in the list of subjects (:gh:`4001` by `Yasmin Mzayek`_).
+
 Enhancements
 ------------
 

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -238,11 +238,10 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
 
             self.mask_img_ = _utils.check_niimg_3d(self.mask_img)
 
+        self._reporting_data = None
         if self.reports:  # save inputs for reporting
             imgs = imgs[0] if isinstance(imgs, list) else imgs
             self._reporting_data = {"images": imgs, "mask": self.mask_img_}
-        else:
-            self._reporting_data = None
 
         # If resampling is requested, resample the mask as well.
         # Resampling: allows the user to change the affine, the shape or both.

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -279,7 +279,7 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
                     target_affine=self.affine_,
                     copy=False,
                     interpolation="nearest",
-                )       
+                )
 
             self._reporting_data["transform"] = [resampl_imgs, self.mask_img_]
 

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -273,15 +273,14 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
             or (self.target_affine is not None)
             and self.reports
         ):
+            resampl_imgs = None
             if imgs is not None:
                 resampl_imgs = self._cache(image.resample_img)(
                     imgs,
                     target_affine=self.affine_,
                     copy=False,
                     interpolation="nearest",
-                )
-            else:  # imgs not provided to fit
-                resampl_imgs = None
+                )       
 
             self._reporting_data["transform"] = [resampl_imgs, self.mask_img_]
 

--- a/nilearn/maskers/tests/test_multi_nifti_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_masker.py
@@ -15,6 +15,13 @@ from nilearn._utils.testing import write_tmp_imgs
 from nilearn.image import get_data
 from nilearn.maskers import MultiNiftiMasker
 
+try:
+    import matplotlib  # noqa: F401
+except ImportError:
+    not_have_mpl = True
+else:
+    not_have_mpl = False
+
 
 def test_auto_mask():
     # This mostly a smoke test
@@ -259,6 +266,9 @@ def test_standardization():
         )
 
 
+@pytest.mark.skipif(
+    not_have_mpl, reason="Matplotlib not installed; required for this test"
+)
 def test_generate_report():
     """Smoke test for generate_report method."""
     imgs = _get_random_imgs((9, 9, 5), 2)

--- a/nilearn/maskers/tests/test_multi_nifti_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_masker.py
@@ -269,8 +269,34 @@ def test_standardization():
 @pytest.mark.skipif(
     not_have_mpl, reason="Matplotlib not installed; required for this test"
 )
-def test_generate_report():
-    """Smoke test for generate_report method."""
-    imgs = _get_random_imgs((9, 9, 5), 2)
+def test_generate_report_imgs():
+    """Smoke test for generate_report method with image data."""
+    data_shape = (9, 9, 5)
+    imgs = _get_random_imgs(data_shape, 2)
     masker = MultiNiftiMasker()
+    masker.fit(imgs).generate_report()
+
+
+def test_generate_report_mask():
+    """Smoke test for generate_report method with only mask."""
+    data_shape = (9, 9, 5)
+    mask = Nifti1Image(np.ones(data_shape), np.eye(4))
+    masker = MultiNiftiMasker(
+        mask_img=mask,
+        target_affine=np.eye(4),  # to test resampling lines
+        target_shape=data_shape,  # to test resampling lines
+    )
+    masker.fit().generate_report()
+
+
+def test_generate_report_imgs_and_mask():
+    """Smoke test for generate_report method with images and mask."""
+    data_shape = (9, 9, 5)
+    imgs = _get_random_imgs(data_shape, 2)
+    mask = Nifti1Image(np.ones(data_shape), np.eye(4))
+    masker = MultiNiftiMasker(
+        mask_img=mask,
+        target_affine=np.eye(4),  # to test resampling lines
+        target_shape=data_shape,  # to test resampling lines
+    )
     masker.fit(imgs).generate_report()

--- a/nilearn/maskers/tests/test_multi_nifti_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_masker.py
@@ -269,26 +269,38 @@ def test_standardization():
 @pytest.mark.skipif(
     not_have_mpl, reason="Matplotlib not installed; required for this test"
 )
-def test_generate_report_imgs():
+@pytest.mark.parametrize(
+    "reports,expected", [(True, dict), (False, type(None))]
+)
+def test_generate_report_imgs(reports, expected):
     """Smoke test for generate_report method with image data."""
     data_shape = (9, 9, 5)
     imgs = _get_random_imgs(data_shape, 2)
-    masker = MultiNiftiMasker()
-    masker.fit(imgs).generate_report()
+    masker = MultiNiftiMasker(reports=reports)
+    masker.fit(imgs)
+    assert isinstance(masker._reporting_data, expected)
+    masker.generate_report()
 
 
+@pytest.mark.skipif(
+    not_have_mpl, reason="Matplotlib not installed; required for this test"
+)
 def test_generate_report_mask():
     """Smoke test for generate_report method with only mask."""
     data_shape = (9, 9, 5)
     mask = Nifti1Image(np.ones(data_shape), np.eye(4))
     masker = MultiNiftiMasker(
         mask_img=mask,
-        target_affine=np.eye(4),  # to test resampling lines
-        target_shape=data_shape,  # to test resampling lines
+        # to test resampling lines without imgs
+        target_affine=np.eye(4),
+        target_shape=data_shape,
     )
     masker.fit().generate_report()
 
 
+@pytest.mark.skipif(
+    not_have_mpl, reason="Matplotlib not installed; required for this test"
+)
 def test_generate_report_imgs_and_mask():
     """Smoke test for generate_report method with images and mask."""
     data_shape = (9, 9, 5)
@@ -296,7 +308,8 @@ def test_generate_report_imgs_and_mask():
     mask = Nifti1Image(np.ones(data_shape), np.eye(4))
     masker = MultiNiftiMasker(
         mask_img=mask,
-        target_affine=np.eye(4),  # to test resampling lines
-        target_shape=data_shape,  # to test resampling lines
+        # to test resampling lines with imgs
+        target_affine=np.eye(4),
+        target_shape=data_shape,
     )
     masker.fit(imgs).generate_report()

--- a/nilearn/maskers/tests/test_multi_nifti_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_masker.py
@@ -257,3 +257,10 @@ def test_standardization():
         np.testing.assert_almost_equal(
             ts, (s / s.mean(1)[:, np.newaxis] * 100 - 100).T
         )
+
+
+def test_generate_report():
+    """Smoke test for generate_report method."""
+    imgs = _get_random_imgs((9, 9, 5), 2)
+    masker = MultiNiftiMasker()
+    masker.fit(imgs).generate_report()


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Fixes bug reported in #3960
- Relates to #3935

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Allow MultiNiftiMasker to use `generate_report` for one subject for now (mimicking multi labels and maps masker behavior)
