### PR TITLE
[ENH] pad t and F 'short' contrasts with zeros

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -20,6 +20,7 @@ Enhancements
 ------------
 
 - Allow setting ``vmin`` in :func:`~nilearn.plotting.plot_glass_brain` and :func:`~nilearn.plotting.plot_stat_map` (:gh:`3993` by `Michelle Wang`_).
+- Support passing t and F contrasts to :func:`~nilearn.glm.contrasts.compute_contrast` that that have fewer columns than the number of estimated parameters. Remaining columns are padded with zero (:gh:`4067` by `Remi Gau`_).
 
 Changes
 -------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -20,7 +20,7 @@ Enhancements
 ------------
 
 - Allow setting ``vmin`` in :func:`~nilearn.plotting.plot_glass_brain` and :func:`~nilearn.plotting.plot_stat_map` (:gh:`3993` by `Michelle Wang`_).
-- Support passing t and F contrasts to :func:`~nilearn.glm.contrasts.compute_contrast` that that have fewer columns than the number of estimated parameters. Remaining columns are padded with zero (:gh:`4067` by `Remi Gau`_).
+- :bdg-success:`API` Support passing t and F contrasts to :func:`~nilearn.glm.contrasts.compute_contrast` that that have fewer columns than the number of estimated parameters. Remaining columns are padded with zero (:gh:`4067` by `Remi Gau`_).
 
 Changes
 -------

--- a/nilearn/glm/_utils.py
+++ b/nilearn/glm/_utils.py
@@ -356,11 +356,15 @@ def pad_contrast(con_val, theta, contrast_type):
 
     Parameters
     ----------
-    con_val : numpy.ndarray of shape (p) or (q, p)
-        Where q = number of :term:`contrast` vectors
-        and p = number of regressors.
+    con_val : numpy.ndarray of shape (p) or (n, p)
+        Where p = number of regressors
+        with a value explicitly passed by the user.
+        p must be <= P,
+        where P is the total number of regressors in the design matrix.
 
-    theta theta of RegressionResults instances
+    theta : numpy.ndarray with shape (P,m)
+        theta of RegressionResults instances
+        where P is the total number of regressors in the design matrix.
 
     contrast_type : {'t', 'F'}, optional
         Type of the :term:`contrast`.

--- a/nilearn/glm/_utils.py
+++ b/nilearn/glm/_utils.py
@@ -343,3 +343,59 @@ def positive_reciprocal(X):
     """
     X = np.asarray(X)
     return np.where(X <= 0, 0, 1.0 / X)
+
+
+def pad_contrast(con_val, theta, contrast_type):
+    """Pad contrast with zeros if necessary.
+
+    If the contrast is shorter than the number of parameters,
+    it is padded with zeros.
+
+    If the contrast is longer than the number of parameters,
+    a ValueError is raised.
+
+    Parameters
+    ----------
+    con_val : numpy.ndarray of shape (p) or (q, p)
+        Where q = number of :term:`contrast` vectors
+        and p = number of regressors.
+
+    theta theta of RegressionResults instances
+
+    contrast_type : {'t', 'F'}, optional
+        Type of the :term:`contrast`.
+    """
+    nb_cols = con_val.shape[0] if con_val.ndim == 1 else con_val.shape[1]
+    if nb_cols > theta.shape[0]:
+        if contrast_type == "t":
+            raise ValueError(
+                f"t contrasts should be of length P={theta.shape[0]}, "
+                f"but it has length {nb_cols}."
+            )
+        if contrast_type == "F":
+            raise ValueError(
+                f"F contrasts should have {theta.shape[0]} columns, "
+                f"but it has {nb_cols}."
+            )
+
+    pad = False
+    if nb_cols < theta.shape[0]:
+        pad = True
+        if contrast_type == "t":
+            warn(
+                f"t contrasts should be of length P={theta.shape[0]}, "
+                f"but it has length {nb_cols}. "
+                "The rest of the contrast was padded with zeros."
+            )
+        if contrast_type == "F":
+            warn(
+                f"F contrasts should have {theta.shape[0]} colmuns, "
+                f"but it has only {nb_cols}. "
+                "The rest of the contrast was padded with zeros."
+            )
+
+    if pad:
+        padding = np.zeros((nb_cols, theta.shape[0] - nb_cols))
+        con_val = np.hstack((con_val, padding))
+
+    return con_val

--- a/nilearn/glm/contrasts.py
+++ b/nilearn/glm/contrasts.py
@@ -107,7 +107,7 @@ def compute_contrast(labels, regression_result, con_val, contrast_type=None):
         # TODO
         # explain why we cannot simply do
         # reg = regression_result[label_].Tcontrast(con_val)
-        #  like above or refactor the code so it can be done
+        # like above or refactor the code so it can be done
         for label_ in regression_result:
             label_mask = labels == label_
             reg = regression_result[label_]

--- a/nilearn/glm/contrasts.py
+++ b/nilearn/glm/contrasts.py
@@ -104,6 +104,10 @@ def compute_contrast(labels, regression_result, con_val, contrast_type=None):
 
         effect_ = np.zeros((dim, labels.size))
         var_ = np.zeros(labels.size)
+        # TODO
+        # explain why we cannot simply do
+        # reg = regression_result[label_].Tcontrast(con_val)
+        #  like above or refactor the code so it can be done
         for label_ in regression_result:
             label_mask = labels == label_
             reg = regression_result[label_]

--- a/nilearn/glm/model.py
+++ b/nilearn/glm/model.py
@@ -2,14 +2,12 @@
 
 Author: Bertrand Thirion, 2011--2015
 """
