### PR TITLE
[DOC] display all masker reports in the doc

### DIFF
--- a/.github/codespell_ignore_words.txt
+++ b/.github/codespell_ignore_words.txt
@@ -9,4 +9,5 @@ mapp
 nin
 serie
 fwe
+fo
 coo

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ build
 dist/
 nilearn/_version.py
 
+# notebooks
+.ipynb_checkpoints
+
 # virtual environment
 env/
 venv/

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -21,7 +21,7 @@ Enhancements
 Changes
 -------
 
-- :bdg-primary:`Doc` Render several examples of GLM reports as part of the documentation (:gh:`4267` by `Rémi Gau`_).
+- :bdg-primary:`Doc` Render examples of GLM and masker reports as part of the documentation (:gh:`4267` and :gh:`4295` by `Rémi Gau`_).
 - :bdg-dark:`Code` Improve colorbar size and labels in mosaic display (:gh:`4284` by `Rémi Gau`_).
 - :bdg-primary:`Doc` Render the description of the templates, atlases and datasets of the :mod:`nilearn.datasets` as part of the documentation (:gh:`4232` by `Rémi Gau`_).
 - :bdg-dark:`Code` Change the colormap to ``gray`` for the background image in the :class:`nilearn.maskers.NiftiSpheresMasker` (:gh:`4269` by `Rémi Gau`_).

--- a/doc/modules/generated_reports/masker_reports_examples.rst
+++ b/doc/modules/generated_reports/masker_reports_examples.rst
@@ -5,10 +5,50 @@
 Examples masker reports
 =======================
 
+Nifti masker
+------------
+
+.. raw:: html
+   :file: nifti_masker.html
+
+.. raw:: html
+   :file: multi_nifti_masker.html
+
+.. raw:: html
+   :file: multi_nifti_masker_fitted.html
+
+
+Nifti labels masker
+-------------------
+
+.. raw:: html
+   :file: nifti_labels_masker_fitted.html
+
+.. raw:: html
+   :file: nifti_labels_masker_atlas.html
+
+.. raw:: html
+   :file: multi_nifti_labels_masker_atlas.html
+
+.. raw:: html
+   :file: multi_nifti_labels_masker_fitted.html
+
+Nifti maps masker
+-----------------
+
+.. raw:: html
+   :file: nifti_maps_masker.html
+
+.. raw:: html
+   :file: multi_nifti_maps_masker_atlas.html
+
+.. raw:: html
+   :file: multi_nifti_maps_masker_fitted.html
+
 Nifti sphere masker
 -------------------
 
 Adapted from :ref:`sphx_glr_auto_examples_04_glm_first_level_plot_adhd_dmn.py`
 
 .. raw:: html
-   :file: flm_adhd_dmn_sphere_masker.html
+   :file: nifti_sphere_masker.html

--- a/doc/modules/generated_reports/masker_reports_examples.rst
+++ b/doc/modules/generated_reports/masker_reports_examples.rst
@@ -33,7 +33,7 @@ Adapted from :ref:`sphx_glr_auto_examples_06_manipulating_images_plot_nifti_labe
 .. raw:: html
    :file: nifti_labels_masker_atlas.html
 
-Adapted from :ref:`sphx_glr_auto_examples_03_connectivity_plot_atlas_decomposition.py`
+Adapted from :ref:`sphx_glr_auto_examples_03_connectivity_plot_atlas_comparison.py`
 
 .. raw:: html
    :file: multi_nifti_labels_masker_atlas.html
@@ -49,7 +49,7 @@ Adapted from :ref:`sphx_glr_auto_examples_03_connectivity_plot_probabilistic_atl
 .. raw:: html
    :file: nifti_maps_masker.html
 
-Adapted from :ref:`sphx_glr_auto_examples_03_connectivity_plot_atlas_decomposition.py`
+Adapted from :ref:`sphx_glr_auto_examples_03_connectivity_plot_atlas_comparison.py`
 
 .. raw:: html
    :file: multi_nifti_maps_masker_atlas.html

--- a/doc/modules/generated_reports/masker_reports_examples.rst
+++ b/doc/modules/generated_reports/masker_reports_examples.rst
@@ -8,8 +8,12 @@ Examples masker reports
 Nifti masker
 ------------
 
