### PR TITLE
[FIX] rich display in jupyter notebook/lab

### DIFF
--- a/nilearn/plotting/html_document.py
+++ b/nilearn/plotting/html_document.py
@@ -162,6 +162,9 @@ class HTMLDocument:
         Used by the Jupyter notebook.
 
         Users normally won't call this method explicitly.
+
+        See the jupyter documentation:
+        https://ipython.readthedocs.io/en/stable/config/integrating.html
         """
         return self.get_iframe()
 
@@ -171,6 +174,9 @@ class HTMLDocument:
         Used by the Jupyter notebook.
 
         Users normally won't call this method explicitly.
+
+        See the jupyter documentation:
+        https://ipython.readthedocs.io/en/stable/config/integrating.html
         """
         del include, exclude
         return {"text/html": self.get_iframe()}

--- a/nilearn/plotting/html_document.py
+++ b/nilearn/plotting/html_document.py
@@ -165,6 +165,16 @@ class HTMLDocument:
         """
         return self.get_iframe()
 
+    def _repr_mimebundle_(self, include=None, exclude=None):
+        """Return html representation of the plot.
+
+        Used by the Jupyter notebook.
+
+        Users normally won't call this method explicitly.
+        """
+        del include, exclude
+        return {"text/html": self.get_iframe()}
+
     def __str__(self):
         return self.html
 

--- a/nilearn/plotting/tests/test_html_document.py
+++ b/nilearn/plotting/tests/test_html_document.py
@@ -84,3 +84,9 @@ def test_open_view_warning():
     assert_no_warnings(_open_views)
     html_document.set_max_img_views_before_warning(6)
     pytest.warns(UserWarning, _open_views)
+
+
+def test_repr():
+    doc = html_document.HTMLDocument("hello")
+    assert "hello" in doc._repr_html_()
+    assert "hello" in doc._repr_mimebundle_()["text/html"]


### PR DESCRIPTION
I'm not 100% sure why but at least on some jupyter versions defining `_repr_html_` is not enough; defining `_repr_mimebundle_` instead (or as well) fixes the issue.

main branch:

![screenshot_2024-01-03T11:35:24+01:00](https://github.com/nilearn/nilearn/assets/9196501/671449c1-d0e4-4035-a54e-d42f00bfb9e2)

this PR:

![Screenshot 2024-01-03 at 11-34-30 Untitled](https://github.com/nilearn/nilearn/assets/9196501/06553711-50a5-4a5e-a87f-8d9fa1ff77e6)


```
❯ jupyter --version
Selected Jupyter core packages...
IPython          : 8.19.0
ipykernel        : 6.28.0
ipywidgets       : 8.1.1
jupyter_client   : 8.6.0
jupyter_core     : 5.6.1
jupyter_server   : 2.12.1
jupyterlab       : 4.0.10
nbclient         : 0.8.0
nbconvert        : 7.14.0
nbformat         : 5.9.2
notebook         : 7.0.6
qtconsole        : 5.5.1
traitlets        : 5.14.0
```