### PR TITLE
[FIX] Disable extrapolation of out-of-bounds volumes

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -674,3 +674,9 @@ authors:
     family-names: Nájera
     website: https://github.com/Titan-C
     affiliation: Checkmk
+  - given-names: Jordi
+    family-names: Huguet
+    website: https://github.com/jhuguetn
+    affiliation: BarcelonaBeta Brain Research Center
+    email: jhuguetn@gmail.com
+    orcid: https://orcid.org/0000-0001-8420-4833

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -23,3 +23,5 @@ Enhancements
 
 Changes
 -------
+
+- :bdg-success:`API` Expose scipy CubicSpline ``extrapolate`` parameter in :func:`~signal.clean` to control the interpolation of censored volumes in both ends of the BOLD signal data (:gh:`4028` by `Jordi Huguet`_).

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -854,9 +854,9 @@ def _interpolate_volumes(volumes, sample_mask, t_r, extrapolate):
         extrapolate_default = (
             "By default the cubic spline interpolator extrapolates "
             "the out-of-bounds censored volumes in the data run. This "
-            "can lead to undesired filtered signal results. In future "
-            "releases, the default strategy will be not to extrapolate "
-            "and discard those volumes at filtering."
+            "can lead to undesired filtered signal results. Starting in "
+            "version 0.13, the default strategy will be not to extrapolate "
+            "but discard those volumes at filtering."
         )
         warnings.warn(
             category=FutureWarning,

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -856,7 +856,7 @@ def _interpolate_volumes(volumes, sample_mask, t_r, extrapolate):
             "the out-of-bounds censored volumes in the data run. This "
             "can lead to undesired filtered signal results. Starting in "
             "version 0.13, the default strategy will be not to extrapolate "
-            "but discard those volumes at filtering."
+            "but to discard those volumes at filtering."
         )
         warnings.warn(
             category=FutureWarning,

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -1101,11 +1101,6 @@ def test_handle_scrubbed_volumes_extrapolation():
     ) = nisignal._handle_scrubbed_volumes(
         signals, confounds, sample_mask, "butterworth", 2.5, True
     )
-    extrapolated_signals = \
-        extrapolated_signals[~np.isnan(extrapolated_signals).all(axis=1), :]
-    extrapolated_confounds = \
-        extrapolated_confounds[~np.isnan(extrapolated_confounds).all(axis=1), :]
-
     np.testing.assert_equal(
         signals.shape[0], extrapolated_signals.shape[0]
     )
@@ -1122,11 +1117,6 @@ def test_handle_scrubbed_volumes_extrapolation():
     ) = nisignal._handle_scrubbed_volumes(
         signals, confounds, sample_mask, "butterworth", 2.5, False
     )
-    interpolated_signals = \
-        interpolated_signals[~np.isnan(interpolated_signals).all(axis=1), :]
-    interpolated_confounds = \
-        interpolated_confounds[~np.isnan(interpolated_confounds).all(axis=1), :]
-
     np.testing.assert_equal(
         signals.shape[0], interpolated_signals.shape[0] + censored_samples
     )

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -1094,6 +1094,7 @@ def test_handle_scrubbed_volumes_extrapolation():
     )
 
     censored_samples = 5
+    total_samples = censored_samples + 3
     sample_mask = np.arange(signals.shape[0])
     scrub_index = np.concatenate((np.arange(censored_samples), [10, 20, 30]))
     sample_mask = np.delete(sample_mask, scrub_index)
@@ -1138,3 +1139,16 @@ def test_handle_scrubbed_volumes_extrapolation():
         confounds.shape[0], interpolated_confounds.shape[0] + censored_samples
     )
     np.testing.assert_equal(sample_mask - sample_mask[0], interpolated_sample_mask)
+
+    # Assert that the modified sample mask (interpolated_sample_mask)
+    # can be applied to the interpolated signals and confounds
+    (
+        censored_signals,
+        censored_confounds,
+    ) = nisignal._censor_signals(interpolated_signals,
+                                 interpolated_confounds,
+                                 interpolated_sample_mask)
+    np.testing.assert_equal(
+        signals.shape[0], censored_signals.shape[0] + total_samples)
+    np.testing.assert_equal(
+        confounds.shape[0], censored_confounds.shape[0] + total_samples)

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -1107,9 +1107,7 @@ def test_handle_scrubbed_volumes_extrapolation():
     ) = nisignal._handle_scrubbed_volumes(
         signals, confounds, sample_mask, "butterworth", 2.5, True
     )
-    np.testing.assert_equal(
-        signals.shape[0], extrapolated_signals.shape[0]
-    )
+    np.testing.assert_equal(signals.shape[0], extrapolated_signals.shape[0])
     np.testing.assert_equal(
         confounds.shape[0], extrapolated_confounds.shape[0]
     )

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -1065,6 +1065,7 @@ def test_handle_scrubbed_volumes():
     (
         interpolated_signals,
         interpolated_confounds,
+        sample_mask,
     ) = nisignal._handle_scrubbed_volumes(
         signals, confounds, sample_mask, "butterworth", 2.5, True
     )
