### PR TITLE
[ENH] Update binarize_img for negative value handling

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -25,6 +25,7 @@ Enhancements
 - :bdg-info:`Plotting` Allow setting ``vmin`` in :func:`~nilearn.plotting.plot_glass_brain` and :func:`~nilearn.plotting.plot_stat_map` (:gh:`3993` by `Michelle Wang`_).
 - :bdg-success:`API` Support passing t and F contrasts to :func:`~nilearn.glm.compute_contrast` that that have fewer columns than the number of estimated parameters. Remaining columns are padded with zero (:gh:`4067` by `Rémi Gau`_).
 - :bdg-dark:`Code` Multi-subject maskers' ``generate_report`` method no longer fails with 5D data but instead shows report of first subject. User can index input list to show report for different subjects (:gh:`3935` by `Yasmin Mzayek`_).
+- :bdg-primary:`Code` Add `two_sided` option for :class:`~nilearn.image.binarize_img` (:gh:`4121` by `Steven Meisler`_).
 
 Changes
 -------

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1117,7 +1117,7 @@ def binarize_img(img, threshold=0, two_sided=True, mask_img=None):
     warnings.warn(
         'The current default behavior for the "two_sided argument "'
         'is  "True". This behavior will be changed to "False" in '
-        'version 0.3."',
+        'version 0.13."',
         DeprecationWarning,
         stacklevel=3,
     )

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1117,7 +1117,7 @@ def binarize_img(img, threshold=0, two_sided=True, mask_img=None):
     warnings.warn(
         'The current default behavior for the "two_sided" argument '
         'is  "True". This behavior will be changed to "False" in '
-        'version 0.13."',
+        'version 0.13.',
         DeprecationWarning,
         stacklevel=3,
     )

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1114,6 +1114,8 @@ def binarize_img(img, threshold=0, two_sided=True, mask_img=None):
      >>> img = binarize_img(anatomical_image)
 
     """
+
+
 warnings.warn(
     'The current default behavior for the "two_sided argument "'
     'is  "True". This behavior will be changed to "False" in '
@@ -1121,12 +1123,10 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=3,
 )
-        
+
 return math_img(
     "img.astype(bool).astype(int)",
-    img=threshold_img(
-        img, threshold, mask_img=mask_img, two_sided=two_sided
-    ),
+    img=threshold_img(img, threshold, mask_img=mask_img, two_sided=two_sided),
 )
 
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1115,7 +1115,7 @@ def binarize_img(img, threshold=0, two_sided=True, mask_img=None):
 
     """
     warnings.warn(
-        'The current default behavior for the "two_sided argument "'
+        'The current default behavior for the "two_sided" argument '
         'is  "True". This behavior will be changed to "False" in '
         'version 0.13."',
         DeprecationWarning,

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1082,15 +1082,15 @@ def binarize_img(img, threshold=0, mask_img=None, two_sided=True):
         threshold based on the score obtained using this percentile on
         the image data. The voxels which have intensities greater than
         this score will be kept. The given string should be
-        within the range of "0%" to "100%".
-
-    two_sided : :obj:`bool`
-        If `True`, threshold is applied to the absolute value of the image.
-        If `False`, threshold is applied to the original value of the image.
+        within the range of "0%" to "100%"
 
     mask_img : Niimg-like object, default=None
         Mask image applied to mask the input data.
         If None, no masking will be applied.
+
+    two_sided : :obj:`bool`
+        If `True`, threshold is applied to the absolute value of the image.
+        If `False`, threshold is applied to the original value of the image.
 
     Returns
     -------

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1063,7 +1063,7 @@ def math_img(formula, **imgs):
     return new_img_like(niimg, result, niimg.affine)
 
 
-def binarize_img(img, threshold=0, mask_img=None):
+def binarize_img(img, threshold=0, two_sided=True, mask_img=None):
     """Binarize an image such that its values are either 0 or 1.
 
     .. versionadded:: 0.8.1
@@ -1083,6 +1083,10 @@ def binarize_img(img, threshold=0, mask_img=None):
         the image data. The voxels which have intensities greater than
         this score will be kept. The given string should be
         within the range of "0%" to "100%".
+
+    two_sided : :obj:`bool`
+        If `True`, threshold is applied to the absolute value of the image.
+        If `False`, threshold is applied to the original value of the image.
 
     mask_img : Niimg-like object, default=None
         Mask image applied to mask the input data.
@@ -1110,9 +1114,17 @@ def binarize_img(img, threshold=0, mask_img=None):
      >>> img = binarize_img(anatomical_image)
 
     """
+    warnings.warn(
+            'The current default behavior for the "two_sided argument "'
+            'is  "True". This behavior will be changed to "False" in '
+            'version 0.3."',
+            DeprecationWarning,
+            stacklevel=3
+        )
+        
     return math_img(
         "img.astype(bool).astype(int)",
-        img=threshold_img(img, threshold, mask_img=mask_img),
+        img=threshold_img(img, threshold, mask_img=mask_img, two_sided=two_sided)
     )
 
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1082,7 +1082,7 @@ def binarize_img(img, threshold=0, mask_img=None, two_sided=True):
         threshold based on the score obtained using this percentile on
         the image data. The voxels which have intensities greater than
         this score will be kept. The given string should be
-        within the range of "0%" to "100%"
+        within the range of "0%" to "100%".
 
     mask_img : Niimg-like object, default=None
         Mask image applied to mask the input data.

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1125,7 +1125,9 @@ def binarize_img(img, threshold=0, two_sided=True, mask_img=None):
 
     return math_img(
         "img.astype(bool).astype(int)",
-        img=threshold_img(img, threshold, mask_img=mask_img, two_sided=two_sided),
+        img=threshold_img(
+            img, threshold, mask_img=mask_img, two_sided=two_sided
+        ),
     )
 
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1063,7 +1063,7 @@ def math_img(formula, **imgs):
     return new_img_like(niimg, result, niimg.affine)
 
 
-def binarize_img(img, threshold=0, two_sided=True, mask_img=None):
+def binarize_img(img, threshold=0, mask_img=None, two_sided=True):
     """Binarize an image such that its values are either 0 or 1.
 
     .. versionadded:: 0.8.1
@@ -1117,7 +1117,7 @@ def binarize_img(img, threshold=0, two_sided=True, mask_img=None):
     warnings.warn(
         'The current default behavior for the "two_sided" argument '
         'is  "True". This behavior will be changed to "False" in '
-        'version 0.13.',
+        "version 0.13.",
         DeprecationWarning,
         stacklevel=3,
     )

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1114,18 +1114,20 @@ def binarize_img(img, threshold=0, two_sided=True, mask_img=None):
      >>> img = binarize_img(anatomical_image)
 
     """
-    warnings.warn(
-            'The current default behavior for the "two_sided argument "'
-            'is  "True". This behavior will be changed to "False" in '
-            'version 0.3."',
-            DeprecationWarning,
-            stacklevel=3
-        )
+warnings.warn(
+    'The current default behavior for the "two_sided argument "'
+    'is  "True". This behavior will be changed to "False" in '
+    'version 0.3."',
+    DeprecationWarning,
+    stacklevel=3,
+)
         
-    return math_img(
-        "img.astype(bool).astype(int)",
-        img=threshold_img(img, threshold, mask_img=mask_img, two_sided=two_sided)
-    )
+return math_img(
+    "img.astype(bool).astype(int)",
+    img=threshold_img(
+        img, threshold, mask_img=mask_img, two_sided=two_sided
+    ),
+)
 
 
 @rename_parameters({"sessions": "runs"}, "0.10.0")

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1115,19 +1115,18 @@ def binarize_img(img, threshold=0, two_sided=True, mask_img=None):
 
     """
 
+    warnings.warn(
+        'The current default behavior for the "two_sided argument "'
+        'is  "True". This behavior will be changed to "False" in '
+        'version 0.3."',
+        DeprecationWarning,
+        stacklevel=3,
+    )
 
-warnings.warn(
-    'The current default behavior for the "two_sided argument "'
-    'is  "True". This behavior will be changed to "False" in '
-    'version 0.3."',
-    DeprecationWarning,
-    stacklevel=3,
-)
-
-return math_img(
-    "img.astype(bool).astype(int)",
-    img=threshold_img(img, threshold, mask_img=mask_img, two_sided=two_sided),
-)
+    return math_img(
+        "img.astype(bool).astype(int)",
+        img=threshold_img(img, threshold, mask_img=mask_img, two_sided=two_sided),
+    )
 
 
 @rename_parameters({"sessions": "runs"}, "0.10.0")

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1114,7 +1114,6 @@ def binarize_img(img, threshold=0, two_sided=True, mask_img=None):
      >>> img = binarize_img(anatomical_image)
 
     """
-
     warnings.warn(
         'The current default behavior for the "two_sided argument "'
         'is  "True". This behavior will be changed to "False" in '

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -858,14 +858,14 @@ def test_binarize_img(img_4d_rand_eye):
     img3.dataobj[img_4d_rand_eye.dataobj >= 0.5] = 1
 
     assert_array_equal(img2.dataobj, img3.dataobj)
-    
+
     # Test option to use original or absolute values
     img4_data = img_4d_rand_eye.get_fdata()
     # Create a mask for half of the values and them negative
     neg_mask = np.random.choice(
         [True, False], size=img_4d_rand_eye.shape, p=[0.5, 0.5]
     )
-    
+
     img4_data[neg_mask] *= -1
     img4 = new_img_like(img_4d_rand_eye, img4_data)
     # Binarize using original and absolute values

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -858,8 +858,9 @@ def test_binarize_img(img_4d_rand_eye):
     img3.dataobj[img_4d_rand_eye.dataobj >= 0.5] = 1
 
     assert_array_equal(img2.dataobj, img3.dataobj)
+    
 
-def test_binarize_negative_img(img_4d_rand_eye): 
+def test_binarize_negative_img(img_4d_rand_eye):
     # Test option to use original or absolute values
     img_data = img_4d_rand_eye.dataobj
     # Create a mask for half of the values and make them negative

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -858,7 +858,7 @@ def test_binarize_img(img_4d_rand_eye):
     img3.dataobj[img_4d_rand_eye.dataobj >= 0.5] = 1
 
     assert_array_equal(img2.dataobj, img3.dataobj)
-    
+
 
 def test_binarize_negative_img(img_4d_rand_eye):
     # Test option to use original or absolute values

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -860,12 +860,11 @@ def test_binarize_img(img_4d_rand_eye):
     assert_array_equal(img2.dataobj, img3.dataobj)
 
     # Test option to use original or absolute values
-    img4_data = img_4d_rand_eye.get_fdata()
-    # Create a mask for half of the values and them negative
+    img4_data = img_4d_rand_eye.dataobj
+    # Create a mask for half of the values and make them negative
     neg_mask = np.random.choice(
         [True, False], size=img_4d_rand_eye.shape, p=[0.5, 0.5]
     )
-
     img4_data[neg_mask] *= -1
     img4 = new_img_like(img_4d_rand_eye, img4_data)
     # Binarize using original and absolute values

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -859,21 +859,22 @@ def test_binarize_img(img_4d_rand_eye):
 
     assert_array_equal(img2.dataobj, img3.dataobj)
 
+def test_binarize_negative_img(img_4d_rand_eye): 
     # Test option to use original or absolute values
-    img4_data = img_4d_rand_eye.dataobj
+    img_data = img_4d_rand_eye.dataobj
     # Create a mask for half of the values and make them negative
     neg_mask = np.random.choice(
         [True, False], size=img_4d_rand_eye.shape, p=[0.5, 0.5]
     )
-    img4_data[neg_mask] *= -1
-    img4 = new_img_like(img_4d_rand_eye, img4_data)
+    img_data[neg_mask] *= -1
+    img = new_img_like(img_4d_rand_eye, img_data)
     # Binarize using original and absolute values
-    img4_original = binarize_img(img4, threshold=0, two_sided=False)
-    img4_absolute = binarize_img(img4, threshold=0, two_sided=True)
+    img_original = binarize_img(img, threshold=0, two_sided=False)
+    img_absolute = binarize_img(img, threshold=0, two_sided=True)
     # Check that all values are 1 for absolute valued threshold
-    assert_array_equal(np.unique(img4_absolute.dataobj), np.array([1]))
+    assert_array_equal(np.unique(img_absolute.dataobj), np.array([1]))
     # Check that binarized image contains 0 and 1 for original threshold
-    assert_array_equal(np.unique(img4_original.dataobj), np.array([0, 1]))
+    assert_array_equal(np.unique(img_original.dataobj), np.array([0, 1]))
 
 
 def test_clean_img(affine_eye, shape_3d_default, rng):

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -862,7 +862,10 @@ def test_binarize_img(img_4d_rand_eye):
     # Test option to use original or absolute values
     img4_data = img_4d_rand_eye.get_fdata()
     # Create a mask for half of the values and them negative
-    neg_mask = np.random.choice([True, False], size=img_4d_rand_eye.shape, p=[0.5, 0.5])
+    neg_mask = np.random.choice(
+        [True, False], size=img_4d_rand_eye.shape, p=[0.5, 0.5]
+    )
+    
     img4_data[neg_mask] *= -1
     img4 = new_img_like(img_4d_rand_eye, img4_data)
     # Binarize using original and absolute values
@@ -871,7 +874,8 @@ def test_binarize_img(img_4d_rand_eye):
     # Check that all values are 1 for absolute valued threshold
     assert_array_equal(np.unique(img4_absolute.dataobj), np.array([1]))
     # Check that binarized image contains 0 and 1 for original threshold
-    assert_array_equal(np.unique(img4_original.dataobj), np.array([0,1]))
+    assert_array_equal(np.unique(img4_original.dataobj), np.array([0, 1]))
+
 
 def test_clean_img(affine_eye, shape_3d_default, rng):
     data = rng.standard_normal(size=(10, 10, 10, 100)) + 0.5


### PR DESCRIPTION
Addresses #3467.

 This change introduces the `two_sided` argument for `binarize_img` which allows users to control whether the `threshold` is applied to the original value of the image (`two_sided=False`) or absolute value of the image (`two_sided=True`). The behavior does not change from what is was (`two_sided` was always `True`), but I think it should change to default to `False` as it is more intuitive when thresholding images with negative values.

I am also interested in expanding the function to include multiple operators (less than, more than, etc), but figured this is a good place to start that addresses the linked issue.