### PR TITLE
[FIX] throw warning a masker `generate_report` is called without matplotlib

### DIFF
--- a/nilearn/experimental/surface/tests/test_maskers.py
+++ b/nilearn/experimental/surface/tests/test_maskers.py
@@ -95,7 +95,7 @@ def test_transform_inverse_transform_with_mask(
 
 
 @pytest.mark.skipif(
-    have_mpl, reason="Test requires matplotlib to be not installed."
+    have_mpl, reason="Test requires matplotlib not to be installed."
 )
 def test_masker_reporting_mpl_warning(mini_mask, mini_label_img):
     """Raise warning after exception if matplotlib is not installed."""

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -350,7 +350,17 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
 
     def generate_report(self):
         """Generate a report."""
-        from nilearn.reporting.html_report import generate_report
+        try:
+            from nilearn.reporting.html_report import generate_report
+        except ImportError:
+            with warnings.catch_warnings():
+                mpl_unavail_msg = (
+                    "Matplotlib is not imported! "
+                    "No reports will be generated."
+                )
+                warnings.filterwarnings("always", message=mpl_unavail_msg)
+                warnings.warn(category=ImportWarning, message=mpl_unavail_msg)
+                return [None]
 
         return generate_report(self)
 
@@ -363,18 +373,9 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
             A list of all displays to be rendered.
 
         """
-        try:
-            import matplotlib.pyplot as plt
+        import matplotlib.pyplot as plt
 
-            from nilearn import plotting
-        except ImportError:
-            with warnings.catch_warnings():
-                mpl_unavail_msg = (
-                    "Matplotlib is not imported! No reports will be generated."
-                )
-                warnings.filterwarnings("always", message=mpl_unavail_msg)
-                warnings.warn(category=ImportWarning, message=mpl_unavail_msg)
-                return [None]
+        from nilearn import plotting
 
         if self._reporting_data is not None:
             labels_image = self._reporting_data["labels_image"]

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -248,7 +248,17 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
         report : `nilearn.reporting.html_report.HTMLReport`
             HTML report for the masker.
         """
-        from nilearn.reporting.html_report import generate_report
+        try:
+            from nilearn.reporting.html_report import generate_report
+        except ImportError:
+            with warnings.catch_warnings():
+                mpl_unavail_msg = (
+                    "Matplotlib is not imported! "
+                    "No reports will be generated."
+                )
+                warnings.filterwarnings("always", message=mpl_unavail_msg)
+                warnings.warn(category=ImportWarning, message=mpl_unavail_msg)
+                return [None]
 
         incorrect_type = not isinstance(
             displayed_maps, (list, np.ndarray, int, str)

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -307,7 +307,17 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
 
     def generate_report(self):
         """Generate a report of the masker."""
-        from nilearn.reporting.html_report import generate_report
+        try:
+            from nilearn.reporting.html_report import generate_report
+        except ImportError:
+            with warnings.catch_warnings():
+                mpl_unavail_msg = (
+                    "Matplotlib is not imported! "
+                    "No reports will be generated."
+                )
+                warnings.filterwarnings("always", message=mpl_unavail_msg)
+                warnings.warn(category=ImportWarning, message=mpl_unavail_msg)
+                return [None]
 
         return generate_report(self)
 
@@ -320,23 +330,9 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
             A list of all displays to be rendered.
 
         """
-        try:
-            import matplotlib.pyplot as plt
+        import matplotlib.pyplot as plt
 
-            from nilearn import plotting
-
-        except ImportError:
-            with warnings.catch_warnings():
-                mpl_unavail_msg = (
-                    "Matplotlib is not imported! "
-                    "No reports will be generated."
-                )
-                warnings.filterwarnings("always", message=mpl_unavail_msg)
-                warnings.warn(
-                    category=ImportWarning,
-                    message=mpl_unavail_msg,
-                )
-                return [None]
+        from nilearn import plotting
 
         # Handle the edge case where this function is
         # called with a masker having report capabilities disabled

--- a/nilearn/maskers/tests/test_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_nifti_labels_masker.py
@@ -18,6 +18,7 @@ from nilearn._utils.data_gen import (
 )
 from nilearn._utils.exceptions import DimensionError
 from nilearn._utils.testing import write_imgs_to_path
+from nilearn.conftest import have_mpl
 from nilearn.image import get_data
 from nilearn.maskers import NiftiLabelsMasker, NiftiMasker
 
@@ -929,3 +930,25 @@ def test_3d_images(affine_eye, shape_3d_default, n_regions):
     epis = masker.fit_transform([epi_img1, epi_img2])
 
     assert epis.shape == (2, n_regions)
+
+
+@pytest.mark.skipif(
+    have_mpl, reason="Test requires matplotlib to be not installed."
+)
+def test_nifti_labels_masker_reporting_mpl_warning(
+    shape_3d_default, n_regions, length, affine_eye
+):
+    """Raise warning after exception if matplotlib is not installed."""
+    shape1 = (*shape_3d_default, length)
+    labels_img = generate_labeled_regions(
+        shape1[:3],
+        affine=affine_eye,
+        n_regions=n_regions,
+    )
+
+    with warnings.catch_warnings(record=True) as warning_list:
+        result = NiftiLabelsMasker(labels_img).generate_report()
+
+    assert len(warning_list) == 1
+    assert issubclass(warning_list[0].category, ImportWarning)
+    assert result == [None]

--- a/nilearn/maskers/tests/test_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_nifti_labels_masker.py
@@ -933,7 +933,7 @@ def test_3d_images(affine_eye, shape_3d_default, n_regions):
 
 
 @pytest.mark.skipif(
-    have_mpl, reason="Test requires matplotlib to be not installed."
+    have_mpl, reason="Test requires matplotlib not to be installed."
 )
 def test_nifti_labels_masker_reporting_mpl_warning(
     shape_3d_default, n_regions, length, affine_eye

--- a/nilearn/maskers/tests/test_nifti_maps_masker.py
+++ b/nilearn/maskers/tests/test_nifti_maps_masker.py
@@ -14,6 +14,7 @@ import pytest
 
 from nilearn._utils import data_gen, testing
 from nilearn._utils.exceptions import DimensionError
+from nilearn.conftest import have_mpl
 from nilearn.image import get_data
 from nilearn.maskers import NiftiMapsMasker
 
@@ -573,3 +574,24 @@ def test_3d_images():
     assert epis.shape == (1, 3)
     epis = masker.fit_transform([epi_img1, epi_img2])
     assert epis.shape == (2, 3)
+
+
+@pytest.mark.skipif(
+    have_mpl, reason="Test requires matplotlib to be not installed."
+)
+def test_nifti_maps_masker_reporting_mpl_warning():
+    """Raise warning after exception if matplotlib is not installed."""
+    n_regions = 9
+    length = 3
+    shape1 = (13, 11, 12, length)
+    affine1 = np.eye(4)
+    labels11_img, _ = data_gen.generate_maps(
+        shape1[:3], n_regions, affine=affine1
+    )
+
+    with warnings.catch_warnings(record=True) as warning_list:
+        result = NiftiMapsMasker(labels11_img).generate_report()
+
+    assert len(warning_list) == 1
+    assert issubclass(warning_list[0].category, ImportWarning)
+    assert result == [None]

--- a/nilearn/maskers/tests/test_nifti_maps_masker.py
+++ b/nilearn/maskers/tests/test_nifti_maps_masker.py
@@ -577,7 +577,7 @@ def test_3d_images():
 
 
 @pytest.mark.skipif(
-    have_mpl, reason="Test requires matplotlib to be not installed."
+    have_mpl, reason="Test requires matplotlib not to be installed."
 )
 def test_nifti_maps_masker_reporting_mpl_warning():
     """Raise warning after exception if matplotlib is not installed."""

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -18,6 +18,7 @@ from numpy.testing import assert_array_equal
 
 from nilearn._utils import data_gen, exceptions, testing
 from nilearn._utils.class_inspect import get_params
+from nilearn.conftest import have_mpl
 from nilearn.image import get_data, index_img
 from nilearn.maskers import NiftiMasker
 from nilearn.maskers.nifti_masker import _filter_and_mask
@@ -600,3 +601,16 @@ def test_nifti_masker_io_shapes(rng):
 
     with pytest.raises(TypeError):
         masker.inverse_transform(data_2d.T)
+
+
+@pytest.mark.skipif(
+    have_mpl, reason="Test requires matplotlib to be not installed."
+)
+def test_nifti_masker_reporting_mpl_warning():
+    """Raise warning after exception if matplotlib is not installed."""
+    with warnings.catch_warnings(record=True) as warning_list:
+        result = NiftiMasker().generate_report()
+
+    assert len(warning_list) == 1
+    assert issubclass(warning_list[0].category, ImportWarning)
+    assert result == [None]

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -604,7 +604,7 @@ def test_nifti_masker_io_shapes(rng):
 
 
 @pytest.mark.skipif(
-    have_mpl, reason="Test requires matplotlib to be not installed."
+    have_mpl, reason="Test requires matplotlib not to be installed."
 )
 def test_nifti_masker_reporting_mpl_warning():
     """Raise warning after exception if matplotlib is not installed."""

--- a/nilearn/maskers/tests/test_nifti_spheres_masker.py
+++ b/nilearn/maskers/tests/test_nifti_spheres_masker.py
@@ -395,7 +395,7 @@ def test_nifti_spheres_masker_io_shapes(rng, shape_3d_default, affine_eye):
 
 
 @pytest.mark.skipif(
-    have_mpl, reason="Test requires matplotlib to be not installed."
+    have_mpl, reason="Test requires matplotlib not to be installed."
 )
 def test_nifti_spheres_masker_reporting_mpl_warning():
     """Raise warning after exception if matplotlib is not installed."""


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4456

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:
- move where warning is actually thrown
- add tests for the behavior

based on #4432 so needs to be merged after it (requires some conftest refactoring)
