### PR TITLE
[MAINT] use pytest-reporter-html1 to create test reports

### DIFF
--- a/.github/workflows/test_with_tox.yml
+++ b/.github/workflows/test_with_tox.yml
@@ -54,6 +54,11 @@ jobs:
             run: tox c
         -   name: Run test suite
             run: tox run -e ${{ matrix.env }} -- nilearn
+        -   name: Upload documentation
+            uses: actions/upload-artifact@v4
+            with:
+                name: report
+                path: report.html
         -   name: Upload coverage to CodeCov
             uses: codecov/codecov-action@v4
             with:

--- a/.github/workflows/test_with_tox.yml
+++ b/.github/workflows/test_with_tox.yml
@@ -57,7 +57,7 @@ jobs:
         -   name: Upload documentation
             uses: actions/upload-artifact@v4
             with:
-                name: report
+                name: ${{ matrix.os }}_${{ matrix.py }}_${{ matrix.description }}_report.html
                 path: report.html
         -   name: Upload coverage to CodeCov
             uses: codecov/codecov-action@v4

--- a/.github/workflows/test_with_tox.yml
+++ b/.github/workflows/test_with_tox.yml
@@ -54,7 +54,8 @@ jobs:
             run: tox c
         -   name: Run test suite
             run: tox run -e ${{ matrix.env }} -- nilearn
-        -   name: Upload documentation
+        -   name: Upload test report
+            if: success() || failure()
             uses: actions/upload-artifact@v4
             with:
                 name: ${{ matrix.os }}_${{ matrix.py }}_${{ matrix.description }}_report.html

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ venv/
 
 # testing
 .pytest_cache
