### PR TITLE
[FIX] update to new colormap api

### DIFF
--- a/examples/01_plotting/plot_colormaps.py
+++ b/examples/01_plotting/plot_colormaps.py
@@ -50,7 +50,7 @@ m_cmaps.sort()
 
 for index, cmap in enumerate(m_cmaps):
     plt.subplot(1, len(m_cmaps) + 1, index + 1)
-    plt.imshow(a, cmap=plt.get_cmap(cmap), aspect="auto")
+    plt.imshow(a, cmap=plt.colormaps[cmap], aspect="auto")
     plt.axis("off")
     plt.title(cmap, fontsize=10, va="bottom", rotation=90)
 

--- a/nilearn/plotting/__init__.py
+++ b/nilearn/plotting/__init__.py
@@ -4,7 +4,7 @@
 import importlib
 import warnings
 
-OPTIONAL_MATPLOTLIB_MIN_VERSION = "3.3.0"
+OPTIONAL_MATPLOTLIB_MIN_VERSION = "3.6.0"
 
 ###############################################################################
 # Make sure that we don't get DISPLAY problems when running without X on

--- a/nilearn/plotting/cm.py
+++ b/nilearn/plotting/cm.py
@@ -1,7 +1,12 @@
 """Matplotlib colormaps useful for neuroimaging."""
 
 import numpy as _np
-from matplotlib import cm as _cm, colors as _colors, rcParams as _rcParams
+from matplotlib import (
+    cm as _cm,
+    colormaps,
+    colors as _colors,
+    rcParams as _rcParams,
+)
 
 ###############################################################################
 # Custom colormaps for two-tailed symmetric statistics
@@ -203,6 +208,8 @@ def _revcmap(data):
     return data_r
 
 
+import contextlib
+
 _cmap_d = dict()
 
 for _cmapname in list(_cmaps_data.keys()):  # needed as dict changes in loop
