### PR TITLE
add width input to view_img()

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -726,3 +726,7 @@ authors:
     family-names: Nájera
     website: https://github.com/Titan-C
     affiliation: Checkmk
+  - given-names: Alexandre
+    family-names: Sayal
+    website: https://github.com/alexsayal
+    affiliation: CIBIT, University of Coimbra, Portugal

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -26,3 +26,5 @@ Changes
 - :bdg-dark:`Code` Implement argument ``sample_mask`` for :meth:`nilearn.maskers.MultiNiftiMasker.transform_imgs` (:gh:`4273` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Remove the unused arguments ``upper_cutoff`` and ``exclude_zeros`` for :func:`nilearn.masking.compute_multi_background_mask` (:gh:`4273` by `Rémi Gau`_).
+
+- :bdg-dark:`Code` Add option to resize output image width ``width_view`` in :func:`nilearn.plotting.html_stat_map.view_img` (:gh:`4416` by `Alexandre Sayal`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -16,6 +16,8 @@ Fixes
 Enhancements
 ------------
 
+- :bdg-success:`API` Add option to resize output image width ``width_view`` in :func:`nilearn.plotting.view_img` (:gh:`4416` by `Alexandre Sayal`_).
+
 Changes
 -------
 
@@ -27,4 +29,3 @@ Changes
 
 - :bdg-dark:`Code` Remove the unused arguments ``upper_cutoff`` and ``exclude_zeros`` for :func:`nilearn.masking.compute_multi_background_mask` (:gh:`4273` by `Rémi Gau`_).
 
-- :bdg-dark:`Code` Add option to resize output image width ``width_view`` in :func:`nilearn.plotting.html_stat_map.view_img` (:gh:`4416` by `Alexandre Sayal`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -28,4 +28,3 @@ Changes
 - :bdg-dark:`Code` Implement argument ``sample_mask`` for :meth:`nilearn.maskers.MultiNiftiMasker.transform_imgs` (:gh:`4273` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Remove the unused arguments ``upper_cutoff`` and ``exclude_zeros`` for :func:`nilearn.masking.compute_multi_background_mask` (:gh:`4273` by `Rémi Gau`_).
-

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -317,7 +317,7 @@ def _json_view_params(
     return params
 
 
-def _json_view_size(params,width_view=600):
+def _json_view_size(params, width_view=600):
     """Define the size of the viewer.
 
     Returns: width_view, height_view
@@ -412,7 +412,7 @@ def _json_view_data(
     return json_view
 
 
-def _json_view_to_html(json_view,width_view=600):
+def _json_view_to_html(json_view, width_view=600):
     """Fill a brainsprite html template with relevant parameters and data.
 
     Returns: html_view

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -419,7 +419,7 @@ def _json_view_to_html(json_view,width_view=600):
 
     """
     # Fix the size of the viewer
-    width, height = _json_view_size(json_view["params"],width_view)
+    width, height = _json_view_size(json_view["params"], width_view)
 
     # Populate all missing keys with html-ready data
     json_view["INSERT_PAGE_TITLE_HERE"] = (

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -317,7 +317,7 @@ def _json_view_params(
     return params
 
 
-def _json_view_size(params):
+def _json_view_size(params,width_view=600):
     """Define the size of the viewer.
 
     Returns: width_view, height_view
@@ -333,7 +333,7 @@ def _json_view_size(params):
     slices_height = 1.20 * slices_height
 
     # Get the final size of the viewer
-    width_view = 600
+    # width_view = 600
     ratio = slices_height / slices_width
     height_view = np.ceil(ratio * width_view)
 
@@ -412,14 +412,14 @@ def _json_view_data(
     return json_view
 
 
-def _json_view_to_html(json_view):
+def _json_view_to_html(json_view,width_view=600):
     """Fill a brainsprite html template with relevant parameters and data.
 
     Returns: html_view
 
     """
     # Fix the size of the viewer
-    width, height = _json_view_size(json_view["params"])
+    width, height = _json_view_size(json_view["params"],width_view)
 
     # Populate all missing keys with html-ready data
     json_view["INSERT_PAGE_TITLE_HERE"] = (
@@ -489,6 +489,7 @@ def view_img(
     vmax=None,
     vmin=None,
     resampling_interpolation="continuous",
+    width_view=600,
     opacity=1,
 ):
     """Interactive html viewer of a statistical map, with optional background.
@@ -553,6 +554,11 @@ def view_img(
         image, or 0 when a threshold is used.
     %(resampling_interpolation)s
         Default='continuous'.
+
+    width_view : int, optional
+        Default=600.
+        Width of the viewer in pixels.
+
     opacity : float in [0,1], default=1
         The level of opacity of the overlay (0: transparent, 1: opaque).
 
@@ -627,6 +633,6 @@ def view_img(
         value=False,
     )
 
-    html_view = _json_view_to_html(json_view)
+    html_view = _json_view_to_html(json_view, width_view)
 
     return html_view

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -333,7 +333,6 @@ def _json_view_size(params, width_view=600):
     slices_height = 1.20 * slices_height
 
     # Get the final size of the viewer
-    # width_view = 600
     ratio = slices_height / slices_width
     height_view = np.ceil(ratio * width_view)
 

--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -10,7 +10,6 @@ from nibabel import Nifti1Image
 from nilearn import datasets, image
 from nilearn.image import get_data, new_img_like
 from nilearn.plotting import html_stat_map
-
 from nilearn.plotting.js_plotting_utils import colorscale
 
 

--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -11,7 +11,7 @@ from nilearn import datasets, image
 from nilearn.image import get_data, new_img_like
 from nilearn.plotting import html_stat_map
 
-from ..js_plotting_utils import colorscale
+from nilearn.plotting.js_plotting_utils import colorscale
 
 
 def _check_html(html_view, title=None):
@@ -379,6 +379,8 @@ def test_view_img():
         html_view = html_stat_map.view_img(img_4d, threshold=2.0, vmax=4.0)
         _check_html(html_view)
         html_view = html_stat_map.view_img(img_4d, threshold=1e6)
+        _check_html(html_view)
+        html_view = html_stat_map.view_img(img_4d, width_view=1000)
         _check_html(html_view)
 
     # Check that all warnings were expected


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4415 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add input field for the output image width of view_img() in pixels