+Adapted from :ref:`sphx_glr_auto_examples_06_manipulating_images_plot_nifti_simple.py`
+
 .. raw:: html
    :file: nifti_masker.html
+
+Adapted from :ref:`sphx_glr_auto_examples_02_decoding_plot_miyawaki_encoding.py`
 
 .. raw:: html
    :file: multi_nifti_masker.html
@@ -21,11 +25,15 @@ Nifti masker
 Nifti labels masker
 -------------------
 
+Adapted from :ref:`sphx_glr_auto_examples_06_manipulating_images_plot_nifti_labels_simple.py`
+
 .. raw:: html
    :file: nifti_labels_masker_fitted.html
 
 .. raw:: html
    :file: nifti_labels_masker_atlas.html
+
+Adapted from :ref:`sphx_glr_auto_examples_03_connectivity_plot_atlas_decomposition.py`
 
 .. raw:: html
    :file: multi_nifti_labels_masker_atlas.html
@@ -36,8 +44,12 @@ Nifti labels masker
 Nifti maps masker
 -----------------
 
+Adapted from :ref:`sphx_glr_auto_examples_03_connectivity_plot_probabilistic_atlas_extraction.py`
+
 .. raw:: html
    :file: nifti_maps_masker.html
+
+Adapted from :ref:`sphx_glr_auto_examples_03_connectivity_plot_atlas_decomposition.py`
 
 .. raw:: html
    :file: multi_nifti_maps_masker_atlas.html

--- a/doc/visual_testing/reporter_visual_inspection_suite.py
+++ b/doc/visual_testing/reporter_visual_inspection_suite.py
@@ -346,6 +346,8 @@ def report_nifti_masker():
     return report
 
 
+# %%
+# Adapted from examples/02_decoding/plot_miyawaki_encoding.py
 def report_multi_nifti_masker():
 
     data = datasets.fetch_miyawaki2008()

--- a/doc/visual_testing/reporter_visual_inspection_suite.py
+++ b/doc/visual_testing/reporter_visual_inspection_suite.py
@@ -8,7 +8,6 @@ of nilearn.reporting.make_glm_reports().
 """
 
 import time
-from functools import lru_cache
 from pathlib import Path
 
 import numpy as np
@@ -39,14 +38,13 @@ REPORTS_DIR.mkdir(parents=True, exist_ok=True)
 
 # %%
 # Adapted from examples/04_glm_first_level/plot_adhd_dmn.py
-@lru_cache
-def report_nifti_sphere_masker():
+def report_flm_adhd_dmn():
 
     t_r = 2.0
+    slice_time_ref = 0.0
+    n_scans = 176
 
     pcc_coords = (0, -53, 26)
-
-    adhd_dataset = datasets.fetch_adhd(n_subjects=1)
 
     seed_masker = NiftiSpheresMasker(
         [pcc_coords],
@@ -59,22 +57,11 @@ def report_nifti_sphere_masker():
         memory="nilearn_cache",
     )
 
+    adhd_dataset = datasets.fetch_adhd(n_subjects=1)
     seed_time_series = seed_masker.fit_transform(adhd_dataset.func[0])
+
     report = seed_masker.generate_report()
     report.save_as_html(REPORTS_DIR / "nifti_sphere_masker.html")
-
-    return seed_time_series
-
-
-def report_flm_adhd_dmn():
-
-    t_r = 2.0
-    slice_time_ref = 0.0
-    n_scans = 176
-
-    adhd_dataset = datasets.fetch_adhd(n_subjects=1)
-
-    seed_time_series = report_nifti_sphere_masker()
 
     frametimes = np.linspace(0, (n_scans - 1) * t_r, n_scans)
 
@@ -105,7 +92,6 @@ def report_flm_adhd_dmn():
     )
 
     report.save_as_html(REPORTS_DIR / "flm_adhd_dmn.html")
-    report.get_iframe()
 
 
 # %%
@@ -345,8 +331,7 @@ def report_nifti_masker():
         mask_strategy="epi",
         memory="nilearn_cache",
         memory_level=2,
-        smoothing_fwhm=2,
-        mask_args=dict(upper_cutoff=0.9, lower_cutoff=0.8, opening=False),
+        smoothing_fwhm=8,
         cmap="grey",
     )
 
@@ -436,7 +421,6 @@ if __name__ == "__main__":
     t0 = time.time()
 
     report_nifti_masker()
-    report_nifti_sphere_masker()
     report_nifti_maps_masker()
     report_nifti_labels_masker()
     report_multi_nifti_masker()

--- a/doc/visual_testing/reporter_visual_inspection_suite.py
+++ b/doc/visual_testing/reporter_visual_inspection_suite.py
@@ -8,6 +8,7 @@ of nilearn.reporting.make_glm_reports().
 """
 
 import time
