### PR TITLE
[ENH] Add warning for future change of the default of `force_resample` to True

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -61,6 +61,7 @@ Some other past or present contributors are:
 * `Alisha Kodibagkar`_: MIT McGovern Institute, Cambridge, Massachusetts, United States
 * `Amadeus Kanaan`_
 * `Ana Luisa Pinho`_: Western University, London, Ontario, Canada
+* `Anand Joshi`_: University of Southern California, Los Angeles, California, United States
 * `Andrés Hoyos Idrobo`_: Rakuten, France
 * `Anne-Sophie Kieslinger`_: Max Planck Institute for Human Cognitive and Brain Sciences, Leipzig, Germnay
 * `Ariel Rokem`_: University of Washington, Psychology, Seattle, Washington, 98107, USA

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -102,7 +102,8 @@ authors:
   - given-names: Anand
     family-names: Joshi
     website: https://github.com/ajoshiusc
-    affiliation: University of Southern California, Los Angeles, California, United States
+    affiliation: University of Southern California, Los Angeles, California, United
+      States
   - given-names: Andrés Hoyos
     family-names: Idrobo
     website: https://github.com/ahoyosid

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -99,6 +99,10 @@ authors:
     family-names: Pinho
     website: https://github.com/alpinho
     affiliation: Western University, London, Ontario, Canada
+  - given-names: Anand
+    family-names: Joshi
+    website: https://github.com/ajoshiusc
+    affiliation: University of Southern California, Los Angeles, California, United States
   - given-names: Andrés Hoyos
     family-names: Idrobo
     website: https://github.com/ahoyosid

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -32,3 +32,5 @@ Changes
 - :bdg-dark:`Code` Throw error in :func:`nilearn.glm.first_level.first_level_from_bids` if unknown ``kwargs`` are passed (:gh:`4414` by `Michelle Wang`_).
 
 - :bdg-primary:`Doc` Refactor design matrix and contrast formula for the two-sample T-test example in :ref:`sphx_glr_auto_examples_05_glm_second_level_plot_second_level_two_sample_test.py` (:gh:`4407` by `Yichun Huang`_).
+
+- :bdg-success:`API` The default for ``force_resample`` in :func:`nilearn.image.resample_img` and :func:`nilearn.image.resample_to_img` will be set to ``True`` from Nilearn 0.13.0.

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -36,4 +36,3 @@ Changes
 - :bdg-success:`API` The default for ``force_resample`` in :func:`nilearn.image.resample_img` and :func:`nilearn.image.resample_to_img` will be set to ``True`` from Nilearn 0.13.0.
 
 - :bdg-success:`API` Allow users to control copying header to the output in :func:`nilearn.image` functions and add future warning to copy headers by default in release 0.13.0 onwards (:gh:`4397` by `Himanshu Aggarwal`_).
-

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -33,6 +33,6 @@ Changes
 
 - :bdg-primary:`Doc` Refactor design matrix and contrast formula for the two-sample T-test example in :ref:`sphx_glr_auto_examples_05_glm_second_level_plot_second_level_two_sample_test.py` (:gh:`4407` by `Yichun Huang`_).
 
-- :bdg-success:`API` The default for ``force_resample`` in :func:`nilearn.image.resample_img` and :func:`nilearn.image.resample_to_img` will be set to ``True`` from Nilearn 0.13.0.
+- :bdg-success:`API` The default for ``force_resample`` in :func:`nilearn.image.resample_img` and :func:`nilearn.image.resample_to_img` will be set to ``True`` from Nilearn 0.13.0. (:gh:`4412` by `Rémi Gau`_ and `Anand Joshi`_)
 
 - :bdg-success:`API` Allow users to control copying header to the output in :func:`nilearn.image` functions and add future warning to copy headers by default in release 0.13.0 onwards (:gh:`4397` by `Himanshu Aggarwal`_).

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -30,6 +30,8 @@
 
 .. _Ana Luisa Pinho: https://github.com/alpinho
 
+.. _Anand Joshi: https://github.com/ajoshiusc
+
 .. _Andrés Hoyos Idrobo: https://github.com/ahoyosid
 
 .. _Anne-Sophie Kieslinger: https://github.com/askieslinger

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -3,9 +3,8 @@
 See http://nilearn.github.io/stable/manipulating_images/input_output.html
 """
 
-import numbers
-
 # Author: Gael Varoquaux, Alexandre Abraham, Michael Eickenberg
+import numbers
 import warnings
 
 import numpy as np
@@ -331,6 +330,21 @@ def _resample_one_img(
     return out
 
 
+def _check_force_resample(force_resample):
+    if force_resample is None:
+        force_resample = False
+        warnings.warn(
+            (
+                "'force_resample' will be set to 'True'"
+                " by default in Nilearn 0.13.0. \n"
+                "Use 'force_resample=True' to suppress this warning."
+            ),
+            FutureWarning,
+            stacklevel=2,
+        )
+    return force_resample
+
+
 def resample_img(
     img,
     target_affine=None,
@@ -340,7 +354,7 @@ def resample_img(
     order="F",
     clip=True,
     fill_value=0,
-    force_resample=True,
+    force_resample=None,
 ):
     """Resample a Niimg-like object.
 
