### PR TITLE
FIX/EHN update load_confound_strategy defaults

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -56,4 +56,4 @@ Changes
 - :bdg-dark:`Code` Remove leading underscore from non private functions to align with PEP8 (:gh:`4086` by `Rémi Gau`_).
 - :bdg-dark:`Code` Make ``decoding/proximal_operator`` explicitly private to align with PEP8 (:gh:`4153` by `Rémi Gau`_).
 - :bdg-dark:`Code` Make private functions public when used outside of their module ``nilearn.interface`` to align with PEP8 (:gh:`4168` by `Rémi Gau`_).
-- :bdg-danger:`Deprecation` the default parameter of ``fd_threshold`` and ``std_dvars_threshold`` in :func:`~interfaces.fmriprep.load_confounds` with be updated to match ``fmriprep`` default in version 0.15 (:gh:`4225` by `Hao-Ting Wang`_).
+- :bdg-danger:`Deprecation` the default parameter of ``fd_threshold`` and ``std_dvars_threshold`` in :func:`~interfaces.fmriprep.load_confounds` with be updated to match ``fmriprep`` default in version 0.13 (:gh:`4225` by `Hao-Ting Wang`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -40,7 +40,7 @@ Enhancements
 - :bdg-primary:`Doc`  Specify full form of LSS in  :ref:`sphx_glr_auto_examples_07_advanced_plot_beta_series.py` (:gh:`4141` by `Tamer Gezici`_).
 - :bdg-primary:`Doc` Don't fetch tmaps in examples if tmaps aren't used in the example. (:gh:`4136` by `Christina Roßmanith`_).
 - :bdg-primary:`Doc` Describe the return value in :func:`~nilearn.datasets.fetch_abide_pcp` documentation (:gh:`4159` by `Suramya Pokharel`_).
-- :bdg-primary:`Code` Allow ``global_signal`` parameter in :func:`~interfaces.fmriprep.load_confounds_strategy` in ``denoise_strategy='compcor'`` (:gh:`xxxx` by `Hao-Ting Wang`_).
+- :bdg-dark:`Code` Allow ``global_signal`` parameter in :func:`~interfaces.fmriprep.load_confounds_strategy` in ``denoise_strategy='compcor'`` (:gh:`4225` by `Hao-Ting Wang`_).
 
 Changes
 -------
@@ -56,4 +56,4 @@ Changes
 - :bdg-dark:`Code` Remove leading underscore from non private functions to align with PEP8 (:gh:`4086` by `Rémi Gau`_).
 - :bdg-dark:`Code` Make ``decoding/proximal_operator`` explicitly private to align with PEP8 (:gh:`4153` by `Rémi Gau`_).
 - :bdg-dark:`Code` Make private functions public when used outside of their module ``nilearn.interface`` to align with PEP8 (:gh:`4168` by `Rémi Gau`_).
-- :bdg-primary:`Code` the default parameter of ``fd_threshold`` and ``std_dvars_threshold`` in :func:`~interfaces.fmriprep.load_confounds` with be updated to match ``fmriprep`` default in version 0.15 (:gh:`xxxx` by `Hao-Ting Wang`_).
+- :bdg-dark:`Code` the default parameter of ``fd_threshold`` and ``std_dvars_threshold`` in :func:`~interfaces.fmriprep.load_confounds` with be updated to match ``fmriprep`` default in version 0.15 (:gh:`4225` by `Hao-Ting Wang`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -40,6 +40,7 @@ Enhancements
 - :bdg-primary:`Doc`  Specify full form of LSS in  :ref:`sphx_glr_auto_examples_07_advanced_plot_beta_series.py` (:gh:`4141` by `Tamer Gezici`_).
 - :bdg-primary:`Doc` Don't fetch tmaps in examples if tmaps aren't used in the example. (:gh:`4136` by `Christina Roßmanith`_).
 - :bdg-primary:`Doc` Describe the return value in :func:`~nilearn.datasets.fetch_abide_pcp` documentation (:gh:`4159` by `Suramya Pokharel`_).
+- :bdg-primary:`Code` Allow ``global_signal`` parameter in :func:`~interfaces.fmriprep.load_confounds_strategy` in ``denoise_strategy='compcor'`` (:gh:`xxxx` by `Hao-Ting Wang`_).
 
 Changes
 -------
@@ -55,3 +56,4 @@ Changes
 - :bdg-dark:`Code` Remove leading underscore from non private functions to align with PEP8 (:gh:`4086` by `Rémi Gau`_).
 - :bdg-dark:`Code` Make ``decoding/proximal_operator`` explicitly private to align with PEP8 (:gh:`4153` by `Rémi Gau`_).
 - :bdg-dark:`Code` Make private functions public when used outside of their module ``nilearn.interface`` to align with PEP8 (:gh:`4168` by `Rémi Gau`_).
+- :bdg-primary:`Code` the default parameter of ``fd_threshold`` and ``std_dvars_threshold`` in :func:`~interfaces.fmriprep.load_confounds` with be updated to match ``fmriprep`` default in version 0.15 (:gh:`xxxx` by `Hao-Ting Wang`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -56,4 +56,4 @@ Changes
 - :bdg-dark:`Code` Remove leading underscore from non private functions to align with PEP8 (:gh:`4086` by `Rémi Gau`_).
 - :bdg-dark:`Code` Make ``decoding/proximal_operator`` explicitly private to align with PEP8 (:gh:`4153` by `Rémi Gau`_).
 - :bdg-dark:`Code` Make private functions public when used outside of their module ``nilearn.interface`` to align with PEP8 (:gh:`4168` by `Rémi Gau`_).
-- :bdg-dark:`Code` the default parameter of ``fd_threshold`` and ``std_dvars_threshold`` in :func:`~interfaces.fmriprep.load_confounds` with be updated to match ``fmriprep`` default in version 0.15 (:gh:`4225` by `Hao-Ting Wang`_).
+- :bdg-danger:`Deprecation` the default parameter of ``fd_threshold`` and ``std_dvars_threshold`` in :func:`~interfaces.fmriprep.load_confounds` with be updated to match ``fmriprep`` default in version 0.15 (:gh:`4225` by `Hao-Ting Wang`_).

--- a/examples/03_connectivity/plot_signal_extraction.py
+++ b/examples/03_connectivity/plot_signal_extraction.py
@@ -187,8 +187,8 @@ confounds_scrub, sample_mask = load_confounds(
     motion="basic",
     wm_csf="basic",
     scrub=5,
-    fd_threshold=0.2,
-    std_dvars_threshold=3,
+    fd_threshold=0.5,
+    std_dvars_threshold=1.5,
 )
 
 print(

--- a/nilearn/interfaces/fmriprep/load_confounds.py
+++ b/nilearn/interfaces/fmriprep/load_confounds.py
@@ -206,10 +206,19 @@ def load_confounds(
         DVARS only.
 
     fd_threshold : :obj:`float`, default=0.2
+
+        .. deprecated:: 0.11.0
+           The default value will be changed to 0.5 in 0.x.
+
         Framewise displacement threshold for scrub in mm.
 
     std_dvars_threshold : :obj:`float`, default=3
+
+        .. deprecated:: 0.11.0
+           The default value will be changed to 1.5 in 0.x.
+
         Standardized DVARS threshold for scrub.
+        The default threashould matchines :term:`fMRIPrep`.
         DVARs is defined as root mean squared intensity difference of volume N
         to volume N+1 :footcite:t:`Power2012`.
         D referring to temporal derivative of timecourses,
@@ -295,7 +304,30 @@ def load_confounds(
 
     """
     _check_strategy(strategy)
-
+    if fd_threshold == 0.2:
+        fd_threshold_default = (
+            "The default parameter for standardize is currently 0.2 "
+            "which is inconsistent with the fMRIPrep default of 0.5. "
+            "In release X, the default strategy will be replaced by "
+            "0.5."
+        )
+        warnings.warn(
+            category=DeprecationWarning,
+            message=fd_threshold_default,
+            stacklevel=3,
+        )
+    if std_dvars_threshold == 3:
+        std_dvars_threshold_default = (
+            "The default parameter for standardize is currently 3 "
+            "which is inconsistent with the fMRIPrep default of 1.5. "
+            "In release X, the default strategy will be replaced by "
+            "1.5."
+        )
+        warnings.warn(
+            category=DeprecationWarning,
+            message=std_dvars_threshold_default,
+            stacklevel=3,
+        )
     # load confounds per image provided
     img_files, flag_single = sanitize_confounds(img_files)
     confounds_out = []

--- a/nilearn/interfaces/fmriprep/load_confounds.py
+++ b/nilearn/interfaces/fmriprep/load_confounds.py
@@ -304,9 +304,9 @@ def load_confounds(
 
     """
     _check_strategy(strategy)
-    if fd_threshold == 0.2:
+    if "scrub" in strategy and fd_threshold == 0.2:
         fd_threshold_default = (
-            "The default parameter for standardize is currently 0.2 "
+            "The default parameter for fd_threshold is currently 0.2 "
             "which is inconsistent with the fMRIPrep default of 0.5. "
             "In release 0.13.0, "
             "the default strategy will be replaced by 0.5."
@@ -314,11 +314,11 @@ def load_confounds(
         warnings.warn(
             category=DeprecationWarning,
             message=fd_threshold_default,
-            stacklevel=3,
+            stacklevel=2,
         )
-    if std_dvars_threshold == 3:
+    if "scrub" in strategy and std_dvars_threshold == 3:
         std_dvars_threshold_default = (
-            "The default parameter for standardize is currently 3 "
+            "The default parameter for std_dvars_threshold is currently 3 "
             "which is inconsistent with the fMRIPrep default of 1.5. "
             "In release 0.13.0, "
             "the default strategy will be replaced by 1.5."
@@ -326,7 +326,7 @@ def load_confounds(
         warnings.warn(
             category=DeprecationWarning,
             message=std_dvars_threshold_default,
-            stacklevel=3,
+            stacklevel=2,
         )
     # load confounds per image provided
     img_files, flag_single = sanitize_confounds(img_files)

--- a/nilearn/interfaces/fmriprep/load_confounds.py
+++ b/nilearn/interfaces/fmriprep/load_confounds.py
@@ -208,17 +208,17 @@ def load_confounds(
     fd_threshold : :obj:`float`, default=0.2
 
         .. deprecated:: 0.11.0
-           The default value will be changed to 0.5 in 0.x.
+           The default value will be changed to 0.5 in 0.13.0
 
         Framewise displacement threshold for scrub in mm.
 
     std_dvars_threshold : :obj:`float`, default=3
 
         .. deprecated:: 0.11.0
-           The default value will be changed to 1.5 in 0.x.
+           The default value will be changed to 1.5 in 0.13.0
 
         Standardized DVARS threshold for scrub.
-        The default threashould matchines :term:`fMRIPrep`.
+        The default threshold matching :term:`fMRIPrep`.
         DVARs is defined as root mean squared intensity difference of volume N
         to volume N+1 :footcite:t:`Power2012`.
         D referring to temporal derivative of timecourses,
@@ -308,8 +308,8 @@ def load_confounds(
         fd_threshold_default = (
             "The default parameter for standardize is currently 0.2 "
             "which is inconsistent with the fMRIPrep default of 0.5. "
-            "In release X, the default strategy will be replaced by "
-            "0.5."
+            "In release 0.13.0, "
+            "the default strategy will be replaced by 0.5."
         )
         warnings.warn(
             category=DeprecationWarning,
@@ -320,8 +320,8 @@ def load_confounds(
         std_dvars_threshold_default = (
             "The default parameter for standardize is currently 3 "
             "which is inconsistent with the fMRIPrep default of 1.5. "
-            "In release X, the default strategy will be replaced by "
-            "1.5."
+            "In release 0.13.0, "
+            "the default strategy will be replaced by 1.5."
         )
         warnings.warn(
             category=DeprecationWarning,

--- a/nilearn/interfaces/fmriprep/load_confounds_strategy.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_strategy.py
@@ -27,8 +27,8 @@ preset_strategies = {
         "motion": "full",
         "wm_csf": "full",
         "scrub": 5,
-        "fd_threshold": 0.2,  # updated here and doc to 0.5 in v0.15
-        "std_dvars_threshold": 3,  # updated here and doc to 1.5 in v0.15
+        "fd_threshold": 0.2,  # updated here and doc to 0.5 in v0.13
+        "std_dvars_threshold": 3,  # updated here and doc to 1.5 in v0.13
         "global_signal": None,
         "demean": True,
     },

--- a/nilearn/interfaces/fmriprep/load_confounds_strategy.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_strategy.py
@@ -157,7 +157,7 @@ def load_confounds_strategy(img_files, denoise_strategy="simple", **kwargs):
         N/A                 N/A            N/A       N/A       True*
         scrubbing True      full*  full   None*         5*    0.2*         \
         3*                  N/A            N/A       N/A       True*
-        compcor   True      full*  N/A    None*           N/A   N/A          \
+        compcor   True      full*  N/A    None*         N/A   N/A          \
         N/A                 anat_combined* all*      N/A       True*
         ica_aroma True      N/A    basic* None*         N/A   N/A          \
         N/A                 N/A            N/A       full      True*

--- a/nilearn/interfaces/fmriprep/load_confounds_strategy.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_strategy.py
@@ -27,8 +27,8 @@ preset_strategies = {
         "motion": "full",
         "wm_csf": "full",
         "scrub": 5,
-        "fd_threshold": 0.2,
-        "std_dvars_threshold": 3,
+        "fd_threshold": 0.2,  # updated here and doc to 0.5 in v0.15
+        "std_dvars_threshold": 3,  # updated here and doc to 1.5 in v0.15
         "global_signal": None,
         "demean": True,
     },
@@ -37,6 +37,7 @@ preset_strategies = {
         "motion": "full",
         "n_compcor": "all",
         "compcor": "anat_combined",
+        "global_signal": None,
         "demean": True,
     },
     "ica_aroma": {
@@ -101,6 +102,10 @@ def load_confounds_strategy(img_files, denoise_strategy="simple", **kwargs):
           variance as the noise component estimation as the number of compcor
           component can be really high. Please refer to :term:`fMRIPrep`
           documentation for more details.
+
+          .. versionadded:: 0.11.0
+            `golobal_signal` is now a tunable parameter for compcor.
+
         - 'ica_aroma': Load confounds for non-aggresive ICA-AROMA strategy
           described in :footcite:t:`Pruim2015`. The strategy requires
           :term:`fMRIPrep` outputs generated with `--use-aroma` suffixed with
@@ -152,7 +157,7 @@ def load_confounds_strategy(img_files, denoise_strategy="simple", **kwargs):
         N/A                 N/A            N/A       N/A       True*
         scrubbing True      full*  full   None*         5*    0.2*         \
         3*                  N/A            N/A       N/A       True*
-        compcor   True      full*  N/A    N/A           N/A   N/A          \
+        compcor   True      full*  N/A    None*           N/A   N/A          \
         N/A                 anat_combined* all*      N/A       True*
         ica_aroma True      N/A    basic* None*         N/A   N/A          \
         N/A                 N/A            N/A       full      True*

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds_strategy.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds_strategy.py
@@ -166,6 +166,14 @@ def test_strategy_compcor(tmp_path, fmriprep_version):
         "a_comp_cor_57" if fmriprep_version == "1.4.x" else "w_comp_cor_00"
     )
     assert expected not in compcor_col_str_anat
+    assert "global_signal" not in compcor_col_str_anat
+
+    # test the global signal option
+    confounds, _ = load_confounds_strategy(
+        file_nii, denoise_strategy="compcor", global_signal="basic"
+    )
+    compcor_col_str_anat = "".join(confounds.columns)
+    assert "global_signal" in compcor_col_str_anat
 
 
 @pytest.mark.parametrize("fmriprep_version", ["1.4.x", "21.x.x"])


### PR DESCRIPTION
Closes #4222
Closes #4223

- deprecation for scrubbing thresholds to match fmriprep docmentation (`fd_threshold=0.5`; `std_dvars_threshold=1.5`)

- for `load_confounds_strategy` allow global signal in compcor strategy to reflect on fmriprep documentation. This change does not break any existing behaviour as the default remains to be False

Need help: 

- [x] deprecated version?
- [x] docstring formatting
- [x] Release note badges????
