### PR TITLE
[MAINT] relocate functions from nilearn.datasets.utils

### DIFF
--- a/nilearn/datasets/__init__.py
+++ b/nilearn/datasets/__init__.py
@@ -41,6 +41,7 @@ from .func import (
     fetch_spm_auditory,
     fetch_spm_multimodal_fmri,
     fetch_surf_nki_enhanced,
+    load_sample_motor_activation_image,
     patch_openneuro_dataset,
     select_from_index,
 )
@@ -65,7 +66,7 @@ from .struct import (
     load_mni152_wm_mask,
     load_mni152_wm_template,
 )
-from .utils import get_data_dirs, load_sample_motor_activation_image
+from .utils import get_data_dirs
 
 __all__ = [
     "MNI152_FILE_PATH",

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -8,6 +8,7 @@ import os
 import re
 import warnings
 from io import BytesIO
+from pathlib import Path
 
 import nibabel
 import nibabel as nib
@@ -2987,3 +2988,14 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
         return fetch_fiac_first_level(data_dir=data_dir)
 
     return _glob_fiac_data()
+
+
+def load_sample_motor_activation_image():
+    """Load a single functional image showing motor activations.
+
+    Returns
+    -------
+    str
+        Path to the sample functional image.
+    """
+    return str(Path(__file__).parent / "data" / "image_10426.nii.gz")

--- a/nilearn/datasets/tests/test_func.py
+++ b/nilearn/datasets/tests/test_func.py
@@ -11,7 +11,6 @@ import uuid
 from collections import OrderedDict
 from pathlib import Path
 
-import nibabel
 import nibabel as nib
 import numpy as np
 import pandas as pd
@@ -20,6 +19,7 @@ import pytest
 from nilearn.datasets import func
 from nilearn.datasets._utils import get_dataset_dir
 from nilearn.datasets.tests._testing import dict_to_archive, list_to_archive
+from nilearn.image import load_img
 
 
 def _load_localizer_index():
@@ -390,7 +390,7 @@ def test__load_mixed_gambles(rng, affine_eye):
     n_trials = 48
     for n_subjects in [1, 5, 16]:
         zmaps = [
-            nibabel.Nifti1Image(
+            nib.Nifti1Image(
                 rng.standard_normal((3, 4, 5, n_trials)), affine_eye
             )
             for _ in range(n_subjects)
@@ -1039,3 +1039,10 @@ def test_fiac(tmp_path):
     assert isinstance(dataset.design_matrix1, str)
     assert isinstance(dataset.design_matrix2, str)
     assert isinstance(dataset.mask, str)
+
+
+def test_load_sample_motor_activation_image():
+    path_img = func.load_sample_motor_activation_image()
+
+    assert os.path.exists(path_img)
+    assert load_img(path_img)

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -510,3 +510,15 @@ def test_naive_ftp_adapter():
         resp = sender.send(
             requests.Request("GET", "ftp://example.com").prepare()
         )
+
+
+# TODO remove for release 0.13.0
+from nilearn.datasets import utils
+
+
+def test_load_sample_motor_activation_image():
+    with pytest.warns(
+        DeprecationWarning,
+        match="Please import this function from 'nilearn.datasets.func'",
+    ):
+        utils.load_sample_motor_activation_image()

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -16,8 +16,7 @@ import numpy as np
 import pytest
 import requests
 
-from nilearn.datasets import _utils, utils
-from nilearn.image import load_img
+from nilearn.datasets import _utils
 
 currdir = os.path.dirname(os.path.abspath(__file__))
 datadir = os.path.join(currdir, "data")
@@ -511,10 +510,3 @@ def test_naive_ftp_adapter():
         resp = sender.send(
             requests.Request("GET", "ftp://example.com").prepare()
         )
-
-
-def test_load_sample_motor_activation_image():
-    path_img = utils.load_sample_motor_activation_image()
-
-    assert os.path.exists(path_img)
-    assert load_img(path_img)

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -1,8 +1,14 @@
 """Downloading NeuroImaging datasets: utility functions."""
 import os
-from pathlib import Path
+from warnings import warn
 
 from .._utils import fill_doc
+
+_GENERAL_MESSAGE = (
+    "The import path 'nilearn.utils' will deprecated in version 0.13. "
+    "Importing from 'nilearn.utils' will be possible "
+    "at least until release 0.13.0."
+)
 
 
 @fill_doc
@@ -64,4 +70,13 @@ def load_sample_motor_activation_image():
     str
         Path to the sample functional image.
     """
-    return str(Path(__file__).parent / "data" / "image_10426.nii.gz")
+    from .func import load_sample_motor_activation_image as tmp
+
+    warn(
+        (
+            f"{_GENERAL_MESSAGE}"
+            "Please import from 'nilearn.datasets.func' instead."
+        ),
+        DeprecationWarning,
+    )
+    return tmp()

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -5,8 +5,9 @@ from warnings import warn
 from .._utils import fill_doc
 
 _GENERAL_MESSAGE = (
-    "The import path 'nilearn.utils' will deprecated in version 0.13. "
-    "Importing from 'nilearn.utils' will be possible "
+    "The import path 'nilearn.datasets.utils' "
+    "will deprecated in version 0.13. "
+    "Importing from 'nilearn.datasets.utils will be possible "
     "at least until release 0.13.0."
 )
 
@@ -75,7 +76,7 @@ def load_sample_motor_activation_image():
     warn(
         (
             f"{_GENERAL_MESSAGE}"
-            "Please import from 'nilearn.datasets.func' instead."
+            "Please import this function from 'nilearn.datasets.func' instead."
         ),
         DeprecationWarning,
     )


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4139

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- relocate load_sample_motor_activation_image
- throw deprecation warning when imported from the older location

## TODO

- [x] add test for deprecation warning
- [ ] relocate `get_data_dirs`
