### PR TITLE
[MAINT] Ignore private visual testing file when running pytest

### DIFF
--- a/nilearn/conftest.py
+++ b/nilearn/conftest.py
@@ -11,6 +11,7 @@ from nilearn.datasets._testing import request_mocker  # noqa: F401
 from nilearn.datasets._testing import temp_nilearn_data_dir  # noqa: F401
 
 collect_ignore = ["datasets/data/convert_templates.py"]
+collect_ignore_glob = ["reporting/_visual_testing/*"]
 
 
 try:


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes None

Minor maintenance thing. Running pytest automatically imports all files in nilearn modules and the file `reporting/_visual_testing/_glm_reporter_visual_inspection_suite_.py` writes an empty directory when imported. So this it just to prevent its import since it is only for visual testing and not actually used by nilearn