+from functools import lru_cache
 from pathlib import Path
 
 import numpy as np
@@ -21,7 +22,15 @@ from nilearn.glm.first_level.design_matrix import (
 from nilearn.glm.second_level import SecondLevelModel
 from nilearn.image import mean_img, resample_to_img
 from nilearn.interfaces.fsl import get_design_from_fslmat
-from nilearn.maskers import NiftiSpheresMasker
+from nilearn.maskers import (
+    MultiNiftiLabelsMasker,
+    MultiNiftiMapsMasker,
+    MultiNiftiMasker,
+    NiftiLabelsMasker,
+    NiftiMapsMasker,
+    NiftiMasker,
+    NiftiSpheresMasker,
+)
 from nilearn.reporting import make_glm_report
 
 REPORTS_DIR = Path(__file__).parent.parent / "modules" / "generated_reports"
@@ -30,11 +39,11 @@ REPORTS_DIR.mkdir(parents=True, exist_ok=True)
 
 # %%
 # Adapted from examples/04_glm_first_level/plot_adhd_dmn.py
-def report_flm_adhd_dmn():
+@lru_cache
+def report_nifti_sphere_masker():
 
     t_r = 2.0
-    slice_time_ref = 0.0
-    n_scans = 176
+
     pcc_coords = (0, -53, 26)
 
     adhd_dataset = datasets.fetch_adhd(n_subjects=1)
@@ -48,13 +57,24 @@ def report_flm_adhd_dmn():
         high_pass=0.01,
         t_r=t_r,
         memory="nilearn_cache",
-        memory_level=1,
-        verbose=0,
     )
 
     seed_time_series = seed_masker.fit_transform(adhd_dataset.func[0])
     report = seed_masker.generate_report()
-    report.save_as_html(REPORTS_DIR / "flm_adhd_dmn_sphere_masker.html")
+    report.save_as_html(REPORTS_DIR / "nifti_sphere_masker.html")
+
+    return seed_time_series
+
+
+def report_flm_adhd_dmn():
+
+    t_r = 2.0
+    slice_time_ref = 0.0
+    n_scans = 176
+
+    adhd_dataset = datasets.fetch_adhd(n_subjects=1)
+
+    seed_time_series = report_nifti_sphere_masker()
 
     frametimes = np.linspace(0, (n_scans - 1) * t_r, n_scans)
 
@@ -179,7 +199,6 @@ def report_flm_bids_features():
     )
 
     report.save_as_html(REPORTS_DIR / "flm_bids_features.html")
-    report.get_iframe()
 
 
 # %%
@@ -216,7 +235,6 @@ def report_flm_fiac():
     )
 
     report.save_as_html(REPORTS_DIR / "flm_fiac.html")
-    report.get_iframe()
 
 
 # %%
@@ -264,14 +282,164 @@ def report_slm_oasis():
     )
 
     report.save_as_html(REPORTS_DIR / "slm_oasis.html")
