### PR TITLE
[FIX] ensure that threshold passed to plotting functions are positive

### DIFF
--- a/nilearn/_utils/param_validation.py
+++ b/nilearn/_utils/param_validation.py
@@ -14,7 +14,7 @@ MNI152_BRAIN_VOLUME = 1827243.0
 
 def check_threshold_is_positive(threshold):
     """Ensure that threshold values are positive."""
-    if threshold is None or not isinstance(threshold, numbers.Real):
+    if threshold is None or isinstance(threshold, (str, list)):
         return threshold
     if threshold < 0:
         warnings.warn(
@@ -25,6 +25,7 @@ def check_threshold_is_positive(threshold):
             stacklevel=2,
         )
         threshold = np.abs(threshold)
+    return threshold
 
 
 def check_threshold(threshold, data, percentile_func, name="threshold"):

--- a/nilearn/_utils/param_validation.py
+++ b/nilearn/_utils/param_validation.py
@@ -12,6 +12,21 @@ from .niimg import _get_data
 MNI152_BRAIN_VOLUME = 1827243.0
 
 
+def check_threshold_is_positive(threshold):
+    """Ensure that threshold values are positive."""
+    if threshold is None or not isinstance(threshold, numbers.Real):
+        return threshold
+    if threshold < 0:
+        warnings.warn(
+            (
+                f"A negative threshold was passed: {threshold}.\n"
+                "Will use the absolute value instead"
+            ),
+            stacklevel=2,
+        )
+        threshold = np.abs(threshold)
+
+
 def check_threshold(threshold, data, percentile_func, name="threshold"):
     """Check if the given threshold is in correct format \
     and within the limit.

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -27,6 +27,7 @@ from nibabel.spatialimages import SpatialImage
 from scipy import stats
 from scipy.ndimage import binary_fill_holes
 
+from nilearn._utils.numpy_conversions import as_ndarray
 from nilearn.image.resampling import reorder_img
 from nilearn.maskers import NiftiMasker
 from nilearn.plotting.displays import get_projector, get_slicer
@@ -37,8 +38,10 @@ from .._utils import compare_version, fill_doc
 from .._utils.extmath import fast_abs_percentile
 from .._utils.ndimage import get_border_data
 from .._utils.niimg import safe_get_data
-from .._utils.numpy_conversions import as_ndarray
-from .._utils.param_validation import check_threshold
+from .._utils.param_validation import (
+    check_threshold,
+    check_threshold_is_positive,
+)
 from ..datasets import load_mni152_template
 from ..image import get_data, iter_img, math_img, new_img_like, resample_to_img
 from ..masking import apply_mask, compute_epi_mask
@@ -232,6 +235,8 @@ def _plot_img_with_bg(
             "You provided single cut, "
             f"cut_coords={cut_coords}"
         )
+
+    threshold = check_threshold_is_positive(threshold)
 
     if img is not False and img is not None:
         img = _utils.check_niimg_3d(img, dtype="auto")
@@ -1139,14 +1144,14 @@ def plot_prob_atlas(
     if isinstance(threshold, collections.abc.Iterable) and not isinstance(
         threshold, str
     ):
-        threshold = [thr for thr in threshold]
+        threshold = [check_threshold_is_positive(thr) for thr in threshold]
         if len(threshold) != n_maps:
             raise TypeError(
                 "The list of values to threshold "
                 "should be equal to number of maps"
             )
     else:
-        threshold = [threshold] * n_maps
+        threshold = [check_threshold_is_positive(threshold)] * n_maps
 
     filled = view_type.startswith("filled")
     for map_img, color, thr in zip(iter_img(maps_img), color_list, threshold):

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -236,8 +236,6 @@ def _plot_img_with_bg(
             f"cut_coords={cut_coords}"
         )
 
-    threshold = check_threshold_is_positive(threshold)
-
     if img is not False and img is not None:
         img = _utils.check_niimg_3d(img, dtype="auto")
         data = safe_get_data(img, ensure_finite=True)
@@ -253,6 +251,8 @@ def _plot_img_with_bg(
             threshold = fast_abs_percentile(data) - 1e-5
 
         img = new_img_like(img, as_ndarray(data), affine)
+
+    threshold = check_threshold_is_positive(threshold)
 
     display = display_factory(display_mode)(
         img,

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -18,6 +18,7 @@ from nilearn import image, surface
 from nilearn._utils import check_niimg_3d, compare_version, fill_doc
 from nilearn._utils.helpers import is_kaleido_installed, is_plotly_installed
 from nilearn.plotting.cm import cold_hot, mix_colormaps
+from nilearn._utils.param_validation import check_threshold_is_positive
 from nilearn.plotting.displays._slicers import _get_cbar_ticks
 from nilearn.plotting.html_surface import get_vertexcolor
 from nilearn.plotting.img_plotting import get_colorbar_and_data_ranges
@@ -823,6 +824,14 @@ def plot_surf(surf_mesh, surf_map=None, bg_map=None,
                      f"Use '{parameter} = None' to silence this warning."))
 
     coords, faces = load_surf_mesh(surf_mesh)
+
+    threshold = check_threshold_is_positive(threshold)
+
+    if threshold is not None and threshold < 0:
+        warn((f"A negative threshold was passed: {threshold}.\n"
+              "Will use the absolute value instead"),
+             stacklevel=2)
+        threshold = np.abs(threshold)
 
     if engine == 'matplotlib':
         # setting defaults

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -17,8 +17,8 @@ from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 from nilearn import image, surface
 from nilearn._utils import check_niimg_3d, compare_version, fill_doc
 from nilearn._utils.helpers import is_kaleido_installed, is_plotly_installed
-from nilearn.plotting.cm import cold_hot, mix_colormaps
 from nilearn._utils.param_validation import check_threshold_is_positive
+from nilearn.plotting.cm import cold_hot, mix_colormaps
 from nilearn.plotting.displays._slicers import _get_cbar_ticks
 from nilearn.plotting.html_surface import get_vertexcolor
 from nilearn.plotting.img_plotting import get_colorbar_and_data_ranges

--- a/nilearn/plotting/tests/test_img_plotting/test_plot_stat_map.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_plot_stat_map.py
@@ -78,9 +78,17 @@ def test_plot_stat_map_with_masked_image(img_3d_mni, affine_mni):
     ],
 )
 def test_plot_stat_map_threshold(data, affine_eye):
-    """Tests plot_stat_map with threshold (see #510)."""
+    """Test plot_stat_map with threshold.
+
+    See https://github.com/nilearn/nilearn/issues/510.
+    """
     plot_stat_map(Nifti1Image(data, affine_eye), threshold=1000, colorbar=True)
     plt.close()
+
+
+def test_plot_stat_map_negative_threshold(img_3d_rand_eye):
+    with pytest.warns(match="negative"):
+        plot_stat_map(img_3d_rand_eye, threshold=-0.1)
 
 
 def test_plot_stat_map_threshold_for_affine_with_rotation(rng):

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -667,6 +667,23 @@ def test_plot_surf_stat_map(engine, rng):
     plt.close()
 
 
+@pytest.mark.parametrize("engine", ["matplotlib", "plotly"])
+def test_plot_surf_negative_threshold(engine, rng):
+    if not is_plotly_installed() and engine == "plotly":
+        pytest.skip('Plotly is not installed; required for this test.')
+    mesh = generate_surf()
+    bg = rng.standard_normal(size=mesh[0].shape[0])
+    data = 10 * rng.standard_normal(size=mesh[0].shape[0])
+    threshold = -0.3
+
+    with pytest.warns(match='negative threshold was passed'):
+        plot_surf(mesh,
+                  data,
+                  bg_map=bg,
+                  threshold=threshold,
+                  engine=engine)
+
+
 def test_plot_surf_stat_map_matplotlib_specific(rng):
     mesh = generate_surf()
     data = 10 * rng.standard_normal(size=mesh[0].shape[0])


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Relates to https://github.com/nilearn/nilearn/issues/4296#issuecomment-2015801304
- closes #4340 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

As far as I can tell all plotting threshold are implicitly expected to be positive numbers but this is never checked or enforced.

- add a function to convert negative threshold to their absolute values if they are negative
