### PR TITLE
[MAINT] clean up makefiles and allow color in CLI in github workflows

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,6 +15,10 @@ on:
     schedule:
     -   cron: 0 6 * * *
 
+# Force to use color
+env:
+    FORCE_COLOR: true
+
 jobs:
 
     # Make citation metadata from CITATION.cff is valid.

--- a/.github/workflows/detect_test_pollution.yml
+++ b/.github/workflows/detect_test_pollution.yml
@@ -28,6 +28,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:
 
+# Force to use color
+env:
+    FORCE_COLOR: true
+
 jobs:
     random:
         if: github.repository == 'nilearn/nilearn'

--- a/.github/workflows/detect_test_pollution.yml
+++ b/.github/workflows/detect_test_pollution.yml
@@ -45,5 +45,7 @@ jobs:
                 python-version: 3.12
         -   name: Install tox
             run: python -m pip install tox
+        -   name: Show tox config
+            run: tox c
         -   name: Run test suite
             run: tox run -e test_randomize

--- a/.github/workflows/numpy2_compatibility.yml
+++ b/.github/workflows/numpy2_compatibility.yml
@@ -14,6 +14,10 @@ on:
     -   cron: 0 8 * * *
     workflow_dispatch:
 
+# Force to use color
+env:
+    FORCE_COLOR: true
+
 jobs:
     test_numpy2:
         if: github.repository == 'nilearn/nilearn'

--- a/.github/workflows/numpy2_compatibility.yml
+++ b/.github/workflows/numpy2_compatibility.yml
@@ -36,5 +36,7 @@ jobs:
                 ruff check --preview --select NPY201 .
         -   name: Install tox
             run: python -m pip install tox
+        -   name: Show tox config
+            run: tox c
         -   name: Run test suite
             run: tox run -e test_numpy2 -- nilearn

--- a/.github/workflows/test_with_tox.yml
+++ b/.github/workflows/test_with_tox.yml
@@ -50,6 +50,8 @@ jobs:
                 python-version: ${{ matrix.py }}
         -   name: Install tox
             run: python -m pip install tox
+        -   name: Show tox config
+            run: tox c
         -   name: Run test suite
             run: tox run -e ${{ matrix.env }} -- nilearn
         -   name: Upload coverage to CodeCov

--- a/.github/workflows/test_with_tox.yml
+++ b/.github/workflows/test_with_tox.yml
@@ -13,6 +13,10 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
+# Force to use color
+env:
+    FORCE_COLOR: true
+
 jobs:
     test_and_coverage:
         if: github.repository == 'nilearn/nilearn'

--- a/.github/workflows/testing_minimum.yml
+++ b/.github/workflows/testing_minimum.yml
@@ -32,6 +32,10 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
+# Force to use color
+env:
+    FORCE_COLOR: true
+
 jobs:
     test_min_install:
         if: github.repository == 'nilearn/nilearn'

--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,10 @@ pip-log.txt
 
 .ropeproject/
 
-tags
-
 tmp
+
+#  prettier and other JS
+node_modules
 
 # Mac OS X
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,8 @@
 # caution: testing won't work on windows, see README
 
 PYTHON ?= python
-CYTHON ?= cython
-CTAGS ?= ctags
 
-all: clean doc-noplot
+all: clean
 
 clean-pyc:
 	find . -name "*.pyc" | xargs rm -f
@@ -19,34 +17,4 @@ clean-so:
 clean-build:
 	rm -rf build
 
-clean-ctags:
-	rm -f tags
-
-clean: clean-build clean-pyc clean-so clean-ctags
-
-trailing-spaces:
-	find . -name "*.py" | xargs perl -pi -e 's/[ \t]*$$//'
-
-cython:
-	find -name "*.pyx" | xargs $(CYTHON)
-
-ctags:
-	# make tags for symbol based navigation in emacs and vim
-	# Install with: sudo apt-get install exuberant-ctags
-	$(CTAGS) -R *
-
-.PHONY : doc-plot
-doc-plot:
-	make -C doc html
-
-.PHONY : doc
-doc:
-	make -C doc html-noplot
-
-.PHONY : ci-doc
-ci-doc:
-	make -C doc ci-html-noplot
-
-.PHONY : pdf
-pdf:
-	make -C doc pdf
+clean: clean-build clean-pyc clean-so

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,6 +1,18 @@
 # Makefile for Sphinx documentation
 #
 
+#  script to open an html file a browser
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+
+from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
+
 # You can set these variables from the command line.
 SPHINXOPTS    = -v
 SPHINXBUILD   = sphinx-build
