### PR TITLE
[MAINT] Improve error for nifti masker when fit is called without imgs or mask_img

### DIFF
--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -428,6 +428,12 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
 
         # Compute the mask if not given by the user
         if self.mask_img is None:
+            if imgs is None:
+                raise ValueError(
+                    "Parameter 'imgs' must be provided to "
+                    f"{self.__class__.__name__}.fit() "
+                    "if no mask is passed to mask_img."
+                )
             mask_args = self.mask_args if self.mask_args is not None else {}
             compute_mask = _get_mask_strategy(self.mask_strategy)
             if self.verbose > 0:

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -353,6 +353,15 @@ def test_joblib_cache(tmp_path):
         shutil.rmtree(cachedir, ignore_errors=True)
 
 
+def test_fit_no_mask_no_img_error():
+    """Check error is raised when no mask and no img is provided."""
+    mask = NiftiMasker(mask_img=None)
+    with pytest.raises(
+        ValueError, match="Parameter 'imgs' must be provided to "
+    ):
+        mask.fit()
+
+
 def test_mask_strategy_errors(rng):
     """Check that mask_strategy errors are raised."""
     # Error with unknown mask_strategy

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -365,15 +365,15 @@ def test_fit_no_mask_no_img_error():
 def test_mask_strategy_errors(rng):
     """Check that mask_strategy errors are raised."""
     # Error with unknown mask_strategy
+    img = rng.uniform(size=(9, 9, 5))
+    img = nibabel.Nifti1Image(img, np.eye(4))
     mask = NiftiMasker(mask_strategy="oops")
     with pytest.raises(
         ValueError, match="Unknown value of mask_strategy 'oops'"
     ):
-        mask.fit()
+        mask.fit(img)
     # Warning with deprecated 'template' strategy,
     # plus an exception because there's no resulting mask
-    img = rng.uniform(size=(9, 9, 5))
-    img = nibabel.Nifti1Image(img, np.eye(4))
     mask = NiftiMasker(mask_strategy="template")
     with pytest.warns(
         UserWarning, match="Masking strategy 'template' is deprecated."


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Related to https://github.com/nilearn/nilearn/pull/4126#issuecomment-1847137828

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Raise a more meaningful error than 
```bash
E TypeError: Data given cannot be loaded because it is not compatible with nibabel format:
E None
```

