### PR TITLE
[FIX] Raise error if unknown kwargs are given to `first_level_from_bids`

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -26,3 +26,5 @@ Changes
 - :bdg-dark:`Code` Implement argument ``sample_mask`` for :meth:`nilearn.maskers.MultiNiftiMasker.transform_imgs` (:gh:`4273` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Remove the unused arguments ``upper_cutoff`` and ``exclude_zeros`` for :func:`nilearn.masking.compute_multi_background_mask` (:gh:`4273` by `Rémi Gau`_).
+
+- :bdg-dark:`Code` Throw error in :func:`nilearn.glm.first_level.first_level_from_bids` if unknown ``kwargs`` are passed (:gh:`4414` by `Michelle Wang`_).

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1298,7 +1298,8 @@ def first_level_from_bids(
 
     if len(remaining_kwargs) > 0:
         raise RuntimeError(
-            f"Unknown keyword arguments. Keyword arguments should start with `confounds_` prefix: {remaining_kwargs}"
+            "Unknown keyword arguments. Keyword arguments should start with "
+            f"`confounds_` prefix: {remaining_kwargs}"
         )
 
     if drift_model is not None and kwargs_load_confounds is not None:

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1298,7 +1298,7 @@ def first_level_from_bids(
 
     if len(remaining_kwargs) > 0:
         raise RuntimeError(
-            f"Some keyword arguments were unused: {remaining_kwargs}"
+            f"Unknown keyword arguments. Keyword arguments should start with `confounds_` prefix: {remaining_kwargs}"
         )
 
     if drift_model is not None and kwargs_load_confounds is not None:

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -1963,9 +1963,7 @@ def test_first_level_from_bids_unused_kwargs(tmp_path):
     bids_path = create_fake_bids_dataset(
         base_dir=tmp_path, n_sub=1, n_ses=1, tasks=["main"], n_runs=[2]
     )
-    with pytest.raises(
-        RuntimeError, match="Unknown keyword arguments"
-    ):
+    with pytest.raises(RuntimeError, match="Unknown keyword arguments"):
         # wrong kwarg name `confound_strategy` (wrong)
         # instead of `confounds_strategy` (correct)
         first_level_from_bids(

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -1964,7 +1964,7 @@ def test_first_level_from_bids_unused_kwargs(tmp_path):
         base_dir=tmp_path, n_sub=1, n_ses=1, tasks=["main"], n_runs=[2]
     )
     with pytest.raises(
-        RuntimeError, match="Some keyword arguments were unused:"
+        RuntimeError, match="Unknown keyword arguments"
     ):
         # wrong kwarg name `confound_strategy` (wrong)
         # instead of `confounds_strategy` (correct)

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -1958,6 +1958,23 @@ def test_first_level_from_bids_no_subject(tmp_path):
         )
 
 
+def test_first_level_from_bids_unused_kwargs(tmp_path):
+    """Check that unused kwargs are properly handled."""
+    bids_path = create_fake_bids_dataset(
+        base_dir=tmp_path, n_sub=1, n_ses=1, tasks=["main"], n_runs=[2]
+    )
+    with pytest.raises(
+        RuntimeError, match="Some keyword arguments were unused:"
+    ):
+        first_level_from_bids(
+            dataset_path=bids_path,
+            task_label="main",
+            space_label="MNI",
+            slice_time_ref=None,
+            confound_strategy="motion",
+        )
+
+
 def test_check_run_tables_errors():
     # check high level wrapper keeps behavior
     with pytest.raises(ValueError, match="len.* does not match len.*"):

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -1966,6 +1966,8 @@ def test_first_level_from_bids_unused_kwargs(tmp_path):
     with pytest.raises(
         RuntimeError, match="Some keyword arguments were unused:"
     ):
+        # wrong kwarg name `confound_strategy` (wrong)
+        # instead of `confounds_strategy` (correct)
         first_level_from_bids(
             dataset_path=bids_path,
             task_label="main",


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4357 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Make `_check_kwargs_load_confounds` return unused `remaining_kwargs` in addition to `kwargs_load_confounds`
- Throw an error in `first_level_from_bids` if there are any remaining kwargs after the confound ones are extracted
  - Not sure if this is too strong, we could also raise a warning instead