-from warnings import warn
-
 import numpy as np
 from nibabel.onetime import auto_attr
 from scipy.linalg import inv
 from scipy.stats import t as t_distribution
 
-from nilearn.glm._utils import positive_reciprocal
+from nilearn.glm._utils import pad_contrast, positive_reciprocal
 
 # Inverse t cumulative distribution
 inv_t_cdf = t_distribution.ppf
@@ -198,20 +196,9 @@ class LikelihoodModelResults:
             matrix = matrix[None]
         if matrix.shape[0] != 1:
             raise ValueError("t contrasts should have only one row")
-        if matrix.shape[1] > self.theta.shape[0]:
-            raise ValueError(
-                f"t contrasts should be of length P={self.theta.shape[0]}, "
-                f"but it has length {matrix.shape[1]}."
-            )
-        elif matrix.shape[1] < self.theta.shape[0]:
-            warn(
-                f"t contrasts should be of length P={self.theta.shape[0]}, "
-                f"but it has length {matrix.shape[1]}. "
-                "The rest of the contrast was padded with zeros."
-            )
-            padding = np.zeros((1, self.theta.shape[0] - matrix.shape[1]))
-            matrix = np.hstack((matrix, padding))
-
+        matrix = pad_contrast(
+            con_val=matrix, theta=self.theta, contrast_type="t"
+        )
         store = set(store)
         if not store.issubset(("t", "effect", "sd")):
             raise ValueError(f"Unexpected store request in {store}")
@@ -279,6 +266,9 @@ class LikelihoodModelResults:
                 f"F contrasts should have shape[1] P={self.theta.shape[0]}, "
                 f"but this has shape[1] {matrix.shape[1]}"
             )
+        matrix = pad_contrast(
+            con_val=matrix, theta=self.theta, contrast_type="F"
+        )
         ctheta = np.dot(matrix, self.theta)
         if matrix.ndim == 1:
             matrix = matrix.reshape((1, matrix.shape[0]))

