### PR TITLE
[ENH] Add `avg_method` to `plot_surf_stat_map`

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -27,6 +27,7 @@ Enhancements
 Changes
 -------
 
+- :bdg-dark:`Code` Throw warnings when passing parameters to surface plotting functions that are not used by the plolty engine (:gh:`4298` by `Rémi Gau`_).
 - :bdg-primary:`Doc` Render examples of GLM and masker reports as part of the documentation (:gh:`4267` and :gh:`4295` by `Rémi Gau`_).
 - :bdg-dark:`Code` Improve colorbar size and labels in mosaic display (:gh:`4284` by `Rémi Gau`_).
 - :bdg-primary:`Doc` Render the description of the templates, atlases and datasets of the :mod:`nilearn.datasets` as part of the documentation (:gh:`4232` by `Rémi Gau`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -22,6 +22,8 @@ Fixes
 Enhancements
 ------------
 
+- :bdg-success:`API` Add an ``avg_method`` parameter to :func:`nilearn.plotting.plot_surf_stat_map` (:gh:`4298` by `Rémi Gau`_).
+
 Changes
 -------
 

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -32,7 +32,8 @@ annotate : :obj:`bool`, default=True
 docdict[
     "avg_method"
 ] = """
-avg_method : {"mean", "median", "min", "max", custom function}, default="mean"
+avg_method : {"mean", "median", "min", "max", custom function, None}, \
+             default=None
     How to average vertex values to derive the face value:
 
         - `mean`: results in smooth boundaries

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -1009,7 +1009,7 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
                        cmap='cold_hot', colorbar=True, symmetric_cbar="auto",
                        cbar_tick_format="auto", bg_on_data=False, darkness=.7,
                        title=None, title_font_size=18, output_file=None,
-                       axes=None, figure=None, **kwargs):
+                       axes=None, figure=None, avg_method='mean', **kwargs):
     """Plot a stats map on a surface :term:`mesh` with optional background.
 
     .. versionadded:: 0.3
@@ -1128,6 +1128,14 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
             This option is currently only implemented for the
             ``matplotlib`` engine.
 
+    %(avg_method)s
+
+        .. note::
+            This option is currently only implemented for the
+            ``matplotlib`` engine.
+
+        Default='mean'.
+
     kwargs : dict, optional
         Keyword arguments passed to :func:`nilearn.plotting.plot_surf`.
 
@@ -1155,7 +1163,7 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
     display = plot_surf(
         surf_mesh, surf_map=loaded_stat_map,
         bg_map=bg_map, hemi=hemi,
-        view=view, engine=engine, avg_method='mean', threshold=threshold,
+        view=view, engine=engine, avg_method=avg_method, threshold=threshold,
         cmap=cmap, symmetric_cmap=True, colorbar=colorbar,
         cbar_tick_format=cbar_tick_format, alpha=alpha,
         bg_on_data=bg_on_data, darkness=darkness,
@@ -1565,7 +1573,6 @@ def plot_surf_roi(surf_mesh,
         .. warning::
             The ``plotly`` engine is new and experimental.
             Please report bugs that you may encounter.
-
 
     %(avg_method)s
 

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -715,7 +715,8 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
             This option is currently only implemented for the
             ``matplotlib`` engine.
 
-        Default='mean'.
+        When using matplolib as engine,
+        `avg_method` will default to ``"mean"`` if ``None`` is passed.
 
     threshold : a number or None, default=None.
         If None is given, the image is not thresholded.
@@ -724,7 +725,8 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
 
     alpha : float or 'auto', default='auto'
         Alpha level of the :term:`mesh` (not surf_data).
-        Will default to ``"auto"`` of ``None`` is passed.
+        When using matplolib as engine,
+        `alpha` will default to ``"auto"`` if ``None`` is passed.
         If 'auto' is chosen, alpha will default to 0.5 when no bg_map
         is passed and to 1 if a bg_map is passed.
 
@@ -820,15 +822,15 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
                      f"Got '{parameter} = {value}'.\n"
                      f"Use '{parameter} = None' to silence this warning."))
 
-    # setting defaults
-    if avg_method is None:
-        avg_method = 'mean'
-
-    if alpha is None:
-        alpha = 'auto'
-
     coords, faces = load_surf_mesh(surf_mesh)
+
     if engine == 'matplotlib':
+        # setting defaults
+        if avg_method is None:
+            avg_method = 'mean'
+        if alpha is None:
+            alpha = 'auto'
+
         if cbar_tick_format == "auto":
             cbar_tick_format = '%.2g'
         fig = _plot_surf_matplotlib(
@@ -839,6 +841,7 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
             cbar_vmax=cbar_vmax, cbar_tick_format=cbar_tick_format,
             title=title,
             output_file=output_file, axes=axes, figure=figure)
+
     elif engine == 'plotly':
         if cbar_tick_format == "auto":
             cbar_tick_format = ".1f"
@@ -850,10 +853,12 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
             vmin=vmin, vmax=vmax, cbar_vmin=cbar_vmin, cbar_vmax=cbar_vmax,
             cbar_tick_format=cbar_tick_format, title=title,
             title_font_size=title_font_size, output_file=output_file)
