### PR TITLE
[FIX] fix typos in Harvard Oxford atlas labels

### DIFF
--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -716,7 +716,14 @@ def _get_atlas_data_and_labels(
                 f"Duplicate index {new_idx} for labels "
                 f"'{names[new_idx]}', and '{label.text}'"
             )
-        names[new_idx] = label.text
+
+        # fix typos in Harvard Oxford labels
+        if atlas_source == "HarvardOxford":
+            label.text = label.text.replace("Ventrical", "Ventricle")
+            label.text = label.text.replace("Operculum", "Opercular")
+
+        names[new_idx] = label.text.strip()
+
     # The label indices should range from 0 to nlabel + 1
     assert list(names.keys()) == list(range(n + 2))
     names = [item[1] for item in sorted(names.items())]

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -221,24 +221,9 @@ def test_fetch_atlas_fsl(
         is_symm=is_symm or split,
     )
 
-
-@pytest.mark.parametrize("symmetric_split", [True, False])
-@pytest.mark.parametrize(
-    "fname",
-    ["cort-maxprob-thr0-1mm", "sub-maxprob-thr0-1mm"],
-)
-def test_typo_harvard_oxford(
-    fname,
-    symmetric_split,
-    tmp_path,
-):
-    # check that labels have not trailing whitespaces
-    atlas_instance = atlas.fetch_atlas_harvard_oxford(
-        atlas_name=fname,
-        data_dir=tmp_path,
-        symmetric_split=symmetric_split,
-    )
+    # check for typo in label names
     for label in atlas_instance.labels:
+        # no extra whitespace
         assert label.strip() == label
 
 

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -222,6 +222,26 @@ def test_fetch_atlas_fsl(
     )
 
 
+@pytest.mark.parametrize("symmetric_split", [True, False])
+@pytest.mark.parametrize(
+    "fname",
+    ["cort-maxprob-thr0-1mm", "sub-maxprob-thr0-1mm"],
+)
+def test_typo_harvard_oxford(
+    fname,
+    symmetric_split,
+    tmp_path,
+):
+    # check that labels have not trailing whitespaces
+    atlas_instance = atlas.fetch_atlas_harvard_oxford(
+        atlas_name=fname,
+        data_dir=tmp_path,
+        symmetric_split=symmetric_split,
+    )
+    for label in atlas_instance.labels:
+        assert label.strip() == label
+
+
 def test_fetch_atlas_craddock_2012(tmp_path, request_mocker):
     local_archive = (
         Path(__file__).parent / "data" / "craddock_2011_parcellations.tar.gz"


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #2588

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- fixes typos and trailing spaces in atlas labels