@@ -383,8 +397,11 @@ def resample_img(
     fill_value : float, default=0
         Use a fill value for points outside of input volume.
 
-    force_resample : bool, default=True; False is
-        intended for testing, this prevents the use of a padding optimization.
+    force_resample : :obj:`bool`, default=None
+        False is intended for testing,
+        this prevents the use of a padding optimization.
+        Will be set to ``False`` if ``None`` is passed.
+        The default value will be set to ``True`` for Nilearn >=0.13.0.
 
     Returns
     -------
@@ -438,6 +455,8 @@ def resample_img(
 
     """
     from .image import new_img_like  # avoid circular imports
+
+    force_resample = _check_force_resample(force_resample)
 
     # Do as many checks as possible before loading data, to avoid potentially
     # costly calls before raising an exception.
@@ -692,7 +711,7 @@ def resample_to_img(
     order="F",
     clip=False,
     fill_value=0,
-    force_resample=True,
+    force_resample=None,
 ):
     """Resample a Niimg-like source image on a target Niimg-like image.
 
@@ -731,8 +750,11 @@ def resample_to_img(
     fill_value : float, default=0
         Use a fill value for points outside of input volume.
 
-    force_resample : bool, default=True; False is
-        intended for testing, this prevents the use of a padding optimization.
+    force_resample : :obj:`bool`, default=None
+        False is intended for testing,
+        this prevents the use of a padding optimization.
+        Will be set to ``False`` if ``None`` is passed.
+        The default value will be set to ``True`` for Nilearn >=0.13.0.
 
     Returns
     -------
@@ -745,6 +767,8 @@ def resample_to_img(
     nilearn.image.resample_img
 
     """
+    force_resample = _check_force_resample(force_resample)
+
     target = _utils.check_niimg(target_img)
     target_shape = target.shape
 
@@ -802,12 +826,14 @@ def reorder_img(img, resample=None):
                 "the image affine contains rotations"
             )
 
-        # Identify the voxel size using a QR decomposition of the
-        # affine
+        # Identify the voxel size using a QR decomposition of the affine
         Q, R = np.linalg.qr(affine[:3, :3])
         target_affine = np.diag(np.abs(np.diag(R))[np.abs(Q).argmax(axis=1)])
         return resample_img(
-            img, target_affine=target_affine, interpolation=resample
+            img,
+            target_affine=target_affine,
+            interpolation=resample,
+            force_resample=False,
         )
 
     axis_numbers = np.argmax(np.abs(A), axis=0)

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -340,7 +340,7 @@ def resample_img(
     order="F",
     clip=True,
     fill_value=0,
-    force_resample=False,
+    force_resample=True,
 ):
     """Resample a Niimg-like object.
 
@@ -383,8 +383,8 @@ def resample_img(
     fill_value : float, default=0
         Use a fill value for points outside of input volume.
 
-    force_resample : bool, default=False
-        Intended for testing, this prevents the use of a padding optimization.
+    force_resample : bool, default=True; False is
+        intended for testing, this prevents the use of a padding optimization.
 
     Returns
     -------
@@ -692,7 +692,7 @@ def resample_to_img(
     order="F",
     clip=False,
     fill_value=0,
-    force_resample=False,
+    force_resample=True,
 ):
     """Resample a Niimg-like source image on a target Niimg-like image.
 
@@ -731,8 +731,8 @@ def resample_to_img(
     fill_value : float, default=0
         Use a fill value for points outside of input volume.
 
-    force_resample : bool, default=False
-        Intended for testing, this prevents the use of a padding optimization.
+    force_resample : bool, default=True; False is
+        intended for testing, this prevents the use of a padding optimization.
 
     Returns
     -------

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -88,7 +88,8 @@ def test_identity_resample(shape, affine_eye, rng):
         Nifti1Image(data, affine_eye),
         target_affine=affine_eye,
         interpolation="nearest",
-        force_resample=False, copy_header=True
+        force_resample=False,
+        copy_header=True,
     )
 
     assert_almost_equal(data, get_data(rot_img))
@@ -98,7 +99,8 @@ def test_identity_resample(shape, affine_eye, rng):
         Nifti1Image(data, affine_eye),
         target_affine=affine_eye[:3, :3],
         interpolation="nearest",
-        force_resample=False, copy_header=True
+        force_resample=False,
+        copy_header=True,
     )
 
     assert_almost_equal(data, get_data(rot_img))
@@ -108,7 +110,8 @@ def test_identity_resample(shape, affine_eye, rng):
         Nifti1Image(data, affine_eye),
         target_affine=affine_eye.tolist(),
         interpolation="nearest",
-        force_resample=False, copy_header=True
+        force_resample=False,
+        copy_header=True,
     )
 
 
@@ -129,7 +132,8 @@ def test_identity_resample_non_native_endians(
         Nifti1Image(data.astype(endian_type), affine_eye),
         target_affine=affine_eye.tolist(),
         interpolation=interpolation,
-        force_resample=False, copy_header=True
+        force_resample=False,
+        copy_header=True,
     )
 
     assert_almost_equal(data, get_data(rot_img))
@@ -143,7 +147,8 @@ def test_downsample(shape, affine_eye, rng):
         Nifti1Image(data, affine_eye),
         target_affine=2 * affine_eye,
         interpolation="nearest",
-        force_resample=False, copy_header=True
+        force_resample=False,
+        copy_header=True,
     )
 
     downsampled = data[::2, ::2, ::2, ...]
@@ -181,7 +186,8 @@ def test_downsample_non_native_endian_data(
         Nifti1Image(data, affine_eye),
         target_affine=2 * affine_eye,
         interpolation="nearest",
-        force_resample=False, copy_header=True
+        force_resample=False,
+        copy_header=True,
     )
 
     downsampled = data[::2, ::2, ::2, ...]
@@ -194,7 +200,8 @@ def test_downsample_non_native_endian_data(
         target_affine=2 * affine_eye,
         interpolation="nearest",
         copy=copy_data,
-        force_resample=False, copy_header=True
+        force_resample=False,
+        copy_header=True,
     )
 
     assert_almost_equal(downsampled, get_data(rot_img)[:x, :y, :z, ...])
@@ -219,7 +226,8 @@ def test_resampling_fill_value(affine_eye, shape, value, rng):
             interpolation="nearest",
             fill_value=value,
             clip=False,
-            force_resample=False, copy_header=True
+            force_resample=False,
+            copy_header=True,
         )
     else:
         rot_img = resample_img(
@@ -227,7 +235,8 @@ def test_resampling_fill_value(affine_eye, shape, value, rng):
             target_affine=rot,
             interpolation="nearest",
             clip=False,
-            force_resample=False, copy_header=True
+            force_resample=False,
+            copy_header=True,
         )
 
     assert get_data(rot_img).flatten()[0] == value
@@ -237,7 +246,8 @@ def test_resampling_fill_value(affine_eye, shape, value, rng):
         rot_img,
         interpolation="nearest",
         fill_value=value,
-        force_resample=False, copy_header=True
+        force_resample=False,
+        copy_header=True,
     )
 
     assert get_data(rot_img2).flatten()[0] == value
@@ -257,7 +267,8 @@ def test_resampling_with_affine(affine_eye, shape, angle, rng):
         Nifti1Image(data, affine_eye),
         target_affine=rot,
         interpolation="nearest",
-        force_resample=False, copy_header=True
+        force_resample=False,
+        copy_header=True,
     )
 
     assert np.max(data) == np.max(get_data(rot_img))
@@ -269,7 +280,11 @@ def test_resampling_with_affine(affine_eye, shape, angle, rng):
     rot = rotation(0, angle)
 
     rot_img = resample_img(
-        img, target_affine=rot, interpolation="nearest", force_resample=False, copy_header=True
+        img,
+        target_affine=rot,
+        interpolation="nearest",
+        force_resample=False,
+        copy_header=True,
     )
 
     assert np.max(data) == np.max(get_data(rot_img))
@@ -286,13 +301,15 @@ def test_resampling_continuous_with_affine(affine_eye, shape, angle, rng):
         img,
         target_affine=rot,
         interpolation="continuous",
-        force_resample=False, copy_header=True
+        force_resample=False,
+        copy_header=True,
     )
     rot_img_back = resample_img(
         rot_img,
         target_affine=affine_eye,
         interpolation="continuous",
-        force_resample=False, copy_header=True
+        force_resample=False,
+        copy_header=True,
     )
 
     center = slice(1, 9)
@@ -314,21 +331,30 @@ def test_resampling_error_checks(tmp_path):
         img,
         target_shape=target_shape,
         target_affine=affine,
-        force_resample=False, copy_header=True
+        force_resample=False,
+        copy_header=True,
     )
-    resample_img(img, target_affine=affine, force_resample=False, copy_header=True)
+    resample_img(
+        img, target_affine=affine, force_resample=False, copy_header=True
+    )
 
     filename = testing.write_imgs_to_path(img, file_path=tmp_path)
     resample_img(
         filename,
         target_shape=target_shape,
         target_affine=affine,
-        force_resample=False, copy_header=True,
+        force_resample=False,
+        copy_header=True,
     )
 
     # Missing parameter
     with pytest.raises(ValueError, match="target_affine should be specified"):
-        resample_img(img, target_shape=target_shape, force_resample=False, copy_header=True,)
+        resample_img(
+            img,
+            target_shape=target_shape,
+            force_resample=False,
+            copy_header=True,
+        )
 
     # Invalid shape
     with pytest.raises(ValueError, match="shape .* should be .* 3D grid"):
@@ -336,7 +362,8 @@ def test_resampling_error_checks(tmp_path):
             img,
             target_shape=(2, 3),
             target_affine=affine,
-            force_resample=False, copy_header=True,
+            force_resample=False,
+            copy_header=True,
         )
 
     # Invalid interpolation
@@ -346,7 +373,8 @@ def test_resampling_error_checks(tmp_path):
             target_shape=target_shape,
             target_affine=affine,
             interpolation="an_invalid_interpolation",
-            force_resample=False, copy_header=True,
+            force_resample=False,
+            copy_header=True,
         )
 
 
@@ -361,7 +389,8 @@ def test_resampling_copy_has_no_shared_memory(target_shape):
         target_affine=target_affine,
         target_shape=target_shape,
         copy=False,
-        force_resample=False, copy_header=True,
+        force_resample=False,
+        copy_header=True,
     )
 
     assert img_r == img
@@ -371,7 +400,8 @@ def test_resampling_copy_has_no_shared_memory(target_shape):
         target_affine=target_affine,
         target_shape=target_shape,
         copy=True,
-        force_resample=False, copy_header=True,
+        force_resample=False,
+        copy_header=True,
     )
 
     assert not np.may_share_memory(get_data(img_r), get_data(img))
@@ -386,7 +416,10 @@ def test_resampling_warning_s_form(affine_eye, shape, rng):
 
     with pytest.warns(Warning, match="The provided image has no sform"):
         resample_img(
-            img_no_sform, target_affine=affine_eye, force_resample=False, copy_header=True,
+            img_no_sform,
+            target_affine=affine_eye,
+            force_resample=False,
+            copy_header=True,
         )
 
 
@@ -408,7 +441,8 @@ def test_resampling_warning_binary_image(affine_eye, rng):
             img_binary,
             target_affine=rot,
             interpolation="continuous",
-            force_resample=False, copy_header=True,
+            force_resample=False,
+            copy_header=True,
         )
 
     with pytest.warns(Warning, match="Resampling binary images with"):
@@ -416,16 +450,18 @@ def test_resampling_warning_binary_image(affine_eye, rng):
             img_binary,
             target_affine=rot,
             interpolation="linear",
-
             force_resample=False,
-          copy_header=True,
+            copy_header=True,
         )
 
 
 def test_resample_img_copied_header(img_4d_mni_tr2):
     # Test that the header is copied when resampling
     result = resample_img(
-        img_4d_mni_tr2, target_affine=np.diag((6, 6, 6)), copy_header=True, force_resample=False,
+        img_4d_mni_tr2,
+        target_affine=np.diag((6, 6, 6)),
+        copy_header=True,
+        force_resample=False,
     )
     # pixdim[1:4] should change to [6, 6, 6]
     assert (result.header["pixdim"][1:4] == np.array([6, 6, 6])).all()
@@ -473,15 +509,21 @@ def test_4d_affine_bounding_box_error(affine_eye):
         target_affine=bigger_img.affine,
         target_shape=bigger_img.shape,
         force_resample=False,
-       copy_header=True,
+        copy_header=True,
     )
     # resample using 3D affine and no target shape
     small_to_big_without_shape_3D_affine = resample_img(
-        small_img, target_affine=bigger_img.affine[:3, :3], copy_header=True, force_resample=False
+        small_img,
+        target_affine=bigger_img.affine[:3, :3],
+        copy_header=True,
+        force_resample=False,
     )
     # resample using 4D affine and no target shape
     small_to_big_without_shape = resample_img(
-        small_img, target_affine=bigger_img.affine, copy_header=True, force_resample=False
+        small_img,
+        target_affine=bigger_img.affine,
+        copy_header=True,
+        force_resample=False,
     )
 
     # The first 2 should pass
@@ -518,7 +560,8 @@ def test_raises_upon_3x3_affine_and_no_shape(affine_eye):
             img,
             target_affine=np.eye(3) * 2,
             target_shape=(10, 10, 10),
-            force_resample=False, copy_header=True
+            force_resample=False,
+            copy_header=True,
         )
 
 
@@ -543,11 +586,13 @@ def test_3x3_affine_bbox(affine_eye):
     target_affine_3x3[1] *= -1
 
     img_3d_affine = resample_img(
-        img, target_affine=target_affine_3x3, force_resample=False, copy_header=Tru
+        img,
+        target_affine=target_affine_3x3,
+        force_resample=False,
+        copy_header=True,
     )
 
-    # If the bounding box is computed wrong, the image will be only
-    # zeros
+    # If the bounding box is computed wrong, the image will be only zeros
     assert_allclose(get_data(img_3d_affine).max(), image.max())
 
 
@@ -597,7 +642,12 @@ def test_raises_bbox_error_if_data_outside_box(affine_eye):
     )
     for new_affine in new_affines:
         with pytest.raises(exception, match=message):
-            resample_img(img, target_affine=new_affine, force_resample=False, copy_header=True)
+            resample_img(
+                img,
+                target_affine=new_affine,
+                force_resample=False,
+                copy_header=True,
+            )
 
 
 @pytest.mark.parametrize(
@@ -622,7 +672,10 @@ def test_resampling_result_axis_permutation(affine_eye, axis_permutation):
     target_affine = np.eye(3)[axis_permutation]
 
     resampled_img = resample_img(
-        source_img, target_affine=target_affine, force_resample=False, copy_header=True
+        source_img,
+        target_affine=target_affine,
+        force_resample=False,
+        copy_header=True,
     )
 
     resampled_data = get_data(resampled_img)
@@ -637,7 +690,10 @@ def test_resampling_result_axis_permutation(affine_eye, axis_permutation):
     target_affine[:3, 3] = offset
 
     resampled_img = resample_img(
-        source_img, target_affine=target_affine, force_resample=False, copy_header=True
+        source_img,
+        target_affine=target_affine,
+        force_resample=False,
+        copy_header=True,
     )
 
     resampled_data = get_data(resampled_img)
@@ -676,7 +732,10 @@ def test_resampling_nan(affine_eye, core_shape):
     # check 3x3 transformation matrix
     target_affine = np.eye(3)[axis_permutation]
     resampled_img = resample_img(
-        source_img, target_affine=target_affine, force_resample=False, copy_header=True
+        source_img,
+        target_affine=target_affine,
+        force_resample=False,
+        copy_header=True,
     )
 
     resampled_data = get_data(resampled_img)
@@ -708,7 +767,10 @@ def test_resampling_nan_big(affine_eye):
 
     with pytest.warns(RuntimeWarning):
         resampled_img = resample_img(
-            source_img, target_affine=affine_eye, force_resample=False, copy_header=True
+            source_img,
+            target_affine=affine_eye,
+            force_resample=False,
+            copy_header=True,
         )
 
     resampled_data = get_data(resampled_img)
@@ -725,7 +787,11 @@ def test_resample_to_img(affine_eye, shape, rng):
     target_img = Nifti1Image(data, target_affine)
 
     result_img = resample_to_img(
-        source_img, target_img, interpolation="nearest", force_resample=False, copy_header=True
+        source_img,
+        target_img,
+        interpolation="nearest",
+        force_resample=False,
+        copy_header=True,
     )
 
     downsampled = data[::2, ::2, ::2, ...]
@@ -762,12 +828,20 @@ def test_resample_identify_affine_int_translation(affine_eye, rng):
     target_img = Nifti1Image(target_data, target_affine)
 
     result_img = resample_to_img(
-        source_img, target_img, interpolation="nearest", force_resample=False, copy_header=True
+        source_img,
+        target_img,
+        interpolation="nearest",
+        force_resample=False,
+        copy_header=True,
     )
     assert_almost_equal(get_data(target_img), get_data(result_img))
 
     result_img_2 = resample_to_img(
-        result_img, source_img, interpolation="nearest", force_resample=False, copy_header=True
+        result_img,
+        source_img,
+        interpolation="nearest",
+        force_resample=False,
+        copy_header=True,
     )
     assert_almost_equal(get_data(source_img), get_data(result_img_2))
 
@@ -807,7 +881,7 @@ def test_resample_clip(affine_eye):
             target_affine=affine_eye,
             clip=False,
             force_resample=False,
-          copy_header=True
+            copy_header=True,
         )
     )
     clip_data = get_data(
@@ -816,7 +890,7 @@ def test_resample_clip(affine_eye):
             target_affine=affine_eye,
             clip=True,
             force_resample=False,
-          copy_header=True
+            copy_header=True,
         )
     )
 
@@ -850,10 +924,10 @@ def test_reorder_img(affine_eye, rng):
         new_affine = from_matrix_vector(rot, b)
 
         rot_img = resample_img(
-            ref_img, target_affine=new_affine, force_resample=False
-
-            ref_img, target_affine=new_affine, copy_header=True
-
+            ref_img,
+            target_affine=new_affine,
+            force_resample=False,
+            copy_header=True,
         )
 
         assert_array_equal(rot_img.affine, new_affine)
@@ -960,7 +1034,9 @@ def test_reorder_img_non_native_endianness():
         )
 
         img = Nifti1Image(data, affine)
-        return resample_img(img, target_affine=affine, force_resample=False, copy_header=True)
+        return resample_img(
+            img, target_affine=affine, force_resample=False, copy_header=True
+        )
 
     img_1 = _get_resampled_img("<f8")
     img_2 = _get_resampled_img(">f8")
@@ -1102,7 +1178,12 @@ def test_resample_img_segmentation_fault():
 def test_resampling_with_int_types_no_crash(affine_eye, dtype):
     data = np.zeros((2, 2, 2))
     img = Nifti1Image(data.astype(dtype), affine_eye)
-    resample_img(img, target_affine=2.0 * affine_eye, force_resample=False, copy_header=True)
+    resample_img(
+        img,
+        target_affine=2.0 * affine_eye,
+        force_resample=False,
+        copy_header=True,
+    )
 
 
 @pytest.mark.parametrize("dtype", ["int64", "uint64", "<i8", ">i8"])
@@ -1114,8 +1195,12 @@ def test_resampling_with_int64_types_no_crash(affine_eye, dtype):
     hdr = Nifti1Header()
     hdr.set_data_dtype(dtype)
     img = Nifti1Image(data.astype(dtype), affine_eye, header=hdr)
-    resample_img(img, target_affine=2.0 * affine_eye, force_resample=False, copy_header=True)
-
+    resample_img(
+        img,
+        target_affine=2.0 * affine_eye,
+        force_resample=False,
+        copy_header=True,
+    )
 
 
 def test_resample_input(affine_eye, shape, rng, tmp_path):

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -79,7 +79,8 @@ def test_resample_deprecation_force_resample(shape, affine_eye, rng):
         )
 
 
-def test_identity_resample(shape, affine_eye, rng):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_identity_resample(force_resample, shape, affine_eye, rng):
     """Test resampling with an identity affine."""
     data = rng.integers(0, 10, shape, dtype="int32")
     affine_eye[:3, -1] = 0.5 * np.array(shape[:3])
@@ -88,7 +89,7 @@ def test_identity_resample(shape, affine_eye, rng):
         Nifti1Image(data, affine_eye),
         target_affine=affine_eye,
         interpolation="nearest",
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
@@ -99,7 +100,7 @@ def test_identity_resample(shape, affine_eye, rng):
         Nifti1Image(data, affine_eye),
         target_affine=affine_eye[:3, :3],
         interpolation="nearest",
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
@@ -110,15 +111,16 @@ def test_identity_resample(shape, affine_eye, rng):
         Nifti1Image(data, affine_eye),
         target_affine=affine_eye.tolist(),
         interpolation="nearest",
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
 
+@pytest.mark.parametrize("force_resample", [False, True])
 @pytest.mark.parametrize("endian_type", [">f8", "<f8"])
 @pytest.mark.parametrize("interpolation", ["nearest", "linear", "continuous"])
 def test_identity_resample_non_native_endians(
-    shape, affine_eye, endian_type, interpolation, rng
+    force_resample, shape, affine_eye, endian_type, interpolation, rng
 ):
     """Test resampling with an identity affine with non native endians.
 
@@ -132,14 +134,15 @@ def test_identity_resample_non_native_endians(
         Nifti1Image(data.astype(endian_type), affine_eye),
         target_affine=affine_eye.tolist(),
         interpolation=interpolation,
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
     assert_almost_equal(data, get_data(rot_img))
 
 
-def test_downsample(shape, affine_eye, rng):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_downsample(force_resample, shape, affine_eye, rng):
     """Test resampling with a 1/2 down-sampling affine."""
     data = rng.random(shape)
 
@@ -147,7 +150,7 @@ def test_downsample(shape, affine_eye, rng):
         Nifti1Image(data, affine_eye),
         target_affine=2 * affine_eye,
         interpolation="nearest",
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
@@ -160,7 +163,7 @@ def test_downsample(shape, affine_eye, rng):
         Nifti1Image(data, affine_eye),
         target_affine=2 * affine_eye,
         interpolation="nearest",
-        force_resample=True,
+        force_resample=force_resample,
         copy_header=True,
     )
 
@@ -169,8 +172,9 @@ def test_downsample(shape, affine_eye, rng):
 
 @pytest.mark.parametrize("endian_type", [">f8", "<f8"])
 @pytest.mark.parametrize("copy_data", [True, False])
+@pytest.mark.parametrize("force_resample", [True, False])
 def test_downsample_non_native_endian_data(
-    shape, affine_eye, endian_type, copy_data, rng
+    shape, affine_eye, endian_type, copy_data, force_resample, rng
 ):
     """Test resampling with a 1/2 down-sampling affine with non native endians.
 
@@ -186,7 +190,7 @@ def test_downsample_non_native_endian_data(
         Nifti1Image(data, affine_eye),
         target_affine=2 * affine_eye,
         interpolation="nearest",
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
@@ -200,7 +204,7 @@ def test_downsample_non_native_endian_data(
         target_affine=2 * affine_eye,
         interpolation="nearest",
         copy=copy_data,
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -211,9 +211,10 @@ def test_downsample_non_native_endian_data(
     assert_almost_equal(downsampled, get_data(rot_img)[:x, :y, :z, ...])
 
 
+@pytest.mark.parametrize("force_resample", [False, True])
 @pytest.mark.parametrize("shape", [(1, 4, 4), (1, 4, 4, 3)])
 @pytest.mark.parametrize("value", [-3.75, 0])
-def test_resampling_fill_value(affine_eye, shape, value, rng):
+def test_resampling_fill_value(affine_eye, shape, value, rng, force_resample):
     """Test resampling with a non-zero fill value.
 
     Check on 3D and 4D data.
@@ -230,7 +231,7 @@ def test_resampling_fill_value(affine_eye, shape, value, rng):
             interpolation="nearest",
             fill_value=value,
             clip=False,
-            force_resample=False,
+            force_resample=force_resample,
             copy_header=True,
         )
     else:
@@ -239,7 +240,7 @@ def test_resampling_fill_value(affine_eye, shape, value, rng):
             target_affine=rot,
             interpolation="nearest",
             clip=False,
-            force_resample=False,
+            force_resample=force_resample,
             copy_header=True,
         )
 
@@ -250,16 +251,17 @@ def test_resampling_fill_value(affine_eye, shape, value, rng):
         rot_img,
         interpolation="nearest",
         fill_value=value,
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
     assert get_data(rot_img2).flatten()[0] == value
 
 
+@pytest.mark.parametrize("force_resample", [False, True])
 @pytest.mark.parametrize("shape", [(1, 4, 4), (1, 4, 4, 3)])
 @pytest.mark.parametrize("angle", ANGLES_TO_TEST)
-def test_resampling_with_affine(affine_eye, shape, angle, rng):
+def test_resampling_with_affine(affine_eye, shape, angle, rng, force_resample):
     """Test resampling with a given rotation part of the affine.
 
     Check on 3D and 4D data.
@@ -271,7 +273,7 @@ def test_resampling_with_affine(affine_eye, shape, angle, rng):
         Nifti1Image(data, affine_eye),
         target_affine=rot,
         interpolation="nearest",
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
@@ -287,16 +289,19 @@ def test_resampling_with_affine(affine_eye, shape, angle, rng):
         img,
         target_affine=rot,
         interpolation="nearest",
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
     assert np.max(data) == np.max(get_data(rot_img))
 
 
+@pytest.mark.parametrize("force_resample", [False, True])
 @pytest.mark.parametrize("shape", [(1, 10, 10), (1, 10, 10, 3)])
 @pytest.mark.parametrize("angle", (0, np.pi / 2.0, np.pi, 3 * np.pi / 2.0))
-def test_resampling_continuous_with_affine(affine_eye, shape, angle, rng):
+def test_resampling_continuous_with_affine(
+    affine_eye, shape, angle, rng, force_resample
+):
     data = rng.integers(1, 4, size=shape, dtype="int32")
     rot = rotation(0, angle)
     img = Nifti1Image(data, affine_eye)
@@ -305,14 +310,14 @@ def test_resampling_continuous_with_affine(affine_eye, shape, angle, rng):
         img,
         target_affine=rot,
         interpolation="continuous",
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
     rot_img_back = resample_img(
         rot_img,
         target_affine=affine_eye,
         interpolation="continuous",
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
@@ -326,7 +331,8 @@ def test_resampling_continuous_with_affine(affine_eye, shape, angle, rng):
     )
 
 
-def test_resampling_error_checks(tmp_path):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_resampling_error_checks(tmp_path, force_resample):
     img, affine, _ = _make_resampling_test_data()
     target_shape = (5, 3, 2)
 
@@ -335,11 +341,14 @@ def test_resampling_error_checks(tmp_path):
         img,
         target_shape=target_shape,
         target_affine=affine,
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
     resample_img(
-        img, target_affine=affine, force_resample=False, copy_header=True
+        img,
+        target_affine=affine,
+        force_resample=force_resample,
+        copy_header=True,
     )
 
     filename = testing.write_imgs_to_path(img, file_path=tmp_path)
@@ -347,7 +356,7 @@ def test_resampling_error_checks(tmp_path):
         filename,
         target_shape=target_shape,
         target_affine=affine,
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
@@ -356,7 +365,7 @@ def test_resampling_error_checks(tmp_path):
         resample_img(
             img,
             target_shape=target_shape,
-            force_resample=False,
+            force_resample=force_resample,
             copy_header=True,
         )
 
@@ -366,7 +375,7 @@ def test_resampling_error_checks(tmp_path):
             img,
             target_shape=(2, 3),
             target_affine=affine,
-            force_resample=False,
+            force_resample=force_resample,
             copy_header=True,
         )
 
@@ -377,13 +386,14 @@ def test_resampling_error_checks(tmp_path):
             target_shape=target_shape,
             target_affine=affine,
             interpolation="an_invalid_interpolation",
-            force_resample=False,
+            force_resample=force_resample,
             copy_header=True,
         )
 
 
+@pytest.mark.parametrize("force_resample", [False, True])
 @pytest.mark.parametrize("target_shape", [None, (3, 2, 5)])
-def test_resampling_copy_has_no_shared_memory(target_shape):
+def test_resampling_copy_has_no_shared_memory(target_shape, force_resample):
     """copy=true guarantees output array shares no memory with input array."""
     img, affine, _ = _make_resampling_test_data()
     target_affine = None if target_shape is None else affine
@@ -393,7 +403,7 @@ def test_resampling_copy_has_no_shared_memory(target_shape):
         target_affine=target_affine,
         target_shape=target_shape,
         copy=False,
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
@@ -404,7 +414,7 @@ def test_resampling_copy_has_no_shared_memory(target_shape):
         target_affine=target_affine,
         target_shape=target_shape,
         copy=True,
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
@@ -413,7 +423,11 @@ def test_resampling_copy_has_no_shared_memory(target_shape):
     assert_almost_equal(img_r.affine, img.affine)
 
 
-def test_resampling_warning_s_form(affine_eye, shape, rng):
+@pytest.mark.parametrize(
+    "force_resample",
+    [False, True],
+)
+def test_resampling_warning_s_form(affine_eye, shape, rng, force_resample):
     data = rng.integers(0, 10, shape, dtype="int32")
     img_no_sform = Nifti1Image(data, affine_eye)
     img_no_sform.set_sform(None)
@@ -422,12 +436,13 @@ def test_resampling_warning_s_form(affine_eye, shape, rng):
         resample_img(
             img_no_sform,
             target_affine=affine_eye,
-            force_resample=False,
+            force_resample=force_resample,
             copy_header=True,
         )
 
 
-def test_resampling_warning_binary_image(affine_eye, rng):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_resampling_warning_binary_image(affine_eye, rng, force_resample):
     # Resampling a binary image with continuous or
     # linear interpolation should raise a warning.
     data_binary = rng.integers(4, size=(1, 4, 4), dtype="int32")
@@ -445,7 +460,7 @@ def test_resampling_warning_binary_image(affine_eye, rng):
             img_binary,
             target_affine=rot,
             interpolation="continuous",
-            force_resample=False,
+            force_resample=force_resample,
             copy_header=True,
         )
 
@@ -454,18 +469,19 @@ def test_resampling_warning_binary_image(affine_eye, rng):
             img_binary,
             target_affine=rot,
             interpolation="linear",
-            force_resample=False,
+            force_resample=force_resample,
             copy_header=True,
         )
 
 
-def test_resample_img_copied_header(img_4d_mni_tr2):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_resample_img_copied_header(img_4d_mni_tr2, force_resample):
     # Test that the header is copied when resampling
     result = resample_img(
         img_4d_mni_tr2,
         target_affine=np.diag((6, 6, 6)),
         copy_header=True,
-        force_resample=False,
+        force_resample=force_resample,
     )
     # pixdim[1:4] should change to [6, 6, 6]
     assert (result.header["pixdim"][1:4] == np.array([6, 6, 6])).all()
@@ -490,7 +506,8 @@ def test_resample_img_copied_header(img_4d_mni_tr2):
     )
 
 
-def test_4d_affine_bounding_box_error(affine_eye):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_4d_affine_bounding_box_error(affine_eye, force_resample):
     bigger_data = np.zeros([10, 10, 10])
     bigger_img = Nifti1Image(bigger_data, affine_eye)
 
@@ -512,7 +529,7 @@ def test_4d_affine_bounding_box_error(affine_eye):
         small_img,
         target_affine=bigger_img.affine,
         target_shape=bigger_img.shape,
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
     # resample using 3D affine and no target shape
@@ -520,14 +537,14 @@ def test_4d_affine_bounding_box_error(affine_eye):
         small_img,
         target_affine=bigger_img.affine[:3, :3],
         copy_header=True,
-        force_resample=False,
+        force_resample=force_resample,
     )
     # resample using 4D affine and no target shape
     small_to_big_without_shape = resample_img(
         small_img,
         target_affine=bigger_img.affine,
         copy_header=True,
-        force_resample=False,
+        force_resample=force_resample,
     )
 
     # The first 2 should pass
@@ -552,7 +569,8 @@ def test_4d_affine_bounding_box_error(affine_eye):
     )
 
 
-def test_raises_upon_3x3_affine_and_no_shape(affine_eye):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_raises_upon_3x3_affine_and_no_shape(affine_eye, force_resample):
     img = Nifti1Image(np.zeros([8, 9, 10]), affine=affine_eye)
     message = (
         "Given target shape without anchor "
@@ -564,12 +582,13 @@ def test_raises_upon_3x3_affine_and_no_shape(affine_eye):
             img,
             target_affine=np.eye(3) * 2,
             target_shape=(10, 10, 10),
-            force_resample=False,
+            force_resample=force_resample,
             copy_header=True,
         )
 
 
-def test_3x3_affine_bbox(affine_eye):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_3x3_affine_bbox(affine_eye, force_resample):
     """Test that the bounding-box is properly computed when \
     transforming with a negative affine component.
 
@@ -592,7 +611,7 @@ def test_3x3_affine_bbox(affine_eye):
     img_3d_affine = resample_img(
         img,
         target_affine=target_affine_3x3,
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
@@ -600,7 +619,8 @@ def test_3x3_affine_bbox(affine_eye):
     assert_allclose(get_data(img_3d_affine).max(), image.max())
 
 
-def test_raises_bbox_error_if_data_outside_box(affine_eye):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_raises_bbox_error_if_data_outside_box(affine_eye, force_resample):
     """Make some cases which should raise exceptions."""
     # original image
     data = np.zeros([8, 9, 10])
@@ -649,15 +669,18 @@ def test_raises_bbox_error_if_data_outside_box(affine_eye):
             resample_img(
                 img,
                 target_affine=new_affine,
-                force_resample=False,
+                force_resample=force_resample,
                 copy_header=True,
             )
 
 
+@pytest.mark.parametrize("force_resample", [False, True])
 @pytest.mark.parametrize(
     "axis_permutation", [[0, 1, 2], [1, 0, 2], [2, 1, 0], [0, 2, 1]]
 )
-def test_resampling_result_axis_permutation(affine_eye, axis_permutation):
+def test_resampling_result_axis_permutation(
+    affine_eye, axis_permutation, force_resample
+):
     """Transform real data using easily checkable transformations.
 
     For now: axis permutations
@@ -678,7 +701,7 @@ def test_resampling_result_axis_permutation(affine_eye, axis_permutation):
     resampled_img = resample_img(
         source_img,
         target_affine=target_affine,
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
@@ -696,7 +719,7 @@ def test_resampling_result_axis_permutation(affine_eye, axis_permutation):
     resampled_img = resample_img(
         source_img,
         target_affine=target_affine,
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
@@ -712,8 +735,9 @@ def test_resampling_result_axis_permutation(affine_eye, axis_permutation):
     assert_array_almost_equal(resampled_data, expected_data)
 
 
+@pytest.mark.parametrize("force_resample", [False, True])
 @pytest.mark.parametrize("core_shape", [(3, 5, 4), (3, 5, 4, 2)])
-def test_resampling_nan(affine_eye, core_shape):
+def test_resampling_nan(affine_eye, core_shape, force_resample):
     """Test that when the data has NaNs they do not propagate to the \
     whole image."""
     # create deterministic data, padded with one
@@ -738,7 +762,7 @@ def test_resampling_nan(affine_eye, core_shape):
     resampled_img = resample_img(
         source_img,
         target_affine=target_affine,
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
@@ -758,7 +782,8 @@ def test_resampling_nan(affine_eye, core_shape):
     assert not np.any(np.isfinite(resampled_data[np.logical_not(non_nan)]))
 
 
-def test_resampling_nan_big(affine_eye):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_resampling_nan_big(affine_eye, force_resample):
     """Test with an actual resampling, in the case of a bigish hole.
 
     This checks the extrapolation mechanism: if we don't do any
@@ -773,7 +798,7 @@ def test_resampling_nan_big(affine_eye):
         resampled_img = resample_img(
             source_img,
             target_affine=affine_eye,
-            force_resample=False,
+            force_resample=force_resample,
             copy_header=True,
         )
 
@@ -781,7 +806,8 @@ def test_resampling_nan_big(affine_eye):
     assert_allclose(10, resampled_data[np.isfinite(resampled_data)])
 
 
-def test_resample_to_img(affine_eye, shape, rng):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_resample_to_img(affine_eye, shape, rng, force_resample):
     data = rng.random(shape)
 
     source_affine = affine_eye
@@ -794,7 +820,7 @@ def test_resample_to_img(affine_eye, shape, rng):
         source_img,
         target_img,
         interpolation="nearest",
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
@@ -815,7 +841,10 @@ def test_crop(affine_eye):
     assert_equal(get_data(cropped), data)
 
 
-def test_resample_identify_affine_int_translation(affine_eye, rng):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_resample_identify_affine_int_translation(
+    affine_eye, rng, force_resample
+):
     source_shape = (6, 4, 6)
     source_affine = affine_eye
     source_affine[:, 3] = np.append(rng.integers(0, 4, 3), 1)
@@ -835,7 +864,7 @@ def test_resample_identify_affine_int_translation(affine_eye, rng):
         source_img,
         target_img,
         interpolation="nearest",
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
     assert_almost_equal(get_data(target_img), get_data(result_img))
@@ -844,7 +873,7 @@ def test_resample_identify_affine_int_translation(affine_eye, rng):
         result_img,
         source_img,
         interpolation="nearest",
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
     assert_almost_equal(get_data(source_img), get_data(result_img_2))
@@ -853,7 +882,7 @@ def test_resample_identify_affine_int_translation(affine_eye, rng):
         result_img,
         source_img,
         interpolation="nearest",
-        force_resample=True,
+        force_resample=force_resample,
         copy_header=True,
     )
     assert_almost_equal(get_data(result_img_2), get_data(result_img_3))
@@ -862,13 +891,14 @@ def test_resample_identify_affine_int_translation(affine_eye, rng):
         source_img,
         target_img,
         interpolation="nearest",
-        force_resample=True,
+        force_resample=force_resample,
         copy_header=True,
     )
     assert_almost_equal(get_data(target_img), get_data(result_img_4))
 
 
-def test_resample_clip(affine_eye):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_resample_clip(affine_eye, force_resample):
     # Resample and image and get larger and smaller
     # value than in the original. Use clip to get rid of these images
 
@@ -884,7 +914,7 @@ def test_resample_clip(affine_eye):
             source_img,
             target_affine=affine_eye,
             clip=False,
-            force_resample=False,
+            force_resample=force_resample,
             copy_header=True,
         )
     )
