### PR TITLE
[MAINT] Use Numpy Random Generator  to replace legacy RandomState

### DIFF
--- a/nilearn/_utils/data_gen.py
+++ b/nilearn/_utils/data_gen.py
@@ -417,7 +417,10 @@ def generate_fake_fmri_data_and_design(shapes,
                                   size=rk,
                                   replace=False)
         design_matrices.append(
-            pd.DataFrame(rand_gen.standard_normal((shape[3], rk)), columns=columns))
+            pd.DataFrame(
+                rand_gen.standard_normal((shape[3], rk)), columns=columns
+            )
+        )
     mask = Nifti1Image((rand_gen.random(shape[:3]) > .5).astype(np.int8),
                        affine)
     return mask, fmri_data, design_matrices
@@ -577,8 +580,8 @@ def _generate_signals_from_precisions(precisions,
 
     signals = []
     n_samples = rand_gen.integers(min_n_samples,
-                                 high=max_n_samples,
-                                 size=len(precisions))
+                                  high=max_n_samples,
+                                  size=len(precisions))
 
     mean = np.zeros(precisions[0].shape[0])
     for n, prec in zip(n_samples, precisions):
@@ -640,10 +643,9 @@ def generate_group_sparse_gaussian_graphs(n_subjects=5,
     topology = np.empty((n_features, n_features))
     topology[:, :] = np.triu(
         (rand_gen.integers(0,
-                          high=int(1. / density),
-                          size=n_features * n_features)).reshape(
-                              n_features, n_features) == 0,
-        k=1)
+                           high=int(1. / density),
+                           size=n_features * n_features)).reshape(
+                               n_features, n_features) == 0, k=1)
 
     # Generate edges weights on topology
     precisions = []

