### PR TITLE
FIX] fixes several plotting details in glm reports

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -14,6 +14,8 @@ Fixes
 - :bdg-dark:`Code` Fix color bar handling with color map with only 1 level (:gh:`4255` by `Rémi Gau`_).
 - :bdg-dark:`Code` Fix positions of the markers on the images on the sphere masker reports (:gh:`4285` by `Rémi Gau`_).
 - :bdg-dark:`Code` Make sure that :class:`nilearn.maskers.NiftiSpheresMasker` reports displays properly when it contains only 1 sphere (:gh:`4269` by `Rémi Gau`_).
+- :bdg-dark:`Code` Miscellaneous fixes in GLM reports (only display FIR delay if FIR is used, display color bar "Z score" legend...) (:gh:`4266` by `Rémi Gau`_).
+
 
 Enhancements
 ------------
@@ -26,3 +28,4 @@ Changes
 - :bdg-primary:`Doc` Render the description of the templates, atlases and datasets of the :mod:`nilearn.datasets` as part of the documentation (:gh:`4232` by `Rémi Gau`_).
 - :bdg-dark:`Code` Change the colormap to ``gray`` for the background image in the :class:`nilearn.maskers.NiftiSpheresMasker` (:gh:`4269` by `Rémi Gau`_).
 - :bdg-dark:`Code` Remove unused ``**kwargs`` from :func:`nilearn.plotting.view_img` and :func:`nilearn.plotting.plot_surf` (:gh:`4270` by `Rémi Gau`_).
+- :bdg-dark:`Code` Use red to blue color map in the GLM reports (:gh:`4266` by `Rémi Gau`_).

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -73,7 +73,7 @@ def mean_scaling(Y, axis=0):
     mean = Y.mean(axis=axis)
     if (mean == 0).any():
         warn(
-            "Mean values of 0 observed."
+            "Mean values of 0 observed. "
             "The data have probably been centered."
             "Scaling might not work as expected",
             UserWarning,

--- a/nilearn/reporting/_visual_testing/_glm_reporter_visual_inspection_suite_.py
+++ b/nilearn/reporting/_visual_testing/_glm_reporter_visual_inspection_suite_.py
@@ -167,7 +167,7 @@ def _make_design_matrix_for_bids_feature(
 
 def report_flm_bids_features():  # pragma: no cover # noqa
     data_dir = _fetch_bids_data()
-    model, subject = _make_flm(data_dir)
+    model, _ = _make_flm(data_dir)
     title = "FLM Bids Features Stat maps"
     report = make_glm_report(
         model=model,
@@ -259,9 +259,13 @@ def report_slm_oasis():  # pragma: no cover # noqa
         oasis_dataset.gray_matter_maps, design_matrix=design_matrix
     )
 
-    contrast = [np.array([1, 0]), np.array([0, 1])]
-    contrast = [np.array([1, 0, 0]), np.array([0, 1, 0])]
+    # TODO the following crashes
+    # contrast = [np.array([1, 0]), np.array([0, 1])]
+
+    # The following are equivalent
+    # contrast = [np.array([1, 0, 0]), np.array([0, 1, 0])]
     contrast = ["age", "sex"]
+
     report = make_glm_report(
         model=second_level_model,
         contrasts=contrast,
@@ -310,9 +314,9 @@ def prefer_serial_execution(functions_to_be_called):  # pragma: no cover # noqa
 if __name__ == "__main__":  # pragma: no cover
     functions_to_be_called = [
         report_flm_adhd_dmn,
-        # report_flm_bids_features,
-        # report_flm_fiac,
-        # report_slm_oasis,
+        report_flm_bids_features,
+        report_flm_fiac,
+        report_slm_oasis,
     ]
     # prefer_parallel_execution(functions_to_be_called)
     prefer_serial_execution(functions_to_be_called)

--- a/nilearn/reporting/_visual_testing/_glm_reporter_visual_inspection_suite_.py
+++ b/nilearn/reporting/_visual_testing/_glm_reporter_visual_inspection_suite_.py
@@ -174,6 +174,7 @@ def report_flm_bids_features():  # pragma: no cover # noqa
         contrasts="StopSuccess - Go",
         title=title,
         cluster_threshold=3,
+        plot_type="glass",
     )
     output_filename = "generated_report_flm_bids_features.html"
     output_filepath = os.path.join(REPORTS_DIR, output_filename)
@@ -271,6 +272,7 @@ def report_slm_oasis():  # pragma: no cover # noqa
         contrasts=contrast,
         bg_img=nilearn.datasets.fetch_icbm152_2009()["t1"],
         height_control=None,
+        plot_type="glass",
     )
     output_filename = "generated_report_slm_oasis.html"
     output_filepath = os.path.join(REPORTS_DIR, output_filename)

--- a/nilearn/reporting/_visual_testing/_glm_reporter_visual_inspection_suite_.py
+++ b/nilearn/reporting/_visual_testing/_glm_reporter_visual_inspection_suite_.py
@@ -71,6 +71,7 @@ def report_flm_adhd_dmn():  # pragma: no cover # noqa
         contrasts=contrasts,
         title="ADHD DMN Report",
         cluster_threshold=15,
+        alpha=0.0009,
         height_control="bonferroni",
         min_distance=8.0,
         plot_type="glass",
@@ -258,7 +259,9 @@ def report_slm_oasis():  # pragma: no cover # noqa
         oasis_dataset.gray_matter_maps, design_matrix=design_matrix
     )
 
