### PR TITLE
[ENH] relax requirements for test_sampling_affine

### DIFF
--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -678,10 +678,10 @@ def test_sampling_affine(affine_eye):
     affine[-1, -1] = 1
     texture = surface._nearest_voxel_sampling(
         [img], mesh, affine=affine, radius=1, kind='ball')
-    assert_array_equal(texture[0], [1., 2., 1.])
+    assert_array_almost_equal(texture[0], [1.0, 2.0, 1.0], decimal=15)
     texture = surface._interpolation_sampling(
         [img], mesh, affine=affine, radius=0, kind='ball')
-    assert_array_almost_equal(texture[0], [1.1, 2., 1.])
+    assert_array_almost_equal(texture[0], [1.1, 2.0, 1.0], decimal=15)
 
 
 @pytest.mark.parametrize("kind", ["auto", "line", "ball"])


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4328

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- uses `assert_array_almost_equal` with decimal=15 instead of `assert_array_equal`

