### PR TITLE
[MAINT]  Remove unnecessary lines describe in `test_clean_psc`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -537,6 +537,11 @@ authors:
   - given-names: Paul
     family-names: Bogdan
     website: https://github.com/paulcbogdan
+  - given-names: Paul
+    family-names: Reiners
+    website: https://github.com/paul-reiners
+    affiliation: Masonic Institute for the Developing Brain, University of Minnesota, USA
+    orcid: https://orcid.org/0000-0002-6167-5007
   - given-names: Paula
     family-names: Sanz-Leon
     website: https://github.com/pausz

--- a/doc/changes/0.10.2.rst
+++ b/doc/changes/0.10.2.rst
@@ -85,6 +85,8 @@ Enhancements
 
 - :bdg-success:`API` Improve ``contrasts`` allowing fixed effects on F contrasts (:gh:`3203` by `Bertrand Thirion`_)
 
+- :bdg-dark:`Code` ``nilearn/tests/test_signal.py`` Remove unnecessary code in test (:gh:`4175` by `Paul Reiners`_).
+
 Changes
 -------
 

--- a/doc/changes/0.10.2.rst
+++ b/doc/changes/0.10.2.rst
@@ -85,7 +85,7 @@ Enhancements
 
 - :bdg-success:`API` Improve ``contrasts`` allowing fixed effects on F contrasts (:gh:`3203` by `Bertrand Thirion`_)
 
-- :bdg-dark:`Code` ``nilearn/tests/test_signal.py`` Remove unnecessary code in test (:gh:`4175` by `Paul Reiners`_).
+- :bdg-dark:`Code` ``nilearn/tests/test_signal.py`` Remove unnecessary code in test (:gh:`4208` by `Paul Reiners`_).
 
 Changes
 -------

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -887,16 +887,12 @@ def test_clean_psc(rng):
         cleaned_signals = clean(s, standardize="psc")
         np.testing.assert_almost_equal(cleaned_signals.mean(0), 0)
 
-        cleaned_signals.std(axis=0)
-        np.testing.assert_almost_equal(cleaned_signals.mean(0), 0)
-
         tmp = (s - s.mean(0)) / np.abs(s.mean(0))
         tmp *= 100
         np.testing.assert_almost_equal(cleaned_signals, tmp)
 
     # leave out the last 3 columns with a mean of zero to test user warning
     signals_w_zero = signals + np.append(means[:, :-3], np.zeros((1, 3)))
-    cleaned_w_zero = clean(signals_w_zero, standardize="psc")
     with pytest.warns(UserWarning) as records:
         cleaned_w_zero = clean(signals_w_zero, standardize="psc")
     psc_warning = sum(


### PR DESCRIPTION
This caused a third line to be unnecessary so I removed it also.

- Closes #4175

Changes proposed in this pull request:
- Removed three useless lines.