@@ -893,7 +923,7 @@ def test_resample_clip(affine_eye):
             source_img,
             target_affine=affine_eye,
             clip=True,
-            force_resample=False,
+            force_resample=force_resample,
             copy_header=True,
         )
     )
@@ -909,7 +939,8 @@ def test_resample_clip(affine_eye):
     assert_array_equal(no_clip_data[not_clip], clip_data[not_clip])
 
 
-def test_reorder_img(affine_eye, rng):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_reorder_img(affine_eye, rng, force_resample):
     # We need to test on a square array, as rotation does not change
     # shape, whereas reordering does.
     shape = (5, 5, 5, 2, 2)
@@ -930,7 +961,7 @@ def test_reorder_img(affine_eye, rng):
         rot_img = resample_img(
             ref_img,
             target_affine=new_affine,
-            force_resample=False,
+            force_resample=force_resample,
             copy_header=True,
         )
 
@@ -943,7 +974,8 @@ def test_reorder_img(affine_eye, rng):
         assert_almost_equal(get_data(reordered_img), data)
 
 
-def test_reorder_img_with_resample_arg(affine_eye, rng):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_reorder_img_with_resample_arg(affine_eye, rng, force_resample):
     shape = (5, 5, 5, 2, 2)
     data = rng.uniform(size=shape)
     affine = affine_eye