+
     else:
         raise ValueError(f"Unknown plotting engine {engine}. "
                          "Please use either 'matplotlib' or "
                          "'plotly'.")
+
     return fig
 
 
@@ -1160,8 +1165,8 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
             This option is currently only implemented for the
             ``matplotlib`` engine.
 
-        Default=None.
-        Will default to ``"mean"`` if ``None`` is passed.
+        When using matplolib as engine,
+        `avg_method` will default to ``"mean"`` if ``None`` is passed.
 
         .. versionadded:: 0.10.3dev
 
@@ -1614,7 +1619,8 @@ def plot_surf_roi(surf_mesh,
             This option is currently only implemented for the
             ``matplotlib`` engine.
 
-        Will default to ``"median"`` if None is passed.
+        When using matplolib as engine,
+        `avg_method` will default to ``"median"`` if ``None`` is passed.
 
     threshold : a number or None, default=1e-14
         Threshold regions that are labelled 0.
@@ -1631,8 +1637,8 @@ def plot_surf_roi(surf_mesh,
 
     alpha : float or 'auto' or None, default=None
         Alpha level of the :term:`mesh` (not surf_data).
-        Will default to ``"auto"`` if ``None`` is passed.
-``` + same comment as above
+        When using matplolib as engine,
+        `alpha` will default to ``"auto"`` if ``None`` is passed.
         If 'auto' is chosen, alpha will default to 0.5 when no bg_map
         is passed and to 1 if a bg_map is passed.
 

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -1111,7 +1111,7 @@ def plot_surf_stat_map(surf_mesh, stat_map, bg_map=None,
 
     alpha : float or 'auto' or None, default=None
         Alpha level of the :term:`mesh` (not the stat_map).
-        Will default to ``"auto"`` of ``None`` is passed.
+        Will default to ``"auto"`` if ``None`` is passed.
         If 'auto' is chosen, alpha will default to .5 when no bg_map is
         passed and to 1 if a bg_map is passed.
 
@@ -1631,7 +1631,8 @@ def plot_surf_roi(surf_mesh,
 
     alpha : float or 'auto' or None, default=None
         Alpha level of the :term:`mesh` (not surf_data).
-        Will default to ``"auto"`` of ``None`` is passed.
+        Will default to ``"auto"`` if ``None`` is passed.
+``` + same comment as above
         If 'auto' is chosen, alpha will default to 0.5 when no bg_map
         is passed and to 1 if a bg_map is passed.
 

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -536,6 +536,8 @@ def test_plot_surf_error(engine, rng):
 
 @pytest.mark.parametrize("kwargs", [{"avg_method": "mean"}, {"alpha": "auto"}])
 def test_plot_surf_warnings_not_implemented_in_plotly(rng, kwargs):
+    if not is_plotly_installed() and engine == "plotly":
+        pytest.skip('Plotly is not installed; required for this test.')
     mesh = generate_surf()
     with pytest.warns(UserWarning,
                       match='is not implemented for the plotly engine'):

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -412,13 +412,22 @@ def test_plot_surf(engine, tmp_path, rng):
     mesh = generate_surf()
     bg = rng.standard_normal(size=mesh[0].shape[0])
 
+    # to avoid extra warnings
+    alpha = None
+    cbar_vmin = None
+    cbar_vmax = None
+    if engine == "matplotlib":
+        alpha = 0.5
+        cbar_vmin = 0
+        cbar_vmax = 150
+
     # Plot mesh only
     plot_surf(mesh, engine=engine)
 
     # Plot mesh with background
     plot_surf(mesh, bg_map=bg, engine=engine)
     plot_surf(mesh, bg_map=bg, darkness=0.5, engine=engine)
-    plot_surf(mesh, bg_map=bg, alpha=0.5,
+    plot_surf(mesh, bg_map=bg, alpha=alpha,
               output_file=tmp_path / 'tmp.png', engine=engine)
 
     # Plot different views
@@ -428,8 +437,8 @@ def test_plot_surf(engine, tmp_path, rng):
 
     # Plot with colorbar
     plot_surf(mesh, bg_map=bg, colorbar=True, engine=engine)
-    plot_surf(mesh, bg_map=bg, colorbar=True, cbar_vmin=0,
-              cbar_vmax=150, cbar_tick_format="%i", engine=engine)
+    plot_surf(mesh, bg_map=bg, colorbar=True, cbar_vmin=cbar_vmin,
+              cbar_vmax=cbar_vmax, cbar_tick_format="%i", engine=engine)
     # Save execution time and memory
     plt.close()
 
@@ -525,6 +534,17 @@ def test_plot_surf_error(engine, rng):
         )
 
 
+@pytest.mark.parametrize("kwargs", [{"avg_method": "mean"}, {"alpha": "auto"}])
+def test_plot_surf_warnings_not_implemented_in_plotly(rng, kwargs):
+    mesh = generate_surf()
+    with pytest.warns(UserWarning,
+                      match='is not implemented for the plotly engine'):
+        plot_surf(mesh,
+                  surf_map=rng.standard_normal(size=mesh[0].shape[0]),
+                  engine='plotly',
+                  **kwargs)
+
+
 def test_plot_surf_avg_method_errors(rng):
     mesh = generate_surf()
     with pytest.raises(
@@ -596,10 +616,15 @@ def test_plot_surf_stat_map(engine, rng):
     bg = rng.standard_normal(size=mesh[0].shape[0])
     data = 10 * rng.standard_normal(size=mesh[0].shape[0])
 
+    # to avoid extra warnings
+    alpha = None
+    if engine == "matplotlib":
+        alpha = 1
+
     # Plot mesh with stat map
     plot_surf_stat_map(mesh, stat_map=data, engine=engine)
     plot_surf_stat_map(mesh, stat_map=data, colorbar=True, engine=engine)
-    plot_surf_stat_map(mesh, stat_map=data, alpha=1, engine=engine)
+    plot_surf_stat_map(mesh, stat_map=data, alpha=alpha, engine=engine)
 
     # Plot mesh with background and stat map
     plot_surf_stat_map(mesh, stat_map=data, bg_map=bg, engine=engine)
@@ -1166,6 +1191,11 @@ def test_compute_facecolors_matplotlib():
 def test_plot_surf_roi_default_arguments(engine, symmetric_cmap, avg_method):
     """Regression test for https://github.com/nilearn/nilearn/issues/3941."""
     mesh, roi_map, _ = _generate_data_test_surf_roi()
+
+    # To avoid extra warnings
+    if engine == "plotly":
+        avg_method = None
+
     plot_surf_roi(mesh, roi_map=roi_map,
                   engine=engine,
                   symmetric_cmap=symmetric_cmap,

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -536,7 +536,7 @@ def test_plot_surf_error(engine, rng):
 
 @pytest.mark.parametrize("kwargs", [{"avg_method": "mean"}, {"alpha": "auto"}])
 def test_plot_surf_warnings_not_implemented_in_plotly(rng, kwargs):
-    if not is_plotly_installed() and engine == "plotly":
+    if not is_plotly_installed():
         pytest.skip('Plotly is not installed; required for this test.')
     mesh = generate_surf()
     with pytest.warns(UserWarning,


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Related to #4296 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- add `avg_method` parameter to `plot_surf_stat_map`
- throw warnings when using plotly and passing an unimplemented parameter to one of the surface plotting function to avoid users being confused why some parameters have no effect.
  - this required setting the default of a few parameters to `None` in the function declaration and using the original default when using the matplotlib engine.
  - this should now be reflected in the doc strings
