### PR TITLE
[STY] Minor doc formatting

### DIFF
--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -156,9 +156,9 @@ docdict[
             :class:`{logistic} <sklearn.linear_model.LogisticRegressionCV>` \
             with L2 penalty.
 
-            .. code-block:: python
+        .. code-block:: python
 
-                logistic = LogisticRegression(penalty="l2", solver="liblinear")
+            logistic = LogisticRegression(penalty="l2", solver="liblinear")
 
         - `logistic_l1`: \
             :class:`{logistic} <sklearn.linear_model.LogisticRegressionCV>` \

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -136,22 +136,26 @@ docdict[
 ] = f"""
 
         - `svc`: :class:`{svc} <sklearn.svm.LinearSVC>` with L2 penalty.
-            .. code-block:: python
 
-                svc = LinearSVC(penalty="l2", max_iter=1e4)
+        .. code-block:: python
+
+            svc = LinearSVC(penalty="l2", max_iter=1e4)
 
         - `svc_l2`: :class:`{svc} <sklearn.svm.LinearSVC>` with L2 penalty.
-            .. note::
-                Same as option `svc`.
+
+        .. note::
+            Same as option `svc`.
 
         - `svc_l1`: :class:`{svc} <sklearn.svm.LinearSVC>` with L1 penalty.
-            .. code-block:: python
 
-                svc_l1 = LinearSVC(penalty="l1", dual=False, max_iter=1e4)
+        .. code-block:: python
+
+            svc_l1 = LinearSVC(penalty="l1", dual=False, max_iter=1e4)
 
         - `logistic`: \
             :class:`{logistic} <sklearn.linear_model.LogisticRegressionCV>` \
             with L2 penalty.
+
             .. code-block:: python
 
                 logistic = LogisticRegression(penalty="l2", solver="liblinear")
@@ -159,26 +163,30 @@ docdict[
         - `logistic_l1`: \
             :class:`{logistic} <sklearn.linear_model.LogisticRegressionCV>` \
             with L1 penalty.
-            .. code-block:: python
 
-                logistic_l1 = LogisticRegression(penalty="l1", solver="liblinear")  # noqa
+        .. code-block:: python
+
+            logistic_l1 = LogisticRegression(penalty="l1", solver="liblinear")
 
         - `logistic_l2`: \
             :class:`{logistic} <sklearn.linear_model.LogisticRegressionCV>` \
             with L2 penalty
-            .. note::
-                Same as option `logistic`.
+
+        .. note::
+            Same as option `logistic`.
 
         - `ridge_classifier`: \
             :class:`{rc} <sklearn.linear_model.RidgeClassifierCV>`.
-            .. code-block:: python
 
-                ridge_classifier = RidgeClassifierCV()
+        .. code-block:: python
+
+            ridge_classifier = RidgeClassifierCV()
 
         - `dummy_classifier`: :class:`{dc} <sklearn.dummy.DummyClassifier>`.
-            .. code-block:: python
 
-                dummy = DummyClassifier(strategy="stratified", random_state=0)
+        .. code-block:: python
+
+            dummy = DummyClassifier(strategy="stratified", random_state=0)
 
 """
 
@@ -525,9 +533,9 @@ mask_strategy : {"background", "epi", "whole-brain-template",\
           part of your data by resampling the MNI152 brain mask for
           your data's field of view.
 
-            .. note::
-                This option is equivalent to the previous 'template' option
-                which is now deprecated.
+        .. note::
+            This option is equivalent to the previous 'template' option
+            which is now deprecated.
 
         - `"gm-template"`: This will extract the gray matter part of your
           data by resampling the corresponding MNI152 template for your
@@ -705,36 +713,42 @@ docdict[
 
         - `ridge`: \
             :class:`{Ridge regression} <sklearn.linear_model.RidgeCV>`.
-            .. code-block:: python
 
-                ridge = RidgeCV()
+        .. code-block:: python
+
+            ridge = RidgeCV()
 
         - `ridge_regressor`: \
             :class:`{Ridge regression} <sklearn.linear_model.RidgeCV>`.
-            .. note::
-                Same option as `ridge`.
+
+        .. note::
+            Same option as `ridge`.
 
         - `svr`: :class:`{Support vector regression} <sklearn.svm.SVR>`.
-            .. code-block:: python
 
-                svr = SVR(kernel="linear", max_iter=1e4)
+        .. code-block:: python
+
+            svr = SVR(kernel="linear", max_iter=1e4)
 
         - `lasso`: \
             :class:`{Lasso regression} <sklearn.linear_model.LassoCV>`.
-            .. code-block:: python
 
-                lasso = LassoCV()
+        .. code-block:: python
+
+            lasso = LassoCV()
 
         - `lasso_regressor`: \
             :class:`{Lasso regression} <sklearn.linear_model.LassoCV>`.
-            .. note::
-                Same option as `lasso`.
+
+        .. note::
+            Same option as `lasso`.
 
         - `dummy_regressor`: \
             :class:`{Dummy regressor} <sklearn.dummy.DummyRegressor>`.
-            .. code-block:: python
 
-                dummy = DummyRegressor(strategy="mean")
+        .. code-block:: python
+
+            dummy = DummyRegressor(strategy="mean")
 
 """
 

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -408,17 +408,17 @@ class ConnectivityMeasure(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    `cov_estimator_` : estimator object
+    cov_estimator_ : estimator object
         A new covariance estimator with the same parameters as cov_estimator.
 
-    `mean_` : numpy.ndarray
+    mean_ : numpy.ndarray
         The mean connectivity matrix across subjects. For 'tangent' kind,
         it is the geometric mean of covariances (a group covariance
         matrix that captures information from both correlation and partial
         correlation matrices). For other values for "kind", it is the
         mean of the corresponding matrices
 
-    `whitening_` : numpy.ndarray
+    whitening_ : numpy.ndarray
         The inverted square-rooted geometric mean of the covariance matrices.
 
     References

--- a/nilearn/connectome/group_sparse_cov.py
+++ b/nilearn/connectome/group_sparse_cov.py
@@ -533,10 +533,10 @@ class GroupSparseCovariance(BaseEstimator, CacheMixin):
 
     Attributes
     ----------
-    `covariances_` : numpy.ndarray, shape (n_features, n_features, n_subjects)
+    covariances_ : numpy.ndarray, shape (n_features, n_features, n_subjects)
         empirical covariance matrices.
 
-    `precisions_` : numpy.ndarraye, shape (n_features, n_features, n_subjects)
+    precisions_ : numpy.ndarraye, shape (n_features, n_features, n_subjects)
         precisions matrices estimated using the group-sparse algorithm.
 
     References
@@ -969,21 +969,21 @@ class GroupSparseCovarianceCV(BaseEstimator, CacheMixin):
 
     Attributes
     ----------
-    `covariances_` : numpy.ndarray, shape (n_features, n_features, n_subjects)
+    covariances_ : numpy.ndarray, shape (n_features, n_features, n_subjects)
         covariance matrices, one per subject.
 
-    `precisions_` : numpy.ndarray, shape (n_features, n_features, n_subjects)
+    precisions_ : numpy.ndarray, shape (n_features, n_features, n_subjects)
         precision matrices, one per subject. All matrices have the same
         sparsity pattern (if a coefficient is zero for a given matrix, it
         is also zero for every other.)
 
-    `alpha_` : float
+    alpha_ : float
         penalization parameter value selected.
 
-    `cv_alphas_` : list of floats
+    cv_alphas_ : list of floats
         all values of the penalization parameter explored.
 
-    `cv_scores_` : numpy.ndarray, shape (n_alphas, n_folds)
+    cv_scores_ : numpy.ndarray, shape (n_alphas, n_folds)
         scores obtained on test set for each value of the penalization
         parameter explored.
 

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -626,51 +626,51 @@ class _BaseDecoder(LinearRegression, CacheMixin):
 
         Attributes
         ----------
-        `masker_` : instance of NiftiMasker or MultiNiftiMasker
+        masker_ : instance of NiftiMasker or MultiNiftiMasker
             The NiftiMasker used to mask the data.
 
-        `mask_img_` : Nifti1Image
+        mask_img_ : Nifti1Image
             Mask computed by the masker object.
 
-        `classes_` : numpy.ndarray
+        classes_ : numpy.ndarray
             Classes to predict. For classification only.
 
-        `screening_percentile_` : float
+        screening_percentile_ : float
             Screening percentile corrected according to volume of mask,
             relative to the volume of standard brain.
 
-        `coef_` : numpy.ndarray, shape=(n_classes, n_features)
+        coef_ : numpy.ndarray, shape=(n_classes, n_features)
             Contains the mean of the models weight vector across
             fold for each class. Returns None for Dummy estimators.
 
-        `coef_img_` : dict of Nifti1Image
+        coef_img_ : dict of Nifti1Image
             Dictionary containing `coef_` with class names as keys,
             and `coef_` transformed in Nifti1Images as values. In the case of
             a regression, it contains a single Nifti1Image at the key 'beta'.
             Ignored if Dummy estimators are provided.
 
-        `intercept_` : ndarray, shape (nclasses,)
+        intercept_ : ndarray, shape (nclasses,)
             Intercept (a.k.a. bias) added to the decision function.
             Ignored if Dummy estimators are provided.
 
-        `cv_` : list of pairs of lists
+        cv_ : list of pairs of lists
             List of the (n_folds,) folds. For the corresponding fold,
             each pair is composed of two lists of indices,
             one for the train samples and one for the test samples.
 
-        `std_coef_` : numpy.ndarray, shape=(n_classes, n_features)
+        std_coef_ : numpy.ndarray, shape=(n_classes, n_features)
             Contains the standard deviation of the models weight vector across
             fold for each class. Note that folds are not independent, see
             https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators-for-grouped-data
             Ignored if Dummy estimators are provided.
 
-        `std_coef_img_` : dict of Nifti1Image
+        std_coef_img_ : dict of Nifti1Image
             Dictionary containing `std_coef_` with class names as keys,
             and `coef_` transformed in Nifti1Image as values. In the case of
             a regression, it contains a single Nifti1Image at the key 'beta'.
             Ignored if Dummy estimators are provided.
 
-        `cv_params_` : dict of lists
+        cv_params_ : dict of lists
             Best point in the parameter grid for each tested fold
             in the inner cross validation loop. The grid is empty
             when Dummy estimators are provided. Note: if the estimator used its
@@ -680,17 +680,17 @@ class _BaseDecoder(LinearRegression, CacheMixin):
             RidgeCV/RidgeClassifierCV/LassoCV), in addition to the input list
             of values.
 
-        'scorer_' : function
+        scorer_ : function
             Scorer function used on the held out data to choose the best
             parameters for the model.
 
-        `cv_scores_` : dict, (classes, n_folds)
+        cv_scores_ : dict, (classes, n_folds)
             Scores (misclassification) for each parameter, and on each fold
 
-        `n_outputs_` : int
+        n_outputs_ : int
             Number of outputs (column-wise)
 
-        `dummy_output_`: ndarray, shape=(n_classes, 2)
+        dummy_output_: ndarray, shape=(n_classes, 2)
             or shape=(1, 1) for regression
             Contains dummy estimator attributes after class predictions
             using strategies of DummyClassifier (class_prior)

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -631,7 +631,7 @@ class BaseSpaceNet(LinearRegression, CacheMixin):
 
     Attributes
     ----------
-    `all_coef_` : ndarray, shape (n_l1_ratios, n_folds, n_features)
+    all_coef_ : ndarray, shape (n_l1_ratios, n_folds, n_features)
         Coefficients for all folds and features.
 
     `alpha_grids_` : ndarray, shape (n_folds, n_alphas)
@@ -660,10 +660,10 @@ class BaseSpaceNet(LinearRegression, CacheMixin):
     `mask_` : ndarray 3D
         An array contains values of the mask image.
 
-    `masker_` : instance of NiftiMasker
+    masker_ : instance of NiftiMasker
         The nifti masker used to mask the data.
 
-    `mask_img_` : Nifti like image
+    mask_img_ : Nifti like image
         The mask of the data. If no mask was supplied by the user,
         this attribute is the mask image computed automatically from the
         data `X`.
@@ -1167,75 +1167,75 @@ class SpaceNetClassifier(BaseSpaceNet):
 
     Attributes
     ----------
-    `all_coef_` : ndarray, shape (n_l1_ratios, n_folds, n_features)
+    all_coef_ : ndarray, shape (n_l1_ratios, n_folds, n_features)
         Coefficients for all folds and features.
 
-    `alpha_grids_` : ndarray, shape (n_folds, n_alphas)
+    alpha_grids_ : ndarray, shape (n_folds, n_alphas)
         Alpha values considered for selection of the best ones
         (saved in `best_model_params_`)
 
-    `best_model_params_` : ndarray, shape (n_folds, n_parameter)
+    best_model_params_ : ndarray, shape (n_folds, n_parameter)
         Best model parameters (alpha, l1_ratio) saved for the different
         cross-validation folds.
 
-    `classes_` : ndarray of labels (`n_classes_`)
+    classes_ : ndarray of labels (`n_classes_`)
         Labels of the classes
 
-    `n_classes_` : int
+    n_classes_ : int
         Number of classes
 
-    `coef_` : ndarray, shape
+    coef_ : ndarray, shape
         (1, n_features) for 2 class classification problems (i.e n_classes = 2)
         (n_classes, n_features) for n_classes > 2
         Coefficient of the features in the decision function.
 
-    `coef_img_` : nifti image
+    coef_img_ : nifti image
         Masked model coefficients
 
-    `mask_` : ndarray 3D
+    mask_ : ndarray 3D
         An array contains values of the mask image.
 
-    `masker_` : instance of NiftiMasker
+    masker_ : instance of NiftiMasker
         The nifti masker used to mask the data.
 
-    `mask_img_` : Nifti like image
+    mask_img_ : Nifti like image
         The mask of the data. If no mask was supplied by the user,
         this attribute is the mask image computed automatically from the
         data `X`.
 
-    `memory_` : joblib memory cache
+    memory_ : joblib memory cache
 
-    `intercept_` : narray, shape
+    intercept_ : narray, shape
         (1, ) for 2 class classification problems (i.e n_classes = 2)
         (n_classes, ) for n_classes > 2
         Intercept (a.k.a. bias) added to the decision function.
         It is available only when parameter intercept is set to True.
 
-    `cv_` : list of pairs of lists
+    cv_ : list of pairs of lists
         Each pair is the list of indices for the train and test
         samples for the corresponding fold.
 
-    `cv_scores_` : ndarray, shape (n_folds, n_alphas)\
+    cv_scores_ : ndarray, shape (n_folds, n_alphas)\
         or (n_l1_ratios, n_folds, n_alphas)
         Scores (misclassification) for each alpha, and on each fold
 
-    `screening_percentile_` : float
+    screening_percentile_ : float
         Screening percentile corrected according to volume of mask,
         relative to the volume of standard brain.
 
-    `w_` : ndarray, shape
+    w_ : ndarray, shape
         (1, n_features + 1) for 2 class classification problems
         (i.e n_classes = 2)
         (n_classes, n_features + 1) for n_classes > 2
         Model weights
 
-    `ymean_` : array, shape (n_samples,)
+    ymean_ : array, shape (n_samples,)
         Mean of prediction targets
 
-    `Xmean_` : array, shape (n_features,)
+    Xmean_ : array, shape (n_features,)
         Mean of X across samples
 
-    `Xstd_` : array, shape (n_features,)
+    Xstd_ : array, shape (n_features,)
         Standard deviation of X across samples
 
     See Also
@@ -1414,61 +1414,61 @@ class SpaceNetRegressor(BaseSpaceNet):
 
     Attributes
     ----------
-    `all_coef_` : ndarray, shape (n_l1_ratios, n_folds, n_features)
+    all_coef_ : ndarray, shape (n_l1_ratios, n_folds, n_features)
         Coefficients for all folds and features.
 
-    `alpha_grids_` : ndarray, shape (n_folds, n_alphas)
+    alpha_grids_ : ndarray, shape (n_folds, n_alphas)
         Alpha values considered for selection of the best ones
         (saved in `best_model_params_`)
 
-    `best_model_params_` : ndarray, shape (n_folds, n_parameter)
+    best_model_params_ : ndarray, shape (n_folds, n_parameter)
         Best model parameters (alpha, l1_ratio) saved for the different
         cross-validation folds.
 
-    `coef_` : ndarray, shape (n_features,)
+    coef_ : ndarray, shape (n_features,)
         Coefficient of the features in the decision function.
 
-    `coef_img_` : nifti image
+    coef_img_ : nifti image
         Masked model coefficients
 
-    `mask_` : ndarray 3D
+    mask_ : ndarray 3D
         An array contains values of the mask image.
 
-    `masker_` : instance of NiftiMasker
+    masker_ : instance of NiftiMasker
         The nifti masker used to mask the data.
 
-    `mask_img_` : Nifti like image
+    mask_img_ : Nifti like image
         The mask of the data. If no mask was supplied by the user, this
         attribute is the mask image computed automatically from the data `X`.
 
-    `memory_` : joblib memory cache
+    memory_ : joblib memory cache
 
-    `intercept_` : narray, shape (1)
+    intercept_ : narray, shape (1)
         Intercept (a.k.a. bias) added to the decision function.
         It is available only when parameter intercept is set to True.
 
-    `cv_` : list of pairs of lists
+    cv_ : list of pairs of lists
         Each pair is the list of indices for the train and test
         samples for the corresponding fold.
 
-    `cv_scores_` : ndarray, shape (n_folds, n_alphas)\
+    cv_scores_ : ndarray, shape (n_folds, n_alphas)\
         or (n_l1_ratios, n_folds, n_alphas)
         Scores (misclassification) for each alpha, and on each fold
 
-    `screening_percentile_` : float
+    screening_percentile_ : float
         Screening percentile corrected according to volume of mask,
         relative to the volume of standard brain.
 
-    `w_` : ndarray, shape (n_features,)
+    w_ : ndarray, shape (n_features,)
         Model weights
 
-    `ymean_` : array, shape (n_samples,)
+    ymean_ : array, shape (n_samples,)
         Mean of prediction targets
 
-    `Xmean_` : array, shape (n_features,)
+    Xmean_ : array, shape (n_features,)
         Mean of X across samples
 
-    `Xstd_` : array, shape (n_features,)
+    Xstd_ : array, shape (n_features,)
         Standard deviation of X across samples
 
     See Also

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -634,30 +634,30 @@ class BaseSpaceNet(LinearRegression, CacheMixin):
     all_coef_ : ndarray, shape (n_l1_ratios, n_folds, n_features)
         Coefficients for all folds and features.
 
-    `alpha_grids_` : ndarray, shape (n_folds, n_alphas)
+    alpha_grids_ : ndarray, shape (n_folds, n_alphas)
         Alpha values considered for selection of the best ones
         (saved in `best_model_params_`)
 
-    `best_model_params_` : ndarray, shape (n_folds, n_parameter)
+    best_model_params_ : ndarray, shape (n_folds, n_parameter)
         Best model parameters (alpha, l1_ratio) saved for the different
         cross-validation folds.
 
-    `classes_` : ndarray of labels (`n_classes_`)
+    classes_ : ndarray of labels (`n_classes_`)
         Labels of the classes (for classification problems)
 
-    `n_classes_` : int
+    n_classes_ : int
         Number of classes (for classification problems)
 
-    `coef_` : ndarray, shape\
+    coef_ : ndarray, shape\
         (1, n_features) for 2 class classification problems\
         (i.e n_classes = 2)\
         (n_classes, n_features) for n_classes > 2
         Coefficient of the features in the decision function.
 
-    `coef_img_` : nifti image
+    coef_img_ : nifti image
         Masked model coefficients
 
-    `mask_` : ndarray 3D
+    mask_ : ndarray 3D
         An array contains values of the mask image.
 
     masker_ : instance of NiftiMasker
@@ -668,40 +668,40 @@ class BaseSpaceNet(LinearRegression, CacheMixin):
         this attribute is the mask image computed automatically from the
         data `X`.
 
-    `memory_` : joblib memory cache
+    memory_ : joblib memory cache
 
-    `intercept_` : narray, shape
+    intercept_ : narray, shape
         (1,) for 2 class classification problems (i.e n_classes = 2)
         (n_classes,) for n_classes > 2
         Intercept (a.k.a. bias) added to the decision function.
         It is available only when parameter intercept is set to True.
 
-    `cv_` : list of pairs of lists
+    cv_ : list of pairs of lists
         Each pair is the list of indices for the train and test samples
         for the corresponding fold.
 
-    `cv_scores_` : ndarray, shape (n_folds, n_alphas)\
+    cv_scores_ : ndarray, shape (n_folds, n_alphas)\
         or (n_l1_ratios, n_folds, n_alphas)
         Scores (misclassification) for each alpha, and on each fold
 
-    `screening_percentile_` : float
+    screening_percentile_ : float
         Screening percentile corrected according to volume of mask,
         relative to the volume of standard brain.
 
-    `w_` : ndarray, shape
+    w_ : ndarray, shape
         (1, n_features + 1) for 2 class classification problems
         (i.e n_classes = 2)
         (n_classes, n_features + 1) for n_classes > 2, and (n_features,)
         for regression
         Model weights
 
-    `ymean_` : array, shape (n_samples,)
+    ymean_ : array, shape (n_samples,)
         Mean of prediction targets
 
-    `Xmean_` : array, shape (n_features,)
+    Xmean_ : array, shape (n_features,)
         Mean of X across samples
 
-    `Xstd_` : array, shape (n_features,)
+    Xstd_ : array, shape (n_features,)
         Standard deviation of X across samples
     """
 

--- a/nilearn/decomposition/_base.py
+++ b/nilearn/decomposition/_base.py
@@ -325,7 +325,7 @@ class _BaseDecomposition(BaseEstimator, CacheMixin, TransformerMixin):
 
     Attributes
     ----------
-    `mask_img_` : Niimg-like object
+    mask_img_ : Niimg-like object
         See :ref:`extracting_data`.
         The mask of the data. If no mask was given at masker creation, contains
         the automatically computed mask.

--- a/nilearn/decomposition/_multi_pca.py
+++ b/nilearn/decomposition/_multi_pca.py
@@ -103,32 +103,32 @@ class _MultiPCA(_BaseDecomposition):
 
     Attributes
     ----------
-    `masker_` : instance of MultiNiftiMasker
+    masker_ : instance of MultiNiftiMasker
         Masker used to filter and mask data as first step. If an instance of
-        MultiNiftiMasker is given in `mask` parameter,
+        MultiNiftiMasker is given in ``mask`` parameter,
         this is a copy of it. Otherwise, a masker is created using the value
-        of `mask` and other NiftiMasker related parameters as initialization.
+        of ``mask`` and other NiftiMasker related parameters as initialization.
 
-    `mask_img_` : Niimg-like object
+    mask_img_ : Niimg-like object
         See :ref:`extracting_data`.
         The mask of the data. If no mask was given at masker creation, contains
         the automatically computed mask.
 
-    `components_` : 2D numpy array (n_components x n-voxels)
+    components_ : 2D numpy array (n_components x n-voxels)
         Array of masked extracted components.
 
         .. note::
 
-            Use attribute `components_img_` rather than manually unmasking
-            `components_` with `masker_` attribute.
+            Use attribute ``components_img_`` rather than manually unmasking
+            ``components_`` with ``masker_`` attribute.
 
-    `components_img_` : 4D Nifti image
+    components_img_ : 4D Nifti image
         4D image giving the extracted PCA components. Each 3D image is a
         component.
 
         .. versionadded:: 0.4.1
 
-    `variance_` : numpy array (n_components,)
+    variance_ : numpy array (n_components,)
         The amount of variance explained by each of the selected components.
 
     """

--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -120,27 +120,27 @@ class CanICA(_MultiPCA):
 
     Attributes
     ----------
-    `components_` : 2D numpy array (n_components x n-voxels)
+    components_ : 2D numpy array (n_components x n-voxels)
         Masked ICA components extracted from the input images.
 
         .. note::
 
-            Use attribute `components_img_` rather than manually unmasking
-            `components_` with `masker_` attribute.
+            Use attribute ``components_img_`` rather than manually unmasking
+            ``components_`` with ``masker_`` attribute.
 
-    `components_img_` : 4D Nifti image
+    components_img_ : 4D Nifti image
         4D image giving the extracted ICA components. Each 3D image is a
         component.
 
         .. versionadded:: 0.4.1
 
-    `masker_` : instance of MultiNiftiMasker
+    masker_ : instance of MultiNiftiMasker
         Masker used to filter and mask data as first step. If an instance of
-        MultiNiftiMasker is given in `mask` parameter,
+        MultiNiftiMasker is given in ``mask`` parameter,
         this is a copy of it. Otherwise, a masker is created using the value
-        of `mask` and other NiftiMasker related parameters as initialization.
+        of ``mask`` and other NiftiMasker related parameters as initialization.
 
-    `mask_img_` : Niimg-like object
+    mask_img_ : Niimg-like object
         See :ref:`extracting_data`.
         The mask of the data. If no mask was given at masker creation, contains
         the automatically computed mask.

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -150,7 +150,7 @@ class DictLearning(_BaseDecomposition):
 
     Attributes
     ----------
-    `components_` : 2D numpy array (n_components x n-voxels)
+    components_ : 2D numpy array (n_components x n-voxels)
         Masked dictionary components extracted from the input images.
 
         .. note::
@@ -158,18 +158,18 @@ class DictLearning(_BaseDecomposition):
             Use attribute `components_img_` rather than manually unmasking
             `components_` with `masker_` attribute.
 
-    `components_img_` : 4D Nifti image
+    components_img_ : 4D Nifti image
         4D image giving the extracted components. Each 3D image is a component.
 
         .. versionadded:: 0.4.1
 
-    `masker_` : instance of MultiNiftiMasker
+    masker_ : instance of MultiNiftiMasker
         Masker used to filter and mask data as first step. If an instance of
         MultiNiftiMasker is given in `mask` parameter,
         this is a copy of it. Otherwise, a masker is created using the value
         of `mask` and other NiftiMasker related parameters as initialization.
 
-    `mask_img_` : Niimg-like object
+    mask_img_ : Niimg-like object
         See :ref:`extracting_data`.
         The mask of the data. If no mask was given at masker creation, contains
         the automatically computed mask.

--- a/nilearn/plotting/displays/_projectors.py
+++ b/nilearn/plotting/displays/_projectors.py
@@ -35,10 +35,10 @@ class OrthoProjector(OrthoSlicer):
     Attributes
     ----------
     axes : :obj:`dict` of :class:`~nilearn.plotting.displays.GlassBrainAxes`
-     The 3 axes used to plot each view ('x', 'y', and 'z').
+        The 3 axes used to plot each view ('x', 'y', and 'z').
 
     frame_axes : :class:`~matplotlib.axes.Axes`
-     The axes framing the whole set of views.
+        The axes framing the whole set of views.
 
     """
 
@@ -286,10 +286,10 @@ class XProjector(OrthoProjector):
     Attributes
     ----------
     axes : :obj:`dict` of :class:`~nilearn.plotting.displays.GlassBrainAxes`
-        The axes used for plotting.
+           The axes used for plotting.
 
     frame_axes : :class:`~matplotlib.axes.Axes`
-     The axes framing the whole set of views.
+                 The axes framing the whole set of views.
 
     See Also
     --------
@@ -354,10 +354,10 @@ class ZProjector(OrthoProjector):
     Attributes
     ----------
     axes : :obj:`dict` of :class:`~nilearn.plotting.displays.GlassBrainAxes`
-     The axes used for plotting.
+        The axes used for plotting.
 
     frame_axes : :class:`~matplotlib.axes.Axes`
-     The axes framing the whole set of views.
+        The axes framing the whole set of views.
 
     See Also
     --------
@@ -391,10 +391,10 @@ class XZProjector(OrthoProjector):
     Attributes
     ----------
     axes : :obj:`dict` of :class:`~nilearn.plotting.displays.GlassBrainAxes`
-            The axes used for plotting in each direction ('x' and 'z' here).
+        The axes used for plotting in each direction ('x' and 'z' here).
 
     frame_axes : :class:`~matplotlib.axes.Axes`
-                 The axes framing the whole set of views.
+        The axes framing the whole set of views.
 
     See Also
     --------
@@ -427,10 +427,10 @@ class YXProjector(OrthoProjector):
     Attributes
     ----------
     axes : :obj:`dict` of :class:`~nilearn.plotting.displays.GlassBrainAxes`
-     The axes used for plotting in each direction ('x' and 'y' here).
+        The axes used for plotting in each direction ('x' and 'y' here).
 
     frame_axes : :class:`~matplotlib.axes.Axes`
-     The axes framing the whole set of views.
+        The axes framing the whole set of views.
 
     See Also
     --------
@@ -462,10 +462,10 @@ class YZProjector(OrthoProjector):
     Attributes
     ----------
     axes : :obj:`dict` of :class:`~nilearn.plotting.displays.GlassBrainAxes`
-           The axes used for plotting in each direction ('y' and 'z' here).
+        The axes used for plotting in each direction ('y' and 'z' here).
 
     frame_axes : :class:`~matplotlib.axes.Axes`
-                 The axes framing the whole set of views.
+        The axes framing the whole set of views.
 
     See Also
     --------
@@ -498,7 +498,7 @@ class LYRZProjector(OrthoProjector):
     Attributes
     ----------
     axes : :obj:`dict` of :class:`~nilearn.plotting.displays.GlassBrainAxes`
-     The axes used for plotting in each direction ('l', 'y', 'r',
+        The axes used for plotting in each direction ('l', 'y', 'r',
         and 'z' here).
 
     frame_axes : :class:`~matplotlib.axes.Axes`

--- a/nilearn/regions/hierarchical_kmeans_clustering.py
+++ b/nilearn/regions/hierarchical_kmeans_clustering.py
@@ -192,10 +192,10 @@ class HierarchicalKMeans(BaseEstimator, ClusterMixin, TransformerMixin):
 
     Attributes
     ----------
-    `labels_ `: ndarray, shape = [n_features]
+    labels_ : ndarray, shape = [n_features]
         cluster labels for each feature.
 
-    `sizes_`: ndarray, shape = [n_features]
+    sizes_ : ndarray, shape = [n_features]
         It contains the size of each cluster.
 
     """

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -232,14 +232,14 @@ class Parcellations(_MultiPCA):
 
     Attributes
     ----------
-    `labels_img_` : :class:`nibabel.nifti1.Nifti1Image`
+    labels_img_ : :class:`nibabel.nifti1.Nifti1Image`
         Labels image to each parcellation learned on fmri images.
 
-    `masker_` : :class:`nilearn.maskers.NiftiMasker` or \
+    masker_ : :class:`nilearn.maskers.NiftiMasker` or \
                 :class:`nilearn.maskers.MultiNiftiMasker`
         The masker used to mask the data.
 
-    `connectivity_` : :class:`numpy.ndarray`
+    connectivity_ : :class:`numpy.ndarray`
         Voxel-to-voxel connectivity matrix computed from a mask.
         Note that this attribute is only seen if selected methods are
         Agglomerative Clustering type, 'ward', 'complete', 'average'.

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -364,11 +364,11 @@ class RegionExtractor(NiftiMapsMasker):
 
     Attributes
     ----------
-    `index_` : :class:`numpy.ndarray`
+    index_ : :class:`numpy.ndarray`
         Array of list of indices where each index value is assigned to
         each separate region of its corresponding family of brain maps.
 
-    `regions_img_` : :class:`nibabel.nifti1.Nifti1Image`
+    regions_img_ : :class:`nibabel.nifti1.Nifti1Image`
         List of separated regions with each region lying on an
         original volume concatenated into a 4D image.
 

--- a/nilearn/regions/rena_clustering.py
+++ b/nilearn/regions/rena_clustering.py
@@ -459,13 +459,13 @@ class ReNA(BaseEstimator, ClusterMixin, TransformerMixin):
 
     Attributes
     ----------
-    `labels_ ` : :class:`numpy.ndarray`, shape = [n_features]
+    labels_ : :class:`numpy.ndarray`, shape = [n_features]
         Cluster labels for each feature.
 
-    `n_clusters_` : :obj:`int`
+    n_clusters_ : :obj:`int`
         Number of clusters.
 
-    `sizes_` : :class:`numpy.ndarray`, shape = [n_features]
+    sizes_ : :class:`numpy.ndarray`, shape = [n_features]
         It contains the size of each cluster.
 
     References


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4016

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- unindent some code blocks
- remove extra backticks in class attributes doc

Started to solve #4016 and improve visual rendering, also ended up homogenzing Attributes in classes doc string to match [numpy styles](https://numpydoc.readthedocs.io/en/latest/format.html#class-docstring)