-    contrast = [[1, 0, 0], [0, 1, 0]]
+    contrast = [np.array([1, 0]), np.array([0, 1])]
+    contrast = [np.array([1, 0, 0]), np.array([0, 1, 0])]
+    contrast = ["age", "sex"]
     report = make_glm_report(
         model=second_level_model,
         contrasts=contrast,
@@ -307,9 +310,9 @@ def prefer_serial_execution(functions_to_be_called):  # pragma: no cover # noqa
 if __name__ == "__main__":  # pragma: no cover
     functions_to_be_called = [
         report_flm_adhd_dmn,
-        report_flm_bids_features,
-        report_flm_fiac,
-        report_slm_oasis,
+        # report_flm_bids_features,
+        # report_flm_fiac,
+        # report_slm_oasis,
     ]
-    prefer_parallel_execution(functions_to_be_called)
-    # prefer_serial_execution(functions_to_be_called)
+    # prefer_parallel_execution(functions_to_be_called)
+    prefer_serial_execution(functions_to_be_called)

--- a/nilearn/reporting/glm_reporter.py
+++ b/nilearn/reporting/glm_reporter.py
@@ -964,8 +964,6 @@ def _stat_map_to_svg(
     data = safe_get_data(stat_img, ensure_finite=True)
     stat_map_min = np.nanmin(data)
     stat_map_max = np.nanmax(data)
-    print(stat_map_min)
-    print(stat_map_max)
     symmetric_cbar = True
     cmap = "bwr"
     if stat_map_min >= 0.0:
@@ -993,7 +991,7 @@ def _stat_map_to_svg(
             display_mode=display_mode,
             colorbar=True,
             plot_abs=False,
-            symmetric_cbar=True,
+            symmetric_cbar=symmetric_cbar,
             cmap=cmap,
             threshold=threshold,
         )
@@ -1003,19 +1001,18 @@ def _stat_map_to_svg(
             "Acceptable options are 'slice' or 'glass'."
         )
 
+    x_label_color = "black"
+    if plot_type == "slice":
+        x_label_color = "white"
+
     if hasattr(stat_map_plot, "_cbar"):
         cbar_ax = stat_map_plot._cbar.ax
         cbar_ax.set_xlabel(
-            "Z score", labelpad=7, fontweight="bold", loc="right"
-        )
-    elif hasattr(stat_map_plot, "_colorbar_ax"):
-        cbar_ax = stat_map_plot._colorbar_ax
-        cbar_ax.set_xlabel(
             "Z score",
-            labelpad=7,
+            labelpad=5,
             fontweight="bold",
             loc="right",
-            color="white",
+            color=x_label_color,
         )
 
     with pd.option_context("display.precision", 2):

--- a/nilearn/reporting/glm_reporter.py
+++ b/nilearn/reporting/glm_reporter.py
@@ -950,12 +950,14 @@ def _stat_map_to_svg(
     data = safe_get_data(stat_img, ensure_finite=True)
     stat_map_min = np.nanmin(data)
     stat_map_max = np.nanmax(data)
+    print(stat_map_min)
+    print(stat_map_max)
     symmetric_cbar = True
     cmap = "bwr"
-    if stat_map_min > 0:
+    if stat_map_min >= 0.0:
         symmetric_cbar = False
         cmap = "red_transparent_full_alpha_range"
-    elif stat_map_max < 0:
+    elif stat_map_max <= 0.0:
         symmetric_cbar = False
         cmap = "blue_transparent_full_alpha_range"
         cmap = nilearn_cmaps[cmap].reversed()
@@ -976,6 +978,8 @@ def _stat_map_to_svg(
             display_mode=display_mode,
             colorbar=True,
             plot_abs=False,
+            symmetric_cbar=True,
+            cmap=cmap,
         )
     else:
         raise ValueError(


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #2405

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- [x] only display FIR delay if FIR is used
- [x] make sure the run number does not overlap with the design matrix also only display it if there is more then one run
- [x] change number of significant figure in parameters for thresholding to make sure default alpha is properly displayed and use scientific notation for very small alphas
- [x] add "z-score" next to color bar
  - [x] handle black background
- [x] for `plot_type="slice"`
  - [x] use symmetric blue to white colormap when data has both positive and negative values
  - [x] use "red_transparent_full_alpha_range" colormap when data only has positive values
  - [x] use "blue_transparent_full_alpha_range" colormap when data only has negative values 
- [x] use a proper color map for glass brain