@@ -1075,7 +1076,11 @@ def test_handle_scrubbed_volumes():
         interpolated_confounds[sample_mask, :], confounds[sample_mask, :]
     )
 
-    scrubbed_signals, scrubbed_confounds = nisignal._handle_scrubbed_volumes(
+    (
+        scrubbed_signals,
+        scrubbed_confounds,
+        sample_mask,
+    ) = nisignal._handle_scrubbed_volumes(
         signals, confounds, sample_mask, "cosine", 2.5, True
     )
     np.testing.assert_equal(scrubbed_signals, signals[sample_mask, :])
@@ -1098,6 +1103,7 @@ def test_handle_scrubbed_volumes_extrapolation():
     (
         extrapolated_signals,
         extrapolated_confounds,
+        sample_mask,
     ) = nisignal._handle_scrubbed_volumes(
         signals, confounds, sample_mask, "butterworth", 2.5, True
     )
@@ -1114,6 +1120,7 @@ def test_handle_scrubbed_volumes_extrapolation():
     (
         interpolated_signals,
         interpolated_confounds,
+        sample_mask,
     ) = nisignal._handle_scrubbed_volumes(
         signals, confounds, sample_mask, "butterworth", 2.5, False
     )

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -1095,7 +1095,7 @@ def test_handle_scrubbed_volumes_extrapolation():
 
     censored_samples = 5
     sample_mask = np.arange(signals.shape[0])
-    scrub_index = np.arange(censored_samples)
+    scrub_index = np.concatenate((np.arange(censored_samples), [10, 20, 30]))
     sample_mask = np.delete(sample_mask, scrub_index)
 
     # Test cubic spline interpolation (enabled extrapolation) in the
@@ -1111,7 +1111,7 @@ def test_handle_scrubbed_volumes_extrapolation():
         (
             extrapolated_signals,
             extrapolated_confounds,
-            sample_mask,
+            extrapolated_sample_mask,
         ) = nisignal._handle_scrubbed_volumes(
             signals, confounds, sample_mask, "butterworth", 2.5, True
         )
@@ -1119,6 +1119,7 @@ def test_handle_scrubbed_volumes_extrapolation():
     np.testing.assert_equal(
         confounds.shape[0], extrapolated_confounds.shape[0]
     )
+    np.testing.assert_equal(sample_mask, extrapolated_sample_mask)
 
     # Test cubic spline interpolation without predicting values outside
     # the range of the signal available (disabled extrapolation), discarding
@@ -1126,7 +1127,7 @@ def test_handle_scrubbed_volumes_extrapolation():
     (
         interpolated_signals,
         interpolated_confounds,
-        sample_mask,
+        interpolated_sample_mask,
     ) = nisignal._handle_scrubbed_volumes(
         signals, confounds, sample_mask, "butterworth", 2.5, False
     )
@@ -1136,3 +1137,4 @@ def test_handle_scrubbed_volumes_extrapolation():
     np.testing.assert_equal(
         confounds.shape[0], interpolated_confounds.shape[0] + censored_samples
     )
+    np.testing.assert_equal(sample_mask - sample_mask[0], interpolated_sample_mask)

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -1100,13 +1100,21 @@ def test_handle_scrubbed_volumes_extrapolation():
 
     # Test cubic spline interpolation (enabled extrapolation) in the
     # very first n=5 samples of generated signal
-    (
-        extrapolated_signals,
-        extrapolated_confounds,
-        sample_mask,
-    ) = nisignal._handle_scrubbed_volumes(
-        signals, confounds, sample_mask, "butterworth", 2.5, True
+    extrapolate_warning = (
+        "By default the cubic spline interpolator extrapolates "
+        "the out-of-bounds censored volumes in the data run. This "
+        "can lead to undesired filtered signal results. Starting in "
+        "version 0.13, the default strategy will be not to extrapolate "
+        "but to discard those volumes at filtering."
     )
+    with pytest.warns(FutureWarning, match=extrapolate_warning):
+        (
+            extrapolated_signals,
+            extrapolated_confounds,
+            sample_mask,
+        ) = nisignal._handle_scrubbed_volumes(
+            signals, confounds, sample_mask, "butterworth", 2.5, True
+        )
     np.testing.assert_equal(signals.shape[0], extrapolated_signals.shape[0])
     np.testing.assert_equal(
         confounds.shape[0], extrapolated_confounds.shape[0]


### PR DESCRIPTION
- Closes #4024

Changes proposed in this pull request:

- include a `extrapolate` parameter in the `signal._interpolate_volumes()` function, exposing the identically named parameter from the Scipy class used underneath for the Splines-based interpolation (see https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.CubicSpline.html#scipy.interpolate.CubicSpline). 
- setting the default `extrapolate` new parameter value to False, disabling the undesired interpolation on out-of-bounds volumes