@@ -291,16 +298,8 @@ _cmap_d["videen_style"] = _colors.LinearSegmentedColormap.from_list(
 globals().update(_cmap_d)
 # Register cmaps in matplotlib too
 for k, v in _cmap_d.items():
-    try:
-        from matplotlib import colormaps as _colormaps
-    except ImportError:
-        _register_cmap = _cm.register_cmap
-    else:
-        _register_cmap = _colormaps.register  # 3.5+
-    try:  # "bwr" is in latest matplotlib
-        _register_cmap(name=k, cmap=v)
-    except ValueError:
-        pass
+    with contextlib.suppress(ValueError):  # "bwr" is already registered
+        colormaps.register(name=k, cmap=v)
 
 
 ###############################################################################

--- a/nilearn/plotting/cm.py
+++ b/nilearn/plotting/cm.py
@@ -1,5 +1,7 @@
 """Matplotlib colormaps useful for neuroimaging."""
 
+import contextlib
+
 import numpy as _np
 from matplotlib import (
     cm as _cm,
@@ -207,8 +209,6 @@ def _revcmap(data):
         data_r[key] = [(1.0 - x, y1, y0) for x, y0, y1 in reversed(val)]
     return data_r
 
-
-import contextlib
 
 _cmap_d = dict()
 

--- a/nilearn/plotting/displays/_slicers.py
+++ b/nilearn/plotting/displays/_slicers.py
@@ -3,6 +3,7 @@ import numbers
 
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib import colormaps
 from matplotlib.colorbar import ColorbarBase
 from matplotlib.colors import LinearSegmentedColormap, ListedColormap
 from matplotlib.transforms import Bbox
@@ -537,7 +538,10 @@ class BaseSlicer:
         self._colorbar_ax = figure.add_axes(lt_wid_top_ht)
         self._colorbar_ax.set_facecolor("w")
 
-        our_cmap = plt.cm.ColormapRegistry.get_cmap(cmap)
+        if isinstance(cmap, (LinearSegmentedColormap, ListedColormap)):
+            our_cmap = cmap
+        else:
+            our_cmap = colormaps[cmap]
         # edge case where the data has a single value
         # yields a cryptic matplotlib error message
         # when trying to plot the color bar

--- a/nilearn/plotting/displays/_slicers.py
+++ b/nilearn/plotting/displays/_slicers.py
@@ -537,7 +537,7 @@ class BaseSlicer:
         self._colorbar_ax = figure.add_axes(lt_wid_top_ht)
         self._colorbar_ax.set_facecolor("w")
 
-        our_cmap = plt.colormaps[cmap]
+        our_cmap = plt.cm.ColormapRegistry.get_cmap(cmap)
         # edge case where the data has a single value
         # yields a cryptic matplotlib error message
         # when trying to plot the color bar

--- a/nilearn/plotting/displays/_slicers.py
+++ b/nilearn/plotting/displays/_slicers.py
@@ -537,7 +537,7 @@ class BaseSlicer:
         self._colorbar_ax = figure.add_axes(lt_wid_top_ht)
         self._colorbar_ax.set_facecolor("w")
 
-        our_cmap = plt.get_cmap(cmap)
+        our_cmap = plt.colormaps[cmap]
         # edge case where the data has a single value
         # yields a cryptic matplotlib error message
         # when trying to plot the color bar

--- a/nilearn/plotting/displays/_slicers.py
+++ b/nilearn/plotting/displays/_slicers.py
@@ -3,7 +3,6 @@ import numbers
 
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib import colormaps
 from matplotlib.colorbar import ColorbarBase
 from matplotlib.colors import LinearSegmentedColormap, ListedColormap
 from matplotlib.transforms import Bbox
@@ -538,10 +537,7 @@ class BaseSlicer:
         self._colorbar_ax = figure.add_axes(lt_wid_top_ht)
         self._colorbar_ax.set_facecolor("w")
 
-        if isinstance(cmap, (LinearSegmentedColormap, ListedColormap)):
-            our_cmap = cmap
-        else:
-            our_cmap = colormaps[cmap]
+        our_cmap = plt.colormaps[cmap] if isinstance(cmap, str) else cmap
         # edge case where the data has a single value
         # yields a cryptic matplotlib error message
         # when trying to plot the color bar

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -342,7 +342,7 @@ def _json_view_size(params, width_view=600):
 def _get_bg_mask_and_cmap(bg_img, black_bg):
     """Get background data for _json_view_data."""
     bg_mask = np.ma.getmaskarray(get_data(bg_img))
-    bg_cmap = copy.copy(matplotlib.pyplot.get_cmap("gray"))
+    bg_cmap = copy.copy(matplotlib.colormaps["gray"])
     if black_bg:
         bg_cmap.set_bad("black")
     else:

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -1,13 +1,12 @@
 """Visualizing 3D stat maps in a Brainsprite viewer."""
 
-import copy
 import json
 import os
 import warnings
 from base64 import b64encode
 from io import BytesIO
 
-import matplotlib
+import matplotlib as mpl
 import numpy as np
 from matplotlib.image import imsave
 from nibabel.affines import apply_affine
@@ -342,7 +341,7 @@ def _json_view_size(params, width_view=600):
 def _get_bg_mask_and_cmap(bg_img, black_bg):
     """Get background data for _json_view_data."""
     bg_mask = np.ma.getmaskarray(get_data(bg_img))
-    bg_cmap = copy.copy(matplotlib.colormaps["gray"])
+    bg_cmap = mpl.colormaps["gray"]
     if black_bg:
         bg_cmap.set_bad("black")
     else:

--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -56,7 +56,7 @@ def get_vertexcolor(surf_map,
             DeprecationWarning,
         )
 
-    bg_colors = plt.get_cmap('Greys')(bg_data)
+    bg_colors = plt.colormaps['Greys'](bg_data)
 
     # select vertices which are filtered out by the threshold
     if absolute_threshold is None:

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -17,7 +17,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import gridspec as mgs
-from matplotlib.colors import LinearSegmentedColormap, ListedColormap
+from matplotlib.colors import LinearSegmentedColormap
 from nibabel.spatialimages import SpatialImage
 from scipy import stats
 from scipy.ndimage import binary_fill_holes
@@ -803,8 +803,7 @@ def _plot_roi_contours(display, roi_img, cmap, alpha, linewidths):
     roi_data = get_data(roi_img)
     labels = np.unique(roi_data)
 
-    if not isinstance(cmap, (LinearSegmentedColormap, ListedColormap)):
-        cmap = mpl.colormaps[cmap]
+    cmap = plt.colormaps[cmap] if isinstance(cmap, str) else cmap
 
     color_list = cmap(np.linspace(0, 1, len(labels)))
     for idx, label in enumerate(labels):
@@ -1112,8 +1111,7 @@ def plot_prob_atlas(
             f"Valid view types are {valid_view_types}."
         )
 
-    if not isinstance(cmap, (LinearSegmentedColormap, ListedColormap)):
-        cmap = mpl.colormaps[cmap]
+    cmap = plt.colormaps[cmap] if isinstance(cmap, str) else cmap
     color_list = cmap(np.linspace(0, 1, n_maps))
 
     if view_type == "auto":

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -807,7 +807,7 @@ def _plot_roi_contours(display, roi_img, cmap, alpha, linewidths):
     roi_img = _utils.check_niimg_3d(roi_img)
     roi_data = get_data(roi_img)
     labels = np.unique(roi_data)
-    cmap = plt.colormaps[cmap]
+    cmap = plt.cm.ColormapRegistry.get_cmap(cmap)
     color_list = cmap(np.linspace(0, 1, len(labels)))
     for idx, label in enumerate(labels):
         if label == 0:
@@ -1114,7 +1114,7 @@ def plot_prob_atlas(
             f"Valid view types are {valid_view_types}."
         )
 
-    cmap = plt.colormaps[cmap]
+    cmap = plt.cm.ColormapRegistry.get_cmap(cmap)
     color_list = cmap(np.linspace(0, 1, n_maps))
 
     if view_type == "auto":

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -807,7 +807,7 @@ def _plot_roi_contours(display, roi_img, cmap, alpha, linewidths):
     roi_img = _utils.check_niimg_3d(roi_img)
     roi_data = get_data(roi_img)
     labels = np.unique(roi_data)
-    cmap = plt.get_cmap(cmap)
+    cmap = plt.colormaps[cmap]
     color_list = cmap(np.linspace(0, 1, len(labels)))
     for idx, label in enumerate(labels):
         if label == 0:
@@ -1114,7 +1114,7 @@ def plot_prob_atlas(
             f"Valid view types are {valid_view_types}."
         )
 
-    cmap = plt.get_cmap(cmap)
+    cmap = plt.colormaps[cmap]
     color_list = cmap(np.linspace(0, 1, n_maps))
 
     if view_type == "auto":
@@ -1791,7 +1791,7 @@ def plot_markers(
         node_vmax = 1.1 * node_vmax
     norm = matplotlib.colors.Normalize(vmin=node_vmin, vmax=node_vmax)
     node_cmap = (
-        plt.get_cmap(node_cmap) if isinstance(node_cmap, str) else node_cmap
+        plt.colormaps[node_cmap] if isinstance(node_cmap, str) else node_cmap
     )
     node_color = [node_cmap(norm(node_value)) for node_value in node_values]
 

--- a/nilearn/plotting/js_plotting_utils.py
+++ b/nilearn/plotting/js_plotting_utils.py
@@ -70,7 +70,7 @@ def get_html_template(template_name):
 def colorscale(cmap, values, threshold=None, symmetric_cmap=True,
                vmax=None, vmin=None):
     """Normalize a cmap, put it in plotly format, get threshold and range."""
-    cmap = plt.colormaps[cmap]
+    cmap = plt.cm.ColormapRegistry.get_cmap(cmap)
     abs_values = np.abs(values)
     if not symmetric_cmap and (values.min() < 0):
         warnings.warn('you have specified symmetric_cmap=False '

--- a/nilearn/plotting/js_plotting_utils.py
+++ b/nilearn/plotting/js_plotting_utils.py
@@ -7,8 +7,8 @@ import warnings
 from string import Template
 
 import matplotlib as mpl
-import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.colors import LinearSegmentedColormap, ListedColormap
 
 from nilearn.plotting.html_document import (  # noqa: F401
     HTMLDocument,
@@ -70,7 +70,8 @@ def get_html_template(template_name):
 def colorscale(cmap, values, threshold=None, symmetric_cmap=True,
                vmax=None, vmin=None):
     """Normalize a cmap, put it in plotly format, get threshold and range."""
-    cmap = plt.cm.ColormapRegistry.get_cmap(cmap)
+    if not isinstance(cmap, (LinearSegmentedColormap, ListedColormap)):
+        cmap = mpl.colormaps[cmap]
     abs_values = np.abs(values)
     if not symmetric_cmap and (values.min() < 0):
         warnings.warn('you have specified symmetric_cmap=False '

--- a/nilearn/plotting/js_plotting_utils.py
+++ b/nilearn/plotting/js_plotting_utils.py
@@ -70,7 +70,7 @@ def get_html_template(template_name):
 def colorscale(cmap, values, threshold=None, symmetric_cmap=True,
                vmax=None, vmin=None):
     """Normalize a cmap, put it in plotly format, get threshold and range."""
-    cmap = plt.get_cmap(cmap)
+    cmap = plt.colormaps[cmap]
     abs_values = np.abs(values)
     if not symmetric_cmap and (values.min() < 0):
         warnings.warn('you have specified symmetric_cmap=False '

--- a/nilearn/plotting/js_plotting_utils.py
+++ b/nilearn/plotting/js_plotting_utils.py
@@ -8,7 +8,6 @@ from string import Template
 
 import matplotlib as mpl
 import numpy as np
-from matplotlib.colors import LinearSegmentedColormap, ListedColormap
 
 from nilearn.plotting.html_document import (  # noqa: F401
     HTMLDocument,
@@ -70,8 +69,9 @@ def get_html_template(template_name):
 def colorscale(cmap, values, threshold=None, symmetric_cmap=True,
                vmax=None, vmin=None):
     """Normalize a cmap, put it in plotly format, get threshold and range."""
-    if not isinstance(cmap, (LinearSegmentedColormap, ListedColormap)):
-        cmap = mpl.colormaps[cmap]
+    cmap = (
+        mpl.colormaps[cmap] if isinstance(cmap, str) else cmap
+    )
     abs_values = np.abs(values)
     if not symmetric_cmap and (values.min() < 0):
         warnings.warn('you have specified symmetric_cmap=False '

--- a/nilearn/plotting/matrix_plotting.py
+++ b/nilearn/plotting/matrix_plotting.py
@@ -549,7 +549,7 @@ def plot_event(model_event, cmap=None, output_file=None, **fig_kwargs):
     if cmap is None:
         cmap = plt.cm.tab20
     elif isinstance(cmap, str):
-        cmap = plt.get_cmap(cmap)
+        cmap = plt.colormaps[cmap]
 
     event_labels = pd.concat(event["trial_type"] for event in model_event)
     event_labels = np.unique(event_labels)

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -10,12 +10,7 @@ import numpy as np
 from matplotlib import gridspec
 from matplotlib.cm import ScalarMappable
 from matplotlib.colorbar import make_axes
-from matplotlib.colors import (
-    LinearSegmentedColormap,
-    ListedColormap,
-    Normalize,
-    to_rgba,
-)
+from matplotlib.colors import LinearSegmentedColormap, Normalize, to_rgba
 from matplotlib.patches import Patch
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 
@@ -435,10 +430,9 @@ def _get_cmap_matplotlib(cmap, vmin, vmax, cbar_tick_format, threshold=None):
 
     This function returns the colormap.
     """
-    if not isinstance(cmap, (LinearSegmentedColormap, ListedColormap)):
-        our_cmap = mpl.colormaps[cmap]
-    else:
-        our_cmap = cmap
+    our_cmap = (
+        plt.colormaps[cmap] if isinstance(cmap, str) else cmap
+    )
 
     norm = Normalize(vmin=vmin, vmax=vmax)
     cmaplist = [our_cmap(i) for i in range(our_cmap.N)]

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -10,7 +10,12 @@ import numpy as np
 from matplotlib import gridspec
 from matplotlib.cm import ScalarMappable
 from matplotlib.colorbar import make_axes
-from matplotlib.colors import LinearSegmentedColormap, Normalize, to_rgba
+from matplotlib.colors import (
+    LinearSegmentedColormap,
+    ListedColormap,
+    Normalize,
+    to_rgba,
+)
 from matplotlib.patches import Patch
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 
@@ -430,7 +435,11 @@ def _get_cmap_matplotlib(cmap, vmin, vmax, cbar_tick_format, threshold=None):
 
     This function returns the colormap.
     """
-    our_cmap = plt.cm.ColormapRegistry.get_cmap(cmap)
+    if not isinstance(cmap, (LinearSegmentedColormap, ListedColormap)):
+        our_cmap = mpl.colormaps[cmap]
+    else:
+        our_cmap = cmap
+
     norm = Normalize(vmin=vmin, vmax=vmax)
     cmaplist = [our_cmap(i) for i in range(our_cmap.N)]
     if threshold is not None:

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -15,7 +15,7 @@ from matplotlib.patches import Patch
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 
 from nilearn import image, surface
-from nilearn._utils import check_niimg_3d, compare_version, fill_doc
+from nilearn._utils import check_niimg_3d, fill_doc
 from nilearn._utils.helpers import is_kaleido_installed, is_plotly_installed
 from nilearn.plotting.cm import cold_hot, mix_colormaps
 from nilearn.plotting.displays._slicers import _get_cbar_ticks
@@ -1016,23 +1016,14 @@ def plot_surf_contours(surf_mesh, roi_map, axes=None, figure=None, levels=None,
     for level, color, label in zip(levels, colors, labels):
         roi_indices = np.where(roi == level)[0]
         faces_outside = _get_faces_on_edge(faces, roi_indices)
-        # Fix: Matplotlib version 3.3.2 to 3.3.3
-        # Attribute _facecolors3d changed to _facecolor3d in
-        # matplotlib version 3.3.3
-        if compare_version(mpl.__version__, "<", "3.3.3"):
-            axes.collections[0]._facecolors3d[faces_outside] = color
-            if axes.collections[0]._edgecolors3d.size == 0:
-                axes.collections[0].set_edgecolor(
-                    axes.collections[0]._facecolors3d
-                )
-            axes.collections[0]._edgecolors3d[faces_outside] = color
-        else:
-            axes.collections[0]._facecolor3d[faces_outside] = color
-            if axes.collections[0]._edgecolor3d.size == 0:
-                axes.collections[0].set_edgecolor(
-                    axes.collections[0]._facecolor3d
-                )
-            axes.collections[0]._edgecolor3d[faces_outside] = color
+
+        axes.collections[0]._facecolor3d[faces_outside] = color
+        if axes.collections[0]._edgecolor3d.size == 0:
+            axes.collections[0].set_edgecolor(
+                axes.collections[0]._facecolor3d
+            )
+        axes.collections[0]._edgecolor3d[faces_outside] = color
+
         if label and legend:
             patch_list.append(Patch(color=color, label=label))
     # plot legend only if indicated and labels provided

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -430,7 +430,7 @@ def _get_cmap_matplotlib(cmap, vmin, vmax, cbar_tick_format, threshold=None):
 
     This function returns the colormap.
     """
-    our_cmap = plt.get_cmap(cmap)
+    our_cmap = plt.colormaps[cmap]
     norm = Normalize(vmin=vmin, vmax=vmax)
     cmaplist = [our_cmap(i) for i in range(our_cmap.N)]
     if threshold is not None:
@@ -550,10 +550,10 @@ def _plot_surf_matplotlib(coords, faces, surf_map=None, bg_map=None,
 
     # if no cmap is given, set to matplotlib default
     if cmap is None:
-        cmap = plt.get_cmap(plt.rcParamsDefault['image.cmap'])
+        cmap = plt.colormaps[plt.rcParamsDefault['image.cmap']]
     # if cmap is given as string, translate to matplotlib cmap
     elif isinstance(cmap, str):
-        cmap = plt.get_cmap(cmap)
+        cmap = plt.colormaps[cmap]
 
     figsize = _default_figsize
     # Leave space for colorbar
@@ -993,7 +993,7 @@ def plot_surf_contours(surf_mesh, roi_map, axes=None, figure=None, levels=None,
     if colors is None:
         n_levels = len(levels)
         vmax = n_levels
-        cmap = plt.get_cmap(cmap)
+        cmap = plt.colormaps[cmap]
         norm = Normalize(vmin=0, vmax=vmax)
         colors = [cmap(norm(color_i)) for color_i in range(vmax)]
     else:
@@ -1535,7 +1535,7 @@ def plot_img_on_surf(stat_map, surf_mesh='fsaverage5', mask_img=None,
             vmax,
             threshold,
             symmetric_cbar=symmetric_cbar,
-            cmap=plt.get_cmap(cmap),
+            cmap=plt.colormaps[cmap],
         )
 
         cbar_grid = gridspec.GridSpecFromSubplotSpec(3, 3, grid[-1, :])

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -430,7 +430,7 @@ def _get_cmap_matplotlib(cmap, vmin, vmax, cbar_tick_format, threshold=None):
 
     This function returns the colormap.
     """
-    our_cmap = plt.colormaps[cmap]
+    our_cmap = plt.cm.ColormapRegistry.get_cmap(cmap)
     norm = Normalize(vmin=vmin, vmax=vmax)
     cmaplist = [our_cmap(i) for i in range(our_cmap.N)]
     if threshold is not None:

--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -129,7 +129,7 @@ def test_save_sprite(rng):
         mask=html_stat_map._data_to_sprite(mask),
     )
     correct_img = plt.Normalize(0, 1)(correct_img)
-    cmapped = plt.get_cmap("Greys")(correct_img)
+    cmapped = plt.colormaps["Greys"](correct_img)
     assert np.allclose(img, cmapped, atol=0.1)
 
 
@@ -148,7 +148,7 @@ def test_save_cmap(cmap, n_colors):
     decoded_io.write(base64.b64decode(cmap_base64))
     decoded_io.seek(0)
     img = plt.imread(decoded_io, format="png")
-    expected = plt.get_cmap(cmap)(np.linspace(0, 1, n_colors))
+    expected = plt.colormaps[cmap](np.linspace(0, 1, n_colors))
     assert np.allclose(img, expected, atol=0.1)
 
 

--- a/nilearn/plotting/tests/test_img_plotting/test_plot_markers.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_plot_markers.py
@@ -71,7 +71,7 @@ def test_plot_markers_node_sizes_lyrz_display(node_size, coords):
     "cmap,vmin,vmax",
     [
         ("RdBu", 0, None),
-        (plt.get_cmap("jet"), None, 5),
+        (plt.colormaps["jet"], None, 5),
         (plt.cm.viridis_r, 2, 3),
     ],
 )

--- a/nilearn/plotting/tests/test_img_plotting/test_plot_roi.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_plot_roi.py
@@ -84,10 +84,6 @@ def test_cmap_with_one_level(shape_3d_default, affine_eye):
 
     clust_ids = list(np.unique(img.get_fdata())[1:])
 
-    try:
-        cmap = plt.colormaps["tab20"].resampled(len(clust_ids))
-    except TypeError:
-        # for older versions of matplotlib
-        cmap = plt.cm.get_cmap("tab20", len(clust_ids))
+    cmap = plt.colormaps["tab20"].resampled(len(clust_ids))
 
     plot_roi(img, alpha=0.8, colorbar=True, cmap=cmap)

--- a/nilearn/plotting/tests/test_surf_plotting.py
+++ b/nilearn/plotting/tests/test_surf_plotting.py
@@ -474,7 +474,7 @@ def test_plot_surf_avg_method(rng):
         vmax = np.max(agg_faces)
         agg_faces -= vmin
         agg_faces /= (vmax - vmin)
-        cmap = plt.get_cmap(plt.rcParamsDefault['image.cmap'])
+        cmap = plt.colormaps[plt.rcParamsDefault['image.cmap']]
         assert_array_equal(
             cmap(agg_faces),
             display._axstack.as_list()[0].collections[0]._facecolors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ plotly = ["nilearn[plotting]"]
 # Kaleido version is pinned for windows due to bug
 # See https://github.com/plotly/Kaleido/issues/134 for more detail
 plotting = [
-    "matplotlib>=3.3.0",
+    "matplotlib>=3.6.0",
     "plotly",
     "kaleido ; platform_system != 'Windows'",
     "kaleido==0.1.0.post1 ; platform_system == 'Windows'"

--- a/tox.ini
+++ b/tox.ini
@@ -30,13 +30,13 @@ deps =
 description = environment with minimum matplotlib version
 skip_install = false
 deps =
-    matplotlib==3.3.0
+    matplotlib==3.6.0
 
 [matplotlib]
 description = environment with matplotlib dependencies
 skip_install = false
 deps =
-    matplotlib>=3.3.0
+    matplotlib>=3.6.0
 
 [plotting]
 description = environment with all plotting dependencies


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4420 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- convert `get_cmap` to `colormaps` (`get_cmap` removed in [matplotlib 3.9.0](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.9.0.html#removals))
- bump base matplotlib version to 3.6.0 (introduced [resampled](https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.6.0.html#colormap-method-for-creating-a-different-lookup-table-size))