@@ -960,7 +992,7 @@ def test_reorder_img_with_resample_arg(affine_eye, rng):
         ref_img,
         target_affine=reordered_img.affine,
         interpolation=interpolation,
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
     assert_array_equal(get_data(reordered_img), get_data(resampled_img))
@@ -1024,7 +1056,8 @@ def test_reorder_img_error_interpolation(affine_eye, rng):
         )
 
 
-def test_reorder_img_non_native_endianness():
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_reorder_img_non_native_endianness(force_resample):
     def _get_resampled_img(dtype):
         data = np.ones((10, 10, 10), dtype=dtype)
         data[3:7, 3:7, 3:7] = 2
@@ -1039,7 +1072,10 @@ def test_reorder_img_non_native_endianness():
 
         img = Nifti1Image(data, affine)
         return resample_img(
-            img, target_affine=affine, force_resample=False, copy_header=True
+            img,
+            target_affine=affine,
+            force_resample=force_resample,
+            copy_header=True,
         )
 
     img_1 = _get_resampled_img("<f8")
@@ -1130,6 +1166,7 @@ def test_coord_transform_trivial(affine_eye, rng):
 
 
 #  TODO "This test does not run on ARM arch.",
+@pytest.mark.parametrize("force_resample", [False, True])
 @pytest.mark.skipif(
     not testing.is_64bit(), reason="This test only runs on 64bits machines."
 )
