### PR TITLE
[FIX] force views in surface plotting to be pairs of `int` or `float` when not a `string`

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -12,6 +12,7 @@ Fixes
 - :bdg-dark:`Code` Fix errant warning when using ``stat_type`` in :func:`nilearn.glm.compute_contrast` (:gh:`4257` by `Eric Larson`_).
 - :bdg-dark:`Code` Fix when thresholding is applied to images by GLM reports (:gh:`4258` by `Rémi Gau`_).
 - :bdg-dark:`Code` Fix color bar handling with color map with only 1 level (:gh:`4255` by `Rémi Gau`_).
+- :bdg-dark:`Code` Check that the ``view`` parameter in surface plotting functions is a pair of ``int`` or ``float`` when it is not a ``string`` (:gh:`4297` by `Rémi Gau`_).
 - :bdg-dark:`Code` Fix positions of the markers on the images on the sphere masker reports (:gh:`4285` by `Rémi Gau`_).
 - :bdg-dark:`Code` Make sure that :class:`nilearn.maskers.NiftiSpheresMasker` reports displays properly when it contains only 1 sphere (:gh:`4269` by `Rémi Gau`_).
 

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -990,12 +990,12 @@ docdict["verbose0"] = verbose.format(0)
 docdict[
     "view"
 ] = """
-view : :obj:`str` or a pair of :obj:`float`, default="lateral"
-    If a string, must be in {"lateral", "medial", "dorsal", "ventral",\
-"anterior", "posterior"}.
-    If a sequence, must be a pair (elev, azim) of float
+view : :obj:`str`, or a pair of :obj:`float` or :obj:`int`, default="lateral"
+    If a string, must be in \
+    {"lateral", "medial", "dorsal", "ventral", "anterior", "posterior"}.
+    If a sequence, must be a pair (elev, azim) of :obj:`float` or :obj:`int`
     angles in degrees that will manually set a custom view.
-    E.g., view=[270.0, 90.0] or view=(0.0, -180.0).
+    E.g., view=[270.0, 90] or view=(0, -180.0).
     View of the surface that is rendered.
 """
 

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -1205,7 +1205,11 @@ def _check_view_is_valid(view) -> bool:
     """
     if isinstance(view, str) and (view in VALID_VIEWS):
         return True
-    if isinstance(view, Sequence) and len(view) == 2:
+    if (
+        isinstance(view, Sequence)
+        and len(view) == 2
+        and all(isinstance(x, (int, float)) for x in view)
+    ):
         return True
     return False
 

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -322,7 +322,10 @@ def test_instantiation_error_plotly_surface_figure(input_obj):
         ("medial", True),
         ("latreal", False),
         ((100, 100), True),
+        ([100.0, 100.0], True),
         ((100, 100, 1), False),
+        (("lateral", "medial"), False),
+        ([100, "bar"], False),
     ]
 )
 def test_check_view_is_valid(view, is_valid):


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4294

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- enforce type for views in surface plotting
- update test
- update doc string
