### PR TITLE
[ENH]  rename `nilearn.datasets._utils.fetch_file` to `nilearn.datasets._utils.fetch_single_file`

### DIFF
--- a/nilearn/datasets/_utils.py
+++ b/nilearn/datasets/_utils.py
@@ -483,7 +483,7 @@ class _NaiveFTPAdapter(requests.adapters.BaseAdapter):
 
 
 @fill_doc
-def fetch_file(
+def fetch_single_file(
     url,
     data_dir,
     resume=True,
@@ -530,7 +530,7 @@ def fetch_file(
     if session is None:
         with requests.Session() as session:
             session.mount("ftp:", _NaiveFTPAdapter())
-            return fetch_file(
+            return fetch_single_file(
                 url,
                 data_dir,
                 resume=resume,
@@ -611,7 +611,7 @@ def fetch_file(
             except Exception:
                 if verbose > 0:
                     print("Resuming failed, try to download the whole file.")
-                return fetch_file(
+                return fetch_single_file(
                     url,
                     data_dir,
                     resume=False,
@@ -810,7 +810,7 @@ def fetch_files(data_dir, files, resume=True, verbose=1, session=None):
                 os.mkdir(temp_dir)
             md5sum = opts.get("md5sum", None)
 
-            dl_file = fetch_file(
+            dl_file = fetch_single_file(
                 url,
                 temp_dir,
                 resume=resume,

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -27,8 +27,8 @@ from nilearn.image import get_data
 from .._utils import check_niimg, fill_doc
 from .._utils.numpy_conversions import csv_to_array
 from ._utils import (
-    fetch_file,
     fetch_files,
+    fetch_single_file,
     filter_columns,
     get_dataset_descr,
     get_dataset_dir,
@@ -763,7 +763,7 @@ def fetch_localizer_contrasts(
     data_dir = get_dataset_dir(
         dataset_name, data_dir=data_dir, verbose=verbose
     )
-    index_file = fetch_file(index_url, data_dir, verbose=verbose)
+    index_file = fetch_single_file(index_url, data_dir, verbose=verbose)
     with open(index_file) as of:
         index = json.load(of)
 
@@ -2565,7 +2565,7 @@ def _download_spm_auditory_data(data_dir, subject_dir, subject_id):
         "MoAEpilot.zip"
     )
     archive_path = os.path.join(subject_dir, os.path.basename(url))
-    fetch_file(url, subject_dir)
+    fetch_single_file(url, subject_dir)
     try:
         uncompress_file(archive_path)
     except Exception:
@@ -2832,7 +2832,7 @@ def _download_data_spm_multimodal(data_dir, subject_dir, subject_id):
 
     for url in urls:
         archive_path = os.path.join(subject_dir, os.path.basename(url))
-        fetch_file(url, subject_dir)
+        fetch_single_file(url, subject_dir)
         try:
             uncompress_file(archive_path)
         except Exception:
@@ -2979,7 +2979,7 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
     url = "https://nipy.org/data-packages/nipy-data-0.2.tar.gz"
 
     archive_path = os.path.join(data_dir, os.path.basename(url))
-    fetch_file(url, data_dir)
+    fetch_single_file(url, data_dir)
     try:
         uncompress_file(archive_path)
     except Exception:

--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -22,7 +22,7 @@ from sklearn.feature_extraction import DictVectorizer
 from sklearn.utils import Bunch
 
 from ..image import resample_img
-from ._utils import fetch_file, get_dataset_descr, get_dataset_dir
+from ._utils import fetch_single_file, get_dataset_descr, get_dataset_dir
 
 _NEUROVAULT_BASE_URL = "https://neurovault.org/api/"
 _NEUROVAULT_COLLECTIONS_URL = urljoin(_NEUROVAULT_BASE_URL, "collections/")
@@ -1128,7 +1128,7 @@ def _yield_from_url_list(url_list, verbose=3):
 
 
 def _simple_download(url, target_file, temp_dir, verbose=3):
-    """Wrap around ``utils.fetch_file``.
+    """Wrap around ``utils.fetch_single_file``.
 
     This allows specifying the target file name.
 
@@ -1141,7 +1141,7 @@ def _simple_download(url, target_file, temp_dir, verbose=3):
         Location of the downloaded file on filesystem.
 
     temp_dir : str
-        Location of sandbox directory used by ``fetch_file``.
+        Location of sandbox directory used by ``fetch_single_file``.
 
     verbose : int, default=3
         An integer in [0, 1, 2, 3] to control the verbosity level.
@@ -1158,12 +1158,12 @@ def _simple_download(url, target_file, temp_dir, verbose=3):
 
     See Also
     --------
-    nilearn.datasets._utils.fetch_file
+    nilearn.datasets._utils.fetch_single_file
 
     """
     _print_if(f"Downloading file: {url}", _DEBUG, verbose)
     try:
-        downloaded = fetch_file(
+        downloaded = fetch_single_file(
             url, temp_dir, resume=False, overwrite=True, verbose=0
         )
     except Exception:

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -395,7 +395,7 @@ def test_fetch_file_overwrite(
         tmp_path = str(tmp_path)
 
     # overwrite non-exiting file.
-    fil = _utils.fetch_file(
+    fil = _utils.fetch_single_file(
         url="http://foo/", data_dir=str(tmp_path), verbose=0, overwrite=True
     )
 
@@ -409,7 +409,7 @@ def test_fetch_file_overwrite(
         fp.write("some content")
 
     # Don't overwrite existing file.
-    fil = _utils.fetch_file(
+    fil = _utils.fetch_single_file(
         url="http://foo/", data_dir=str(tmp_path), verbose=0, overwrite=False
     )
 
@@ -419,7 +419,7 @@ def test_fetch_file_overwrite(
         assert fp.read() == "some content"
 
     # Overwrite existing file.
-    fil = _utils.fetch_file(
+    fil = _utils.fetch_single_file(
         url="http://foo/", data_dir=str(tmp_path), verbose=0, overwrite=True
     )
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4155

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- rename `nilearn.datasets._utils.fetch_file` to `nilearn.datasets._utils.fetch_single_file`

