### PR TITLE
[FIX] use string as label names in example involving the new surface based destrieux atlas

### DIFF
--- a/examples/08_experimental/plot_3d_map_to_surface_projection_experimental.py
+++ b/examples/08_experimental/plot_3d_map_to_surface_projection_experimental.py
@@ -168,8 +168,8 @@ destrieux_atlas, label_names = fetch_destrieux(mesh_type="inflated")
 
 # these are the regions we want to outline
 regions_dict = {
-    b"G_postcentral": "Postcentral gyrus",
-    b"G_precentral": "Precentral gyrus",
+    "G_postcentral": "Postcentral gyrus",
+    "G_precentral": "Precentral gyrus",
 }
 
 # get indices in atlas for these labels

--- a/examples/08_experimental/plot_surf_stat_map_experimental.py
+++ b/examples/08_experimental/plot_surf_stat_map_experimental.py
@@ -92,7 +92,7 @@ print(f"Fsaverage5 sulcal curvature map: {fsaverage_curvature}")
 timeseries = nki_dataset[0].data.parts[hemi].T
 
 # Extract seed region via label
-pcc_region = b"G_cingul-Post-dorsal"
+pcc_region = "G_cingul-Post-dorsal"
 
 import numpy as np
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but should fix doc build failure in main

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- the exprimental [fetch_destrieux for surface data returns a list of strings](https://github.com/nilearn/nilearn/commit/59c236d74b56d18f0c0c534fa329666cfc7bfb98#r143380304) as label names and not a list of bytes as its volume counterpart: this PR fixes this