@@ -62,6 +74,10 @@ force_html: force html
 
 force:
 	find . -name \*.rst -exec touch {} \;
+
+# view doc
+view: _build/html/index.html
+	$(BROWSER) _build/html/index.html
 
 html:	sym_links sym_links_datasets glm_reports
 	# These two lines make the build a bit more lengthy, and the
@@ -158,20 +174,10 @@ doctest:
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
-download-data:
-
 zip: html pdf
 	mkdir -p _build/nilearn ;
 	cp -r _build/html _build/nilearn ;
-	cp -r data _build/nilearn ;
-	cp nilearn.pdf _build/nilearn;
 	zip -r _build/nilearn.zip _build/nilearn
-
-pdf: latex
-	cd _build/latex ; make all-pdf ; pdfnup niearn.pdf
-	cp _build/latex/nilearn.pdf nilearn-simple.pdf
-	cp _build/latex/nilearn-nup.pdf nilearn.pdf
-	#cd _build/latex ; make all-pdf ; pdfnup nilearn.pdf
 
 check:
 	rm -rf _build/doctrees

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ deps =
     kaleido==0.1.0.post1 ; platform_system == 'Windows'
 
 [global_var]
-passenv = 
+passenv =
     USERNAME
     # Pass user color preferences through
     PY_COLORS

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,15 @@ deps =
     kaleido ; platform_system != 'Windows'
     kaleido==0.1.0.post1 ; platform_system == 'Windows'
 
+[global_var]
+passenv = 
+    USERNAME
+    # Pass user color preferences through
+    PY_COLORS
+    FORCE_COLOR
+    NO_COLOR
+    CLICOLOR
+    CLICOLOR_FORCE
 
 ; COMMANDS
 ; --------
@@ -81,14 +90,14 @@ commands =
 
 [testenv:test_latest]
 description = run tests on latest version of all dependencies (plotting not included)
-passenv = USERNAME
+passenv = {[global_var]passenv}
 extras = test
 commands =
     pytest --cov=nilearn --cov-report=xml {posargs:}
 
 [testenv:test_plotting]
 description = run tests on latest version of all dependencies
-passenv = USERNAME
+passenv = {[global_var]passenv}
 extras = test
 deps =
     {[plotting]deps}
@@ -98,7 +107,7 @@ commands =
 
 [testenv:test_doc]
 description = run tests on doc
-passenv = USERNAME
+passenv = {[global_var]passenv}
 extras = test
 deps =
     {[plotting]deps}
@@ -109,8 +118,7 @@ commands =
 
 [testenv:test_pre]
 description = run test_latest and test_doc on pre-release version of all dependencies
-passenv =
-    USERNAME
+passenv = {[global_var]passenv}
 pip_pre = true
 extras = test
 deps =
@@ -121,7 +129,7 @@ commands =
 
 [testenv:test_min]
 description = run tests on minimum version of all dependencies (plotting not included)
-passenv = USERNAME
+passenv = {[global_var]passenv}
 extras = test
 deps =
     {[min]deps}
@@ -132,7 +140,7 @@ commands =
 description = run tests on minimum version of all dependencies (no plotly).
               Plotly is additional for supporting interactive plots
               but is not actually needed to use nilearn plotting functionality
-passenv = USERNAME
+passenv = {[global_var]passenv}
 extras = test
 deps =
     {[min]deps}
@@ -142,7 +150,7 @@ commands =
 
 [testenv:test_randomize]
 description = run all tests in a random order
-passenv = USERNAME
+passenv = {[global_var]passenv}
 extras = test
 deps =
     {[plotting]deps}
@@ -152,7 +160,7 @@ commands =
 
 [testenv:test_numpy2]
 description = run tests on latest version of all dependencies
-passenv = USERNAME
+passenv = {[global_var]passenv}
 setenv =
     nightlies_url=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 extras = test
@@ -165,3 +173,12 @@ commands =
     pip install --pre --upgrade -i {env:nightlies_url} pandas scipy scikit-learn matplotlib
     pip install --pre --upgrade -i {env:nightlies_url} numpy
     pytest {posargs:}
+
+[testenv:doc]
+description = build doc
+extras = doc
+passenv = {[global_var]passenv}
+allowlist_externals =
+    make
+commands =
+	make -C doc html-noplot


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4314

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- clean up makefiles to remove unused recipes
- transfer basic doc building from main makefile to tox.ini
- add recipe in doc/makefile to allow easy viewing of the built doc with `make view` or `make -D doc view`
- update tox config and CI workflows so that the tests and doc output shows color in CI reports
