### PR TITLE
[MAINT] change schedule of GH workflows

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,6 +16,9 @@ on:
     # Run every Monday at 8am UTC
     -   cron: 0 8 * * 1
 
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
+
 # Force to use color
 env:
     FORCE_COLOR: true

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -13,7 +13,8 @@ on:
         branches:
         -   '*'
     schedule:
-    -   cron: 0 6 * * *
+    # Run every Monday at 8am UTC
+    -   cron: 0 8 * * 1
 
 # Force to use color
 env:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,9 +3,11 @@ name: Codespell
 
 on:
     push:
-        branches: [main]
+        branches:
+        -   main
     pull_request:
-        branches: [main]
+        branches:
+        -   '*'
 
 jobs:
     codespell:

--- a/.github/workflows/detect_test_pollution.yml
+++ b/.github/workflows/detect_test_pollution.yml
@@ -23,7 +23,8 @@ on:
 #            │ │ │ │ │
 #            * * * * *
     schedule:
-    -   cron: 0 0 25 * * # on the 25th of every monday
+    # Run first day of the month at midnight UTC
+    -   cron: 0 0 1 * *
 
   # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:

--- a/.github/workflows/numpy2_compatibility.yml
+++ b/.github/workflows/numpy2_compatibility.yml
@@ -4,14 +4,11 @@
 name: Numpy2 compatibility
 
 on:
-
-    pull_request:
-        branches:
-        -   '*'
-
+    push:
+        branches: [main]
     schedule:
-    # Run every day at 8am UTC
-    -   cron: 0 8 * * *
+    # Run every Monday at 8am UTC
+    -   cron: 0 8 * * 1
     workflow_dispatch:
 
 # Force to use color

--- a/.github/workflows/testing_minimum.yml
+++ b/.github/workflows/testing_minimum.yml
@@ -23,7 +23,8 @@ on:
     #            │ │ │ │ │
     #            * * * * *
     schedule:
-    -   cron: 0 0 1 * * # every first day of the month
+    # Run first day of the month at midnight UTC
+    -   cron: 0 0 1 * *
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:

--- a/.github/workflows/update_precommit_hooks.yml
+++ b/.github/workflows/update_precommit_hooks.yml
@@ -18,8 +18,8 @@ on:
 #            │ │ │ │ │
 #            * * * * *
     schedule:
-    # Run every Monday at midnight UTC
-    -   cron: 0 0 * * 1
+    # Run first day of the month at midnight UTC
+    -   cron: 0 0 1 * *
 
   # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:

--- a/.github/workflows/update_precommit_hooks.yml
+++ b/.github/workflows/update_precommit_hooks.yml
@@ -18,7 +18,8 @@ on:
 #            │ │ │ │ │
 #            * * * * *
     schedule:
-    -   cron: 0 0 * * 1 # every monday
+    # Run every Monday at midnight UTC
+    -   cron: 0 0 * * 1
 
   # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

Motivation: some GH workflows were run daily on top of being run after a merge on main.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- change schedule of github workflows
  - all monthly actions run on the first of the month
  - all other actions with a schedule run once a week on monday (numpy 2 check, and doc build)
- make sure all scheduled workflow can also be triggered 'manually' from the github GUI in [the action tab](https://github.com/nilearn/nilearn/actions).