@@ -1137,7 +1174,7 @@ def test_coord_transform_trivial(affine_eye, rng):
     os.environ.get("APPVEYOR") == "True",
     reason="This test too slow (7-8 minutes) on AppVeyor",
 )
-def test_resample_img_segmentation_fault():
+def test_resample_img_segmentation_fault(force_resample):
     # see https://github.com/nilearn/nilearn/issues/346
     shape_in = (64, 64, 64)
     aff_in = np.diag([2.0, 2.0, 2.0, 1.0])
@@ -1158,11 +1195,12 @@ def test_resample_img_segmentation_fault():
             img_in,
             target_affine=aff_out,
             interpolation="nearest",
-            force_resample=False,
+            force_resample=force_resample,
             copy_header=True,
         )
 
 
+@pytest.mark.parametrize("force_resample", [False, True])
 @pytest.mark.parametrize(
     "dtype",
     [
@@ -1179,20 +1217,23 @@ def test_resample_img_segmentation_fault():
         "<i4",
     ],
 )
-def test_resampling_with_int_types_no_crash(affine_eye, dtype):
+def test_resampling_with_int_types_no_crash(affine_eye, dtype, force_resample):
     data = np.zeros((2, 2, 2))
     img = Nifti1Image(data.astype(dtype), affine_eye)
     resample_img(
         img,
         target_affine=2.0 * affine_eye,
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
 
+@pytest.mark.parametrize("force_resample", [False, True])
 @pytest.mark.parametrize("dtype", ["int64", "uint64", "<i8", ">i8"])
 @pytest.mark.parametrize("no_int64_nifti", ["allow for this test"])
-def test_resampling_with_int64_types_no_crash(affine_eye, dtype):
+def test_resampling_with_int64_types_no_crash(
+    affine_eye, dtype, force_resample
+):
     data = np.zeros((2, 2, 2))
     # Passing dtype or header is required when using int64
     # https://nipy.org/nibabel/changelog.html#api-changes-and-deprecations
@@ -1202,12 +1243,13 @@ def test_resampling_with_int64_types_no_crash(affine_eye, dtype):
     resample_img(
         img,
         target_affine=2.0 * affine_eye,
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
 
-def test_resample_input(affine_eye, shape, rng, tmp_path):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_resample_input(affine_eye, shape, rng, tmp_path, force_resample):
     data = rng.integers(0, 10, shape, dtype="int32")
     affine = affine_eye
     affine[:3, -1] = 0.5 * np.array(shape[:3])
@@ -1221,12 +1263,13 @@ def test_resample_input(affine_eye, shape, rng, tmp_path):
         filename,
         target_affine=affine,
         interpolation="nearest",
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )
 
 
-def test_smoke_resampling_non_nifti(affine_eye, shape, rng):
+@pytest.mark.parametrize("force_resample", [False, True])
+def test_smoke_resampling_non_nifti(affine_eye, shape, rng, force_resample):
     target_affine = 2 * affine_eye
     data = rng.integers(0, 10, shape, dtype="int32")
     img = MGHImage(data, affine_eye)
@@ -1235,6 +1278,6 @@ def test_smoke_resampling_non_nifti(affine_eye, shape, rng):
         img,
         target_affine=target_affine,
         interpolation="nearest",
-        force_resample=False,
+        force_resample=force_resample,
         copy_header=True,
     )

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -65,7 +65,7 @@ def shape():
     return SHAPE
 
 
-def test_resample_depreacation_force_resample(shape, affine_eye, rng):
+def test_resample_deprecation_force_resample(shape, affine_eye, rng):
     """Test change of value of force_resample."""
     data = rng.integers(0, 10, shape, dtype="int32")
     affine_eye[:3, -1] = 0.5 * np.array(shape[:3])


### PR DESCRIPTION
- closes [2305](https://github.com/nilearn/nilearn/issues/2305).

The force_resample=False which is currently default, the code is not implemented correctly. There are several of #TODO flags in the code for force_resample=False case. Therefore, changed the default option to force_resample=True. 