--- a/nilearn/glm/model.py
+++ b/nilearn/glm/model.py
@@ -2,6 +2,8 @@
 
 Author: Bertrand Thirion, 2011--2015
 """
+from warnings import warn
+
 import numpy as np
 from nibabel.onetime import auto_attr
 from scipy.linalg import inv
@@ -196,11 +198,20 @@ class LikelihoodModelResults:
             matrix = matrix[None]
         if matrix.shape[0] != 1:
             raise ValueError("t contrasts should have only one row")
-        if matrix.shape[1] != self.theta.shape[0]:
+        if matrix.shape[1] > self.theta.shape[0]:
             raise ValueError(
-                f"t contrasts should be length P={self.theta.shape[0]}, "
-                f"but this is length {matrix.shape[1]}"
+                f"t contrasts should be of length P={self.theta.shape[0]}, "
+                f"but it has length {matrix.shape[1]}."
             )
+        elif matrix.shape[1] < self.theta.shape[0]:
+            warn(
+                f"t contrasts should be of length P={self.theta.shape[0]}, "
+                f"but it has length {matrix.shape[1]}. "
+                "The rest of the contrast was padded with zeros."
+            )
+            padding = np.zeros((1, self.theta.shape[0] - matrix.shape[1]))
+            matrix = np.hstack((matrix, padding))
+
         store = set(store)
         if not store.issubset(("t", "effect", "sd")):
             raise ValueError(f"Unexpected store request in {store}")

--- a/nilearn/glm/tests/test_contrasts.py
+++ b/nilearn/glm/tests/test_contrasts.py
@@ -229,3 +229,19 @@ def test_invalid_contarst_type():
     variance = np.ones(1)
     with pytest.raises(ValueError, match="is not a valid contrast_type."):
         Contrast(effect, variance, contrast_type="foo")
+
+
+def test_contrast_padding(rng):
+    n, p, q = 100, 80, 10
+    X, Y = rng.standard_normal(size=(p, q)), rng.standard_normal(size=(p, n))
+    labels, results = run_glm(Y, X, "ar1")
+
+    con_val = [1]
+
+    with pytest.warns(
+        UserWarning, match="The rest of the contrast was padded with zeros."
+    ):
+        compute_contrast(labels, results, con_val).z_score()
+
+    con_val = np.eye(q)[:3, :3]
+    compute_contrast(labels, results, con_val, contrast_type="F").z_score()

--- a/nilearn/glm/tests/test_model.py
+++ b/nilearn/glm/tests/test_model.py
@@ -67,8 +67,6 @@ def test_t_contrast():
     assert_array_almost_equal(RESULTS.Tcontrast([0, 1]).t, 7.181, 3)
     # Input matrix checked for size
     with pytest.raises(ValueError):
-        RESULTS.Tcontrast([1])
-    with pytest.raises(ValueError):
         RESULTS.Tcontrast([1, 0, 0])
     # And shape
     with pytest.raises(ValueError):

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -1080,7 +1080,7 @@ def test_second_level_contrast_computation_errors(tmp_path, rng):
         model.compute_contrast(None)
 
 
-def test_second_level_contrast_length_errors(tmp_path):
+def test_second_level_t_contrast_length_errors(tmp_path):
     func_img, mask = fake_fmri_data(file_path=tmp_path)
 
     model = SecondLevelModel(mask_img=mask)
@@ -1095,6 +1095,23 @@ def test_second_level_contrast_length_errors(tmp_path):
         match=("t contrasts should be of length P=1, but it has length 2."),
     ):
         model.compute_contrast(second_level_contrast=[1, 2])
+
+
+def test_second_level_F_contrast_length_errors(tmp_path):
+    func_img, mask = fake_fmri_data(file_path=tmp_path)
+
+    model = SecondLevelModel(mask_img=mask)
+
+    func_img, mask = fake_fmri_data(file_path=tmp_path)
+    Y = [func_img] * 4
+    X = pd.DataFrame([[1]] * 4, columns=["intercept"])
+    model = model.fit(Y, design_matrix=X)
+
+    with pytest.raises(
+        ValueError,
+        match=("F contrasts should have .* columns, but it has .*"),
+    ):
+        model.compute_contrast(second_level_contrast=np.eye(2))
 
 
 def test_non_parametric_inference_contrast_computation(tmp_path):

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -1080,7 +1080,7 @@ def test_second_level_contrast_computation_errors(tmp_path, rng):
         model.compute_contrast(None)
 
 
-def test_second_level_contrast_length_errors_and_warnings(tmp_path):
+def test_second_level_contrast_length_errors(tmp_path):
     func_img, mask = fake_fmri_data(file_path=tmp_path)
 
     model = SecondLevelModel(mask_img=mask)
@@ -1089,15 +1089,6 @@ def test_second_level_contrast_length_errors_and_warnings(tmp_path):
     Y = [func_img] * 4
     X = pd.DataFrame([[1]] * 4, columns=["intercept"])
     model = model.fit(Y, design_matrix=X)
-
-    with pytest.warns(
-        UserWarning,
-        match=(
-            "t contrasts should be of length P=1, but it has length 0. "
-            "The rest of the contrast was padded with zeros."
-        ),
-    ):
-        model.compute_contrast(second_level_contrast=[])
 
     with pytest.raises(
         ValueError,

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -1059,11 +1059,6 @@ def test_second_level_contrast_computation_errors(tmp_path, rng):
         model.compute_contrast(cnull)
 
     # passing wrong parameters
-    with pytest.raises(
-        ValueError,
-        match=("t contrasts should be length P=1, but this is length 0"),
-    ):
-        model.compute_contrast(second_level_contrast=[])
     with pytest.raises(ValueError, match="Allowed types are .*'t', 'F'"):
         model.compute_contrast(
             second_level_contrast=c1, second_level_stat_type=""
@@ -1083,11 +1078,32 @@ def test_second_level_contrast_computation_errors(tmp_path, rng):
         ValueError, match="No second-level contrast is specified"
     ):
         model.compute_contrast(None)
+
+
+def test_second_level_contrast_length_errors_and_warnings(tmp_path):
+    func_img, mask = fake_fmri_data(file_path=tmp_path)
+
+    model = SecondLevelModel(mask_img=mask)
+
+    func_img, mask = fake_fmri_data(file_path=tmp_path)
+    Y = [func_img] * 4
+    X = pd.DataFrame([[1]] * 4, columns=["intercept"])
+    model = model.fit(Y, design_matrix=X)
+
+    with pytest.warns(
+        UserWarning,
+        match=(
+            "t contrasts should be of length P=1, but it has length 0. "
+            "The rest of the contrast was padded with zeros."
+        ),
+    ):
+        model.compute_contrast(second_level_contrast=[])
+
     with pytest.raises(
         ValueError,
-        match=("t contrasts should be length P=2, but this is length 1"),
+        match=("t contrasts should be of length P=1, but it has length 2."),
     ):
-        model.compute_contrast([1])
+        model.compute_contrast(second_level_contrast=[1, 2])
 
 
 def test_non_parametric_inference_contrast_computation(tmp_path):


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #2396

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- pad t and F constrast when they are too short
- throw a warning when padding is done
- throw error only when contrast are longer than the number of columns
