### PR TITLE
[DOC] Specify full form of LSS in beta series tutorial

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -30,7 +30,7 @@ Enhancements
 - :bdg-info:`Plotting` When plotting thresholded statistical maps with a colorbar, the threshold value(s) will now be displayed as tick labels on the colorbar (:gh:`#2833` by `Nicolas Gensollen`_).
 - :bdg-success:`API` :class:`~maskers.NiftiSpheresMasker` now has ``generate_report`` method (:gh:`3102` by `Yasmin Mzayek`_ and `Nicolas Gensollen`_).
 - :bdg-primary:`Doc`  Mention the classification type (all-vs-one) in  :ref:`sphx_glr_auto_examples_02_decoding_plot_haxby_glm_decoding.py` (:gh:`4122` by `Tamer Gezici`_). 
-- :bdg-primary:`Doc`  Specify full form of LSS in  :ref:`plot_beta_series.py` (:gh:`4122` by `Tamer Gezici`_). 
+- :bdg-primary:`Doc`  Specify full form of LSS in  :ref:`sphx_glr_auto_examples_07_advanced_plot_beta_series.py` (:gh:`4141` by `Tamer Gezici`_). 
 
 Changes
 -------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -30,6 +30,7 @@ Enhancements
 - :bdg-info:`Plotting` When plotting thresholded statistical maps with a colorbar, the threshold value(s) will now be displayed as tick labels on the colorbar (:gh:`#2833` by `Nicolas Gensollen`_).
 - :bdg-success:`API` :class:`~maskers.NiftiSpheresMasker` now has ``generate_report`` method (:gh:`3102` by `Yasmin Mzayek`_ and `Nicolas Gensollen`_).
 - :bdg-primary:`Doc`  Mention the classification type (all-vs-one) in  :ref:`sphx_glr_auto_examples_02_decoding_plot_haxby_glm_decoding.py` (:gh:`4122` by `Tamer Gezici`_). 
+- :bdg-primary:`Doc`  Specify full form of LSS in  :ref:`plot_beta_series.py` (:gh:`4122` by `Tamer Gezici`_). 
 
 Changes
 -------

--- a/examples/07_advanced/plot_beta_series.py
+++ b/examples/07_advanced/plot_beta_series.py
@@ -162,8 +162,8 @@ lsa_beta_maps = {
 # %%
 # Define the LSS models
 # ---------------------
-# We will now create a separate Least Squares- Separate (LSS) model for each trial
-# of interest.
+# We will now create a separate Least Squares- Separate (LSS) model for each
+# trial of interest.
 # The transformation is much like the LSA approach, except that we only
 # relabel *one* trial in the DataFrame.
 # We loop through the trials, create a version of the DataFrame where the

--- a/examples/07_advanced/plot_beta_series.py
+++ b/examples/07_advanced/plot_beta_series.py
@@ -162,7 +162,7 @@ lsa_beta_maps = {
 # %%
 # Define the LSS models
 # ---------------------
-# We will now create a separate LSS model for each trial of interest.
+# We will now create a separate least squares seperate (LSS) model for each trial of interest.
 # The transformation is much like the LSA approach, except that we only
 # relabel *one* trial in the DataFrame.
 # We loop through the trials, create a version of the DataFrame where the

--- a/examples/07_advanced/plot_beta_series.py
+++ b/examples/07_advanced/plot_beta_series.py
@@ -162,7 +162,8 @@ lsa_beta_maps = {
 # %%
 # Define the LSS models
 # ---------------------
-# We will now create a separate least squares seperate (LSS) model for each trial of interest.
+# We will now create a separate Least Squares- Separate (LSS) model for each trial
+# of interest.
 # The transformation is much like the LSA approach, except that we only
 # relabel *one* trial in the DataFrame.
 # We loop through the trials, create a version of the DataFrame where the


### PR DESCRIPTION
Makes the text more coherent (as the full form for LSA is written above) and prevents people from scrolling up to remember what LSS stands for.