-    report.get_iframe()
+
+
+# %%
+# Adapted from examples/03_connectivity/plot_probabilistic_atlas_extraction.py
+def report_nifti_maps_masker():
+
+    atlas = datasets.fetch_atlas_msdl()
+    atlas_filename = atlas["maps"]
+
+    data = datasets.fetch_development_fmri(n_subjects=1)
+
+    masker = NiftiMapsMasker(
+        maps_img=atlas_filename,
+        standardize="zscore_sample",
+        standardize_confounds="zscore_sample",
+        memory="nilearn_cache",
+        cmap="grey",
+    )
+    masker.fit(data.func[0])
+
+    report = masker.generate_report(displayed_maps=[2, 6, 7, 16, 21])
+    report.save_as_html(REPORTS_DIR / "nifti_maps_masker.html")
+
+
+#  %%
+# Adapted from examples/06_manipulating_images/plot_nifti_labels_simple.py
+def report_nifti_labels_masker():
+
+    atlas = datasets.fetch_atlas_schaefer_2018()
+
+    atlas.labels = np.insert(atlas.labels, 0, "Background")
+
+    masker = NiftiLabelsMasker(
+        atlas.maps,
+        labels=atlas.labels,
+        standardize="zscore_sample",
+    )
+    masker.fit()
+    report = masker.generate_report()
+    report.save_as_html(REPORTS_DIR / "nifti_labels_masker_atlas.html")
+
+    data = datasets.fetch_development_fmri(n_subjects=1)
+    masker.fit(data.func[0])
+    report = masker.generate_report()
+    report.save_as_html(REPORTS_DIR / "nifti_labels_masker_fitted.html")
+
+
+#  %%
+# Adapted from examples/06_manipulating_images/plot_nifti_simple.py
+def report_nifti_masker():
+
+    masker = NiftiMasker(
+        standardize="zscore_sample",
+        mask_strategy="epi",
+        memory="nilearn_cache",
+        memory_level=2,
+        smoothing_fwhm=2,
+        mask_args=dict(upper_cutoff=0.9, lower_cutoff=0.8, opening=False),
+        cmap="grey",
+    )
+
+    data = datasets.fetch_development_fmri(n_subjects=1)
+    masker.fit(data.func[0])
+    report = masker.generate_report()
+    report.save_as_html(REPORTS_DIR / "nifti_masker.html")
+
+
+def report_multi_nifti_masker():
+
+    data = datasets.fetch_miyawaki2008()
+
+    masker = MultiNiftiMasker(
+        mask_img=data.mask,
+        detrend=True,
+        standardize="zscore_sample",
+        n_jobs=2,
+        cmap="grey",
+    )
+    masker.fit()
+    report = masker.generate_report()
+    report.save_as_html(REPORTS_DIR / "multi_nifti_masker.html")
+
+    fmri_random_runs_filenames = data.func[12:]
+    masker.fit(fmri_random_runs_filenames)
+    report = masker.generate_report()
+    report.save_as_html(REPORTS_DIR / "multi_nifti_masker_fitted.html")
+
+
+#  %%
+#  Adapted from examples/03_connectivity/plot_atlas_comparison.py
+def report_multi_nifti_labels_masker():
+
+    yeo = datasets.fetch_atlas_yeo_2011()
+
+    data = datasets.fetch_development_fmri(n_subjects=2)
+
+    masker = MultiNiftiLabelsMasker(
+        labels_img=yeo["thick_17"],
+        standardize="zscore_sample",
+        standardize_confounds="zscore_sample",
+        memory="nilearn_cache",
+        n_jobs=2,
+    )
+
+    masker.fit()
+    report = masker.generate_report()
+    report.save_as_html(REPORTS_DIR / "multi_nifti_labels_masker_atlas.html")
+
+    _ = masker.fit_transform(data.func, confounds=data.confounds)
+    report = masker.generate_report()
+    report.save_as_html(REPORTS_DIR / "multi_nifti_labels_masker_fitted.html")
+
+
+#  %%
+#  Adapted from examples/03_connectivity/plot_atlas_comparison.py
+def report_multi_nifti_maps_masker():
+
+    difumo = datasets.fetch_atlas_difumo(
+        dimension=64, resolution_mm=2, legacy_format=False
+    )
+
+    data = datasets.fetch_development_fmri(n_subjects=2)
+
+    masker = MultiNiftiMapsMasker(
+        maps_img=difumo.maps,
+        standardize="zscore_sample",
+        standardize_confounds="zscore_sample",
+        memory="nilearn_cache",
+        n_jobs=2,
+    )
+
+    masker.fit()
+    report = masker.generate_report()
+    report.save_as_html(REPORTS_DIR / "multi_nifti_maps_masker_atlas.html")
+
+    _ = masker.fit_transform(data.func, confounds=data.confounds)
+    report = masker.generate_report()
+    report.save_as_html(REPORTS_DIR / "multi_nifti_maps_masker_fitted.html")
 
 
 # %%
 if __name__ == "__main__":
 
