### PR TITLE
[FIX] Change default `ratio` value in glover to fit canonical Glover HRF (1999)

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -13,6 +13,8 @@ Fixes
 
 - :bdg-dark:`Code` Fix failing test in ``test_nilearn_standardize`` on MacOS 14 by adding trend in simulated data (:gh:`4411` by `Hao-Ting Wang`_).
 
+- :bdg-dark:`Code` Fix previous Glover HRF implementation to fit the original paper (Glover, 1999) (:gh:`4452` by `Kun CHEN`_).
+
 Enhancements
 ------------
 

--- a/nilearn/glm/first_level/hemodynamic_models.py
+++ b/nilearn/glm/first_level/hemodynamic_models.py
@@ -349,7 +349,7 @@ def glover_dispersion_derivative(
         time_length=time_length,
         onset=onset,
         undershoot=12.0,
-        ratio=0.35,
+        ratio=0.48,
         dispersion=0.9,
     )
 

--- a/nilearn/glm/first_level/hemodynamic_models.py
+++ b/nilearn/glm/first_level/hemodynamic_models.py
@@ -141,7 +141,7 @@ def glover_hrf(tr, oversampling=50, time_length=32.0, onset=0.0):
         undershoot=12.0,
         dispersion=0.9,
         u_dispersion=0.9,
-        ratio=0.35,
+        ratio=0.48,
     )
 
 

--- a/nilearn/glm/tests/test_dmtx.py
+++ b/nilearn/glm/tests/test_dmtx.py
@@ -436,7 +436,9 @@ def test_compare_design_matrix_to_spm(block_duration, array):
     # Check that the nilearn design matrix is close enough to the SPM one
     # (it cannot be identical, because the hrf shape is different)
     events, frame_times = spm_paradigm(block_duration=block_duration)
-    X1 = make_first_level_design_matrix(frame_times, events, drift_model=None)
+    X1 = make_first_level_design_matrix(
+        frame_times, events, drift_model=None, hrf_model="spm"
+    )
     _, matrix, _ = check_design_matrix(X1)
 
     spm_design_matrix = DESIGN_MATRIX[array]


### PR DESCRIPTION
- Closes #2981

Changes proposed in this pull request:
- Change the default `ratio` value to `0.48` in `glover_hrf` & `glover_dispersion_derivative` when calling `_gamma_difference_hrf` to fit the canonical Glover HRF (1999) curve.