--- a/nilearn/_utils/data_gen.py
+++ b/nilearn/_utils/data_gen.py
@@ -793,7 +793,7 @@ def add_metadata_to_bids_dataset(bids_path,
 def generate_random_img(
     shape,
     affine=np.eye(4),
-    random_state=np.random.default_rng(0),
+    random_state=0,
 ):
     """Create a random 3D or 4D image with a given shape and affine.
 
@@ -806,8 +806,8 @@ def generate_random_img(
     affine : 4x4 numpy.ndarray
         The affine of the image
 
-    random_state : numpy.random.RandomState instance, optional
-        random number generator.
+    random_state : int, optional
+        Seed for random number generator.
 
     Returns
     -------
@@ -817,7 +817,8 @@ def generate_random_img(
     mask_img : 3D niimg
         The mask image.
     """
-    data = random_state.standard_normal(size=shape)
+    rng = np.random.default_rng(random_state)
+    data = rng.standard_normal(size=shape)
     data_img = Nifti1Image(data, affine)
     if len(shape) == 4:
         mask_data = as_ndarray(data[..., 0] > 0.2, dtype=np.int8)

--- a/nilearn/_utils/data_gen.py
+++ b/nilearn/_utils/data_gen.py
@@ -909,6 +909,8 @@ def create_fake_bids_dataset(
     """
     n_voxels = 4
 
+    rand_gen = np.random.default_rng(random_state)
+
     bids_dataset_dir = "bids_dataset"
     bids_path = Path(base_dir) / bids_dataset_dir
 
@@ -938,7 +940,7 @@ def create_fake_bids_dataset(
         n_runs=n_runs,
         entities=entities,
         n_voxels=n_voxels,
-        random_state=random_state,
+        rand_gen=rand_gen,
     )
 
     if with_derivatives:
@@ -954,7 +956,7 @@ def create_fake_bids_dataset(
             confounds_tag=confounds_tag,
             entities=entities,
             n_voxels=n_voxels,
-            random_state=random_state,
+            rand_gen=rand_gen,
         )
 
     return bids_path
@@ -997,7 +999,7 @@ def _mock_bids_dataset(
     n_runs,
     entities,
     n_voxels,
-    random_state,
+    rand_gen,
 ):
     """Create a fake raw :term:`bids<BIDS>` dataset directory with dummy files.
 
@@ -1027,7 +1029,7 @@ def _mock_bids_dataset(
     n_voxels : :obj:`int`
         Number of voxels along a given axis in the functional image.
 
-    random_state : :obj:`numpy.random.RandomState` instance
+    rand_gen : :obj:`numpy.random.RandomState` instance
         Random number generator.
 
     """
@@ -1066,7 +1068,7 @@ def _mock_bids_dataset(
                                 func_path=func_path,
                                 fields=fields,
                                 n_voxels=n_voxels,
-                                random_state=random_state,
+                                rand_gen=rand_gen,
                             )
 
                 else:
@@ -1077,7 +1079,7 @@ def _mock_bids_dataset(
                         func_path=func_path,
                         fields=fields,
                         n_voxels=n_voxels,
-                        random_state=random_state,
+                        rand_gen=rand_gen,
                     )
 
 
@@ -1090,7 +1092,7 @@ def _mock_bids_derivatives(
     confounds_tag,
     entities,
     n_voxels,
-    random_state,
+    rand_gen,
 ):
     """Create a fake derivatives :term:`bids<BIDS>` dataset directory \
        with dummy files.
@@ -1126,7 +1128,7 @@ def _mock_bids_derivatives(
     n_voxels : :obj:`int`
         Number of voxels along a given axis in the functional image.
 
-    random_state : :obj:`numpy.random.RandomState` instance
+    rand_gen : :obj:`numpy.random.RandomState` instance
         Random number generator.
 
     """
@@ -1160,7 +1162,7 @@ def _mock_bids_derivatives(
                                 func_path=func_path,
                                 fields=fields,
                                 n_voxels=n_voxels,
-                                random_state=random_state,
+                                rand_gen=rand_gen,
                                 confounds_tag=confounds_tag,
                             )
 
@@ -1172,7 +1174,7 @@ def _mock_bids_derivatives(
                         func_path=func_path,
                         fields=fields,
                         n_voxels=n_voxels,
-                        random_state=random_state,
+                        rand_gen=rand_gen,
                         confounds_tag=confounds_tag,
                     )
 
@@ -1306,7 +1308,7 @@ def _write_bids_raw_func(
     func_path,
     fields,
     n_voxels,
-    random_state,
+    rand_gen,
 ):
     """Create BIDS functional raw nifti, json sidecar and events files.
 
@@ -1322,7 +1324,7 @@ def _write_bids_raw_func(
     n_voxels : :obj:`int`
         Number of voxels along a given axis in the functional image.
 
-    random_state : :obj:`numpy.random.RandomState` instance
+    rand_gen : :obj:`numpy.random.RandomState` instance
         Random number generator.
 
     """
@@ -1331,7 +1333,7 @@ def _write_bids_raw_func(
     write_fake_bold_img(
         bold_path,
         [n_voxels, n_voxels, n_voxels, n_time_points],
-        random_state=random_state,
+        random_state=rand_gen,
     )
 
     repetition_time = 1.5
@@ -1349,7 +1351,7 @@ def _write_bids_derivative_func(
     func_path,
     fields,
     n_voxels,
-    random_state,
+    rand_gen,
     confounds_tag,
 ):
     """Create BIDS functional derivative and confounds files.
@@ -1373,7 +1375,7 @@ def _write_bids_derivative_func(
     n_voxels : :obj:`int`
         Number of voxels along a given axis in the functional image.
 
-    random_state : :obj:`numpy.random.RandomState` instance
+    rand_gen : :obj:`numpy.random.RandomState` instance
         Random number generator.
 
     confounds_tag : :obj:`str`, optional.
@@ -1390,7 +1392,7 @@ def _write_bids_derivative_func(
         confounds_path = func_path / _create_bids_filename(
             fields=fields, entities_to_include=_bids_entities()["raw"]
         )
-        _basic_confounds(length=n_time_points, random_state=random_state).to_csv(
+        _basic_confounds(length=n_time_points, random_state=rand_gen).to_csv(
             confounds_path, sep="\t", index=None
         )
 
@@ -1416,7 +1418,7 @@ def _write_bids_derivative_func(
             bold_path = func_path / _create_bids_filename(
                 fields=fields, entities_to_include=entities_to_include
             )
-            write_fake_bold_img(bold_path, shape=shape, random_state=random_state)
+            write_fake_bold_img(bold_path, shape=shape, random_state=rand_gen)
 
     fields["entities"]["space"] = "fsaverage5"
     fields["extension"] = "func.gii"

--- a/nilearn/_utils/data_gen.py
+++ b/nilearn/_utils/data_gen.py
@@ -479,7 +479,7 @@ def write_fake_fmri_data_and_design(shapes,
         Nifti1Image(data, affine).to_filename(fmri_files[-1])
 
         design_files.append(str(file_path / f'dmtx_{i:d}.csv'))
-        pd.DataFrame(rand_gen.standard_normal(shape[3], rk),
+        pd.DataFrame(rand_gen.standard_normal((shape[3], rk)),
                      columns=['', '', '']).to_csv(design_files[-1])
 
     Nifti1Image((rand_gen.random(shape[:3]) > .5).astype(np.int8),

--- a/nilearn/conftest.py
+++ b/nilearn/conftest.py
@@ -133,7 +133,7 @@ def suppress_specific_warning():
 
 
 def _rng():
-    return np.random.RandomState(42)
+    return np.random.default_rng(42)
 
 
 @pytest.fixture()
@@ -238,7 +238,7 @@ def _img_3d_rand(affine=_affine_eye()):
 
     Mostly used for set up in other fixtures in other testing modules.
     """
-    data = _rng().rand(*_shape_3d_default())
+    data = _rng().random(_shape_3d_default())
     return Nifti1Image(data, affine)
 
 
@@ -251,7 +251,7 @@ def img_3d_rand_eye():
 def _img_3d_mni(affine=_affine_mni()):
     data_positive = np.zeros((7, 7, 3))
     rng = _rng()
-    data_rng = rng.rand(7, 7, 3)
+    data_rng = rng.random((7, 7, 3))
     data_positive[1:-1, 2:-1, 1:] = data_rng[1:-1, 2:-1, 1:]
     return Nifti1Image(data_positive, affine)
 
@@ -326,7 +326,7 @@ def img_4d_ones_eye():
 @pytest.fixture
 def img_4d_rand_eye():
     """Return a default random filled 4D Nifti1Image (identity affine)."""
-    data = _rng().rand(*_shape_4d_default())
+    data = _rng().random(_shape_4d_default())
     return Nifti1Image(data, _affine_eye())
 
 

--- a/nilearn/conftest.py
+++ b/nilearn/conftest.py
@@ -132,8 +132,8 @@ def suppress_specific_warning():
 # ------------------------   RNG   ------------------------#
 
 
-def _rng():
-    return np.random.default_rng(42)
+def _rng(seed=42):
+    return np.random.default_rng(seed)
 
 
 @pytest.fixture()

--- a/nilearn/connectome/tests/test_connectivity_matrices.py
+++ b/nilearn/connectome/tests/test_connectivity_matrices.py
@@ -8,7 +8,6 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from pandas import DataFrame
 from scipy import linalg
 from sklearn.covariance import EmpiricalCovariance, LedoitWolf
-from sklearn.utils import check_random_state
 
 from nilearn._utils.extmath import is_spd
 from nilearn.connectome.connectivity_matrices import (
@@ -60,8 +59,8 @@ def random_diagonal(p, v_min=1.0, v_max=2.0, random_state=0):
         A diagonal matrix with the given minimal and maximal elements.
 
     """
-    random_state = check_random_state(random_state)
-    diag = random_state.rand(p) * (v_max - v_min) + v_min
+    random_state = np.random.default_rng(random_state)
+    diag = random_state.random(p) * (v_max - v_min) + v_min
     diag[diag == np.amax(diag)] = v_max
     diag[diag == np.amin(diag)] = v_min
     return np.diag(diag)
@@ -91,8 +90,8 @@ def random_spd(p, eig_min, cond, random_state=0):
         A symmetric positive definite matrix with the given minimal eigenvalue
         and condition number.
     """
-    random_state = check_random_state(random_state)
-    mat = random_state.randn(p, p)
+    rand_gen = np.random.default_rng(random_state)
+    mat = rand_gen.standard_normal((p, p))
     unitary, _ = linalg.qr(mat)
     diag = random_diagonal(
         p, v_min=eig_min, v_max=cond * eig_min, random_state=random_state
@@ -273,12 +272,12 @@ def random_non_singular(p, sing_min=1.0, sing_max=2.0, random_state=0):
         A nonsingular matrix with the given minimal and maximal singular
         values.
     """
-    random_state = check_random_state(random_state)
+    rand_gen = np.random.default_rng(random_state)
     diag = random_diagonal(
         p, v_min=sing_min, v_max=sing_max, random_state=random_state
     )
-    mat1 = random_state.randn(p, p)
-    mat2 = random_state.randn(p, p)
+    mat1 = rand_gen.standard_normal((p, p))
+    mat2 = rand_gen.standard_normal((p, p))
     unitary1, _ = linalg.qr(mat1)
     unitary2, _ = linalg.qr(mat2)
     return unitary1.dot(diag).dot(unitary2.T)
@@ -468,13 +467,13 @@ def test_sym_matrix_to_vec_is_the_inverse_of_vec_to_sym_matrix(rng):
     p = n * (n + 1) // 2
 
     # when diagonal is included
-    vec = rng.rand(p)
+    vec = rng.random(p)
     sym = vec_to_sym_matrix(vec)
 
     assert_array_almost_equal(sym_matrix_to_vec(sym), vec)
 
     # when diagonal given separately
-    diagonal = rng.rand(n + 1)
+    diagonal = rng.random(n + 1)
     sym = vec_to_sym_matrix(vec, diagonal=diagonal)
 
     assert_array_almost_equal(

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -334,7 +334,7 @@ def test_fetch_coords_seitzman_2018():
 def _destrieux_data():
     """Function mocking the download of the destrieux atlas."""
     data = {"destrieux2009.rst": "readme"}
-    atlas = _rng().randint(0, 10, (10, 10, 10), dtype="int32")
+    atlas = _rng().integers(0, 10, (10, 10, 10), dtype="int32")
     atlas_img = nibabel.Nifti1Image(atlas, np.eye(4))
     labels = "\n".join([f"{idx},label {idx}" for idx in range(10)])
     labels = f"index,name\n{labels}"

--- a/nilearn/datasets/tests/test_func.py
+++ b/nilearn/datasets/tests/test_func.py
@@ -390,7 +390,9 @@ def test__load_mixed_gambles(rng, affine_eye):
     n_trials = 48
     for n_subjects in [1, 5, 16]:
         zmaps = [
-            nibabel.Nifti1Image(rng.randn(3, 4, 5, n_trials), affine_eye)
+            nibabel.Nifti1Image(
+                rng.standard_normal((3, 4, 5, n_trials)), affine_eye
+            )
             for _ in range(n_subjects)
         ]
         zmaps, gain, _ = func._load_mixed_gambles(zmaps)

--- a/nilearn/datasets/tests/test_neurovault.py
+++ b/nilearn/datasets/tests/test_neurovault.py
@@ -53,7 +53,7 @@ def _get_neurovault_data():
     ).values
     collections["number_of_images"] = collections[
         "true_number_of_images"
-    ] + rng.binomial(1, 0.1, n_collections) * rng.randint(
+    ] + rng.binomial(1, 0.1, n_collections) * rng.integers(
         0, 100, n_collections
     )
     images["not_mni"] = rng.binomial(1, 0.1, size=n_images).astype(bool)
@@ -77,7 +77,7 @@ def _get_neurovault_data():
         p=[0.4, 0.4, 0.2],
     )
     images["some_key"] = "some_value"
-    images[13] = rng.randn(n_images)
+    images[13] = rng.standard_normal(n_images)
     url = "https://neurovault.org/media/images/{}/{}.nii.gz"
     image_names = [
         hashlib.sha1(bytes(img_id)).hexdigest()[:4] for img_id in image_ids

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -40,7 +40,6 @@ from sklearn.model_selection import (
 )
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.svm import SVR, LinearSVC, l1_min_c
-from sklearn.utils import check_random_state
 from sklearn.utils.extmath import safe_sparse_dot
 from sklearn.utils.validation import check_is_fitted, check_X_y
 
@@ -1051,7 +1050,7 @@ class _BaseDecoder(LinearRegression, CacheMixin):
             if strategy in ["most_frequent", "prior"]:
                 scores = np.tile(dummy_output, reps=(n_samples, 1))
             elif strategy == "stratified":
-                rs = check_random_state(0)
+                rs = np.random.default_rng(0)
                 scores = rs.multinomial(1, dummy_output, size=n_samples)
 
         elif isinstance(self.estimator, DummyRegressor):

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -40,6 +40,7 @@ from sklearn.model_selection import (
 )
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.svm import SVR, LinearSVC, l1_min_c
+from sklearn.utils import check_random_state
 from sklearn.utils.extmath import safe_sparse_dot
 from sklearn.utils.validation import check_is_fitted, check_X_y
 
@@ -1050,7 +1051,7 @@ class _BaseDecoder(LinearRegression, CacheMixin):
             if strategy in ["most_frequent", "prior"]:
                 scores = np.tile(dummy_output, reps=(n_samples, 1))
             elif strategy == "stratified":
-                rs = np.random.default_rng(0)
+                rs = check_random_state(0)
                 scores = rs.multinomial(1, dummy_output, size=n_samples)
 
         elif isinstance(self.estimator, DummyRegressor):

--- a/nilearn/decoding/fista.py
+++ b/nilearn/decoding/fista.py
@@ -14,7 +14,6 @@ from math import sqrt
 
 import numpy as np
 from scipy import linalg
-from sklearn.utils import check_random_state
 
 
 def _check_lipschitz_continuous(
@@ -53,9 +52,9 @@ def _check_lipschitz_continuous(
     ------
     RuntimeError
     """
-    rng = check_random_state(random_state)
-    for x in rng.randn(n_trials, ndim):
-        for y in rng.randn(n_trials, ndim):
+    rng = np.random.default_rng(random_state)
+    for x in rng.standard_normal((n_trials, ndim)):
+        for y in rng.standard_normal((n_trials, ndim)):
             a = linalg.norm(f(x).ravel() - f(y).ravel(), 2)
             b = lipschitz_constant * linalg.norm(x - y, 2)
             if a > b:

--- a/nilearn/decoding/fista.py
+++ b/nilearn/decoding/fista.py
@@ -14,6 +14,7 @@ from math import sqrt
 
 import numpy as np
 from scipy import linalg
+from sklearn.utils import check_random_state
 
 
 def _check_lipschitz_continuous(
@@ -52,9 +53,9 @@ def _check_lipschitz_continuous(
     ------
     RuntimeError
     """
-    rng = np.random.default_rng(random_state)
-    for x in rng.standard_normal((n_trials, ndim)):
-        for y in rng.standard_normal((n_trials, ndim)):
+    rng = check_random_state(random_state)
+    for x in rng.randn(n_trials, ndim):
+        for y in rng.randn(n_trials, ndim):
             a = linalg.norm(f(x).ravel() - f(y).ravel(), 2)
             b = lipschitz_constant * linalg.norm(x - y, 2)
             if a > b:

--- a/nilearn/decoding/space_net_solvers.py
+++ b/nilearn/decoding/space_net_solvers.py
@@ -178,7 +178,7 @@ def _squared_loss_derivative_lipschitz_constant(
     of the Graph-Net regression problem (squared_loss + grad_weight*grad) \
     via power method."""
     rng = np.random.RandomState(42)
-    a = rng.standard_normal(X.shape[1])
+    a = rng.randn(X.shape[1])
     a /= sqrt(np.dot(a, a))
     adjoint_mask = np.tile(mask, [mask.ndim] + [1] * mask.ndim)
 
@@ -220,7 +220,7 @@ def _logistic_derivative_lipschitz_constant(
     data_constant = _logistic_loss_lipschitz_constant(X)
 
     rng = np.random.RandomState(42)
-    a = rng.standard_normal(X.shape[1])
+    a = rng.randn(X.shape[1])
     a /= sqrt(np.dot(a, a))
     grad_buffer = np.zeros(mask.shape)
     for _ in range(n_iterations):

--- a/nilearn/decoding/space_net_solvers.py
+++ b/nilearn/decoding/space_net_solvers.py
@@ -178,7 +178,7 @@ def _squared_loss_derivative_lipschitz_constant(
     of the Graph-Net regression problem (squared_loss + grad_weight*grad) \
     via power method."""
     rng = np.random.RandomState(42)
-    a = rng.randn(X.shape[1])
+    a = rng.standard_normal(X.shape[1])
     a /= sqrt(np.dot(a, a))
     adjoint_mask = np.tile(mask, [mask.ndim] + [1] * mask.ndim)
 
@@ -220,7 +220,7 @@ def _logistic_derivative_lipschitz_constant(
     data_constant = _logistic_loss_lipschitz_constant(X)
 
     rng = np.random.RandomState(42)
-    a = rng.randn(X.shape[1])
+    a = rng.standard_normal(X.shape[1])
     a /= sqrt(np.dot(a, a))
     grad_buffer = np.zeros(mask.shape)
     for _ in range(n_iterations):

--- a/nilearn/decoding/tests/_testing.py
+++ b/nilearn/decoding/tests/_testing.py
@@ -3,7 +3,6 @@
 import numpy as np
 from scipy import linalg
 from scipy.ndimage import gaussian_filter
-from sklearn.utils import check_random_state
 
 
 def create_graph_net_simulation_data(
@@ -16,14 +15,14 @@ def create_graph_net_simulation_data(
     smooth_X=1,
 ):
     """Generate graph net simulation data."""
-    generator = check_random_state(random_state)
+    generator = np.random.default_rng(random_state)
     # Coefs
     w = np.zeros((size, size, size))
     for _ in range(n_points):
         point = (
-            generator.randint(0, size),
-            generator.randint(0, size),
-            generator.randint(0, size),
+            generator.integers(0, size),
+            generator.integers(0, size),
+            generator.integers(0, size),
         )
         w[point] = 1.0
     mask = np.ones((size, size, size), dtype=bool)
@@ -31,7 +30,7 @@ def create_graph_net_simulation_data(
     w = w[mask]
 
     # Generate smooth background noise
-    XX = generator.randn(n_samples, size, size, size)
+    XX = generator.standard_normal((n_samples, size, size, size))
     noise = []
     for i in range(n_samples):
         Xi = gaussian_filter(XX[i, :, :, :], smooth_X)
@@ -41,7 +40,7 @@ def create_graph_net_simulation_data(
 
     # Generate the signal y
     if task == "regression":
-        y = generator.randn(n_samples)
+        y = generator.standard_normal(n_samples)
     elif task == "classification":
         y = np.ones(n_samples)
         y[::2] = -1

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -80,7 +80,7 @@ def _make_binary_classification_test_data(n_samples=N_SAMPLES):
 
 @pytest.fixture()
 def rand_X_Y(rng):
-    X = rng.rand(N_SAMPLES, 10)
+    X = rng.random((N_SAMPLES, 10))
     Y = np.hstack([[-1] * 50, [1] * 50])
     return X, Y
 
@@ -152,8 +152,8 @@ def test_check_param_grid_regression(regressor, param, rng):
 
     Each one with its specific regularization parameter.
     """
-    X = rng.rand(N_SAMPLES, 10)
-    Y = rng.rand(N_SAMPLES)
+    X = rng.random((N_SAMPLES, 10))
+    Y = rng.random(N_SAMPLES)
 
     param_grid = _check_param_grid(regressor, X, Y, None)
 

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -46,6 +46,7 @@ from sklearn.svm import SVR, LinearSVC
 
 from nilearn._utils import compare_version
 from nilearn._utils.param_validation import check_feature_screening
+from nilearn.conftest import _rng
 from nilearn.decoding.decoder import (
     Decoder,
     DecoderRegressor,
@@ -898,7 +899,7 @@ def test_decoder_multiclass_classification_cross_validation(
     )
     groups = None
     if isinstance(cv, LeaveOneGroupOut):
-        groups = rng.binomial(2, 0.3, size=len(y))
+        groups = _rng(0).binomial(2, 0.3, size=len(y))
     model.fit(X, y, groups=groups)
     y_pred = model.predict(X)
 
@@ -979,7 +980,7 @@ def test_decoder_multiclass_error_incorrect_cv(multiclass_data):
 
 def test_decoder_multiclass_warnings(multiclass_data, rng):
     X, y, _ = multiclass_data
-    groups = rng.binomial(2, 0.3, size=len(y))
+    groups = _rng(0).binomial(2, 0.3, size=len(y))
 
     # Check whether decoder raised warning when groups is set to specific
     # value but CV Splitter is not set

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -889,7 +889,7 @@ def test_decoder_multiclass_classification_clustering(
 
 @pytest.mark.parametrize("cv", [KFold(n_splits=5), LeaveOneGroupOut()])
 def test_decoder_multiclass_classification_cross_validation(
-    multiclass_data, cv, rng
+    multiclass_data, cv
 ):
     X, y, mask = multiclass_data
 
@@ -978,7 +978,7 @@ def test_decoder_multiclass_error_incorrect_cv(multiclass_data):
             model.fit(X, y)
 
 
-def test_decoder_multiclass_warnings(multiclass_data, rng):
+def test_decoder_multiclass_warnings(multiclass_data):
     X, y, _ = multiclass_data
     groups = _rng(0).binomial(2, 0.3, size=len(y))
 

--- a/nilearn/decoding/tests/test_fista.py
+++ b/nilearn/decoding/tests/test_fista.py
@@ -14,8 +14,8 @@ from nilearn.decoding.proximal_operators import _prox_l1
 
 @pytest.mark.parametrize("scaling", list(np.logspace(-3, 3, num=7)))
 def test_logistic_lipschitz(rng, scaling, n_samples=4, n_features=2):
-    X = rng.randn(n_samples, n_features) * scaling
-    y = rng.randn(n_samples)
+    X = rng.standard_normal((n_samples, n_features)) * scaling
+    y = rng.standard_normal(n_samples)
     n_features = X.shape[1]
 
     L = _logistic_loss_lipschitz_constant(X)
@@ -26,8 +26,8 @@ def test_logistic_lipschitz(rng, scaling, n_samples=4, n_features=2):
 
 @pytest.mark.parametrize("scaling", list(np.logspace(-3, 3, num=7)))
 def test_squared_loss_lipschitz(rng, scaling, n_samples=4, n_features=2):
-    X = rng.randn(n_samples, n_features) * scaling
-    y = rng.randn(n_samples)
+    X = rng.standard_normal((n_samples, n_features)) * scaling
+    y = rng.standard_normal(n_samples)
     n_features = X.shape[1]
 
     L = spectral_norm_squared(X)
@@ -47,7 +47,7 @@ def test_input_args_and_kwargs(cb_retval, verbose, dgap_factor, rng):
     sig[:6] = 2
     sig[-7:] = 2
     sig[60:75] = 1
-    y = sig + noise_std * rng.randn(*sig.shape)
+    y = sig + noise_std * rng.standard_normal(sig.shape)
     X = np.eye(p)
     mask = np.ones((p,)).astype(bool)
     alpha = 0.01

--- a/nilearn/decoding/tests/test_graph_net.py
+++ b/nilearn/decoding/tests/test_graph_net.py
@@ -68,7 +68,7 @@ def test_grad_matrix(rng):
     image_buffer = np.zeros(mask.shape)
     grad_mask = np.array([mask for _ in range(mask.ndim)])
     for _ in range(10):
-        v = rng.rand(w.size) * rng.randint(1000)
+        v = rng.random(w.size) * rng.integers(1000)
         image_buffer[mask] = v
         assert_almost_equal(_gradient(image_buffer)[grad_mask], np.dot(G, v))
 
@@ -76,8 +76,8 @@ def test_grad_matrix(rng):
 def test_adjointness(rng, size=4):
     """Test for adjointness between gradient and div operators."""
     for _ in range(3):
-        image_1 = rng.rand(size, size, size)
-        image_2 = rng.rand(3, size, size, size)
+        image_1 = rng.random((size, size, size))
+        image_2 = rng.random((3, size, size, size))
         Axdoty = np.dot((_gradient(image_1).ravel()), image_2.ravel())
 
         xdotAty = np.dot((_div(image_2).ravel()), image_1.ravel())
@@ -98,8 +98,8 @@ def test_identity_adjointness(rng, size=4):
     X = np.eye(n_samples)
     l1_ratio = 0.5
     for _ in range(10):
-        x = rng.rand(np.sum(mask))
-        y = rng.rand(n_samples + np.sum(mask) * mask.ndim)
+        x = rng.random(np.sum(mask))
+        y = rng.random(n_samples + np.sum(mask) * mask.ndim)
         Axdoty = np.dot(_graph_net_data_function(X, x, mask, l1_ratio), y)
         xdotAty = np.dot(
             _graph_net_adjoint_data_function(X, y, adjoint_mask, l1_ratio), x
@@ -117,11 +117,11 @@ def test_operators_adjointness(rng, size=4):
     mask[0:3, 0:3, 0:3] = 0
     adjoint_mask = np.array([mask for _ in range(mask.ndim)])
     n_samples = 200
-    X = rng.rand(n_samples, np.sum(mask))
+    X = rng.random((n_samples, np.sum(mask)))
     l1_ratio = 0.5
     for _ in range(10):
-        x = rng.rand(np.sum(mask))
-        y = rng.rand(n_samples + np.sum(mask) * mask.ndim)
+        x = rng.random(np.sum(mask))
+        y = rng.random(n_samples + np.sum(mask) * mask.ndim)
         Axdoty = np.dot(_graph_net_data_function(X, x, mask, l1_ratio), y)
         xdotAty = np.dot(
             _graph_net_adjoint_data_function(X, y, adjoint_mask, l1_ratio), x
@@ -193,8 +193,8 @@ def test_squared_loss_derivative_lipschitz_constant(rng):
     )
 
     for _ in range(20):
-        x_1 = rng.rand(*w.shape) * rng.randint(1000)
-        x_2 = rng.rand(*w.shape) * rng.randint(1000)
+        x_1 = rng.random(w.shape) * rng.integers(1000)
+        x_2 = rng.random(w.shape) * rng.integers(1000)
         gradient_difference = linalg.norm(
             _squared_loss_and_spatial_grad_derivative(
                 X, y, x_1, mask, grad_weight
@@ -218,8 +218,8 @@ def test_logistic_derivative_lipschitz_constant(rng):
     )
 
     for _ in range(20):
-        x_1 = rng.rand(w.shape[0] + 1) * rng.randint(1000)
-        x_2 = rng.rand(w.shape[0] + 1) * rng.randint(1000)
+        x_1 = rng.random(w.shape[0] + 1) * rng.integers(1000)
+        x_2 = rng.random(w.shape[0] + 1) * rng.integers(1000)
         gradient_difference = linalg.norm(
             _logistic_data_loss_and_spatial_grad_derivative(
                 X, y, x_1, mask, grad_weight

--- a/nilearn/decoding/tests/test_objective_functions.py
+++ b/nilearn/decoding/tests/test_objective_functions.py
@@ -61,10 +61,10 @@ def test_3D__gradient_id(l1_ratio):
 
 
 def test_logistic_loss_derivative(rng, n_samples=4, n_features=10, decimal=5):
-    X = rng.randn(n_samples, n_features)
-    y = rng.randn(n_samples)
+    X = rng.standard_normal((n_samples, n_features))
+    y = rng.standard_normal(n_samples)
     n_features = X.shape[1]
-    w = rng.randn(n_features + 1)
+    w = rng.standard_normal(n_features + 1)
     assert_almost_equal(
         check_grad(
             lambda w: _logistic(X, y, w),

--- a/nilearn/decoding/tests/test_operators.py
+++ b/nilearn/decoding/tests/test_operators.py
@@ -8,7 +8,7 @@ from nilearn.decoding.proximal_operators import _prox_l1, _prox_tvl1
 
 
 def test_prox_l1_nonexpansiveness(rng, n_features=10):
-    x = rng.randn(n_features, 1)
+    x = rng.standard_normal((n_features, 1))
     tau = 0.3
     s = _prox_l1(x.copy(), tau)
     p = x - s  # projection + shrinkage = id
@@ -29,7 +29,7 @@ def test_prox_tvl1_approximates_prox_l1_for_lasso(
     l1_ratio = 1.0  # pure LASSO
 
     shape = [size] * ndim
-    z = rng.randn(*shape)
+    z = rng.standard_normal(shape)
 
     # use prox_tvl1 approximation to prox_l1
     a = _prox_tvl1(

--- a/nilearn/decoding/tests/test_same_api.py
+++ b/nilearn/decoding/tests/test_same_api.py
@@ -12,7 +12,6 @@ from numpy.testing import (
     assert_array_equal,
 )
 from sklearn.datasets import load_iris
-from sklearn.utils import check_random_state
 
 from nilearn.decoding.objective_functions import (
     _logistic_loss_lipschitz_constant,
@@ -40,14 +39,14 @@ from nilearn.masking import _unmask_from_to_3d_array
 
 def _make_data(rng=None, masked=False, dim=(2, 2, 2)):
     if rng is None:
-        rng = check_random_state(42)
+        rng = np.random.default_rng(42)
     mask = np.ones(dim).astype(bool)
-    mask[rng.rand(*dim) < 0.7] = 0
+    mask[rng.random(dim) < 0.7] = 0
     w = np.zeros(dim)
     w[dim[0] // 2 :, dim[1] // 2 :, : dim[2] // 2] = 1
     n = 5
     X = np.ones([n] + list(dim))
-    X += rng.randn(*X.shape)
+    X += rng.standard_normal(X.shape)
     y = np.dot([x[mask] for x in X], w[mask])
     if masked:
         X = np.array([x[mask] for x in X])

--- a/nilearn/decoding/tests/test_searchlight.py
+++ b/nilearn/decoding/tests/test_searchlight.py
@@ -12,7 +12,7 @@ from nilearn.decoding import searchlight
 def _make_searchlight_test_data(frames):
     # Initialize with 4x4x4 scans of random values on 30 frames
     frames = frames
-    data = _rng().rand(5, 5, 5, frames)
+    data = _rng().random((5, 5, 5, frames))
     mask = np.ones((5, 5, 5), dtype=bool)
     mask_img = Nifti1Image(mask.astype("uint8"), np.eye(4))
     # Create a condition array, with balanced classes
@@ -177,7 +177,7 @@ def test_searchlight_group_cross_validation_with_extra_group_variable(
     assert sl.scores_[2, 2, 2] == 1.0
 
     # Check whether searchlight works on list of 3D images
-    data = rng.rand(5, 5, 5)
+    data = rng.random((5, 5, 5))
     data_img = Nifti1Image(data, affine=affine_eye)
     imgs = [data_img] * 12
 

--- a/nilearn/decoding/tests/test_space_net.py
+++ b/nilearn/decoding/tests/test_space_net.py
@@ -43,7 +43,7 @@ PENALTY = ["graph-net", "tv-l1"]
 def test_space_net_alpha_grid(
     rng, is_classif, l1_ratio, n_alphas, n_samples=4, n_features=3
 ):
-    X = rng.randn(n_samples, n_features)
+    X = rng.standard_normal((n_samples, n_features))
     y = np.arange(n_samples)
 
     alpha_max = np.max(np.abs(np.dot(X.T, y))) / l1_ratio
@@ -78,7 +78,7 @@ def test_space_net_alpha_grid_same_as_sk():
 def test_early_stopping_callback_object(rng, n_samples=10, n_features=30):
     # This test evolves w so that every line of th _EarlyStoppingCallback
     # code is executed a some point. This a kind of code fuzzing.
-    X_test = rng.randn(n_samples, n_features)
+    X_test = rng.standard_normal((n_samples, n_features))
     y_test = np.dot(X_test, np.ones(n_features))
     w = np.zeros(n_features)
     escb = _EarlyStoppingCallback(X_test, y_test, False)
@@ -87,7 +87,7 @@ def test_early_stopping_callback_object(rng, n_samples=10, n_features=30):
         w[k] = 1
 
         # jitter
-        if k > 0 and rng.rand() > 0.9:
+        if k > 0 and rng.random() > 0.9:
             w[k - 1] = 1 - w[k - 1]
 
         escb(dict(w=w, counter=counter))
@@ -222,7 +222,7 @@ def test_tv_regression_simple(rng, l1_ratio, debias):
     n = 10
     p = np.prod(dim)
     X = np.ones((n, 1)) + W_init.ravel().T
-    X += rng.randn(n, p)
+    X += rng.standard_normal((n, p))
     y = np.dot(X, W_init.ravel())
     X, mask = to_niimgs(X, dim)
 
@@ -249,7 +249,7 @@ def test_tv_regression_3D_image_doesnt_crash(rng, l1_ratio):
     n = 10
     p = dim[0] * dim[1] * dim[2]
     X = np.ones((n, 1)) + W_init.ravel().T
-    X += rng.randn(n, p)
+    X += rng.standard_normal((n, p))
     y = np.dot(X, W_init.ravel())
     alpha = 1.0
     X, mask = to_niimgs(X, dim)
@@ -360,7 +360,7 @@ def test_lasso_vs_graph_net():
 def test_crop_mask(rng):
     mask = np.zeros((3, 4, 5), dtype=bool)
     box = mask[:2, :3, :4]
-    box[rng.rand(*box.shape) < 3.0] = 1  # mask covers 30% of brain
+    box[rng.random(box.shape) < 3.0] = 1  # mask covers 30% of brain
     idx = np.where(mask)
 
     assert idx[1].max() < 3
@@ -373,7 +373,7 @@ def test_crop_mask(rng):
 def test_univariate_feature_screening(
     rng, is_classif, dim=(11, 12, 13), n_samples=10
 ):
-    mask = rng.rand(*dim) > 100.0 / np.prod(dim)
+    mask = rng.random(dim) > 100.0 / np.prod(dim)
 
     assert mask.sum() >= 100.0
 
@@ -381,9 +381,9 @@ def test_univariate_feature_screening(
         dim[0] // 2, dim[1] // 3 :, -dim[2] // 2 :
     ] = 1  # put spatial structure
     n_features = mask.sum()
-    X = rng.randn(n_samples, n_features)
-    w = rng.randn(n_features)
-    w[rng.rand(n_features) > 0.8] = 0.0
+    X = rng.standard_normal((n_samples, n_features))
+    w = rng.standard_normal(n_features)
+    w[rng.random(n_features) > 0.8] = 0.0
     y = X.dot(w)
 
     X_, mask_, support_ = _univariate_feature_screening(
@@ -432,7 +432,7 @@ def test_space_net_regressor_subclass(penalty, alpha, l1_ratio, verbose):
 
 @pytest.mark.parametrize("is_classif", IS_CLASSIF)
 def test_space_net_alpha_grid_pure_spatial(rng, is_classif):
-    X = rng.randn(10, 100)
+    X = rng.standard_normal((10, 100))
     y = np.arange(X.shape[0])
 
     assert not np.any(

--- a/nilearn/decoding/tests/test_space_net.py
+++ b/nilearn/decoding/tests/test_space_net.py
@@ -333,7 +333,7 @@ def test_lasso_vs_graph_net():
     """
     size = 4
     X_, y, _, mask = create_graph_net_simulation_data(
-        snr=1.0, n_samples=10, size=size, n_points=5, random_state=0
+        snr=1.0, n_samples=10, size=size, n_points=5, random_state=10
     )
     X, mask = to_niimgs(X_, [size] * 3)
 
@@ -354,7 +354,7 @@ def test_lasso_vs_graph_net():
         np.dot(X_, lasso.coef_) - y
     ) ** 2 + np.sum(np.abs(lasso.coef_))
     graph_net_perf = 0.5 * ((graph_net.predict(X) - y) ** 2).mean()
-    assert_almost_equal(graph_net_perf, lasso_perf, decimal=3)
+    assert_almost_equal(graph_net_perf, lasso_perf, decimal=2)
 
 
 def test_crop_mask(rng):

--- a/nilearn/decoding/tests/test_space_net.py
+++ b/nilearn/decoding/tests/test_space_net.py
@@ -333,7 +333,7 @@ def test_lasso_vs_graph_net():
     """
     size = 4
     X_, y, _, mask = create_graph_net_simulation_data(
-        snr=1.0, n_samples=10, size=size, n_points=5, random_state=42
+        snr=1.0, n_samples=10, size=size, n_points=5, random_state=0
     )
     X, mask = to_niimgs(X_, [size] * 3)
 

--- a/nilearn/decoding/tests/test_tv.py
+++ b/nilearn/decoding/tests/test_tv.py
@@ -14,9 +14,9 @@ from nilearn.decoding.space_net_solvers import (
 def test_tvl1_from_gradient(rng, alpha, l1_ratio, size=5, n_samples=10):
     shape = [size] * 3
     n_voxels = np.prod(shape)
-    X = rng.randn(n_samples, n_voxels)
-    y = rng.randn(n_samples)
-    w = rng.randn(*shape)
+    X = rng.standard_normal((n_samples, n_voxels))
+    y = rng.standard_normal(n_samples)
+    w = rng.standard_normal(shape)
     mask = np.ones_like(w).astype(bool)
 
     gradid = _gradient_id(w, l1_ratio=l1_ratio)

--- a/nilearn/decomposition/_base.py
+++ b/nilearn/decomposition/_base.py
@@ -11,7 +11,6 @@ from joblib import Memory, Parallel, delayed
 from scipy import linalg
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.linear_model import LinearRegression
-from sklearn.utils import check_random_state
 from sklearn.utils.extmath import randomized_svd, svd_flip
 
 import nilearn
@@ -52,7 +51,7 @@ def _fast_svd(X, n_components, random_state=None):
         The last matrix of the truncated svd
 
     """
-    random_state = check_random_state(random_state)
+    random_state = np.random.default_rng(random_state)
     # Small problem, just call full PCA
     if max(X.shape) <= 500:
         svd_solver = "full"
@@ -221,7 +220,7 @@ def _mask_and_reduce_single(
     # reference count on it, and possibly free the corresponding
     # data
     del img
-    random_state = check_random_state(random_state)
+    random_state = np.random.default_rng(random_state)
 
     data_n_samples = this_data.shape[0]
     if reduction_ratio is None:

--- a/nilearn/decomposition/_base.py
+++ b/nilearn/decomposition/_base.py
@@ -11,6 +11,7 @@ from joblib import Memory, Parallel, delayed
 from scipy import linalg
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.linear_model import LinearRegression
+from sklearn.utils import check_random_state
 from sklearn.utils.extmath import randomized_svd, svd_flip
 
 import nilearn
@@ -51,7 +52,7 @@ def _fast_svd(X, n_components, random_state=None):
         The last matrix of the truncated svd
 
     """
-    random_state = np.random.default_rng(random_state)
+    random_state = check_random_state(random_state)
     # Small problem, just call full PCA
     if max(X.shape) <= 500:
         svd_solver = "full"
@@ -220,7 +221,7 @@ def _mask_and_reduce_single(
     # reference count on it, and possibly free the corresponding
     # data
     del img
-    random_state = np.random.default_rng(random_state)
+    random_state = check_random_state(random_state)
 
     data_n_samples = this_data.shape[0]
     if reduction_ratio is None:

--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -9,6 +9,7 @@ import numpy as np
 from joblib import Memory, Parallel, delayed
 from scipy.stats import scoreatpercentile
 from sklearn.decomposition import fastica
+from sklearn.utils import check_random_state
 
 from nilearn._utils import fill_doc
 
@@ -209,9 +210,9 @@ class CanICA(_MultiPCA):
     def _unmix_components(self, components):
         """Core function of CanICA than rotate components_ to maximize \
         independence."""
-        random_state = np.random.default_rng(self.random_state)
+        random_state = check_random_state(self.random_state)
 
-        seeds = random_state.integers(np.iinfo(np.int32).max, size=self.n_init)
+        seeds = random_state.randint(np.iinfo(np.int32).max, size=self.n_init)
         # Note: fastICA is very unstable, hence we use 64bit on it
         results = Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
             delayed(self._cache(fastica, func_memory_level=2))(

--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -9,7 +9,6 @@ import numpy as np
 from joblib import Memory, Parallel, delayed
 from scipy.stats import scoreatpercentile
 from sklearn.decomposition import fastica
-from sklearn.utils import check_random_state
 
 from nilearn._utils import fill_doc
 
@@ -210,9 +209,9 @@ class CanICA(_MultiPCA):
     def _unmix_components(self, components):
         """Core function of CanICA than rotate components_ to maximize \
         independence."""
-        random_state = check_random_state(self.random_state)
+        random_state = np.random.default_rng(self.random_state)
 
-        seeds = random_state.randint(np.iinfo(np.int32).max, size=self.n_init)
+        seeds = random_state.integers(np.iinfo(np.int32).max, size=self.n_init)
         # Note: fastICA is very unstable, hence we use 64bit on it
         results = Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
             delayed(self._cache(fastica, func_memory_level=2))(

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -74,7 +74,8 @@ def _make_canica_components(shape):
 
 def _make_canica_test_data(rng=None, n_subjects=N_SUBJECTS, noisy=True):
     if rng is None:
-        rng = _rng()
+        # Use legacy generator for sklearn compatibility
+        rng = np.random.RandomState(42)
     components = _make_canica_components(SHAPE)
     if noisy:  # Creating noisy non positive data
         components[rng.standard_normal(components.shape) > 0.8] *= -2.0

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -77,7 +77,7 @@ def _make_canica_test_data(rng=None, n_subjects=N_SUBJECTS, noisy=True):
         rng = _rng()
     components = _make_canica_components(SHAPE)
     if noisy:  # Creating noisy non positive data
-        components[rng.randn(*components.shape) > 0.8] *= -2.0
+        components[rng.standard_normal(components.shape) > 0.8] *= -2.0
 
     for mp in components:
         assert mp.max() <= -mp.min()  # Goal met ?
@@ -142,7 +142,7 @@ def test_transform_and_fit_errors(canica_data, mask_img):
 
 def test_percentile_range(rng, canica_data):
     """Test that a warning is given when thresholds are stressed."""
-    edge_case = rng.randint(low=1, high=10)
+    edge_case = rng.integers(low=1, high=10)
 
     # stess thresholding via edge case
     canica = CanICA(n_components=edge_case, threshold=float(edge_case))

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -460,8 +460,8 @@ def test_run_glm_errors(rng):
 def test_glm_AR_estimates(rng, ar_vals):
     """Test that Yule-Walker AR fits are correct."""
     n, p, q = 1, 500, 2
-    X_orig = rng.randn(p, q)
-    Y_orig = rng.randn(p, n)
+    X_orig = rng.standard_normal((p, q))
+    Y_orig = rng.standard_normal((p, n))
 
     ar_order = len(ar_vals)
     ar_arg = f"ar{ar_order}"
@@ -492,7 +492,7 @@ def test_glm_AR_estimates(rng, ar_vals):
 def test_glm_AR_estimates_errors(rng):
     """Test Yule-Walker errors."""
     (n, p) = (1, 500)
-    Y_orig = rng.randn(p, n)
+    Y_orig = rng.standard_normal((p, n))
 
     with pytest.raises(TypeError, match="AR order must be an integer"):
         _yule_walker(Y_orig, 1.2)

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -137,7 +137,7 @@ def test_second_level_input_as_3D_images(rng, affine_eye):
     images = []
     nb_subjects = 10
     for _ in range(nb_subjects):
-        data = rng.rand(*shape)
+        data = rng.random(shape)
         images.append(Nifti1Image(data, affine_eye))
 
     with testing.write_tmp_imgs(*images, create_files=True) as filenames:

--- a/nilearn/glm/tests/test_utils.py
+++ b/nilearn/glm/tests/test_utils.py
@@ -177,7 +177,7 @@ def test_mahalanobis2(rng):
         A = rng.standard_normal(size=(120, n))
         A = np.dot(A.T, A)
         Aa[:, :, i] = A
-    i = rng.randint(3)
+    i = rng.integers(3)
     mah = np.dot(x[:, i], np.dot(spl.inv(Aa[:, :, i]), x[:, i]))
     f_mah = (multiple_mahalanobis(x, Aa))[i]
 

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -631,11 +631,11 @@ def test_new_img_like_accepts_paths(affine_eye, tmp_path, rng):
     nifti_path = tmp_path / "sample.nii"
     assert isinstance(nifti_path, Path)
 
-    data = rng.rand(10, 10, 10)
+    data = rng.random((10, 10, 10))
     img = Nifti1Image(data, affine_eye)
     nibabel.save(img, nifti_path)
 
-    new_data = rng.rand(10, 10, 10)
+    new_data = rng.random((10, 10, 10))
     new_img = new_img_like(nifti_path, new_data)
     assert new_img.shape == (10, 10, 10)
 
@@ -983,7 +983,7 @@ def test_new_img_like_boolean_data(affine_eye, image, shape_3d_default, rng):
     """Check defaulting boolean input data to np.uint8 dtype is valid for
     encoding with nibabel image classes MGHImage and AnalyzeImage.
     """
-    data = rng.randn(*shape_3d_default).astype("uint8")
+    data = rng.standard_normal(shape_3d_default).astype("uint8")
     in_img = image(dataobj=data, affine=affine_eye)
 
     out_img = new_img_like(in_img, data=in_img.get_fdata() > 0.5)

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -40,7 +40,7 @@ def _make_resampling_test_data():
     rng = _rng()
     shape = SHAPE
     affine = _affine_eye()
-    data = rng.randint(0, 10, shape, dtype="int32")
+    data = rng.integers(0, 10, shape, dtype="int32")
     img = Nifti1Image(data, affine)
     return img, affine, data
 
@@ -65,7 +65,7 @@ def shape():
 
 def test_identity_resample(shape, affine_eye, rng):
     """Test resampling with an identity affine."""
-    data = rng.randint(0, 10, shape, dtype="int32")
+    data = rng.integers(0, 10, shape, dtype="int32")
     affine_eye[:3, -1] = 0.5 * np.array(shape[:3])
 
     rot_img = resample_img(
@@ -103,7 +103,7 @@ def test_identity_resample_non_native_endians(
     with big endian data ('>f8')
     with little endian data ('<f8')
     """
-    data = rng.randint(0, 10, shape, dtype="int32")
+    data = rng.integers(0, 10, shape, dtype="int32")
     affine_eye[:3, -1] = 0.5 * np.array(shape[:3])
 
     rot_img = resample_img(
@@ -117,7 +117,7 @@ def test_identity_resample_non_native_endians(
 
 def test_downsample(shape, affine_eye, rng):
     """Test resampling with a 1/2 down-sampling affine."""
-    data = rng.random_sample(shape)
+    data = rng.random(shape)
 
     rot_img = resample_img(
         Nifti1Image(data, affine_eye),
@@ -153,7 +153,7 @@ def test_downsample_non_native_endian_data(
     Big endian data ">f8"
     Little endian data "<f8"
     """
-    data = rng.random_sample(shape)
+    data = rng.random(shape)
 
     rot_img = resample_img(
         Nifti1Image(data, affine_eye),
@@ -223,7 +223,7 @@ def test_resampling_with_affine(affine_eye, shape, angle, rng):
 
     Check on 3D and 4D data.
     """
-    data = rng.randint(4, size=shape, dtype="int32")
+    data = rng.integers(4, size=shape, dtype="int32")
     rot = rotation(0, angle)
 
     rot_img = resample_img(
@@ -248,7 +248,7 @@ def test_resampling_with_affine(affine_eye, shape, angle, rng):
 @pytest.mark.parametrize("shape", [(1, 10, 10), (1, 10, 10, 3)])
 @pytest.mark.parametrize("angle", (0, np.pi / 2.0, np.pi, 3 * np.pi / 2.0))
 def test_resampling_continuous_with_affine(affine_eye, shape, angle, rng):
-    data = rng.randint(1, 4, size=shape, dtype="int32")
+    data = rng.integers(1, 4, size=shape, dtype="int32")
     rot = rotation(0, angle)
     img = Nifti1Image(data, affine_eye)
 
@@ -322,7 +322,7 @@ def test_resampling_copy_has_no_shared_memory(target_shape):
 
 
 def test_resampling_warning_s_form(affine_eye, shape, rng):
-    data = rng.randint(0, 10, shape, dtype="int32")
+    data = rng.integers(0, 10, shape, dtype="int32")
     img_no_sform = Nifti1Image(data, affine_eye)
     img_no_sform.set_sform(None)
 
@@ -333,7 +333,7 @@ def test_resampling_warning_s_form(affine_eye, shape, rng):
 def test_resampling_warning_binary_image(affine_eye, rng):
     # Resampling a binary image with continuous or
     # linear interpolation should raise a warning.
-    data_binary = rng.randint(4, size=(1, 4, 4), dtype="int32")
+    data_binary = rng.integers(4, size=(1, 4, 4), dtype="int32")
     data_binary[data_binary > 0] = 1
 
     assert sorted(list(np.unique(data_binary))) == [0, 1]
@@ -601,7 +601,7 @@ def test_resampling_nan_big(affine_eye):
 
 
 def test_resample_to_img(affine_eye, shape, rng):
-    data = rng.random_sample(shape)
+    data = rng.random(shape)
 
     source_affine = affine_eye
     source_img = Nifti1Image(data, source_affine)
@@ -633,8 +633,8 @@ def test_crop(affine_eye):
 def test_resample_identify_affine_int_translation(affine_eye, rng):
     source_shape = (6, 4, 6)
     source_affine = affine_eye
-    source_affine[:, 3] = np.append(rng.randint(0, 4, 3), 1)
-    source_data = rng.random_sample(source_shape)
+    source_affine[:, 3] = np.append(rng.integers(0, 4, 3), 1)
+    source_data = rng.random(source_shape)
     source_img = Nifti1Image(source_data, source_affine)
 
     target_shape = (11, 10, 9)
@@ -706,7 +706,7 @@ def test_reorder_img(affine_eye, rng):
     ref_img = Nifti1Image(data, affine)
 
     # Test with purely positive matrices and compare to a rotation
-    for theta, phi in rng.randint(4, size=(5, 2)):
+    for theta, phi in rng.integers(4, size=(5, 2)):
         rot = rotation(theta * np.pi / 2, phi * np.pi / 2)
         rot[np.abs(rot) < 0.001] = 0
         rot[rot > 0.9] = 1
@@ -841,9 +841,9 @@ def test_reorder_img_mirror():
 
 def test_coord_transform_trivial(affine_eye, rng):
     sform = affine_eye
-    x = rng.random_sample((10,))
-    y = rng.random_sample((10,))
-    z = rng.random_sample((10,))
+    x = rng.random((10,))
+    y = rng.random((10,))
+    z = rng.random((10,))
 
     x_, y_, z_ = coord_transform(x, y, z, sform)
     assert_array_equal(x, x_)
@@ -941,7 +941,7 @@ def test_resampling_with_int64_types_no_crash(affine_eye, dtype):
 
 
 def test_resample_input(affine_eye, shape, rng):
-    data = rng.randint(0, 10, shape, dtype="int32")
+    data = rng.integers(0, 10, shape, dtype="int32")
     affine = affine_eye
     affine[:3, -1] = 0.5 * np.array(shape[:3])
     img = Nifti1Image(data, affine)
@@ -953,7 +953,7 @@ def test_resample_input(affine_eye, shape, rng):
 
 def test_smoke_resampling_non_nifti(affine_eye, shape, rng):
     target_affine = 2 * affine_eye
-    data = rng.randint(0, 10, shape, dtype="int32")
+    data = rng.integers(0, 10, shape, dtype="int32")
     img = MGHImage(data, affine_eye)
 
     resample_img(img, target_affine=target_affine, interpolation="nearest")

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
@@ -466,7 +466,7 @@ def test_invalid_filetype(tmp_path, rng):
     (tmp_path / add_conf).unlink()  # Remove for the rest of the tests to run
 
     # invalid fmriprep version: confound file with no header (<1.0)
-    fake_confounds = rng.rand(30, 20)
+    fake_confounds = rng.random((30, 20))
     np.savetxt(bad_conf, fake_confounds, delimiter="\t")
     with pytest.raises(ValueError) as error_log:
         load_confounds(bad_nii)

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds_scrub.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds_scrub.py
@@ -50,7 +50,7 @@ def test_extract_outlier_regressors(rng):
     # Create a fake confound dataframe
     n_scans = 50
     fake_confounds = pd.DataFrame(
-        rng.rand(n_scans, 1), columns=["confound_regressor"]
+        rng.random((n_scans, 1)), columns=["confound_regressor"]
     )
 
     # scrubbed volume one-hot, overlap with non-steady-state

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -250,7 +250,7 @@ def test_4d_single_scan(rng):
     mask[3:7, 3:7, 3:7] = 1
     mask_img = nibabel.Nifti1Image(mask, np.eye(4))
 
-    data_5d = [rng.random_sample(shape_4d) for _ in range(5)]
+    data_5d = [rng.random(shape_4d) for _ in range(5)]
     data_4d = [d[..., 0] for d in data_5d]
     data_5d = [nibabel.Nifti1Image(d, np.eye(4)) for d in data_5d]
     data_4d = [nibabel.Nifti1Image(d, np.eye(4)) for d in data_4d]
@@ -282,7 +282,7 @@ def test_5d(rng):
     mask[3:7, 3:7, 3:7] = 1
     mask_img = nibabel.Nifti1Image(mask, np.eye(4))
 
-    data_5d = [rng.random_sample(shape_4d) for _ in range(5)]
+    data_5d = [rng.random(shape_4d) for _ in range(5)]
     data_5d = [nibabel.Nifti1Image(d, np.eye(4)) for d in data_5d]
 
     masker = NiftiMasker(mask_img=mask_img)

--- a/nilearn/maskers/tests/test_nifti_spheres_masker.py
+++ b/nilearn/maskers/tests/test_nifti_spheres_masker.py
@@ -13,7 +13,7 @@ from nilearn.maskers import NiftiSpheresMasker
 
 def test_seed_extraction(rng):
     """Test seed extraction."""
-    data = rng.random_sample((3, 3, 3, 5))
+    data = rng.random((3, 3, 3, 5))
     img = nibabel.Nifti1Image(data, np.eye(4))
     masker = NiftiSpheresMasker([(1, 1, 1)])
     # Test the fit
@@ -25,7 +25,7 @@ def test_seed_extraction(rng):
 
 def test_sphere_extraction(rng):
     """Test sphere extraction."""
-    data = rng.random_sample((3, 3, 3, 5))
+    data = rng.random((3, 3, 3, 5))
     img = nibabel.Nifti1Image(data, np.eye(4))
     masker = NiftiSpheresMasker([(1, 1, 1)], radius=1)
 
@@ -65,7 +65,7 @@ def test_sphere_extraction(rng):
 
 
 def test_anisotropic_sphere_extraction(rng):
-    data = rng.random_sample((3, 3, 3, 5))
+    data = rng.random((3, 3, 3, 5))
     affine = np.eye(4)
     affine[0, 0] = 2
     affine[2, 2] = 2
@@ -102,7 +102,7 @@ def test_nifti_spheres_masker_overlap(rng):
     affine = np.eye(4)
     shape = (5, 5, 5)
 
-    data = rng.random_sample(shape + (5,))
+    data = rng.random(shape + (5,))
     fmri_img = nibabel.Nifti1Image(data, affine)
 
     seeds = [(0, 0, 0), (2, 2, 2)]
@@ -131,7 +131,7 @@ def test_small_radius(rng):
     affine = np.eye(4)
     shape = (3, 3, 3)
 
-    data = rng.random_sample(shape)
+    data = rng.random(shape)
     mask = np.zeros(shape)
     mask[1, 1, 1] = 1
     mask[2, 2, 2] = 1
@@ -165,7 +165,7 @@ def test_is_nifti_spheres_masker_give_nans(rng):
     data_with_nans = np.zeros((10, 10, 10), dtype=np.float32)
     data_with_nans[:, :, :] = np.nan
 
-    data_without_nans = rng.random_sample((9, 9, 9))
+    data_without_nans = rng.random((9, 9, 9))
     indices = np.nonzero(data_without_nans)
 
     # Leaving nans outside of some data
@@ -185,7 +185,7 @@ def test_is_nifti_spheres_masker_give_nans(rng):
 
 
 def test_standardization(rng):
-    data = rng.random_sample((3, 3, 3, 5))
+    data = rng.random((3, 3, 3, 5))
     img = nibabel.Nifti1Image(data, np.eye(4))
 
     # test zscore
@@ -210,7 +210,7 @@ def test_standardization(rng):
 
 def test_nifti_spheres_masker_inverse_transform(rng):
     # Applying the sphere_extraction example from above backwards
-    data = rng.random_sample((3, 3, 3, 5))
+    data = rng.random((3, 3, 3, 5))
     img = nibabel.Nifti1Image(data, np.eye(4))
     masker = NiftiSpheresMasker([(1, 1, 1)], radius=1)
     # Test the fit
@@ -253,14 +253,14 @@ def test_nifti_spheres_masker_inverse_overlap(rng):
     affine = np.eye(4)
     shape = (5, 5, 5)
 
-    data = rng.random_sample(shape + (5,))
+    data = rng.random(shape + (5,))
     fmri_img = nibabel.Nifti1Image(data, affine)
 
     # Apply mask image - to allow inversion
     mask_img = new_img_like(fmri_img, np.ones(shape))
     seeds = [(0, 0, 0), (2, 2, 2)]
     # Inverse data
-    inv_data = rng.random_sample(len(seeds))
+    inv_data = rng.random(len(seeds))
 
     overlapping_masker = NiftiSpheresMasker(
         seeds, radius=1, allow_overlap=True, mask_img=mask_img
@@ -293,7 +293,7 @@ def test_small_radius_inverse(rng):
     affine = np.eye(4)
     shape = (3, 3, 3)
 
-    data = rng.random_sample(shape)
+    data = rng.random(shape)
     mask = np.zeros(shape)
     mask[1, 1, 1] = 1
     mask[2, 2, 2] = 1

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -11,6 +11,7 @@ import nibabel as nib
 import numpy as np
 from scipy import stats
 from scipy.ndimage import generate_binary_structure, label
+from sklearn.utils import check_random_state
 
 from nilearn import image
 from nilearn.masking import apply_mask
@@ -162,7 +163,7 @@ def _permuted_ols_on_chunk(
 
     """
     # initialize the seed of the random generator
-    rng = np.random.default_rng(random_state)
+    rng = check_random_state(random_state)
 
     n_samples, n_regressors = tested_vars.shape
     n_descriptors = target_vars.shape[1]
@@ -190,7 +191,7 @@ def _permuted_ols_on_chunk(
         if intercept_test:
             # sign swap (random multiplication by 1 or -1)
             target_vars = target_vars * (
-                rng.integers(2, size=(n_samples, 1)) * 2 - 1
+                rng.randint(2, size=(n_samples, 1)) * 2 - 1
             )
 
         else:
@@ -605,7 +606,7 @@ def permuted_ols(
 
     """
     # initialize the seed of the random generator
-    rng = np.random.default_rng(random_state)
+    rng = check_random_state(random_state)
 
     # check n_jobs (number of CPUs)
     if n_jobs == 0:  # invalid according to joblib's conventions
@@ -871,7 +872,7 @@ def permuted_ols(
             two_sided_test=two_sided_test,
             tfce=tfce,
             tfce_original_data=tfce_original_data,
-            random_state=rng.integers(1, np.iinfo(np.int32).max - 1),
+            random_state=rng.randint(1, np.iinfo(np.int32).max - 1),
             verbose=verbose,
         )
         for thread_id, n_perm_chunk in enumerate(n_perm_chunks)

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -163,7 +163,7 @@ def _permuted_ols_on_chunk(
 
     """
     # initialize the seed of the random generator
-    rng = np.random.default_rng(random_state)
+    rng = check_random_state(random_state)
 
     n_samples, n_regressors = tested_vars.shape
     n_descriptors = target_vars.shape[1]
@@ -191,7 +191,7 @@ def _permuted_ols_on_chunk(
         if intercept_test:
             # sign swap (random multiplication by 1 or -1)
             target_vars = target_vars * (
-                rng.integers(2, size=(n_samples, 1)) * 2 - 1
+                rng.randint(2, size=(n_samples, 1)) * 2 - 1
             )
 
         else:

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -163,7 +163,7 @@ def _permuted_ols_on_chunk(
 
     """
     # initialize the seed of the random generator
-    rng = check_random_state(random_state)
+    rng = np.random.default_rng(random_state)
 
     n_samples, n_regressors = tested_vars.shape
     n_descriptors = target_vars.shape[1]
@@ -191,7 +191,7 @@ def _permuted_ols_on_chunk(
         if intercept_test:
             # sign swap (random multiplication by 1 or -1)
             target_vars = target_vars * (
-                rng.randint(2, size=(n_samples, 1)) * 2 - 1
+                rng.integers(2, size=(n_samples, 1)) * 2 - 1
             )
 
         else:

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -11,7 +11,6 @@ import nibabel as nib
 import numpy as np
 from scipy import stats
 from scipy.ndimage import generate_binary_structure, label
-from sklearn.utils import check_random_state
 
 from nilearn import image
 from nilearn.masking import apply_mask
@@ -163,7 +162,7 @@ def _permuted_ols_on_chunk(
 
     """
     # initialize the seed of the random generator
-    rng = check_random_state(random_state)
+    rng = np.random.default_rng(random_state)
 
     n_samples, n_regressors = tested_vars.shape
     n_descriptors = target_vars.shape[1]
@@ -191,7 +190,7 @@ def _permuted_ols_on_chunk(
         if intercept_test:
             # sign swap (random multiplication by 1 or -1)
             target_vars = target_vars * (
-                rng.randint(2, size=(n_samples, 1)) * 2 - 1
+                rng.integers(2, size=(n_samples, 1)) * 2 - 1
             )
 
         else:
@@ -606,7 +605,7 @@ def permuted_ols(
 
     """
     # initialize the seed of the random generator
-    rng = check_random_state(random_state)
+    rng = np.random.default_rng(random_state)
 
     # check n_jobs (number of CPUs)
     if n_jobs == 0:  # invalid according to joblib's conventions
@@ -872,7 +871,7 @@ def permuted_ols(
             two_sided_test=two_sided_test,
             tfce=tfce,
             tfce_original_data=tfce_original_data,
-            random_state=rng.randint(1, np.iinfo(np.int32).max - 1),
+            random_state=rng.integers(1, np.iinfo(np.int32).max - 1),
             verbose=verbose,
         )
         for thread_id, n_perm_chunk in enumerate(n_perm_chunks)

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -60,8 +60,8 @@ def ref_score(tested_var, target_var, covars=None):
 
 
 def _create_design(rng, n_samples, n_descriptors, n_regressors):
-    target_var = rng.randn(n_samples, n_descriptors)
-    tested_var = rng.randn(n_samples, n_regressors)
+    target_var = rng.standard_normal((n_samples, n_descriptors))
+    tested_var = rng.standard_normal((n_samples, n_regressors))
 
     return target_var, tested_var, n_descriptors, n_regressors
 
@@ -81,7 +81,7 @@ def dummy_design(rng):
 
 @pytest.fixture
 def confounding_vars(rng):
-    return rng.randn(N_SAMPLES, N_COVARS)
+    return rng.standard_normal((N_SAMPLES, N_COVARS))
 
 
 @pytest.fixture()
@@ -212,7 +212,7 @@ def test_permuted_ols_check_h0_noeffect_labelswap_centered(
     rng, model_intercept
 ):
     # create dummy design with no effect
-    target_var = rng.randn(N_SAMPLES, 1)
+    target_var = rng.standard_normal((N_SAMPLES, 1))
 
     centered_var = np.arange(N_SAMPLES, dtype="f8").reshape((-1, 1))
     centered_var -= centered_var.mean(0)
@@ -228,7 +228,7 @@ def test_permuted_ols_check_h0_noeffect_labelswap_uncentered_var_and_intercept(
     rng,
 ):
     # create dummy design with no effect
-    target_var = rng.randn(N_SAMPLES, 1)
+    target_var = rng.standard_normal((N_SAMPLES, 1))
 
     uncentered_var = np.arange(N_SAMPLES, dtype="f8").reshape((-1, 1))
 
@@ -247,7 +247,7 @@ def test_permuted_ols_check_h0_noeffect_signswap(rng):
         (= t(n_samples - dof)).
     """
     # create dummy design with no effect
-    target_var = rng.randn(N_SAMPLES, 1)
+    target_var = rng.standard_normal((N_SAMPLES, 1))
     n_regressors = 1
     tested_var = np.ones((N_SAMPLES, n_regressors))
 
@@ -430,7 +430,7 @@ def test_permuted_ols_with_multiple_constants_and_covars(design, rng):
     n_covars = 2
 
     confounding_vars = np.hstack(
-        (rng.randn(N_SAMPLES, n_covars), np.ones([N_SAMPLES, 2]))
+        (rng.standard_normal((N_SAMPLES, n_covars)), np.ones([N_SAMPLES, 2]))
     )
     output = permuted_ols(
         tested_var,
@@ -525,7 +525,7 @@ def test_permuted_ols_intercept_nocovar(rng):
     n_descriptors = 10
     n_regressors = 1
     tested_var = np.ones((N_SAMPLES, n_regressors))
-    target_var = rng.randn(N_SAMPLES, n_descriptors)
+    target_var = rng.standard_normal((N_SAMPLES, n_descriptors))
 
     output = permuted_ols(
         tested_var,
@@ -565,8 +565,8 @@ def test_permuted_ols_intercept_statsmodels_withcovar(
     n_regressors = 1
     n_covars = 2
     tested_var = np.ones((N_SAMPLES, n_regressors))
-    target_var = rng.randn(N_SAMPLES, n_descriptors)
-    confounding_vars = rng.randn(N_SAMPLES, n_covars)
+    target_var = rng.standard_normal((N_SAMPLES, n_descriptors))
+    confounding_vars = rng.standard_normal((N_SAMPLES, n_covars))
 
     output = permuted_ols(
         tested_var,
@@ -603,8 +603,8 @@ def test_one_sided_versus_two_test(rng):
     recovered with one-sided."""
     n_descriptors = 100
     n_regressors = 1
-    target_var = rng.randn(N_SAMPLES, n_descriptors)
-    tested_var = rng.randn(N_SAMPLES, n_regressors)
+    target_var = rng.standard_normal((N_SAMPLES, n_descriptors))
+    tested_var = rng.standard_normal((N_SAMPLES, n_regressors))
 
     # one-sided
     output_1_sided = permuted_ols(

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -269,20 +269,20 @@ def test_permuted_ols_check_h0_noeffect_signswap(rng):
 # Tests for labels swapping permutation scheme
 
 
-def test_permuted_ols_no_covar(design, rng):
+def test_permuted_ols_no_covar(design):
     target_var, tested_var, *_ = design
     output = permuted_ols(
         tested_var,
         target_var,
         model_intercept=False,
         n_perm=0,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
     compare_to_ref_score(output["t"], tested_var, target_var)
 
 
-def test_permuted_ols_no_covar_with_ravelized_tested_var(design, rng):
+def test_permuted_ols_no_covar_with_ravelized_tested_var(design):
     target_var, tested_var, *_ = design
 
     output = permuted_ols(
@@ -290,13 +290,13 @@ def test_permuted_ols_no_covar_with_ravelized_tested_var(design, rng):
         target_var,
         model_intercept=False,
         n_perm=0,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
     compare_to_ref_score(output["t"], tested_var, target_var)
 
 
-def test_permuted_ols_no_covar_with_intercept(design, rng):
+def test_permuted_ols_no_covar_with_intercept(design):
     # Adds intercept (should be equivalent to centering variates)
     target_var, tested_var, *_ = design
 
@@ -305,7 +305,7 @@ def test_permuted_ols_no_covar_with_intercept(design, rng):
         target_var,
         model_intercept=True,
         n_perm=0,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
     target_var -= target_var.mean(0)
@@ -326,7 +326,7 @@ def test_permuted_ols_no_covar_warning(rng):
         target_var,
         model_intercept=False,
         n_perm=N_PERM,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
 
@@ -339,14 +339,14 @@ def test_permuted_ols_no_covar_warning(rng):
             target_var,
             model_intercept=False,
             n_perm=N_PERM,
-            random_state=rng,
+            random_state=0,
             output_type="dict",
         )
 
     assert np.array_equal(output_1["t"][1:], output_2["t"][1:])
 
 
-def test_permuted_ols_no_covar_n_job_error(dummy_design, rng):
+def test_permuted_ols_no_covar_n_job_error(dummy_design):
     """Ensure that a warning is raised when a given voxel has all zeros.
 
     This test also checks that an invalid n_jobs value will raise a ValueError.
@@ -360,11 +360,11 @@ def test_permuted_ols_no_covar_n_job_error(dummy_design, rng):
             model_intercept=False,
             n_perm=N_PERM,
             n_jobs=0,  # not allowed
-            random_state=rng,
+            random_state=0,
         )
 
 
-def test_permuted_ols_with_covar(design, confounding_vars, rng):
+def test_permuted_ols_with_covar(design, confounding_vars):
     target_var, tested_var, n_descriptors, n_regressors = design
 
     output = permuted_ols(
@@ -373,7 +373,7 @@ def test_permuted_ols_with_covar(design, confounding_vars, rng):
         confounding_vars,
         model_intercept=False,
         n_perm=0,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
 
@@ -384,7 +384,7 @@ def test_permuted_ols_with_covar(design, confounding_vars, rng):
     assert ref_score.shape == (n_regressors, n_descriptors)
 
 
-def test_permuted_ols_with_covar_with_intercept(design, confounding_vars, rng):
+def test_permuted_ols_with_covar_with_intercept(design, confounding_vars):
     target_var, tested_var, n_descriptors, n_regressors = design
 
     output = permuted_ols(
@@ -393,7 +393,7 @@ def test_permuted_ols_with_covar_with_intercept(design, confounding_vars, rng):
         confounding_vars,
         model_intercept=True,
         n_perm=0,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
 
@@ -407,7 +407,7 @@ def test_permuted_ols_with_covar_with_intercept(design, confounding_vars, rng):
 
 @pytest.mark.parametrize("model_intercept", [True, False])
 def test_permuted_ols_with_covar_with_intercept_in_confonding_vars(
-    design, model_intercept, rng
+    design, model_intercept
 ):
     target_var, tested_var, n_descriptors, n_regressors = design
     confounding_vars = np.ones([N_SAMPLES, 1])
@@ -418,7 +418,7 @@ def test_permuted_ols_with_covar_with_intercept_in_confonding_vars(
         confounding_vars,
         model_intercept=model_intercept,
         n_perm=0,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
     assert output["t"].shape == (n_regressors, n_descriptors)
@@ -438,13 +438,13 @@ def test_permuted_ols_with_multiple_constants_and_covars(design, rng):
         confounding_vars,
         model_intercept=False,
         n_perm=0,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
     assert output["t"].shape == (n_regressors, n_descriptors)
 
 
-def test_permuted_ols_with_multiple_constants_and_covars_warnings(design, rng):
+def test_permuted_ols_with_multiple_constants_and_covars_warnings(design):
     target_var, tested_var, *_ = design
 
     # Multiple intercepts should raise a warning
@@ -456,7 +456,7 @@ def test_permuted_ols_with_multiple_constants_and_covars_warnings(design, rng):
             target_var,
             confounding_vars,
             n_perm=0,
-            random_state=rng,
+            random_state=0,
         )
 
     # Across tested vars and confounding vars
@@ -468,7 +468,7 @@ def test_permuted_ols_with_multiple_constants_and_covars_warnings(design, rng):
             target_var,
             confounding_vars,
             n_perm=0,
-            random_state=rng,
+            random_state=0,
         )
 
 
@@ -492,7 +492,7 @@ def test_permuted_ols_nocovar_multivariate(rng):
         target_vars,
         model_intercept=False,
         n_perm=n_perm,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
 
@@ -507,7 +507,7 @@ def test_permuted_ols_nocovar_multivariate(rng):
         target_vars,
         model_intercept=True,
         n_perm=0,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
 
@@ -532,7 +532,7 @@ def test_permuted_ols_intercept_nocovar(rng):
         target_var,
         confounding_vars=None,
         n_perm=N_PERM,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
 
@@ -551,7 +551,7 @@ def test_permuted_ols_intercept_nocovar(rng):
         confounding_vars=None,
         model_intercept=False,
         n_perm=0,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
     compare_to_ref_score(output_addintercept["t"], tested_var, target_var)
@@ -573,7 +573,7 @@ def test_permuted_ols_intercept_statsmodels_withcovar(
         target_var,
         confounding_vars,
         n_perm=0,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
     ref_score = compare_to_ref_score(
@@ -589,7 +589,7 @@ def test_permuted_ols_intercept_statsmodels_withcovar(
         confounding_vars,
         model_intercept=True,
         n_perm=0,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
     compare_to_ref_score(
@@ -613,7 +613,7 @@ def test_one_sided_versus_two_test(rng):
         model_intercept=False,
         two_sided_test=False,
         n_perm=N_PERM,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
     assert output_1_sided["logp_max_t"].shape == (n_regressors, n_descriptors)
@@ -625,7 +625,7 @@ def test_one_sided_versus_two_test(rng):
         model_intercept=False,
         two_sided_test=True,
         n_perm=N_PERM,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
     assert output_2_sided["logp_max_t"].shape == (n_regressors, n_descriptors)
@@ -641,9 +641,7 @@ def test_one_sided_versus_two_test(rng):
     )
 
 
-def test_two_sided_recover_positive_and_negative_effects(
-    rng,
-):
+def test_two_sided_recover_positive_and_negative_effects():
     """Check that two-sided can actually recover \
     positive and negative effects."""
     target_var1 = np.arange(0, 10).reshape((-1, 1))  # positive effect
@@ -657,7 +655,7 @@ def test_two_sided_recover_positive_and_negative_effects(
         model_intercept=False,
         two_sided_test=False,
         n_perm=N_PERM,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
     output_1_sided_1["logp_max_t"]
@@ -669,7 +667,7 @@ def test_two_sided_recover_positive_and_negative_effects(
         model_intercept=False,
         two_sided_test=False,
         n_perm=N_PERM,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
 
@@ -680,7 +678,7 @@ def test_two_sided_recover_positive_and_negative_effects(
         model_intercept=False,
         two_sided_test=True,
         n_perm=N_PERM,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
     output_2_sided["logp_max_t"]
@@ -695,7 +693,7 @@ def test_two_sided_recover_positive_and_negative_effects(
     )
 
 
-def test_tfce_no_masker_error(rng):
+def test_tfce_no_masker_error():
     target_var, tested_var, *_ = _tfce_design()
 
     with pytest.raises(ValueError, match="masker must be provided"):
@@ -705,12 +703,12 @@ def test_tfce_no_masker_error(rng):
             model_intercept=False,
             two_sided_test=False,
             n_perm=N_PERM,
-            random_state=rng,
+            random_state=0,
             tfce=True,
         )
 
 
-def test_tfce_smoke_legacy_warnings(rng):
+def test_tfce_smoke_legacy_warnings():
     target_var, tested_var, masker, *_ = _tfce_design()
 
     # tfce is True, but output_type is "legacy".
@@ -722,7 +720,7 @@ def test_tfce_smoke_legacy_warnings(rng):
             model_intercept=False,
             two_sided_test=False,
             n_perm=0,
-            random_state=rng,
+            random_state=0,
             masker=masker,
             tfce=True,
             output_type="legacy",
@@ -739,14 +737,14 @@ def test_tfce_smoke_legacy_warnings(rng):
             model_intercept=False,
             two_sided_test=False,
             n_perm=N_PERM,
-            random_state=rng,
+            random_state=0,
             output_type="legacy",
         )
 
     assert isinstance(out, tuple)
 
 
-def test_tfce_smoke_legacy_smoke(rng):
+def test_tfce_smoke_legacy_smoke():
     (
         target_var,
         tested_var,
@@ -763,7 +761,7 @@ def test_tfce_smoke_legacy_smoke(rng):
         model_intercept=False,
         two_sided_test=False,
         n_perm=0,
-        random_state=rng,
+        random_state=0,
         masker=masker,
         tfce=True,
         output_type="dict",
@@ -784,7 +782,7 @@ def test_tfce_smoke_legacy_smoke(rng):
         model_intercept=False,
         two_sided_test=False,
         n_perm=n_perm,
-        random_state=rng,
+        random_state=0,
         masker=masker,
         tfce=True,
         output_type="dict",
@@ -805,7 +803,7 @@ def test_tfce_smoke_legacy_smoke(rng):
     assert out["h0_max_tfce"].size == n_perm
 
 
-def test_cluster_level_parameters_error_no_masker(cluster_level_design, rng):
+def test_cluster_level_parameters_error_no_masker(cluster_level_design):
     """Test combinations of parameters related to cluster-level inference."""
     target_var, tested_var = cluster_level_design
 
@@ -818,13 +816,13 @@ def test_cluster_level_parameters_error_no_masker(cluster_level_design, rng):
             model_intercept=False,
             two_sided_test=False,
             n_perm=N_PERM,
-            random_state=rng,
+            random_state=0,
             threshold=0.001,
             tfce=False,
         )
 
 
-def test_cluster_level_parameters_warnings(cluster_level_design, masker, rng):
+def test_cluster_level_parameters_warnings(cluster_level_design, masker):
     """Test combinations of parameters related to cluster-level inference."""
     target_var, tested_var = cluster_level_design
 
@@ -837,7 +835,7 @@ def test_cluster_level_parameters_warnings(cluster_level_design, masker, rng):
             model_intercept=False,
             two_sided_test=False,
             n_perm=N_PERM,
-            random_state=rng,
+            random_state=0,
             masker=masker,
             output_type="legacy",
         )
@@ -853,7 +851,7 @@ def test_cluster_level_parameters_warnings(cluster_level_design, masker, rng):
             model_intercept=False,
             two_sided_test=False,
             n_perm=0,
-            random_state=rng,
+            random_state=0,
             threshold=0.001,
             masker=masker,
             output_type="legacy",
@@ -870,14 +868,14 @@ def test_cluster_level_parameters_warnings(cluster_level_design, masker, rng):
             model_intercept=False,
             two_sided_test=False,
             n_perm=N_PERM,
-            random_state=rng,
+            random_state=0,
             output_type="legacy",
         )
 
     assert isinstance(out, tuple)
 
 
-def test_cluster_level_parameters_smoke(cluster_level_design, masker, rng):
+def test_cluster_level_parameters_smoke(cluster_level_design, masker):
     """Test combinations of parameters related to cluster-level inference."""
     target_var, tested_var = cluster_level_design
 
@@ -888,7 +886,7 @@ def test_cluster_level_parameters_smoke(cluster_level_design, masker, rng):
         model_intercept=False,
         two_sided_test=False,
         n_perm=0,
-        random_state=rng,
+        random_state=0,
         output_type="dict",
     )
 
@@ -904,7 +902,7 @@ def test_cluster_level_parameters_smoke(cluster_level_design, masker, rng):
         model_intercept=False,
         two_sided_test=True,
         n_perm=n_perm,
-        random_state=rng,
+        random_state=0,
         threshold=0.001,
         masker=masker,
         output_type="dict",

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -208,11 +208,10 @@ def check_ktest_p_values_distribution_and_mse(all_kstest_pvals, all_mse):
 
 
 @pytest.mark.parametrize("model_intercept", [True, False])
-def test_permuted_ols_check_h0_noeffect_labelswap_centered(
-    rng, model_intercept
-):
+def test_permuted_ols_check_h0_noeffect_labelswap_centered(model_intercept):
     # create dummy design with no effect
-    target_var = rng.standard_normal((N_SAMPLES, 1))
+    rng = np.random.RandomState(0)
+    target_var = rng.randn(N_SAMPLES, 1)
 
     centered_var = np.arange(N_SAMPLES, dtype="f8").reshape((-1, 1))
     centered_var -= centered_var.mean(0)
@@ -224,11 +223,10 @@ def test_permuted_ols_check_h0_noeffect_labelswap_centered(
     check_ktest_p_values_distribution_and_mse(all_kstest_pvals, all_mse)
 
 
-def test_permuted_ols_check_h0_noeffect_labelswap_uncentered_var_and_intercept(
-    rng,
-):
+def test_permuted_ols_check_h0_noeffect_labelswap_uncentered():
     # create dummy design with no effect
-    target_var = rng.standard_normal((N_SAMPLES, 1))
+    rng = np.random.RandomState(0)
+    target_var = rng.randn(N_SAMPLES, 1)
 
     uncentered_var = np.arange(N_SAMPLES, dtype="f8").reshape((-1, 1))
 
@@ -239,7 +237,7 @@ def test_permuted_ols_check_h0_noeffect_labelswap_uncentered_var_and_intercept(
     check_ktest_p_values_distribution_and_mse(all_kstest_pvals, all_mse)
 
 
-def test_permuted_ols_check_h0_noeffect_signswap(rng):
+def test_permuted_ols_check_h0_noeffect_signswap():
     """Check that h0 is close to the theoretical distribution \
     for permuted OLS with sign swap.
 
@@ -247,7 +245,9 @@ def test_permuted_ols_check_h0_noeffect_signswap(rng):
         (= t(n_samples - dof)).
     """
     # create dummy design with no effect
-    target_var = rng.standard_normal((N_SAMPLES, 1))
+    rng = np.random.RandomState(0)
+    target_var = rng.randn(N_SAMPLES, 1)
+
     n_regressors = 1
     tested_var = np.ones((N_SAMPLES, n_regressors))
 

--- a/nilearn/mass_univariate/tests/test_utils.py
+++ b/nilearn/mass_univariate/tests/test_utils.py
@@ -229,7 +229,7 @@ def test_t_score_with_covars_and_normalized_design_nocovar(rng):
 
     # generate data
     var1 = np.ones((n_samples, 1)) / np.sqrt(n_samples)
-    var2 = rng.randn(n_samples, 1)
+    var2 = rng.standard_normal((n_samples, 1))
     var2 = var2 / np.sqrt(np.sum(var2**2, 0))  # normalize
 
     # compute t-scores with nilearn routine
@@ -247,7 +247,7 @@ def test_t_score_with_covars_and_normalized_design_withcovar(rng):
 
     # generate data
     var1 = np.ones((n_samples, 1)) / np.sqrt(n_samples)  # normalized
-    var2 = rng.randn(n_samples, 1)
+    var2 = rng.standard_normal((n_samples, 1))
     var2 = var2 / np.sqrt(np.sum(var2**2, 0))  # normalize
     covars = np.eye(n_samples, 3)  # covars is orthogonal
     covars[3] = -1  # covars is orthogonal to var1

--- a/nilearn/plotting/tests/test_cm.py
+++ b/nilearn/plotting/tests/test_cm.py
@@ -31,8 +31,8 @@ def test_mix_colormaps(rng):
 
     # Mixin map's shape should be equal to that of
     # the foreground and background maps
-    foreground_map = rng.rand(n, 4)
-    background_map = rng.rand(n, 4)
+    foreground_map = rng.random((n, 4))
+    background_map = rng.random((n, 4))
     mix_map = _mix_colormaps(foreground_map, background_map)
     assert mix_map.shape == (n, 4)
     # Transparency of mixin map should be higher
@@ -42,22 +42,22 @@ def test_mix_colormaps(rng):
 
     # If foreground and background maps' shapes are different,
     # an Exception should be raised
-    background_map = rng.rand(n - 1, 4)
+    background_map = rng.random((n - 1, 4))
     with pytest.raises(Exception):
         _mix_colormaps(foreground_map, background_map)
 
     # If foreground map is transparent,
     # mixin should be equal to background map
-    foreground_map = rng.rand(n, 4)
-    background_map = rng.rand(n, 4)
+    foreground_map = rng.random((n, 4))
+    background_map = rng.random((n, 4))
     foreground_map[:, 3] = 0
     mix_map = _mix_colormaps(foreground_map, background_map)
     assert np.allclose(mix_map, background_map)
 
     # If background map is transparent,
     # mixin should be equal to foreground map
-    foreground_map = rng.rand(n, 4)
-    background_map = rng.rand(n, 4)
+    foreground_map = rng.random((n, 4))
+    background_map = rng.random((n, 4))
     background_map[:, 3] = 0
     mix_map = _mix_colormaps(foreground_map, background_map)
     assert np.allclose(mix_map, foreground_map)
@@ -65,7 +65,7 @@ def test_mix_colormaps(rng):
     # If foreground and background maps are equal,
     # RBG values of the mixin map should be equal
     # to that of the foreground and background maps
-    foreground_map = rng.rand(n, 4)
+    foreground_map = rng.random((n, 4))
     background_map = foreground_map
     mix_map = _mix_colormaps(foreground_map, background_map)
     assert np.allclose(mix_map[:, :3], foreground_map[:, :3])

--- a/nilearn/plotting/tests/test_html_surface.py
+++ b/nilearn/plotting/tests/test_html_surface.py
@@ -181,7 +181,7 @@ def test_view_surf(rng):
     assert "SOME_TITLE" in html.html
     html = html_surface.view_surf(fsaverage['pial_right'])
     check_html(html)
-    atlas = rng.randint(0, 10, size=len(mesh[0]))
+    atlas = rng.integers(0, 10, size=len(mesh[0]))
     html = html_surface.view_surf(
         fsaverage['pial_left'], atlas, symmetric_cmap=False)
     check_html(html)

--- a/nilearn/plotting/tests/test_img_plotting/test_plot_glass_brain.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_plot_glass_brain.py
@@ -44,7 +44,7 @@ def test_plot_glass_brain_file_output(img_3d_mni, tmp_path):
 
 def test_plot_noncurrent_axes(affine_eye, rng):
     """Regression test for Issue #450."""
-    maps_img = Nifti1Image(rng.random_sample((10, 10, 10)), np.eye(4))
+    maps_img = Nifti1Image(rng.random((10, 10, 10)), np.eye(4))
     fh1 = plt.figure()
     fh2 = plt.figure()
     ax1 = fh1.add_subplot(1, 1, 1)

--- a/nilearn/plotting/tests/test_img_plotting/test_plot_markers.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_plot_markers.py
@@ -138,7 +138,7 @@ def test_plot_markers_node_kwargs(coords):
     [
         [1, 2, 3, 4, 5],
         [1, 2, 3],
-        _rng().random_sample((4, 4)),
+        _rng().random((4, 4)),
     ],
 )
 def test_plot_markers_dimension_mismatch(matrix, coords):

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -704,7 +704,7 @@ def test_plot_surf_stat_map_error(rng):
 
 def _generate_data_test_surf_roi():
     mesh = generate_surf()
-    roi_idx = _rng().randint(0, mesh[0].shape[0], size=10)
+    roi_idx = _rng().integers(0, mesh[0].shape[0], size=10)
     roi_map = np.zeros(mesh[0].shape[0])
     roi_map[roi_idx] = 1
     parcellation = _rng().uniform(size=mesh[0].shape[0])
@@ -785,7 +785,7 @@ def test_plot_surf_roi_error(engine, rng):
     if not is_plotly_installed() and engine == "plotly":
         pytest.skip('Plotly is not installed; required for this test.')
     mesh = generate_surf()
-    roi_idx = rng.randint(0, mesh[0].shape[0], size=5)
+    roi_idx = rng.integers(0, mesh[0].shape[0], size=5)
     with pytest.raises(
             ValueError,
             match='roi_map does not have the same number of vertices'):

--- a/nilearn/regions/tests/test_region_extractor.py
+++ b/nilearn/regions/tests/test_region_extractor.py
@@ -43,12 +43,14 @@ def labels_img():
 
 @pytest.fixture
 def maps():
-    return generate_maps(shape=MAP_SHAPE, n_regions=N_REGIONS)[0]
+    return generate_maps(
+        shape=MAP_SHAPE, n_regions=N_REGIONS, random_state=42
+    )[0]
 
 
 @pytest.fixture
 def maps_and_mask():
-    return generate_maps(shape=MAP_SHAPE, n_regions=N_REGIONS)
+    return generate_maps(shape=MAP_SHAPE, n_regions=N_REGIONS, random_state=42)
 
 
 @pytest.fixture
@@ -275,7 +277,7 @@ def test_region_extractor_zeros_affine_diagonal(affine_eye):
     affine = affine_eye
     affine[[0, 1]] = affine[[1, 0]]  # permutes first and second lines
     maps, _ = generate_maps(
-        shape=[40, 40, 40], n_regions=n_regions, affine=affine
+        shape=[40, 40, 40], n_regions=n_regions, affine=affine, random_state=42
     )
 
     extract_ratio = RegionExtractor(

--- a/nilearn/reporting/tests/test_html_report.py
+++ b/nilearn/reporting/tests/test_html_report.py
@@ -5,9 +5,11 @@ import pytest
 from nibabel import Nifti1Image
 from numpy.testing import assert_almost_equal
 
-from nilearn._utils import as_ndarray
-from nilearn._utils.data_gen import generate_labeled_regions, generate_maps
-from nilearn.conftest import _rng
+from nilearn._utils.data_gen import (
+    generate_labeled_regions,
+    generate_maps,
+    generate_random_img,
+)
 from nilearn.image import get_data, new_img_like
 from nilearn.maskers import NiftiLabelsMasker, NiftiMapsMasker, NiftiMasker
 
@@ -48,13 +50,6 @@ def niftimapsmasker_inputs():
         shape, n_regions=n_regions, affine=affine
     )
     return {"maps_img": label_img}
-
-
-def generate_random_img(shape, length=1, affine=np.eye(4),
-                        rand_gen=_rng()):
-    data = rand_gen.standard_normal(size=(shape + (length,)))
-    return Nifti1Image(data, affine), Nifti1Image(
-        as_ndarray(data[..., 0] > 0.2, dtype=np.int8), affine)
 
 
 @pytest.fixture
@@ -223,7 +218,7 @@ def test_nifti_maps_masker_report_image_in_fit(niftimapsmasker_inputs,
                                                affine_eye):
     """Tests NiftiMapsMasker reporting with image provided to fit."""
     masker = NiftiMapsMasker(**niftimapsmasker_inputs)
-    image, _ = generate_random_img((13, 11, 12), affine=affine_eye, length=3)
+    image, _ = generate_random_img((13, 11, 12, 3), affine=affine_eye)
     masker.fit(image)
     html = masker.generate_report(2)
     assert masker._report_content['report_id'] == 0

--- a/nilearn/surface/tests/_testing.py
+++ b/nilearn/surface/tests/_testing.py
@@ -13,8 +13,8 @@ def generate_surf():
     This does not generate meaningful surfaces.
     """
     rng = _rng()
-    coords = rng.rand(20, 3)
-    faces = rng.randint(coords.shape[0], size=(30, 3))
+    coords = rng.random((20, 3))
+    faces = rng.integers(coords.shape[0], size=(30, 3))
     return [coords, faces]
 
 

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -765,7 +765,7 @@ def test_check_mesh_and_data(rng):
     assert (d == data).all()
     # Generate faces such that max index is larger than
     # the length of coordinates array.
-    wrong_faces = rng.randint(coords.shape[0] + 1, size=(30, 3))
+    wrong_faces = rng.integers(coords.shape[0] + 1, size=(30, 3))
     wrong_mesh = Mesh(coords, wrong_faces)
     # Check that check_mesh_and_data raises an error
     # with the resulting wrong mesh
@@ -794,7 +794,7 @@ def test_check_surface(rng):
     assert_array_equal(s.mesh.faces, mesh.faces)
     # Generate faces such that max index is larger than
     # the length of coordinates array.
-    wrong_faces = rng.randint(coords.shape[0] + 1, size=(30, 3))
+    wrong_faces = rng.integers(coords.shape[0] + 1, size=(30, 3))
     wrong_mesh = Mesh(coords, wrong_faces)
     wrong_surface = Surface(wrong_mesh, data)
     # Check that check_mesh_and_data raises an error

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -47,9 +47,9 @@ _TEST_DIM_ERROR_MSG = (
 def _simu_img():
     # Random confounds
     rng = _rng()
-    conf = 2 + rng.randn(100, 6)
+    conf = 2 + rng.standard_normal((100, 6))
     # Random 4D volume
-    vol = 100 + 10 * rng.randn(5, 5, 2, 100)
+    vol = 100 + 10 * rng.standard_normal((5, 5, 2, 100))
     img = Nifti1Image(vol, np.eye(4))
     # Create an nifti image with the data, and corresponding mask
     mask = Nifti1Image(np.ones([5, 5, 2]), np.eye(4))
@@ -343,7 +343,7 @@ def test_unmask(rng, affine_eye):
     shape = (10, 20, 30, 40)
     data4D = rng.uniform(size=shape)
     data3D = data4D[..., 0]
-    mask = rng.randint(2, size=shape[:3], dtype="int32")
+    mask = rng.integers(2, size=shape[:3], dtype="int32")
     mask_img = Nifti1Image(mask, affine_eye)
     mask = mask.astype(bool)
 

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -238,7 +238,7 @@ def test_standardize(rng):
     n_samples = 17
 
     # Create random signals with offsets
-    a = rng.random_sample((n_samples, n_features))
+    a = rng.random((n_samples, n_features))
     a += np.linspace(0, 2.0, n_features)
 
     # Test raise error when strategy is not valid option
@@ -872,7 +872,7 @@ def test_clean_psc(rng):
     signals, _, _ = generate_signals(n_features=n_features, length=n_samples)
 
     # positive mean signal
-    means = rng.randn(1, n_features)
+    means = rng.standard_normal((1, n_features))
     signals_pos_mean = signals + means
 
     # a mix of pos and neg mean signal


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4055

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Update Numpy RandomState to Numpy Generator using `numpy.random.default_rng`
  -  The Generator has a similar API to RandomState with some methods having a different name or different signature. [Numpy's API docs](https://numpy.org/doc/stable/reference/random/generator.html) have recommendations for what new methods replace ones in RandomState
- I did not yet update all instances of RandomState in the code but mostly stuck to our tests. The problem comes from some of our functions (e.g. in decomposition, decoding, massunivariate) passing RandomState to scikit learn functions which do not accept the Generator yet so it will take a bit more care to make sure we don't pass these where we call those functions. It could work to just pass a seed as int in some testing cases as scikit learn uses `sklearn.utils.check_random_state` internally to instantiate a RandomState object.
