### PR TITLE
[DOC] Add versionadded directive to `two_sided` parameter of `binarize_img` function

### DIFF
--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1100,6 +1100,8 @@ def binarize_img(img, threshold=0, mask_img=None, two_sided=True):
         If `True`, threshold is applied to the absolute value of the image.
         If `False`, threshold is applied to the original value of the image.
 
+        .. versionadded:: 0.10.3
+
     Returns
     -------
     :class:`~nibabel.nifti1.Nifti1Image`


### PR DESCRIPTION
Hi,

It looks like a `two_sided` parameter was recently added to `binarize_img` (see #4121). However, the documentation doesn't specify the version in which it was added (0.10.3).
Not sure if people use these, but I actually was looking for this information on the API page of the function, and ended up looking at the changelog to know.