### PR TITLE
[FIX] Replace remaining `contrast_type` by `stat_type`

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -8,6 +8,8 @@
 Fixes
 -----
 
+- :bdg-dark:`Code` Fix errant warning when using ``stat_type`` in :func:`nilearn.glm.compute_contrast` (:gh:`4257` by `Eric Larson`_)
+
 Enhancements
 ------------
 

--- a/nilearn/glm/contrasts.py
+++ b/nilearn/glm/contrasts.py
@@ -139,7 +139,7 @@ def compute_contrast(labels, regression_result, con_val, stat_type=None):
         variance=var_,
         dim=dim,
         dof=dof_,
-        contrast_type=stat_type,
+        stat_type=stat_type,
     )
 
 


### PR DESCRIPTION
Looks like `contrast_type` was deprecated but at least one internal use was not updated to `stat_type`. Discovered because I tried to follow the deprecation instructions when using `compute_contrast` but kept getting a DeprecationWarning.