-    print("\nGenerating GLM reports templates\n")
+    print("\nGenerating masker reports templates\n")
+    t0 = time.time()
 
+    report_nifti_masker()
+    report_nifti_sphere_masker()
+    report_nifti_maps_masker()
+    report_nifti_labels_masker()
+    report_multi_nifti_masker()
+    report_multi_nifti_labels_masker()
+    report_multi_nifti_maps_masker()
+
+    t1 = time.time()
+    print(f"\nTook: {(t1 - t0)} seconds\n")
+
+    print("\nGenerating GLM reports templates\n")
     t0 = time.time()
 
     report_flm_adhd_dmn()
@@ -280,5 +448,4 @@ if __name__ == "__main__":
     report_slm_oasis()
 
     t1 = time.time()
-
-    print(f"\nRun took: {(t1 - t0)} seconds\n")
+    print(f"\nTook: {(t1 - t0)} seconds\n")

--- a/doc/visual_testing/reporter_visual_inspection_suite.py
+++ b/doc/visual_testing/reporter_visual_inspection_suite.py
@@ -60,8 +60,8 @@ def report_flm_adhd_dmn():
     adhd_dataset = datasets.fetch_adhd(n_subjects=1)
     seed_time_series = seed_masker.fit_transform(adhd_dataset.func[0])
 
-    report = seed_masker.generate_report()
-    report.save_as_html(REPORTS_DIR / "nifti_sphere_masker.html")
+    masker_report = seed_masker.generate_report()
+    masker_report.save_as_html(REPORTS_DIR / "nifti_sphere_masker.html")
 
     frametimes = np.linspace(0, (n_scans - 1) * t_r, n_scans)
 
@@ -79,7 +79,7 @@ def report_flm_adhd_dmn():
         run_imgs=adhd_dataset.func[0], design_matrices=design_matrix
     )
 
-    report = make_glm_report(
+    glm_report = make_glm_report(
         first_level_model,
         contrasts=contrasts,
         title="ADHD DMN Report",
@@ -90,8 +90,9 @@ def report_flm_adhd_dmn():
         plot_type="glass",
         report_dims=(1200, "a"),
     )
+    glm_report.save_as_html(REPORTS_DIR / "flm_adhd_dmn.html")
 
-    report.save_as_html(REPORTS_DIR / "flm_adhd_dmn.html")
+    return masker_report, glm_report
 
 
 # %%
@@ -187,6 +188,7 @@ def report_flm_bids_features():
     )
 
     report.save_as_html(REPORTS_DIR / "flm_bids_features.html")
+    return report
 
 
 # %%
@@ -221,8 +223,8 @@ def report_flm_fiac():
         bg_img=mean_img_,
         height_control="fdr",
     )
-
     report.save_as_html(REPORTS_DIR / "flm_fiac.html")
+    return report
 
 
 # %%
@@ -273,8 +275,8 @@ def report_slm_oasis():
         height_control=None,
         plot_type="glass",
     )
-
     report.save_as_html(REPORTS_DIR / "slm_oasis.html")
+    return report
 
 
 # %%
@@ -297,6 +299,7 @@ def report_nifti_maps_masker():
 
     report = masker.generate_report(displayed_maps=[2, 6, 7, 16, 21])
     report.save_as_html(REPORTS_DIR / "nifti_maps_masker.html")
+    return report
 
 
 #  %%
@@ -320,6 +323,7 @@ def report_nifti_labels_masker():
     masker.fit(data.func[0])
     report = masker.generate_report()
     report.save_as_html(REPORTS_DIR / "nifti_labels_masker_fitted.html")
+    return report
 
 
 #  %%
@@ -339,6 +343,7 @@ def report_nifti_masker():
     masker.fit(data.func[0])
     report = masker.generate_report()
     report.save_as_html(REPORTS_DIR / "nifti_masker.html")
+    return report
 
 
 def report_multi_nifti_masker():
@@ -353,13 +358,14 @@ def report_multi_nifti_masker():
         cmap="grey",
     )
     masker.fit()
