### PR TITLE
Add future warning about copying header by default

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -32,3 +32,5 @@ Changes
 - :bdg-dark:`Code` Throw error in :func:`nilearn.glm.first_level.first_level_from_bids` if unknown ``kwargs`` are passed (:gh:`4414` by `Michelle Wang`_).
 
 - :bdg-primary:`Doc` Refactor design matrix and contrast formula for the two-sample T-test example in :ref:`sphx_glr_auto_examples_05_glm_second_level_plot_second_level_two_sample_test.py` (:gh:`4407` by `Yichun Huang`_).
+
+- :bdg-success:`API` Add future warning for copying header by default in :func:`nilearn.image` functions from version 0.13.0 onwards (:gh:`4427` by `Himanshu Aggarwal`_).

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -376,6 +376,16 @@ def crop_img(img, rtol=1e-8, copy=True, pad=True, return_offset=False):
         *[(x1_pre, x1_post), (x2_pre, x2_post), ..., (xN_pre, xN_post)]*
 
     """
+    copy_header_default = (
+        "From release 0.13.0 this function will by default copy the header of "
+        "the input image to the cropped image. Currently, the header is "
+        "not copied at all."
+    )
+    warnings.warn(
+        category=FutureWarning,
+        message=copy_header_default,
+    )
+
     img = check_niimg(img)
     data = get_data(img)
     infinity_norm = max(-data.min(), data.max())
@@ -536,6 +546,16 @@ def mean_img(imgs, target_affine=None, target_shape=None, verbose=0, n_jobs=1):
     nilearn.image.math_img : For more general operations on images.
 
     """
+    copy_header_default = (
+        "From release 0.13.0 this function will, by default, copy the header "
+        "of the 4D input image or the first image (if the input is a list of "
+        "3D images) to the output. Currently, the header is not copied at all."
+    )
+    warnings.warn(
+        category=FutureWarning,
+        message=copy_header_default,
+    )
+
     imgs = stringify_path(imgs)
     is_str = isinstance(imgs, str)
     is_iterable = isinstance(imgs, collections.abc.Iterable)
@@ -934,6 +954,16 @@ def threshold_img(
     """
     from .. import masking
     from . import resampling
+
+    copy_header_default = (
+        "From release 0.13.0 this function will, by default, copy the header "
+        "of the input image to the output. Currently, the header is not "
+        "copied at all."
+    )
+    warnings.warn(
+        category=FutureWarning,
+        message=copy_header_default,
+    )
 
     img = check_niimg(img)
     img_data = safe_get_data(img, ensure_finite=True, copy_data=copy)

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -439,6 +439,16 @@ def resample_img(
     """
     from .image import new_img_like  # avoid circular imports
 
+    copy_header_default = (
+        "From release 0.13.0 this function will, by default, copy the header "
+        "of the input image to the output. Currently, the header is not "
+        "copied at all."
+    )
+    warnings.warn(
+        category=FutureWarning,
+        message=copy_header_default,
+    )
+
     # Do as many checks as possible before loading data, to avoid potentially
     # costly calls before raising an exception.
     if target_shape is not None and target_affine is None:
@@ -788,6 +798,16 @@ def reorder_img(img, resample=None):
 
     """
     from .image import new_img_like
+
+    copy_header_default = (
+        "From release 0.13.0 this function will, by default, copy the header "
+        "of the input image to the output. Currently, the header is not "
+        "copied at all."
+    )
+    warnings.warn(
+        category=FutureWarning,
+        message=copy_header_default,
+    )
 
     img = _utils.check_niimg(img)
     # The copy is needed in order not to modify the input img affine


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4426

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- FutureWarning in all the `nilearn.image` functions modified  in #4397