### PR TITLE
Don't use get_tmaps=True if tmaps aren't used

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -705,3 +705,7 @@ authors:
     family-names: Nájera
     website: https://github.com/Titan-C
     affiliation: Checkmk
+  - given-names: Christina
+    family-names: Roßmanith
+    affiliation: University of Heidelberg, Germany
+    email: christina.rossmanith@medma.uni-heidelberg.de

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -707,5 +707,6 @@ authors:
     affiliation: Checkmk
   - given-names: Christina
     family-names: Roßmanith
-    affiliation: University of Heidelberg, Germany
+    affiliation: Dept. of Neurology, Medical Faculty Mannheim, University of Heidelberg, Germany
     email: christina.rossmanith@medma.uni-heidelberg.de
+    website: https://github.com/crossmanith

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -29,6 +29,7 @@ Enhancements
 - :bdg-dark:`Code` :meth:`~maskers.NiftiLabelsMasker.generate_report` now uses appropriate cut coordinates when functional image is provided (:gh:`4099` by `Yasmin Mzayek`_ and `Nicolas Gensollen`_).
 - :bdg-info:`Plotting` When plotting thresholded statistical maps with a colorbar, the threshold value(s) will now be displayed as tick labels on the colorbar (:gh:`#2833` by `Nicolas Gensollen`_).
 - :bdg-primary:`Doc`  Mention the classification type (all-vs-one) in  :ref:`sphx_glr_auto_examples_02_decoding_plot_haxby_glm_decoding.py` (:gh:`4122` by `Tamer Gezici`_). 
+- :bdg-primary:`Doc` Don't tmaps in examples if tmaps aren't used in the example. (:gh: `4135` by `Christina Roßmanith`_).
 
 Changes
 -------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -29,7 +29,7 @@ Enhancements
 - :bdg-dark:`Code` :meth:`~maskers.NiftiLabelsMasker.generate_report` now uses appropriate cut coordinates when functional image is provided (:gh:`4099` by `Yasmin Mzayek`_ and `Nicolas Gensollen`_).
 - :bdg-info:`Plotting` When plotting thresholded statistical maps with a colorbar, the threshold value(s) will now be displayed as tick labels on the colorbar (:gh:`#2833` by `Nicolas Gensollen`_).
 - :bdg-primary:`Doc`  Mention the classification type (all-vs-one) in  :ref:`sphx_glr_auto_examples_02_decoding_plot_haxby_glm_decoding.py` (:gh:`4122` by `Tamer Gezici`_). 
-- :bdg-primary:`Doc` Don't tmaps in examples if tmaps aren't used in the example. (:gh:`4135` by `Christina Roßmanith`_).
+- :bdg-primary:`Doc` Don't fetch tmaps in examples if tmaps aren't used in the example. (:gh:`4136` by `Christina Roßmanith`_).
 
 Changes
 -------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -29,7 +29,7 @@ Enhancements
 - :bdg-dark:`Code` :meth:`~maskers.NiftiLabelsMasker.generate_report` now uses appropriate cut coordinates when functional image is provided (:gh:`4099` by `Yasmin Mzayek`_ and `Nicolas Gensollen`_).
 - :bdg-info:`Plotting` When plotting thresholded statistical maps with a colorbar, the threshold value(s) will now be displayed as tick labels on the colorbar (:gh:`#2833` by `Nicolas Gensollen`_).
 - :bdg-primary:`Doc`  Mention the classification type (all-vs-one) in  :ref:`sphx_glr_auto_examples_02_decoding_plot_haxby_glm_decoding.py` (:gh:`4122` by `Tamer Gezici`_). 
-- :bdg-primary:`Doc` Don't tmaps in examples if tmaps aren't used in the example. (:gh: `4135` by `Christina Roßmanith`_).
+- :bdg-primary:`Doc` Don't tmaps in examples if tmaps aren't used in the example. (:gh:`4135` by `Christina Roßmanith`_).
 
 Changes
 -------

--- a/examples/05_glm_second_level/plot_proportion_activated_voxels.py
+++ b/examples/05_glm_second_level/plot_proportion_activated_voxels.py
@@ -26,8 +26,7 @@ n_subjects = 16
 data = fetch_localizer_contrasts(
     ["left vs right button press"],
     n_subjects,
-    get_tmaps=True,
-    legacy_format=False,
+    legacy_format=False
 )
 # %%
 # Estimate second level model

--- a/examples/05_glm_second_level/plot_proportion_activated_voxels.py
+++ b/examples/05_glm_second_level/plot_proportion_activated_voxels.py
@@ -26,7 +26,7 @@ n_subjects = 16
 data = fetch_localizer_contrasts(
     ["left vs right button press"],
     n_subjects,
-    legacy_format=False
+    legacy_format=False,
 )
 # %%
 # Estimate second level model

--- a/examples/05_glm_second_level/plot_second_level_two_sample_test.py
+++ b/examples/05_glm_second_level/plot_second_level_two_sample_test.py
@@ -39,13 +39,14 @@ from nilearn.datasets import fetch_localizer_contrasts
 # localizer dataset.
 n_subjects = 16
 sample_vertical = fetch_localizer_contrasts(
-    ["vertical checkerboard"], n_subjects, get_tmaps=True, legacy_format=False
+    ["vertical checkerboard"], 
+    n_subjects, 
+    legacy_format=False
 )
 sample_horizontal = fetch_localizer_contrasts(
     ["horizontal checkerboard"],
     n_subjects,
-    get_tmaps=True,
-    legacy_format=False,
+    legacy_format=False
 )
 
 # Implicitly, there is a one-to-one correspondence between the two samples:

--- a/examples/05_glm_second_level/plot_second_level_two_sample_test.py
+++ b/examples/05_glm_second_level/plot_second_level_two_sample_test.py
@@ -39,8 +39,8 @@ from nilearn.datasets import fetch_localizer_contrasts
 # localizer dataset.
 n_subjects = 16
 sample_vertical = fetch_localizer_contrasts(
-    ["vertical checkerboard"], 
-    n_subjects, 
+    ["vertical checkerboard"],
+    n_subjects,
     legacy_format=False
 )
 sample_horizontal = fetch_localizer_contrasts(

--- a/examples/05_glm_second_level/plot_second_level_two_sample_test.py
+++ b/examples/05_glm_second_level/plot_second_level_two_sample_test.py
@@ -41,7 +41,7 @@ n_subjects = 16
 sample_vertical = fetch_localizer_contrasts(
     ["vertical checkerboard"],
     n_subjects,
-    legacy_format=False
+    legacy_format=False,
 )
 sample_horizontal = fetch_localizer_contrasts(
     ["horizontal checkerboard"],

--- a/examples/05_glm_second_level/plot_second_level_two_sample_test.py
+++ b/examples/05_glm_second_level/plot_second_level_two_sample_test.py
@@ -46,7 +46,7 @@ sample_vertical = fetch_localizer_contrasts(
 sample_horizontal = fetch_localizer_contrasts(
     ["horizontal checkerboard"],
     n_subjects,
-    legacy_format=False
+    legacy_format=False,
 )
 
 # Implicitly, there is a one-to-one correspondence between the two samples:


### PR DESCRIPTION
- Closes #4135

Changes proposed in this pull request:

- Remove `get_tmaps=True` from all calls to `fetch_localizer_contrasts() 
` because tmaps aren't used in the examples.