### PR TITLE
[MAINT] add test to `resampling_target = None` for nifti label maskers

### DIFF
--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -96,12 +96,14 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
         is continuous.
 
     resampling_target : {"data", "labels", None}, default="data"
-        Gives which image gives the final shape/size. For example, if
-        `resampling_target` is "data", the atlas is resampled to the
-        shape of the data if needed. If it is "labels" then mask_img
-        and images provided to fit() are resampled to the shape and
-        affine of maps_img. "None" means no resampling: if shapes and
-        affines do not match, a ValueError is raised.
+        Gives which image gives the final shape/size.
+        For example, if ``resampling_target`` is ``"data"``,
+        the atlas is resampled to the shape of the data if needed.
+        If it is ``"labels"`` then mask_img and images provided to fit()
+        are resampled to the shape and affine of maps_img.
+        ``"None"`` means no resampling:
+        if shapes and affines do not match, a ValueError is raised.
+
     %(memory)s
     %(memory_level1)s
     %(verbose0)s

--- a/nilearn/maskers/tests/test_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_nifti_labels_masker.py
@@ -36,72 +36,72 @@ def test_nifti_labels_masker(affine_eye, shape_3d_default, n_regions, length):
     """Check working of shape/affine checks."""
     shape1 = (*shape_3d_default, length)
 
-    shape2 = (12, 10, 14, length)
-
-    fmri11_img, mask11_img = generate_random_img(
+    fmri_img, mask11_img = generate_random_img(
         shape1,
         affine=affine_eye,
     )
 
-    _, mask21_img = generate_random_img(
-        shape2,
-        affine=affine_eye,
-    )
-
-    labels11_img = generate_labeled_regions(
+    labels_img = generate_labeled_regions(
         shape1[:3],
         affine=affine_eye,
         n_regions=n_regions,
     )
 
     # No exception raised here
-    masker11 = NiftiLabelsMasker(labels11_img, resampling_target=None)
-    signals11 = masker11.fit().transform(fmri11_img)
+    masker = NiftiLabelsMasker(labels_img, resampling_target=None)
+    signals = masker.fit().transform(fmri_img)
 
-    assert signals11.shape == (length, n_regions)
+    assert signals.shape == (length, n_regions)
 
     # No exception should be raised either
-    masker11 = NiftiLabelsMasker(labels11_img, resampling_target=None)
+    masker = NiftiLabelsMasker(labels_img, resampling_target=None)
 
     # Check attributes defined at fit
-    assert not hasattr(masker11, "mask_img_")
-    assert not hasattr(masker11, "labels_img_")
-    assert not hasattr(masker11, "n_elements_")
+    assert not hasattr(masker, "mask_img_")
+    assert not hasattr(masker, "labels_img_")
+    assert not hasattr(masker, "n_elements_")
 
-    masker11.fit()
+    masker.fit()
 
     # Check attributes defined at fit
-    assert hasattr(masker11, "mask_img_")
-    assert hasattr(masker11, "labels_img_")
-    assert hasattr(masker11, "n_elements_")
-    assert masker11.n_elements_ == n_regions
+    assert hasattr(masker, "mask_img_")
+    assert hasattr(masker, "labels_img_")
+    assert hasattr(masker, "n_elements_")
+    assert masker.n_elements_ == n_regions
 
-    masker11.inverse_transform(signals11)
+    masker.inverse_transform(signals)
 
-    masker11 = NiftiLabelsMasker(
-        labels11_img, mask_img=mask11_img, resampling_target=None
+    # now with several mask_img
+    masker = NiftiLabelsMasker(
+        labels_img, mask_img=mask11_img, resampling_target=None
     )
-    signals11 = masker11.fit().transform(fmri11_img)
+    signals = masker.fit().transform(fmri_img)
 
-    assert signals11.shape == (length, n_regions)
+    assert signals.shape == (length, n_regions)
 
-    masker11 = NiftiLabelsMasker(
-        labels11_img, mask_img=mask21_img, resampling_target=None
+    shape2 = (12, 10, 14, length)
+    _, mask21_img = generate_random_img(
+        shape2,
+        affine=affine_eye,
+    )
+
+    masker = NiftiLabelsMasker(
+        labels_img, mask_img=mask21_img, resampling_target=None
     )
 
     # Transform, with smoothing (smoke test)
-    masker11 = NiftiLabelsMasker(
-        labels11_img, smoothing_fwhm=3, resampling_target=None
+    masker = NiftiLabelsMasker(
+        labels_img, smoothing_fwhm=3, resampling_target=None
     )
-    signals11 = masker11.fit().transform(fmri11_img)
+    signals = masker.fit().transform(fmri_img)
 
-    assert signals11.shape == (length, n_regions)
+    assert signals.shape == (length, n_regions)
 
     # Call inverse transform (smoke test)
-    fmri11_img_r = masker11.inverse_transform(signals11)
+    fmri_img_r = masker.inverse_transform(signals)
 
-    assert fmri11_img_r.shape == fmri11_img.shape
-    assert_almost_equal(fmri11_img_r.affine, fmri11_img.affine)
+    assert fmri_img_r.shape == fmri_img.shape
+    assert_almost_equal(fmri_img_r.affine, fmri_img.affine)
 
 
 def test_nifti_labels_masker_errors(
@@ -515,33 +515,33 @@ def test_nifti_labels_masker_resampling_to_labels(
     shape3 = (13, 14, 15)
 
     # With data of the same affine
-    fmri11_img, _ = generate_random_img(
+    fmri_img, _ = generate_random_img(
         shape1,
         affine=affine_eye,
     )
-    _, mask22_img = generate_random_img(
+    _, mask_img = generate_random_img(
         shape2,
         affine=affine_eye,
     )
 
-    labels33_img = generate_labeled_regions(
+    labels_img = generate_labeled_regions(
         shape3,
         n_regions,
         affine=affine_eye,
     )
 
     masker = NiftiLabelsMasker(
-        labels33_img, mask_img=mask22_img, resampling_target="labels"
+        labels_img, mask_img=mask_img, resampling_target="labels"
     )
 
     masker.fit()
 
-    assert_almost_equal(masker.labels_img_.affine, labels33_img.affine)
-    assert masker.labels_img_.shape == labels33_img.shape
+    assert_almost_equal(masker.labels_img_.affine, labels_img.affine)
+    assert masker.labels_img_.shape == labels_img.shape
     assert_almost_equal(masker.mask_img_.affine, masker.labels_img_.affine)
     assert masker.mask_img_.shape == masker.labels_img_.shape[:3]
 
-    transformed = masker.transform(fmri11_img)
+    transformed = masker.transform(fmri_img)
 
     assert transformed.shape == (length, n_regions)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but follow up on #4333

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- add match argument to test of errors
- add explicit test of resampling_target=None
- simplify some variable names that were made too complicated after splitting long tests in #4333