-    report = masker.generate_report()
-    report.save_as_html(REPORTS_DIR / "multi_nifti_masker.html")
+    empty_report = masker.generate_report()
+    empty_report.save_as_html(REPORTS_DIR / "multi_nifti_masker.html")
 
     fmri_random_runs_filenames = data.func[12:]
     masker.fit(fmri_random_runs_filenames)
     report = masker.generate_report()
     report.save_as_html(REPORTS_DIR / "multi_nifti_masker_fitted.html")
+    return empty_report, report
 
 
 #  %%
@@ -385,6 +391,7 @@ def report_multi_nifti_labels_masker():
     _ = masker.fit_transform(data.func, confounds=data.confounds)
     report = masker.generate_report()
     report.save_as_html(REPORTS_DIR / "multi_nifti_labels_masker_fitted.html")
+    return report
 
 
 #  %%
@@ -406,12 +413,16 @@ def report_multi_nifti_maps_masker():
     )
 
     masker.fit()
-    report = masker.generate_report()
-    report.save_as_html(REPORTS_DIR / "multi_nifti_maps_masker_atlas.html")
+    empty_report = masker.generate_report()
+    empty_report.save_as_html(
+        REPORTS_DIR / "multi_nifti_maps_masker_atlas.html"
+    )
 
     _ = masker.fit_transform(data.func, confounds=data.confounds)
     report = masker.generate_report()
     report.save_as_html(REPORTS_DIR / "multi_nifti_maps_masker_fitted.html")
+
+    return empty_report, report
 
 
 # %%

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -224,7 +224,7 @@ def get_mask_bounds(img):
     (xmin, xmax), (ymin, ymax), (zmin, zmax) = get_bounds(mask.shape, affine)
     slices = find_objects(mask.astype(int))
     if len(slices) == 0:
-        warnings.warn("empty mask", stacklevel=2)
+        warnings.warn("empty mask", stacklevel=3)
     else:
         x_slice, y_slice, z_slice = slices[0]
         x_width, y_width, z_width = mask.shape

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -238,7 +238,8 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
                     f"[{self.__class__.__name__}.fit] "
                     "Generation of a mask has been requested (imgs != None) "
                     "while a mask has been provided at masker creation. "
-                    "Given mask will be used."
+                    "Given mask will be used.",
+                    stacklevel=2,
                 )
 
             self.mask_img_ = _utils.check_niimg_3d(self.mask_img)

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -363,7 +363,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
                         "A list of 4D subject images were provided to fit. "
                         "Only first subject is shown in the report."
                     )
-                    warnings.warn(msg)
+                    warnings.warn(msg, stacklevel=6)
                     self._report_content["warning_message"] = msg
                 display = plotting.plot_img(
                     img,
@@ -382,7 +382,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
                     "Plotting ROIs of label image on the "
                     "MNI152Template for reporting."
                 )
-                warnings.warn(msg)
+                warnings.warn(msg, stacklevel=6)
                 self._report_content["warning_message"] = msg
                 display = plotting.plot_roi(labels_image)
                 plt.close()

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -325,7 +325,7 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
                 "No image provided to fit in NiftiMapsMasker. "
                 "Plotting only spatial maps for reporting."
             )
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=6)
             self._report_content["warning_message"] = msg
             for component in maps_to_be_displayed:
                 display = plotting.plot_stat_map(
@@ -340,7 +340,7 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
                 "A list of 4D subject images were provided to fit. "
                 "Only first subject is shown in the report."
             )
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=6)
             self._report_content["warning_message"] = msg
         # Find the cut coordinates
         cut_coords = [

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -347,7 +347,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
                 "No image provided to fit in NiftiMasker. "
                 "Setting image to mask for reporting."
             )
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=6)
             self._report_content["warning_message"] = msg
             img = mask
         if self._reporting_data["dim"] == 5:
@@ -355,7 +355,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
                 "A list of 4D subject images were provided to fit. "
                 "Only first subject is shown in the report."
             )
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=6)
             self._report_content["warning_message"] = msg
         # create display of retained input mask, image
         # for visual comparison


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4290

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- [x] example of maskers report are generated on every full build of the doc
- [x] they are viewable in the maskers section of the API part of the doc
- [x] add a notebook to help check the look of reports in notebooks

