### PR TITLE
[INFRA/FIX] Minimum testing with minimum matplotlib is not installing matplotlib

### DIFF
--- a/build_tools/github/install.sh
+++ b/build_tools/github/install.sh
@@ -6,7 +6,7 @@ if [ ! -z "$MIN_REQUIREMENTS" ]; then
     # See pyproject.toml for dependency group options
     if [ ! -z "$MATPLOTLIB" ]; then
         # Include plotting dependencies too
-        pip install --progress-bar off --upgrade -e .[min,plotting_min,test]
+        pip install --progress-bar off --upgrade -e .[min,plotmin,test]
     else
         pip install --progress-bar off --upgrade -e .[min,test]
     fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,8 +84,8 @@ min = [
 # For surface plotting mostly
 plotly = ["kaleido", "plotly"]
 # Necessary req to use nilearn's plotting module
+plotmin = ["matplotlib==3.3.0"]
 plotting = ["matplotlib>=3.3.0"]
-plotting_min = ["matplotlib==3.3.0"]
 # For running unit and docstring tests
 test = [
     "coverage",


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
Since recent CI change in #3976
seems like minimum testing with minimum matplotlib is not installing matptlotlib at all due to a syntax error. See for example https://github.com/nilearn/nilearn/actions/runs/6272781202/job/17034981917?pr=4001