+report.html
 
 # CI benchmark
 maint_tools/*_runs_timing.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,6 +112,11 @@ repos:
     hooks:
     -   id: prettier
         types_or: [css, html]
+        exclude: |
+            (?x)^(
+                maint_tools/templates/index.html
+            )$
+
 
 # Check that Python code complies with PEP8 guidelines
 # flake8 uses pydocstyle to check docstrings: https://flake8.pycqa.org/en/latest/

--- a/maint_tools/templates/index.html
+++ b/maint_tools/templates/index.html
@@ -1,13 +1,11 @@
 {% extends "html1/base.html" %}
-<!--  -->
+
 {% set title = "Nilearn test report" %}
-<!--  -->
+
 {% block style %}
-<!--  -->
-{{ super() }}
-<!--  -->
-.warning-content { margin-bottom: 12px; } {% endblock %}
-<!--  -->
+  {{ super() }}
+  .warning-content { margin-bottom: 12px; }
+{% endblock %}
 
 {% block content %}
 <section id="summary">
@@ -25,116 +23,88 @@
           <th>Ended</th>
           <td>
             {% if ended %}
-            <!--  -->
-            {{ ended|strftime(time_format) }}
-            <!--  -->
+              {{ ended|strftime(time_format) }}
             {% else %}
-            <i>In progress...</i>
+              <i>In progress...</i>
             {% endif %}
           </td>
         </tr>
         {% if ended %}
-        <tr>
-          <th>Duration</th>
-          {% set duration = ended - started %}
-          <td>{{ duration|timedelta }}</td>
-        </tr>
+          <tr>
+            <th>Duration</th>
+            {% set duration = ended - started %}
+            <td>{{ duration|timedelta }}</td>
+          </tr>
         {% endif %}
         <tr>
           <th>Total run time</th>
-          <td>
-            {{ tests|map(attribute='phases')|map('sum',
-            'report.duration')|sum|timedelta }}
-          </td>
+          <td>{{ tests|map(attribute='phases')|map('sum', 'report.duration')|sum|timedelta }}</td>
         </tr>
         {% for key, value in metadata.items() %}
-        <tr>
-          <th>{{ key }}</th>
-          <td>
-            {% if value is mapping %}
-            <!--  -->
-            {% for key, value in value.items() %}
-            <!--  -->
-            {{ key }}: {{ value }}<br />
-            {% endfor %}
-            <!--  -->
-            {% else %}
-            <!--  -->
-            {{ value|urlize }}
-            <!--  -->
-            {% endif %}
-          </td>
-        </tr>
-        {% endfor %} {% endblock %}
+          <tr>
+            <th>{{ key }}</th>
+            <td>
+              {% if value is mapping %}
+                {% for key, value in value.items() %}
+                  {{ key }}: {{ value }}<br>
+                {% endfor %}
+              {% else %}
+                {{ value|urlize }}
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        {% endblock %}
       </table>
     </div>
     <div class="graph">
       {% set tests_by_category = tests|groupby('status.category') %}
-      <!--  -->
       {% set nodes_run = tests|map(attribute='item.nodeid')|list %}
-      <!--  -->
-      {% set nof_nodes_not_run = session.items|rejectattr('nodeid', 'in',
-      nodes_run)|list|count %}
+      {% set nof_nodes_not_run = session.items|rejectattr('nodeid', 'in', nodes_run)|list|count %}
       <svg width="200" height="200" viewBox="0 0 42 42">
         {% set ns = namespace(sum=0.0) %}
-        <!--  -->
         {% set total = tests|count %}
-        <!--  -->
         {% set r = 16 %}
-        <!--  -->
         {% set spacing = 0.4 %}
-        <!--  -->
         {% set C = 2 * 3.141592653589793 * r %}
-        <!--  -->
         {% for category, sub_tests in tests_by_category %}
-        <!--  -->
-        {% set count = sub_tests|count %}
-        <!--  -->
-        {% set L = count / (total + nof_nodes_not_run) * C %}
-        <!--  -->
-        {% set color = colors[category] %}
-        <circle
-          class="donut-segment {{ category }}"
-          stroke-dasharray="{{ [L - spacing, 0]|max }} {{ C - (L - spacing) }}"
-          stroke-dashoffset="{{ C - ns.sum + C / 4 - spacing / 2 }}"
-          cx="21"
-          cy="21"
-          r="{{ r }}"
-          fill="transparent"
-          {%
-          if
-          color
-          %}
-          stroke="{{ color[0] }}"
-          {%
-          endif
-          %}
-          stroke-width="4"
-        ></circle>
-        {% set ns.sum = ns.sum + L %}
-        <!--  -->
+          {% set count = sub_tests|count %}
+          {% set L = count / (total + nof_nodes_not_run) * C %}
+          {% set color = colors[category] %}
+          <circle
+            class="donut-segment {{ category }}"
+            stroke-dasharray="{{ [L - spacing, 0]|max }} {{ C - (L - spacing) }}"
+            stroke-dashoffset="{{ C - ns.sum + C / 4 - spacing / 2 }}"
+            cx="21"
+            cy="21"
+            r="{{ r }}"
+            fill="transparent"
+            {% if color %}
+            stroke="{{ color[0] }}"
+            {% endif %}
+            stroke-width="4">
+          </circle>
+          {% set ns.sum = ns.sum + L %}
         {% endfor %}
         <text x="21" y="24" text-anchor="middle">{{ total }}</text>
       </svg>
       <div class="legend">
         {% for category, tests in tests_by_category %}
-        <span
-          class="status badge {{ category }} {{ tests|map(attribute='status.style')|first|join(' ') }}"
-        >
-          {{ tests|count }}
-        </span>
-        <span>{{ category }}</span>
+          <span class="status badge {{ category }} {{ tests|map(attribute='status.style')|first|join(' ') }}">
+            {{ tests|count }}
+          </span>
+          <span>{{ category }}</span>
         {% endfor %}
-        <!--  -->
         {% if nof_nodes_not_run %}
-        <span class="status badge notrun">{{ nof_nodes_not_run }}</span>
-        <span>not run</span>
+          <span class="status badge notrun">{{ nof_nodes_not_run }}</span>
+          <span>not run</span>
         {% endif %}
       </div>
     </div>
     {% endblock %}
   </div>
 </section>
+
 {% if warnings %}
 <section id="warnings">
   <div class="container">
@@ -144,7 +114,8 @@
         <h2 class="title file-title">
           <span class="fspath"> WARNINGS </span>
           <span class="counts">
-            <span title="{{ warnings|count }}" class="status badge warning">
+            <span title="{{ warnings|count }}"
+                  class="status badge warning">
               {{ warnings|count }}
             </span>
           </span>
@@ -152,80 +123,69 @@
       </summary>
 
       {% set warning_types = warnings|map(attribute='category')|unique|list %}
-      <!--  -->
       {% for type in warning_types %}
 
         {% set nb_warning = namespace(value=0) %}
         {% for warning in warnings %}
-        <!--  -->
-        {% if warning.category == type %}
-        {% set nb_warning.value = nb_warning.value + 1 %}
-        {% endif %}
-        <!--  -->
+          {% if warning.category == type %}
+            {% set nb_warning.value = nb_warning.value + 1 %}
+          {% endif %}
         {% endfor %}
 
       <details>
         <summary>
-          <div class="status">{{ type | replace("<class '", "") | replace("'>", "")  }}
+          <div class="status">
+            {{ type | replace("<class '", "") | replace("'>", "")  }}
             <span class="badge warning counts">{{ nb_warning.value }}</span>
           </div>
         </summary>
         <ul>
           {% for warning in warnings|sort(attribute="filename") %}
-          <!--  -->
-          {% if warning.category == type %}
-          <li>
-            <div class="warning-content">
-              {{ warning.filename }}:{{ warning.lineno }}<br />{{ warning.message }}
-            </div>
-          </li>
-          {% endif %}
-          <!--  -->
+            {% if warning.category == type %}
+              <li>
+                <div class="warning-content">
+                  {{ warning.filename }}:{{ warning.lineno }}<br />{{ warning.message }}
+                </div>
+              </li>
+            {% endif %}
           {% endfor %}
         </ul>
       </details>
-      <!--  -->
-      <!--  -->
       {% endfor %}
     </details>
   </div>
 </section>
 {% endif %}
+
 <section id="test-files">
   <div class="container">
     <h1>Tests</h1>
     {% for fspath, tests in tests|groupby('item.fspath') %}
-    <!--  -->
-    {% set first_item = tests|map(attribute='item')|first %}
-    <details class="file">
-      <summary>
-        <h2 class="title file-title">
-          {% block module_title scoped %}
-          <span class="fspath">
-            {% block module_name scoped %}
-            <!--  -->
-            {{ first_item.nodeid.split('::')|first }}
-            <!--  -->
-            {% endblock %}
-          </span>
-          <span class="counts">
+      {% set first_item = tests|map(attribute='item')|first %}
+      <details class="file">
+        <summary>
+          <h2 class="title file-title">
+            {% block module_title scoped %}
+            <span class="fspath">
+              {% block module_name scoped %}
+              {{ first_item.nodeid.split('::')|first }}
+              {% endblock %}
+            </span>
+            <span class="counts">
             {% for category, tests in tests|groupby('status.category') -%}
-            <span
-              title="{{ tests|count }} {{ category }}"
-              class="count status badge {{ category }} {{ tests|map(attribute='status.style')|first|join(' ') }}"
-              >{{ tests|count }}</span
-            >
+              <span title="{{ tests|count }} {{ category }}" class="count status badge {{ category }} {{ tests|map(attribute='status.style')|first|join(' ') }}">{{ tests|count }}</span>
             {%- endfor %}
-          </span>
-          <span class="duration">
-            {{ tests|map(attribute='phases')|map('sum',
-            'report.duration')|sum|timedelta }}
-          </span>
-          {% endblock %}
-        </h2>
-      </summary>
-      <div class="content box">{% include "html1/module.html" %}</div>
-    </details>
+            </span>
+            <span class="duration">
+              {{ tests|map(attribute='phases')|map('sum', 'report.duration')|sum|timedelta }}
+            </span>
+            {% endblock %}
+          </h2>
+        </summary>
+        <div class="content box">
+          {% include "html1/module.html" %}
+        </div>
+      </details>
     {% endfor %}
   </div>
 </section>

--- a/maint_tools/templates/index.html
+++ b/maint_tools/templates/index.html
@@ -1,192 +1,80 @@
-{% extends "html1/base.html" %}
+<!-- Print the warnings sorted by type first and then by filename -->
 
-{% set title = "Nilearn test report" %}
+{% extends "html1/index.html" %}
+<!-- URL of the extended template -->
+<!-- https://github.com/christiansandberg/pytest-reporter-html1/blob/master/pytest_reporter_html1/templates/html1/index.html -->
 
 {% block style %}
   {{ super() }}
-  .warning-content { margin-bottom: 12px; }
+
+  .warning-list {
+    margin-left: 24px;
+    margin-top: 12px;
+    widt: 90%;
+  }
+
+  #warnings ul {
+    padding: 0;
+    margin-left: 24px;
+    display: block;
+}
+
+  #warnings li {
+    display: block;
+    margin-bottom: 8px;
+  }
+
 {% endblock %}
 
-{% block content %}
-<section id="summary">
-  <div class="container">
-    <h1>Summary</h1>
-    {% block summary %}
-    <div class="metadata">
-      <table>
-        {% block session_metadata %}
-        <tr>
-          <th>Started</th>
-          <td>{{ started|strftime(time_format) }}</td>
-        </tr>
-        <tr>
-          <th>Ended</th>
-          <td>
-            {% if ended %}
-              {{ ended|strftime(time_format) }}
-            {% else %}
-              <i>In progress...</i>
-            {% endif %}
-          </td>
-        </tr>
-        {% if ended %}
-          <tr>
-            <th>Duration</th>
-            {% set duration = ended - started %}
-            <td>{{ duration|timedelta }}</td>
-          </tr>
-        {% endif %}
-        <tr>
-          <th>Total run time</th>
-          <td>{{ tests|map(attribute='phases')|map('sum', 'report.duration')|sum|timedelta }}</td>
-        </tr>
-        {% for key, value in metadata.items() %}
-          <tr>
-            <th>{{ key }}</th>
-            <td>
-              {% if value is mapping %}
-                {% for key, value in value.items() %}
-                  {{ key }}: {{ value }}<br>
-                {% endfor %}
-              {% else %}
-                {{ value|urlize }}
-              {% endif %}
-            </td>
-          </tr>
-          {% endfor %}
-        {% endblock %}
-      </table>
-    </div>
-    <div class="graph">
-      {% set tests_by_category = tests|groupby('status.category') %}
-      {% set nodes_run = tests|map(attribute='item.nodeid')|list %}
-      {% set nof_nodes_not_run = session.items|rejectattr('nodeid', 'in', nodes_run)|list|count %}
-      <svg width="200" height="200" viewBox="0 0 42 42">
-        {% set ns = namespace(sum=0.0) %}
-        {% set total = tests|count %}
-        {% set r = 16 %}
-        {% set spacing = 0.4 %}
-        {% set C = 2 * 3.141592653589793 * r %}
-        {% for category, sub_tests in tests_by_category %}
-          {% set count = sub_tests|count %}
-          {% set L = count / (total + nof_nodes_not_run) * C %}
-          {% set color = colors[category] %}
-          <circle
-            class="donut-segment {{ category }}"
-            stroke-dasharray="{{ [L - spacing, 0]|max }} {{ C - (L - spacing) }}"
-            stroke-dashoffset="{{ C - ns.sum + C / 4 - spacing / 2 }}"
-            cx="21"
-            cy="21"
-            r="{{ r }}"
-            fill="transparent"
-            {% if color %}
-            stroke="{{ color[0] }}"
-            {% endif %}
-            stroke-width="4">
-          </circle>
-          {% set ns.sum = ns.sum + L %}
-        {% endfor %}
-        <text x="21" y="24" text-anchor="middle">{{ total }}</text>
-      </svg>
-      <div class="legend">
-        {% for category, tests in tests_by_category %}
-          <span class="status badge {{ category }} {{ tests|map(attribute='status.style')|first|join(' ') }}">
-            {{ tests|count }}
-          </span>
-          <span>{{ category }}</span>
-        {% endfor %}
-        {% if nof_nodes_not_run %}
-          <span class="status badge notrun">{{ nof_nodes_not_run }}</span>
-          <span>not run</span>
-        {% endif %}
-      </div>
-    </div>
-    {% endblock %}
-  </div>
-</section>
+{% set title = "Nilearn test report" %}
 
-{% if warnings %}
-<section id="warnings">
-  <div class="container">
-    <h1>Warnings</h1>
-    <details class="file">
+{% block warnings %}
+<div class="container">
+  <h1>Warnings</h1>
+  <details class="file">
+    <summary>
+      <h2 class="title file-title">
+        <span class="fspath"> WARNINGS </span>
+        <span class="counts">
+          <span title="{{ warnings|count }}"
+                class="status badge warning">
+            {{ warnings|count }}
+          </span>
+        </span>
+      </h2>
+    </summary>
+
+    {% set warning_types = warnings|map(attribute='category')|unique|list %}
+    {% for type in warning_types %}
+
+      {% set nb_warning = namespace(value=0) %}
+      {% for warning in warnings %}
+        {% if warning.category == type %}
+          {% set nb_warning.value = nb_warning.value + 1 %}
+        {% endif %}
+      {% endfor %}
+
+    <details class="warning-list">
       <summary>
-        <h2 class="title file-title">
-          <span class="fspath"> WARNINGS </span>
-          <span class="counts">
-            <span title="{{ warnings|count }}"
-                  class="status badge warning">
-              {{ warnings|count }}
-            </span>
-          </span>
-        </h2>
+        <div class="status">
+          {{ type.__name__  }}
+          <span class="badge warning counts">{{ nb_warning.value }}</span>
+        </div>
       </summary>
-
-      {% set warning_types = warnings|map(attribute='category')|unique|list %}
-      {% for type in warning_types %}
-
-        {% set nb_warning = namespace(value=0) %}
-        {% for warning in warnings %}
+      <ul>
+        {% for warning in warnings|sort(attribute="filename") %}
           {% if warning.category == type %}
-            {% set nb_warning.value = nb_warning.value + 1 %}
+            <li>
+              <div>
+                <span class="filename">{{ warning.filename }}:{{ warning.lineno }}</span><br />
+                {{ warning.message }}
+              </div>
+            </li>
           {% endif %}
         {% endfor %}
-
-      <details>
-        <summary>
-          <div class="status">
-            {{ type | replace("<class '", "") | replace("'>", "")  }}
-            <span class="badge warning counts">{{ nb_warning.value }}</span>
-          </div>
-        </summary>
-        <ul>
-          {% for warning in warnings|sort(attribute="filename") %}
-            {% if warning.category == type %}
-              <li>
-                <div class="warning-content">
-                  {{ warning.filename }}:{{ warning.lineno }}<br />{{ warning.message }}
-                </div>
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </details>
-      {% endfor %}
+      </ul>
     </details>
-  </div>
-</section>
-{% endif %}
-
-<section id="test-files">
-  <div class="container">
-    <h1>Tests</h1>
-    {% for fspath, tests in tests|groupby('item.fspath') %}
-      {% set first_item = tests|map(attribute='item')|first %}
-      <details class="file">
-        <summary>
-          <h2 class="title file-title">
-            {% block module_title scoped %}
-            <span class="fspath">
-              {% block module_name scoped %}
-              {{ first_item.nodeid.split('::')|first }}
-              {% endblock %}
-            </span>
-            <span class="counts">
-            {% for category, tests in tests|groupby('status.category') -%}
-              <span title="{{ tests|count }} {{ category }}" class="count status badge {{ category }} {{ tests|map(attribute='status.style')|first|join(' ') }}">{{ tests|count }}</span>
-            {%- endfor %}
-            </span>
-            <span class="duration">
-              {{ tests|map(attribute='phases')|map('sum', 'report.duration')|sum|timedelta }}
-            </span>
-            {% endblock %}
-          </h2>
-        </summary>
-        <div class="content box">
-          {% include "html1/module.html" %}
-        </div>
-      </details>
     {% endfor %}
-  </div>
-</section>
+  </details>
+</div>
 {% endblock %}

--- a/maint_tools/templates/index.html
+++ b/maint_tools/templates/index.html
@@ -170,15 +170,19 @@
             <span class="badge warning counts">{{ nb_warning.value }}</span>
           </div>
         </summary>
+        <ul>
           {% for warning in warnings|sort(attribute="filename") %}
           <!--  -->
           {% if warning.category == type %}
-          <div class="warning-content">
-            {{ warning.filename }}:{{ warning.lineno }}<br />{{ warning.message }}
-          </div>
+          <li>
+            <div class="warning-content">
+              {{ warning.filename }}:{{ warning.lineno }}<br />{{ warning.message }}
+            </div>
+          </li>
           {% endif %}
           <!--  -->
           {% endfor %}
+        </ul>
       </details>
       <!--  -->
       <!--  -->

--- a/maint_tools/templates/index.html
+++ b/maint_tools/templates/index.html
@@ -151,20 +151,36 @@
         </h2>
       </summary>
 
-      {% set warning_types = warnings|map(attribute='category') %}
+      {% set warning_types = warnings|map(attribute='category')|unique|list %}
       <!--  -->
       {% for type in warning_types %}
+
+        {% set nb_warning = namespace(value=0) %}
+        {% for warning in warnings %}
+        <!--  -->
+        {% if warning.category == type %}
+        {% set nb_warning.value = nb_warning.value + 1 %}
+        {% endif %}
+        <!--  -->
+        {% endfor %}
+
+      <details>
+        <summary>
+          <div class="status">{{ type | replace("<class '", "") | replace("'>", "")  }}
+            <span class="badge warning counts">{{ nb_warning.value }}</span>
+          </div>
+        </summary>
+          {% for warning in warnings|sort(attribute="filename") %}
+          <!--  -->
+          {% if warning.category == type %}
+          <div class="warning-content">
+            {{ warning.filename }}:{{ warning.lineno }}<br />{{ warning.message }}
+          </div>
+          {% endif %}
+          <!--  -->
+          {% endfor %}
+      </details>
       <!--  -->
-      {% for warning in warnings|sort(attribute="filename") %}
-      <!--  -->
-      {% if warning.category == type %}
-      <div class="status badge warning">WARNING: {{ warning.category }}</div>
-      <div class="warning-content">
-        {{ warning.filename }}:{{ warning.lineno }}<br />{{ warning.message }}
-      </div>
-      {% endif%}
-      <!--  -->
-      {% endfor %}
       <!--  -->
       {% endfor %}
     </details>

--- a/maint_tools/templates/index.html
+++ b/maint_tools/templates/index.html
@@ -1,5 +1,14 @@
-{% extends "html1/base.html" %} {% set title = "Nilearn test report" %} {% block
-style %} {{ super() }} .warning-content { margin-bottom: 8px; } {% endblock %}
+{% extends "html1/base.html" %}
+<!--  -->
+{% set title = "Nilearn test report" %}
+<!--  -->
+{% block style %}
+<!--  -->
+{{ super() }}
+<!--  -->
+.warning-content { margin-bottom: 12px; } {% endblock %}
+<!--  -->
+
 {% block content %}
 <section id="summary">
   <div class="container">
@@ -15,7 +24,11 @@ style %} {{ super() }} .warning-content { margin-bottom: 8px; } {% endblock %}
         <tr>
           <th>Ended</th>
           <td>
-            {% if ended %} {{ ended|strftime(time_format) }} {% else %}
+            {% if ended %}
+            <!--  -->
+            {{ ended|strftime(time_format) }}
+            <!--  -->
+            {% else %}
             <i>In progress...</i>
             {% endif %}
           </td>
@@ -38,24 +51,47 @@ style %} {{ super() }} .warning-content { margin-bottom: 8px; } {% endblock %}
         <tr>
           <th>{{ key }}</th>
           <td>
-            {% if value is mapping %} {% for key, value in value.items() %} {{
-            key }}: {{ value }}<br />
-            {% endfor %} {% else %} {{ value|urlize }} {% endif %}
+            {% if value is mapping %}
+            <!--  -->
+            {% for key, value in value.items() %}
+            <!--  -->
+            {{ key }}: {{ value }}<br />
+            {% endfor %}
+            <!--  -->
+            {% else %}
+            <!--  -->
+            {{ value|urlize }}
+            <!--  -->
+            {% endif %}
           </td>
         </tr>
         {% endfor %} {% endblock %}
       </table>
     </div>
     <div class="graph">
-      {% set tests_by_category = tests|groupby('status.category') %} {% set
-      nodes_run = tests|map(attribute='item.nodeid')|list %} {% set
-      nof_nodes_not_run = session.items|rejectattr('nodeid', 'in',
+      {% set tests_by_category = tests|groupby('status.category') %}
+      <!--  -->
+      {% set nodes_run = tests|map(attribute='item.nodeid')|list %}
+      <!--  -->
+      {% set nof_nodes_not_run = session.items|rejectattr('nodeid', 'in',
       nodes_run)|list|count %}
       <svg width="200" height="200" viewBox="0 0 42 42">
-        {% set ns = namespace(sum=0.0) %} {% set total = tests|count %} {% set r
-        = 16 %} {% set spacing = 0.4 %} {% set C = 2 * 3.141592653589793 * r %}
-        {% for category, sub_tests in tests_by_category %} {% set count =
-        sub_tests|count %} {% set L = count / (total + nof_nodes_not_run) * C %}
+        {% set ns = namespace(sum=0.0) %}
+        <!--  -->
+        {% set total = tests|count %}
+        <!--  -->
+        {% set r = 16 %}
+        <!--  -->
+        {% set spacing = 0.4 %}
+        <!--  -->
+        {% set C = 2 * 3.141592653589793 * r %}
+        <!--  -->
+        {% for category, sub_tests in tests_by_category %}
+        <!--  -->
+        {% set count = sub_tests|count %}
+        <!--  -->
+        {% set L = count / (total + nof_nodes_not_run) * C %}
+        <!--  -->
         {% set color = colors[category] %}
         <circle
           class="donut-segment {{ category }}"
@@ -75,7 +111,9 @@ style %} {{ super() }} .warning-content { margin-bottom: 8px; } {% endblock %}
           %}
           stroke-width="4"
         ></circle>
-        {% set ns.sum = ns.sum + L %} {% endfor %}
+        {% set ns.sum = ns.sum + L %}
+        <!--  -->
+        {% endfor %}
         <text x="21" y="24" text-anchor="middle">{{ total }}</text>
       </svg>
       <div class="legend">
@@ -86,7 +124,9 @@ style %} {{ super() }} .warning-content { margin-bottom: 8px; } {% endblock %}
           {{ tests|count }}
         </span>
         <span>{{ category }}</span>
-        {% endfor %} {% if nof_nodes_not_run %}
+        {% endfor %}
+        <!--  -->
+        {% if nof_nodes_not_run %}
         <span class="status badge notrun">{{ nof_nodes_not_run }}</span>
         <span>not run</span>
         {% endif %}
@@ -100,13 +140,32 @@ style %} {{ super() }} .warning-content { margin-bottom: 8px; } {% endblock %}
   <div class="container">
     <h1>Warnings</h1>
     <details class="file">
-      <summary><h2 class="title file-title">WARNINGS</h2></summary>
-      <div style="padding: 24x !important"><p></p></div>
-      {% for warning in warnings %}
-      <div class="status badge warning">WARNING</div>
+      <summary>
+        <h2 class="title file-title">
+          <span class="fspath"> WARNINGS </span>
+          <span class="counts">
+            <span title="{{ warnings|count }}" class="status badge warning">
+              {{ warnings|count }}
+            </span>
+          </span>
+        </h2>
+      </summary>
+
+      {% set warning_types = warnings|map(attribute='category') %}
+      <!--  -->
+      {% for type in warning_types %}
+      <!--  -->
+      {% for warning in warnings|sort(attribute="filename") %}
+      <!--  -->
+      {% if warning.category == type %}
+      <div class="status badge warning">WARNING: {{ warning.category }}</div>
       <div class="warning-content">
         {{ warning.filename }}:{{ warning.lineno }}<br />{{ warning.message }}
       </div>
+      {% endif%}
+      <!--  -->
+      {% endfor %}
+      <!--  -->
       {% endfor %}
     </details>
   </div>
@@ -115,15 +174,19 @@ style %} {{ super() }} .warning-content { margin-bottom: 8px; } {% endblock %}
 <section id="test-files">
   <div class="container">
     <h1>Tests</h1>
-    {% for fspath, tests in tests|groupby('item.fspath') %} {% set first_item =
-    tests|map(attribute='item')|first %}
+    {% for fspath, tests in tests|groupby('item.fspath') %}
+    <!--  -->
+    {% set first_item = tests|map(attribute='item')|first %}
     <details class="file">
       <summary>
         <h2 class="title file-title">
           {% block module_title scoped %}
           <span class="fspath">
-            {% block module_name scoped %} {{
-            first_item.nodeid.split('::')|first }} {% endblock %}
+            {% block module_name scoped %}
+            <!--  -->
+            {{ first_item.nodeid.split('::')|first }}
+            <!--  -->
+            {% endblock %}
           </span>
           <span class="counts">
             {% for category, tests in tests|groupby('status.category') -%}

--- a/maint_tools/templates/index.html
+++ b/maint_tools/templates/index.html
@@ -1,0 +1,149 @@
+{% extends "html1/base.html" %} {% set title = "Nilearn test report" %} {% block
+style %} {{ super() }} .warning-content { margin-bottom: 8px; } {% endblock %}
+{% block content %}
+<section id="summary">
+  <div class="container">
+    <h1>Summary</h1>
+    {% block summary %}
+    <div class="metadata">
+      <table>
+        {% block session_metadata %}
+        <tr>
+          <th>Started</th>
+          <td>{{ started|strftime(time_format) }}</td>
+        </tr>
+        <tr>
+          <th>Ended</th>
+          <td>
+            {% if ended %} {{ ended|strftime(time_format) }} {% else %}
+            <i>In progress...</i>
+            {% endif %}
+          </td>
+        </tr>
+        {% if ended %}
+        <tr>
+          <th>Duration</th>
+          {% set duration = ended - started %}
+          <td>{{ duration|timedelta }}</td>
+        </tr>
+        {% endif %}
+        <tr>
+          <th>Total run time</th>
+          <td>
+            {{ tests|map(attribute='phases')|map('sum',
+            'report.duration')|sum|timedelta }}
+          </td>
+        </tr>
+        {% for key, value in metadata.items() %}
+        <tr>
+          <th>{{ key }}</th>
+          <td>
+            {% if value is mapping %} {% for key, value in value.items() %} {{
+            key }}: {{ value }}<br />
+            {% endfor %} {% else %} {{ value|urlize }} {% endif %}
+          </td>
+        </tr>
+        {% endfor %} {% endblock %}
+      </table>
+    </div>
+    <div class="graph">
+      {% set tests_by_category = tests|groupby('status.category') %} {% set
+      nodes_run = tests|map(attribute='item.nodeid')|list %} {% set
+      nof_nodes_not_run = session.items|rejectattr('nodeid', 'in',
+      nodes_run)|list|count %}
+      <svg width="200" height="200" viewBox="0 0 42 42">
+        {% set ns = namespace(sum=0.0) %} {% set total = tests|count %} {% set r
+        = 16 %} {% set spacing = 0.4 %} {% set C = 2 * 3.141592653589793 * r %}
+        {% for category, sub_tests in tests_by_category %} {% set count =
+        sub_tests|count %} {% set L = count / (total + nof_nodes_not_run) * C %}
+        {% set color = colors[category] %}
+        <circle
+          class="donut-segment {{ category }}"
+          stroke-dasharray="{{ [L - spacing, 0]|max }} {{ C - (L - spacing) }}"
+          stroke-dashoffset="{{ C - ns.sum + C / 4 - spacing / 2 }}"
+          cx="21"
+          cy="21"
+          r="{{ r }}"
+          fill="transparent"
+          {%
+          if
+          color
+          %}
+          stroke="{{ color[0] }}"
+          {%
+          endif
+          %}
+          stroke-width="4"
+        ></circle>
+        {% set ns.sum = ns.sum + L %} {% endfor %}
+        <text x="21" y="24" text-anchor="middle">{{ total }}</text>
+      </svg>
+      <div class="legend">
+        {% for category, tests in tests_by_category %}
+        <span
+          class="status badge {{ category }} {{ tests|map(attribute='status.style')|first|join(' ') }}"
+        >
+          {{ tests|count }}
+        </span>
+        <span>{{ category }}</span>
+        {% endfor %} {% if nof_nodes_not_run %}
+        <span class="status badge notrun">{{ nof_nodes_not_run }}</span>
+        <span>not run</span>
+        {% endif %}
+      </div>
+    </div>
+    {% endblock %}
+  </div>
+</section>
+{% if warnings %}
+<section id="warnings">
+  <div class="container">
+    <h1>Warnings</h1>
+    <details class="file">
+      <summary><h2 class="title file-title">WARNINGS</h2></summary>
+      <div style="padding: 24x !important"><p></p></div>
+      {% for warning in warnings %}
+      <div class="status badge warning">WARNING</div>
+      <div class="warning-content">
+        {{ warning.filename }}:{{ warning.lineno }}<br />{{ warning.message }}
+      </div>
+      {% endfor %}
+    </details>
+  </div>
+</section>
+{% endif %}
+<section id="test-files">
+  <div class="container">
+    <h1>Tests</h1>
+    {% for fspath, tests in tests|groupby('item.fspath') %} {% set first_item =
+    tests|map(attribute='item')|first %}
+    <details class="file">
+      <summary>
+        <h2 class="title file-title">
+          {% block module_title scoped %}
+          <span class="fspath">
+            {% block module_name scoped %} {{
+            first_item.nodeid.split('::')|first }} {% endblock %}
+          </span>
+          <span class="counts">
+            {% for category, tests in tests|groupby('status.category') -%}
+            <span
+              title="{{ tests|count }} {{ category }}"
+              class="count status badge {{ category }} {{ tests|map(attribute='status.style')|first|join(' ') }}"
+              >{{ tests|count }}</span
+            >
+            {%- endfor %}
+          </span>
+          <span class="duration">
+            {{ tests|map(attribute='phases')|map('sum',
+            'report.duration')|sum|timedelta }}
+          </span>
+          {% endblock %}
+        </h2>
+      </summary>
+      <div class="content box">{% include "html1/module.html" %}</div>
+    </details>
+    {% endfor %}
+  </div>
+</section>
+{% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ test = [
     "coverage",
     "pytest>=6.0.0",
     "pytest-cov",
-    "pytest-reporter-html1"
+    "pytest-reporter-html1>=0.9.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ src_paths = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-ra --strict-config --strict-markers --doctest-modules --showlocals -s -vv --durations=0 --template=maint_tools/templates/index.html --report=report.html"
+addopts = "-ra --strict-config --strict-markers --doctest-modules --showlocals -s -vv --durations=0 --template=maint_tools/templates/index.html"
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
 junit_family = "xunit2"
 minversion = "6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,8 @@ style = [
 test = [
     "coverage",
     "pytest>=6.0.0",
-    "pytest-cov"
+    "pytest-cov",
+    "pytest-reporter-html1"
 ]
 
 [project.urls]
@@ -148,7 +149,7 @@ src_paths = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-ra --strict-config --strict-markers --doctest-modules --showlocals -s -vv --durations=0"
+addopts = "-ra --strict-config --strict-markers --doctest-modules --showlocals -s -vv --durations=0 --template=html1/index.html --report=report.html"
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
 junit_family = "xunit2"
 minversion = "6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ src_paths = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-ra --strict-config --strict-markers --doctest-modules --showlocals -s -vv --durations=0 --template=html1/index.html --report=report.html"
+addopts = "-ra --strict-config --strict-markers --doctest-modules --showlocals -s -vv --durations=0 --template=maint_tools/templates/index.html --report=report.html"
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
 junit_family = "xunit2"
 minversion = "6.0"

--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,7 @@ description = run tests on latest version of all dependencies (plotting not incl
 passenv = {[global_var]passenv}
 extras = test
 commands =
-    pytest --cov=nilearn --cov-report=xml {posargs:}
+    pytest --cov=nilearn --cov-report=xml --report=report.html {posargs:}
 
 [testenv:test_plotting]
 description = run tests on latest version of all dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -112,9 +112,9 @@ extras = test
 deps =
     {[plotting]deps}
 commands =
-	pytest doc/_additional_doctests.txt
+	pytest doc/_additional_doctests.txt --report=report_doc.html
     ; TODO find a way to rely on globbing instead of listing a specific folder
-	pytest --doctest-glob='*.rst' doc/manipulating_images/
+	pytest --doctest-glob='*.rst' doc/manipulating_images/  --report=report_doc.html
 
 [testenv:test_pre]
 description = run test_latest and test_doc on pre-release version of all dependencies


### PR DESCRIPTION
Closes none

Just trying to see if there are some pytest plugin we can use that help us navigate the gigantic output of the test suite.

Other options:

- https://github.com/Teemu/pytest-sugar
- https://github.com/nicoddemus/pytest-rich

See also options that build full HTML reports:
- https://pytest-html.readthedocs.io/en/latest/index.html
- https://github.com/christiansandberg/pytest-reporter-html1
- https://github.com/prashanth-sams/pytest-html-reporter