### PR TITLE
[MAINT] rename `tr` variable - private occurences

### DIFF
--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -1961,7 +1961,7 @@ def fetch_development_fmri(
     """Fetch movie watching based brain development dataset (fMRI).
 
     The data is downsampled to 4mm resolution for convenience
-    with a repetition time (TR) of 2 secs.
+    with a repetition time (t_r) of 2 secs.
     The origin of the data is coming from OpenNeuro. See Notes below.
 
     Please cite :footcite:t:`Richardson2018`
@@ -2807,8 +2807,8 @@ def _make_events_file_spm_auditory_data(events_filepath):
     None
 
     """
-    tr = 7.0
-    epoch_duration = 6 * tr  # duration in seconds
+    t_r = 7.0
+    epoch_duration = 6 * t_r  # duration in seconds
     conditions = ["rest", "active"] * 8
     n_blocks = len(conditions)
     duration = epoch_duration * np.ones(n_blocks)
@@ -2993,7 +2993,7 @@ def _make_events_filepath_spm_multimodal_fmri(_subject_data, session):
 
 
 def _make_events_file_spm_multimodal_fmri(_subject_data, session):
-    tr = 2.0
+    t_r = 2.0
     timing = loadmat(
         _subject_data[f"trials_ses{int(session)}"],
         squeeze_me=True,
@@ -3002,7 +3002,7 @@ def _make_events_file_spm_multimodal_fmri(_subject_data, session):
     faces_onsets = timing["onsets"][0].ravel()
     scrambled_onsets = timing["onsets"][1].ravel()
     onsets = np.hstack((faces_onsets, scrambled_onsets))
-    onsets *= tr  # because onsets were reporting in 'scans' units
+    onsets *= t_r  # because onsets were reporting in 'scans' units
     conditions = ["faces"] * len(faces_onsets) + ["scrambled"] * len(
         scrambled_onsets
     )

--- a/nilearn/glm/first_level/hemodynamic_models.py
+++ b/nilearn/glm/first_level/hemodynamic_models.py
@@ -16,7 +16,7 @@ from nilearn._utils import fill_doc
 
 
 def _gamma_difference_hrf(
-    tr,
+    t_r,
     oversampling=50,
     time_length=32.0,
     onset=0.0,
@@ -30,7 +30,7 @@ def _gamma_difference_hrf(
 
     Parameters
     ----------
-    tr : float
+    t_r : float
         :term:`Repetition time<TR>`, in seconds (sampling period).
 
     oversampling : int, default=50
@@ -59,11 +59,11 @@ def _gamma_difference_hrf(
 
     Returns
     -------
-    hrf : array of shape(length / tr * oversampling, dtype=float)
+    hrf : array of shape(length / t_r * oversampling, dtype=float)
          hrf sampling on the oversampled time grid
 
     """
-    dt = tr / oversampling
+    dt = t_r / oversampling
     time_stamps = np.linspace(
         0, time_length, np.rint(float(time_length) / dt).astype(int)
     )
@@ -151,7 +151,7 @@ def _compute_derivative_from_values(values, values_plus_dt, dt=0.1):
 
 
 def _generic_time_derivative(
-    func, tr, oversampling=50, time_length=32.0, onset=0.0, dt=0.1
+    func, t_r, oversampling=50, time_length=32.0, onset=0.0, dt=0.1
 ):
     """Return the time derivative of an hrf for a given function.
 
@@ -160,7 +160,7 @@ def _generic_time_derivative(
     func : :obj:`function`
         spm_hrf or glover_hrf
 
-    tr : float
+    t_r : float
         :term:`Repetition time<TR>`, in seconds (sampling period).
 
     oversampling : int, default=50
@@ -176,8 +176,8 @@ def _generic_time_derivative(
         Time step for the derivative.
     """
     return _compute_derivative_from_values(
-        func(tr, oversampling, time_length, onset),
-        func(tr, oversampling, time_length, onset + dt),
+        func(t_r, oversampling, time_length, onset),
+        func(t_r, oversampling, time_length, onset + dt),
         dt=dt,
     )
 
@@ -207,7 +207,7 @@ def spm_time_derivative(tr, oversampling=50, time_length=32.0, onset=0.0):
     """
     return _generic_time_derivative(
         spm_hrf,
-        tr=tr,
+        t_r=tr,
         oversampling=oversampling,
         time_length=time_length,
         onset=onset,
@@ -239,7 +239,7 @@ def glover_time_derivative(tr, oversampling=50, time_length=32.0, onset=0.0):
     """
     return _generic_time_derivative(
         glover_hrf,
-        tr=tr,
+        t_r=tr,
         oversampling=oversampling,
         time_length=time_length,
         onset=onset,
@@ -247,7 +247,7 @@ def glover_time_derivative(tr, oversampling=50, time_length=32.0, onset=0.0):
 
 
 def _generic_dispersion_derivative(
-    tr,
+    t_r,
     oversampling=50,
     time_length=32.0,
     onset=0.0,
@@ -267,7 +267,7 @@ def _generic_dispersion_derivative(
     """
     return _compute_derivative_from_values(
         _gamma_difference_hrf(
-            tr,
+            t_r,
             oversampling,
             time_length,
             onset,
@@ -276,7 +276,7 @@ def _generic_dispersion_derivative(
             dispersion=dispersion,
         ),
         _gamma_difference_hrf(
-            tr,
+            t_r,
             oversampling,
             time_length,
             onset,
@@ -558,7 +558,7 @@ def _regressor_names(con_name, hrf_model, fir_delays=None):
     return names
 
 
-def _hrf_kernel(hrf_model, tr, oversampling=50, fir_delays=None):
+def _hrf_kernel(hrf_model, t_r, oversampling=50, fir_delays=None):
     """Return the list of matching kernels \
     given the specification of the hemodynamic model and time parameters.
 
@@ -567,7 +567,7 @@ def _hrf_kernel(hrf_model, tr, oversampling=50, fir_delays=None):
     hrf_model : string, function, list of functions, or None,
         HRF model to be used.
 
-    tr : float
+    t_r : float
         the repetition time in seconds
 
     oversampling : int, default=50
@@ -597,30 +597,30 @@ def _hrf_kernel(hrf_model, tr, oversampling=50, fir_delays=None):
         "Please refer to the related documentation."
     )
     if hrf_model == "spm":
-        hkernel = [spm_hrf(tr, oversampling)]
+        hkernel = [spm_hrf(t_r, oversampling)]
     elif hrf_model == "spm + derivative":
         hkernel = [
-            spm_hrf(tr, oversampling),
-            spm_time_derivative(tr, oversampling),
+            spm_hrf(t_r, oversampling),
+            spm_time_derivative(t_r, oversampling),
         ]
     elif hrf_model == "spm + derivative + dispersion":
         hkernel = [
-            spm_hrf(tr, oversampling),
-            spm_time_derivative(tr, oversampling),
-            spm_dispersion_derivative(tr, oversampling),
+            spm_hrf(t_r, oversampling),
+            spm_time_derivative(t_r, oversampling),
+            spm_dispersion_derivative(t_r, oversampling),
         ]
     elif hrf_model == "glover":
-        hkernel = [glover_hrf(tr, oversampling)]
+        hkernel = [glover_hrf(t_r, oversampling)]
     elif hrf_model == "glover + derivative":
         hkernel = [
-            glover_hrf(tr, oversampling),
-            glover_time_derivative(tr, oversampling),
+            glover_hrf(t_r, oversampling),
+            glover_time_derivative(t_r, oversampling),
         ]
     elif hrf_model == "glover + derivative + dispersion":
         hkernel = [
-            glover_hrf(tr, oversampling),
-            glover_time_derivative(tr, oversampling),
-            glover_dispersion_derivative(tr, oversampling),
+            glover_hrf(t_r, oversampling),
+            glover_time_derivative(t_r, oversampling),
+            glover_dispersion_derivative(t_r, oversampling),
         ]
     elif hrf_model == "fir":
         hkernel = [
@@ -634,14 +634,14 @@ def _hrf_kernel(hrf_model, tr, oversampling=50, fir_delays=None):
         ]
     elif callable(hrf_model):
         try:
-            hkernel = [hrf_model(tr, oversampling)]
+            hkernel = [hrf_model(t_r, oversampling)]
         except TypeError:
             raise ValueError(error_msg)
     elif isinstance(hrf_model, Iterable) and all(
         callable(_) for _ in hrf_model
     ):
         try:
-            hkernel = [model(tr, oversampling) for model in hrf_model]
+            hkernel = [model(t_r, oversampling) for model in hrf_model]
         except TypeError:
             raise ValueError(error_msg)
     elif hrf_model is None:
@@ -703,15 +703,15 @@ def compute_regressor(
         fir_delays = [int(x) for x in fir_delays]
     oversampling = int(oversampling)
 
-    # this is the minimal tr in this run, not necessarily the true tr
-    tr = _calculate_tr(frame_times)
+    # this is the minimal t_r in this run, not necessarily the true t_r
+    t_r = _calculate_tr(frame_times)
     # 1. create the high temporal resolution regressor
     hr_regressor, frame_times_high_res = _sample_condition(
         exp_condition, frame_times, oversampling, min_onset
     )
 
     # 2. create the  hrf model(s)
-    hkernel = _hrf_kernel(hrf_model, tr, oversampling, fir_delays)
+    hkernel = _hrf_kernel(hrf_model, t_r, oversampling, fir_delays)
 
     # 3. convolve the regressor and hrf, and downsample the regressor
     conv_reg = np.array(

--- a/nilearn/glm/tests/test_dmtx.py
+++ b/nilearn/glm/tests/test_dmtx.py
@@ -77,8 +77,8 @@ def n_frames():
 
 @pytest.fixture
 def frame_times(n_frames):
-    tr = 1.0
-    return np.linspace(0, (n_frames - 1) * tr, n_frames)
+    t_r = 1.0
+    return np.linspace(0, (n_frames - 1) * t_r, n_frames)
 
 
 def test_cosine_drift():
@@ -279,8 +279,8 @@ def test_design_matrix_FIR_column_1_3_and_11(frame_times):
 def test_design_matrix_FIR_time_shift(frame_times):
     # Check that the first column of FIR design matrix is OK after a 1/2
     # time shift
-    tr = 1.0
-    frame_times = frame_times + tr / 2
+    t_r = 1.0
+    frame_times = frame_times + t_r / 2
     events = basic_paradigm()
     hrf_model = "FIR"
     X, _ = design_matrix_light(
@@ -402,8 +402,8 @@ def test_oversampling(n_frames):
 
 def test_high_pass(n_frames):
     """Test that high-pass values lead to reasonable design matrices."""
-    tr = 2.0
-    frame_times = np.arange(0, tr * n_frames, tr)
+    t_r = 2.0
+    frame_times = np.arange(0, t_r * n_frames, t_r)
     X = make_first_level_design_matrix(
         frame_times, drift_model="Cosine", high_pass=1.0
     )

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -641,7 +641,7 @@ def test_fmri_inputs_errors(tmp_path):
             ):
                 FirstLevelModel(mask_img=None).fit(fi)
 
-            # If paradigms are given then both tr and slice time ref were
+            # If paradigms are given then both t_r and slice time ref were
             # required
             match = (
                 "t_r not given to FirstLevelModel object "
@@ -1232,7 +1232,7 @@ def test_first_level_predictions_r_square():
         "spm",
         "spm + derivative",
         "glover",
-        lambda tr, ov: np.ones(int(tr * ov)),
+        lambda t_r, ov: np.ones(int(t_r * ov)),
     ],
 )
 @pytest.mark.parametrize("spaces", [False, True])

--- a/nilearn/glm/tests/test_hemodynamic_models.py
+++ b/nilearn/glm/tests/test_hemodynamic_models.py
@@ -50,18 +50,18 @@ def expected_integral(hrf_model):
 
 
 @pytest.fixture
-def expected_length(tr):
-    return int(32 / tr * 50)
+def expected_length(t_r):
+    return int(32 / t_r * 50)
 
 
 @pytest.mark.parametrize("hrf_model", HRF_MODELS)
-@pytest.mark.parametrize("tr", [2, 3])
+@pytest.mark.parametrize("t_r", [2, 3])
 def test_hrf_norm_and_length(
-    hrf_model, tr, expected_integral, expected_length
+    hrf_model, t_r, expected_integral, expected_length
 ):
     """Test that the hrf models are correctly normalized and \
     have correct lengths."""
-    h = hrf_model(tr)
+    h = hrf_model(t_r)
 
     assert_almost_equal(h.sum(), expected_integral)
     assert len(h) == expected_length
@@ -255,8 +255,8 @@ def test_names():
         f"{name}_1",
     ]
 
-    def custom_rf(tr, ov):
-        return np.ones(int(tr * ov))
+    def custom_rf(t_r, ov):
+        return np.ones(int(t_r * ov))
 
     assert _regressor_names(name, custom_rf) == [
         f"{name}_{custom_rf.__name__}"
@@ -271,8 +271,8 @@ def test_names():
         _regressor_names(
             name,
             [
-                lambda tr, ov: np.ones(int(tr * ov)),
-                lambda tr, ov: np.ones(int(tr * ov)),
+                lambda t_r, ov: np.ones(int(t_r * ov)),
+                lambda t_r, ov: np.ones(int(t_r * ov)),
             ],
         )
 
@@ -291,70 +291,70 @@ def test_names():
 )
 def test_hkernel_length(hrf_model, expected_len):
     """Test the hrf computation."""
-    tr = 2.0
-    assert len(_hrf_kernel(hrf_model, tr)) == expected_len
+    t_r = 2.0
+    assert len(_hrf_kernel(hrf_model, t_r)) == expected_len
 
 
 def test_hkernel_length_fir_lambda():
     """Test the hrf computation."""
-    tr = 2.0
+    t_r = 2.0
 
-    h = _hrf_kernel("fir", tr, fir_delays=np.arange(4))
+    h = _hrf_kernel("fir", t_r, fir_delays=np.arange(4))
     assert len(h) == 4
 
-    h = _hrf_kernel(lambda tr, ov: np.ones(int(tr * ov)), tr)
+    h = _hrf_kernel(lambda t_r, ov: np.ones(int(t_r * ov)), t_r)
     assert len(h) == 1
 
-    h = _hrf_kernel([lambda tr, ov: np.ones(int(tr * ov))], tr)
+    h = _hrf_kernel([lambda t_r, ov: np.ones(int(t_r * ov))], t_r)
     assert len(h) == 1
 
 
 def test_hkernel():
     """Test the hrf computation."""
-    tr = 2.0
+    t_r = 2.0
 
-    h = _hrf_kernel("spm", tr)
-    assert_almost_equal(h[0], spm_hrf(tr))
+    h = _hrf_kernel("spm", t_r)
+    assert_almost_equal(h[0], spm_hrf(t_r))
 
-    h = _hrf_kernel("spm + derivative", tr)
-    assert_almost_equal(h[1], spm_time_derivative(tr))
+    h = _hrf_kernel("spm + derivative", t_r)
+    assert_almost_equal(h[1], spm_time_derivative(t_r))
 
-    h = _hrf_kernel("spm + derivative + dispersion", tr)
-    assert_almost_equal(h[2], spm_dispersion_derivative(tr))
+    h = _hrf_kernel("spm + derivative + dispersion", t_r)
+    assert_almost_equal(h[2], spm_dispersion_derivative(t_r))
 
-    h = _hrf_kernel("glover", tr)
-    assert_almost_equal(h[0], glover_hrf(tr))
+    h = _hrf_kernel("glover", t_r)
+    assert_almost_equal(h[0], glover_hrf(t_r))
 
-    h = _hrf_kernel("glover + derivative", tr)
-    assert_almost_equal(h[1], glover_time_derivative(tr))
-    assert_almost_equal(h[0], glover_hrf(tr))
+    h = _hrf_kernel("glover + derivative", t_r)
+    assert_almost_equal(h[1], glover_time_derivative(t_r))
+    assert_almost_equal(h[0], glover_hrf(t_r))
 
-    h = _hrf_kernel("glover + derivative + dispersion", tr)
-    assert_almost_equal(h[2], glover_dispersion_derivative(tr))
-    assert_almost_equal(h[1], glover_time_derivative(tr))
-    assert_almost_equal(h[0], glover_hrf(tr))
+    h = _hrf_kernel("glover + derivative + dispersion", t_r)
+    assert_almost_equal(h[2], glover_dispersion_derivative(t_r))
+    assert_almost_equal(h[1], glover_time_derivative(t_r))
+    assert_almost_equal(h[0], glover_hrf(t_r))
 
-    h = _hrf_kernel("fir", tr, fir_delays=np.arange(4))
+    h = _hrf_kernel("fir", t_r, fir_delays=np.arange(4))
     for dh in h:
         assert_almost_equal(dh.sum(), 1.0)
 
-    h = _hrf_kernel(None, tr)
+    h = _hrf_kernel(None, t_r)
     assert_almost_equal(h[0], np.hstack((1, np.zeros(49))))
 
     with pytest.raises(
         ValueError, match="Could not process custom HRF model provided."
     ):
-        _hrf_kernel(lambda x: np.ones(int(x)), tr)
-        _hrf_kernel([lambda x, y, z: x + y + z], tr)
-        _hrf_kernel([lambda x: np.ones(int(x))] * 2, tr)
+        _hrf_kernel(lambda x: np.ones(int(x)), t_r)
+        _hrf_kernel([lambda x, y, z: x + y + z], t_r)
+        _hrf_kernel([lambda x: np.ones(int(x))] * 2, t_r)
 
-    h = _hrf_kernel(lambda tr, ov: np.ones(int(tr * ov)), tr)
+    h = _hrf_kernel(lambda t_r, ov: np.ones(int(t_r * ov)), t_r)
     assert_almost_equal(h[0], np.ones(100))
 
-    h = _hrf_kernel([lambda tr, ov: np.ones(int(tr * ov))], tr)
+    h = _hrf_kernel([lambda t_r, ov: np.ones(int(t_r * ov))], t_r)
     assert_almost_equal(h[0], np.ones(100))
     with pytest.raises(ValueError, match="is not a known hrf model."):
-        _hrf_kernel("foo", tr)
+        _hrf_kernel("foo", t_r)
 
 
 def test_make_regressor_1():

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -898,7 +898,7 @@ def test_clean_psc(rng):
             detrend=False,
             filter="butterworth",
             high_pass=0.01,
-            tr=2,
+            t_r=2,
             standardize="psc",
         )
         np.testing.assert_almost_equal(butterworth_signals.mean(0), 0)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but relates to https://github.com/nilearn/nilearn/issues/4466#issuecomment-2184903945

Context: aims to have the same variable name in the codebase to avoid issues like the one mentioned in the comment above.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- this "only" rename `tr` into `t_r` in tests and private functions. I will tackle the occurences in public function in another PR as it will involve some deprecation.

