### PR TITLE
[ENH] use nilearn `logger.log` function instead of `print` or `sys.stderr.write`

### DIFF
--- a/nilearn/_utils/class_inspect.py
+++ b/nilearn/_utils/class_inspect.py
@@ -1,11 +1,5 @@
 """Small utilities to inspect classes."""
 
-import inspect
-
-from sklearn.base import BaseEstimator
-
-from .exceptions import AuthorizedException
-
 
 def get_params(cls, instance, ignore=None):
     """Retrieve the initialization parameters corresponding to a class.
@@ -46,44 +40,3 @@ def get_params(cls, instance, ignore=None):
             params[param_name] = getattr(instance, param_name)
 
     return params
-
-
-def enclosing_scope_name(ensure_estimator=True, stack_level=2):
-    """Find the name of the enclosing scope for debug output purpose.
-
-    Use inspection to climb up the stack until the calling object. This is
-    typically used to get the estimator at the origin of a functional call
-    for debug print purpose.
-
-    Parameters
-    ----------
-    ensure_estimator : boolean, default=True
-        If true, find the enclosing object deriving from 'BaseEstimator'.
-
-    stack_level : integer, default=2
-        If ensure_estimator is not True, stack_level quantifies the
-        number of frame we will go up.
-
-    """
-    try:
-        frame = inspect.currentframe()
-        if not ensure_estimator:
-            for _ in range(stack_level):
-                frame = frame.f_back
-        else:
-            while True:
-                frame = frame.f_back
-                if "self" not in frame.f_locals:
-                    continue
-                if not isinstance(frame.f_locals["self"], BaseEstimator):
-                    continue
-                break
-        if "self" in frame.f_locals:
-            caller_name = frame.f_locals["self"].__class__.__name__
-            caller_name = f"{caller_name}.{frame.f_code.co_name}"
-        else:
-            caller_name = frame.f_code.co_name
-
-        return caller_name
-    except AuthorizedException:
-        return "Unknown"

--- a/nilearn/_utils/extmath.py
+++ b/nilearn/_utils/extmath.py
@@ -70,7 +70,9 @@ def is_spd(M, decimal=15, verbose=1):
     eigvalsh = np.linalg.eigvalsh(M)
     ispd = eigvalsh.min() > 0
 
-    if not ispd and verbose > 0:
-        logger.log(f"matrix has a negative eigenvalue: {eigvalsh.min():.3f}")
+    if not ispd:
+        logger.log(
+            f"matrix has a negative eigenvalue: {eigvalsh.min():.3f}", verbose
+        )
 
     return ispd

--- a/nilearn/_utils/extmath.py
+++ b/nilearn/_utils/extmath.py
@@ -4,6 +4,8 @@
 
 import numpy as np
 
+from nilearn._utils import logger
+
 
 def fast_abs_percentile(data, percentile=80):
     """Implement a fast version of the percentile of the absolute value.
@@ -62,11 +64,13 @@ def is_spd(M, decimal=15, verbose=1):
 
     """
     if not np.allclose(M, M.T, atol=0, rtol=10**-decimal):
-        if verbose > 0:
-            print(f"matrix not symmetric to {decimal:d} decimals")
+        logger.log(f"matrix not symmetric to {decimal:d} decimals", verbose)
         return False
+
     eigvalsh = np.linalg.eigvalsh(M)
     ispd = eigvalsh.min() > 0
+
     if not ispd and verbose > 0:
-        print(f"matrix has a negative eigenvalue: {eigvalsh.min():.3f}")
+        logger.log(f"matrix has a negative eigenvalue: {eigvalsh.min():.3f}")
+
     return ispd

--- a/nilearn/_utils/logger.py
+++ b/nilearn/_utils/logger.py
@@ -3,6 +3,7 @@
 # Author: Philippe Gervais
 
 import inspect
+import traceback
 
 from sklearn.base import BaseEstimator
 
@@ -10,7 +11,12 @@ from sklearn.base import BaseEstimator
 # The technique used in the log() function only applies to CPython, because
 # it uses the inspect module to walk the call stack.
 def log(
-    msg, verbose=1, object_classes=(BaseEstimator,), stack_level=1, msg_level=1
+    msg,
+    verbose=1,
+    object_classes=(BaseEstimator,),
+    stack_level=1,
+    msg_level=1,
+    with_traceback=False,
 ):
     """Display a message to the user, depending on the verbosity level.
 
@@ -73,6 +79,9 @@ def log(
             func_name = f"{object_self.__class__.__name__}.{func_name}"
 
         print(f"[{func_name}] {msg}")
+
+        if with_traceback:
+            traceback.print_exc()
 
 
 def compose_err_msg(msg, **kwargs):

--- a/nilearn/_utils/param_validation.py
+++ b/nilearn/_utils/param_validation.py
@@ -155,21 +155,21 @@ def adjust_screening_percentile(screening_percentile, mask_img, verbose=0):
 
     logger.log(
         f"Mask volume = {mask_volume:g}mm^3 = {mask_volume / 1000.0:g}cm^3",
-        versbose=verbose,
+        verbose=verbose,
     )
     logger.log(
         "Standard brain volume "
         f"= {MNI152_BRAIN_VOLUME:g}mm^3 "
         f"= {MNI152_BRAIN_VOLUME / 1.0e3:g}cm^3",
-        versbose=verbose,
+        verbose=verbose,
     )
     logger.log(
         f"Original screening-percentile: {original_screening_percentile:g}",
-        versbose=verbose,
+        verbose=verbose,
     )
     logger.log(
         f"Volume-corrected screening-percentile: {screening_percentile:g}",
-        versbose=verbose,
+        verbose=verbose,
     )
     return screening_percentile
 

--- a/nilearn/_utils/param_validation.py
+++ b/nilearn/_utils/param_validation.py
@@ -156,20 +156,24 @@ def adjust_screening_percentile(screening_percentile, mask_img, verbose=0):
     logger.log(
         f"Mask volume = {mask_volume:g}mm^3 = {mask_volume / 1000.0:g}cm^3",
         verbose=verbose,
+        msg_level=1,
     )
     logger.log(
         "Standard brain volume "
         f"= {MNI152_BRAIN_VOLUME:g}mm^3 "
         f"= {MNI152_BRAIN_VOLUME / 1.0e3:g}cm^3",
         verbose=verbose,
+        msg_level=1,
     )
     logger.log(
         f"Original screening-percentile: {original_screening_percentile:g}",
         verbose=verbose,
+        msg_level=1,
     )
     logger.log(
         f"Volume-corrected screening-percentile: {screening_percentile:g}",
         verbose=verbose,
+        msg_level=1,
     )
     return screening_percentile
 

--- a/nilearn/_utils/param_validation.py
+++ b/nilearn/_utils/param_validation.py
@@ -6,6 +6,8 @@ import warnings
 import numpy as np
 from sklearn.feature_selection import SelectPercentile, f_classif, f_regression
 
+from nilearn._utils import logger
+
 from .niimg import _get_data
 
 # Volume of a standard (MNI152) brain mask in mm^3
@@ -151,21 +153,24 @@ def adjust_screening_percentile(screening_percentile, mask_img, verbose=0):
         screening_percentile = min(screening_percentile, 100.0)
     # if screening_percentile is 100, we don't do anything
 
-    if verbose > 1:
-        print(
-            f"Mask volume = {mask_volume:g}mm^3 = {mask_volume / 1000.0:g}cm^3"
-        )
-        print(
-            "Standard brain volume "
-            f"= {MNI152_BRAIN_VOLUME:g}mm^3 "
-            f"= {MNI152_BRAIN_VOLUME / 1.0e3:g}cm^3"
-        )
-        print(
-            f"Original screening-percentile: {original_screening_percentile:g}"
-        )
-        print(
-            f"Volume-corrected screening-percentile: {screening_percentile:g}"
-        )
+    logger.log(
+        f"Mask volume = {mask_volume:g}mm^3 = {mask_volume / 1000.0:g}cm^3",
+        versbose=verbose,
+    )
+    logger.log(
+        "Standard brain volume "
+        f"= {MNI152_BRAIN_VOLUME:g}mm^3 "
+        f"= {MNI152_BRAIN_VOLUME / 1.0e3:g}cm^3",
+        versbose=verbose,
+    )
+    logger.log(
+        f"Original screening-percentile: {original_screening_percentile:g}",
+        versbose=verbose,
+    )
+    logger.log(
+        f"Volume-corrected screening-percentile: {screening_percentile:g}",
+        versbose=verbose,
+    )
     return screening_percentile
 
 

--- a/nilearn/_utils/tests/test_cache_mixin.py
+++ b/nilearn/_utils/tests/test_cache_mixin.py
@@ -30,12 +30,12 @@ def test_check_memory(tmp_path):
     mem_temp = Memory(location=str(tmp_path))
 
     for mem in [None, mem_none]:
-        memory = cache_mixin._check_memory(mem, verbose=False)
+        memory = cache_mixin._check_memory(mem, verbose=0)
         assert memory, Memory
         assert memory.location == mem_none.location
 
     for mem in [str(tmp_path), mem_temp]:
-        memory = cache_mixin._check_memory(mem, verbose=False)
+        memory = cache_mixin._check_memory(mem, verbose=0)
         assert memory.location == mem_temp.location
         assert memory, Memory
 

--- a/nilearn/_utils/tests/test_class_inspect.py
+++ b/nilearn/_utils/tests/test_class_inspect.py
@@ -24,21 +24,6 @@ class B(A):
         self.a = a
         self.b = b
 
-    def get_scope_name(self, stack=0, *args, **kwargs):
-        c = C()
-        return c.get_scope_name(stack=stack, *args, **kwargs)
-
-
-class C:
-    def get_scope_name(self, *args, **kwargs):
-        return get_scope_name(*args, **kwargs)
-
-
-def get_scope_name(stack=0, *args, **kwargs):
-    if stack == 0:
-        return class_inspect.enclosing_scope_name(*args, **kwargs)
-    return get_scope_name(stack - 1, *args, **kwargs)
-
 
 ##############################################################################
 # The tests themselves
@@ -50,17 +35,3 @@ def test_get_params():
     assert params_a_in_b == dict(a=1)
     params_a_in_b = class_inspect.get_params(A, b, ignore=["a"])
     assert params_a_in_b == {}
-
-
-def test_enclosing_scope_name():
-    b = B()
-    name = b.get_scope_name()
-    assert name == "B.get_scope_name"
-    name = b.get_scope_name(stack=3)
-    assert name == "B.get_scope_name"
-    name = b.get_scope_name(ensure_estimator=False)
-    assert name == "C.get_scope_name"
-    name = b.get_scope_name(stack=3, ensure_estimator=False)
-    assert name == "get_scope_name"
-    name = b.get_scope_name(ensure_estimator=False, stack_level=120)
-    assert name == "Unknown"

--- a/nilearn/connectome/group_sparse_cov.py
+++ b/nilearn/connectome/group_sparse_cov.py
@@ -327,6 +327,7 @@ def _group_sparse_covariance(
                 f"* iteration {n:d} "
                 f"({100.0 * n / max_iter:.0f} %){suffix} ...",
                 verbose=verbose,
+                stack_level=2,
             )
 
         omega_old[...] = omega
@@ -473,6 +474,7 @@ def _group_sparse_covariance(
                     "probe_function interrupted loop",
                     verbose=verbose,
                     msg_level=2,
+                    stack_level=2,
                 )
                 break
 
@@ -486,6 +488,7 @@ def _group_sparse_covariance(
                 f"tolerance reached at iteration number {n + 1:d}: "
                 f"{max_norm:.3e}",
                 verbose=verbose,
+                stack_level=2,
             )
             tolerance_reached = True
             break

--- a/nilearn/datasets/_utils.py
+++ b/nilearn/datasets/_utils.py
@@ -159,10 +159,12 @@ def _chunk_read_(
             total_size = response.headers.get("Content-Length").strip()
         total_size = int(total_size) + initial_size
     except Exception as e:
-        if verbose > 2:
-            print("Warning: total size could not be determined.")
-            if verbose > 3:
-                print(f"Full stack trace: {e}")
+        logger.log(
+            "Warning: total size could not be determined.",
+            verbose=verbose,
+            msg_level=2,
+        )
+        logger.log(f"Full stack trace: {e}", verbose=verbose, msg_level=3)
         total_size = None
     bytes_so_far = initial_size
 
@@ -228,8 +230,7 @@ def get_dataset_dir(
 
     paths.extend([(d, False) for d in get_data_dirs(data_dir=data_dir)])
 
-    if verbose > 2:
-        print(f"Dataset search paths: {paths}")
+    logger.log(f"Dataset search paths: {paths}", verbose=verbose, msg_level=2)
 
     # Check if the dataset exists somewhere
     for path, is_pre_dir in paths:
@@ -239,8 +240,9 @@ def get_dataset_dir(
             # Resolve path
             path = readlinkabs(path)
         if os.path.exists(path) and os.path.isdir(path):
-            if verbose > 1:
-                print(f"\nDataset found in {path}\n")
+            logger.log(
+                f"\nDataset found in {path}\n", verbose=verbose, msg_level=1
+            )
             return path
 
     # If not, create a folder in the first writeable directory
@@ -255,8 +257,9 @@ def get_dataset_dir(
                     data_dir=data_dir,
                     verbose=verbose,
                 )
-                if verbose > 0:
-                    print(f"\nDataset created in {path}\n")
+
+                logger.log(f"\nDataset created in {path}\n", verbose)
+
                 return path
             except Exception as exc:
                 short_error_message = getattr(exc, "strerror", str(exc))
@@ -281,8 +284,8 @@ and atlases downloaded from the internet.
 It can be safely deleted.
 If you delete it, previously downloaded data will be downloaded again."""
                 )
-            if verbose > 0:
-                print(f"\nAdded README.md to {d}\n")
+
+            logger.log(f"\nAdded README.md to {d}\n", verbose)
 
 
 # The functions _is_within_directory and _safe_extract were implemented in
@@ -575,9 +578,10 @@ def fetch_single_file(
                     "Request has been blocked for security reasons."
                 )
             auth = (username, password)
-        if verbose > 0:
-            displayed_url = url.split("?")[0] if verbose == 1 else url
-            print(f"Downloading data from {displayed_url} ...")
+
+        displayed_url = url.split("?")[0] if verbose == 1 else url
+        logger.log(f"Downloading data from {displayed_url} ...", verbose)
+
         if resume and os.path.exists(temp_full_name):
             # Download has been interrupted, we try to resume it.
             local_file_size = os.path.getsize(temp_full_name)
@@ -607,8 +611,9 @@ def fetch_single_file(
                             verbose=verbose,
                         )
             except Exception:
-                if verbose > 0:
-                    print("Resuming failed, try to download the whole file.")
+                logger.log(
+                    "Resuming failed, try to download the whole file.", verbose
+                )
                 return fetch_single_file(
                     url,
                     data_dir,

--- a/nilearn/datasets/_utils.py
+++ b/nilearn/datasets/_utils.py
@@ -90,7 +90,9 @@ def _chunk_report_(bytes_so_far, total_size, initial_size, t0):
 
     """
     if not total_size:
-        logger.log(f"\rDownloaded {int(bytes_so_far)} of ? bytes.")
+        logger.log(
+            f"\rDownloaded {int(bytes_so_far)} of ? bytes.", stack_level=2
+        )
 
     else:
         # Estimate remaining download time
@@ -111,7 +113,8 @@ def _chunk_report_(bytes_so_far, total_size, initial_size, t0):
                 total_size,
                 total_percent * 100,
                 _format_time(time_remaining),
-            )
+            ),
+            stack_level=2,
         )
 
 
@@ -163,8 +166,14 @@ def _chunk_read_(
             "Warning: total size could not be determined.",
             verbose=verbose,
             msg_level=2,
+            stack_level=2,
         )
-        logger.log(f"Full stack trace: {e}", verbose=verbose, msg_level=3)
+        logger.log(
+            f"Full stack trace: {e}",
+            verbose=verbose,
+            msg_level=3,
+            stack_level=2,
+        )
         total_size = None
     bytes_so_far = initial_size
 
@@ -285,7 +294,9 @@ It can be safely deleted.
 If you delete it, previously downloaded data will be downloaded again."""
                 )
 
-            logger.log(f"\nAdded README.md to {d}\n", verbose)
+            logger.log(
+                f"\nAdded README.md to {d}\n", verbose=verbose, stack_level=2
+            )
 
 
 # The functions _is_within_directory and _safe_extract were implemented in

--- a/nilearn/datasets/_utils.py
+++ b/nilearn/datasets/_utils.py
@@ -250,7 +250,7 @@ def get_dataset_dir(
             path = readlinkabs(path)
         if os.path.exists(path) and os.path.isdir(path):
             logger.log(
-                f"\nDataset found in {path}\n", verbose=verbose, msg_level=1
+                f"Dataset found in {path}", verbose=verbose, msg_level=1
             )
             return path
 
@@ -267,7 +267,7 @@ def get_dataset_dir(
                     verbose=verbose,
                 )
 
-                logger.log(f"\nDataset created in {path}\n", verbose)
+                logger.log(f"Dataset created in {path}", verbose)
 
                 return path
             except Exception as exc:
@@ -295,7 +295,7 @@ If you delete it, previously downloaded data will be downloaded again."""
                 )
 
             logger.log(
-                f"\nAdded README.md to {d}\n", verbose=verbose, stack_level=2
+                f"Added README.md to {d}", verbose=verbose, stack_level=2
             )
 
 

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1854,12 +1854,14 @@ def _separate_talairach_levels(atlas_img, labels, output_dir, verbose):
 
     """
     logger.log(
-        f"Separating talairach atlas levels: {_TALAIRACH_LEVELS}", verbose
+        f"Separating talairach atlas levels: {_TALAIRACH_LEVELS}",
+        verbose=verbose,
+        stack_level=2,
     )
     for level_name, old_level_labels in zip(
         _TALAIRACH_LEVELS, np.asarray(labels).T
     ):
-        logger.log(level_name, verbose)
+        logger.log(level_name, verbose=verbose, stack_level=2)
         # level with most regions, ba, has 72 regions
         level_data = np.zeros(atlas_img.shape, dtype="uint8")
         level_labels = {"*": 0}

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1856,12 +1856,12 @@ def _separate_talairach_levels(atlas_img, labels, output_dir, verbose):
     logger.log(
         f"Separating talairach atlas levels: {_TALAIRACH_LEVELS}",
         verbose=verbose,
-        stack_level=2,
+        stack_level=3,
     )
     for level_name, old_level_labels in zip(
         _TALAIRACH_LEVELS, np.asarray(labels).T
     ):
-        logger.log(level_name, verbose=verbose, stack_level=2)
+        logger.log(level_name, verbose=verbose, stack_level=3)
         # level with most regions, ba, has 72 regions
         level_data = np.zeros(atlas_img.shape, dtype="uint8")
         level_labels = {"*": 0}

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 from sklearn.utils import Bunch
 
-from .._utils import check_niimg, fill_doc
+from .._utils import check_niimg, fill_doc, logger
 from ..image import get_data, new_img_like, reorder_img
 from ._utils import fetch_files, get_dataset_descr, get_dataset_dir
 
@@ -1853,13 +1853,13 @@ def _separate_talairach_levels(atlas_img, labels, output_dir, verbose):
     The label '*' is replaced by 'Background' for clarity.
 
     """
-    if verbose:
-        print(f"Separating talairach atlas levels: {_TALAIRACH_LEVELS}")
+    logger.log(
+        f"Separating talairach atlas levels: {_TALAIRACH_LEVELS}", verbose
+    )
     for level_name, old_level_labels in zip(
         _TALAIRACH_LEVELS, np.asarray(labels).T
     ):
-        if verbose:
-            print(level_name)
+        logger.log(level_name, verbose)
         # level with most regions, ba, has 72 regions
         level_data = np.zeros(atlas_img.shape, dtype="uint8")
         level_labels = {"*": 0}

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -784,12 +784,6 @@ def fetch_localizer_contrasts(
         data_types.append("tmaps")
     filenames = []
 
-    def _is_valid_path(path, index, verbose):
-        if path not in index:
-            logger.log(f"Skipping path '{path}'...", verbose)
-            return False
-        return True
-
     for subject_id in subject_ids:
         for data_type in data_types:
             for _, contrast in enumerate(contrasts_wrapped):
@@ -902,6 +896,13 @@ def fetch_localizer_contrasts(
         warnings.warn(_LEGACY_FORMAT_MSG, DeprecationWarning)
         csv_data = csv_data.to_records(index=False)
     return Bunch(ext_vars=csv_data, description=fdescr, **files)
+
+
+def _is_valid_path(path, index, verbose):
+    if path not in index:
+        logger.log(f"Skipping path '{path}'...", verbose)
+        return False
+    return True
 
 
 @fill_doc

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -2690,7 +2690,7 @@ def fetch_localizer_first_level(data_dir=None, verbose=1):
 
 
 def _download_spm_auditory_data(data_dir, subject_dir, subject_id):
-    logger.log("Data absent, downloading...")
+    logger.log("Data absent, downloading...", stack_level=2)
     url = (
         "https://www.fil.ion.ucl.ac.uk/spm/download/data/MoAEpilot/"
         "MoAEpilot.zip"
@@ -2700,7 +2700,9 @@ def _download_spm_auditory_data(data_dir, subject_dir, subject_id):
     try:
         uncompress_file(archive_path)
     except Exception:
-        logger.log("Archive corrupted, trying to download it again.")
+        logger.log(
+            "Archive corrupted, trying to download it again.", stack_level=2
+        )
         return fetch_spm_auditory(
             data_dir=data_dir, data_name="", subject_id=subject_id
         )
@@ -2733,7 +2735,7 @@ def _prepare_downloaded_spm_auditory_data(subject_dir):
         if os.path.exists(file_path):
             subject_data[file_name] = file_path
         else:
-            logger.log(f"{file_name} missing from filelist!")
+            logger.log(f"{file_name} missing from filelist!", stack_level=2)
             return None
 
     _subject_data = {
@@ -2880,7 +2882,8 @@ def _get_func_data_spm_multimodal(subject_dir, session, _subject_data):
     if len(session_func) < 390:
         logger.log(
             f"Missing {390 - len(session_func)} functional scans "
-            f"for session {session}."
+            f"for session {session}.",
+            stack_level=2,
         )
         return None
 
@@ -2893,7 +2896,7 @@ def _get_session_trials_spm_multimodal(subject_dir, session, _subject_data):
         subject_dir, f"fMRI/trials_ses{int(session)}.mat"
     )
     if not os.path.isfile(sess_trials):
-        logger.log(f"Missing session file: {sess_trials}")
+        logger.log(f"Missing session file: {sess_trials}", stack_level=2)
         return None
 
     _subject_data[f"trials_ses{int(session)}"] = sess_trials
@@ -2903,7 +2906,7 @@ def _get_session_trials_spm_multimodal(subject_dir, session, _subject_data):
 def _get_anatomical_data_spm_multimodal(subject_dir, _subject_data):
     anat = os.path.join(subject_dir, "sMRI/smri.img")
     if not os.path.isfile(anat):
-        logger.log("Missing structural image.")
+        logger.log("Missing structural image.", stack_level=2)
         return None
 
     _subject_data["anat"] = anat
@@ -2950,7 +2953,7 @@ def _glob_spm_multimodal_fmri_data(subject_dir):
 
 
 def _download_data_spm_multimodal(data_dir, subject_dir, subject_id):
-    logger.log("Data absent, downloading...")
+    logger.log("Data absent, downloading...", stack_level=2)
     urls = [
         # fmri
         (
@@ -2970,7 +2973,10 @@ def _download_data_spm_multimodal(data_dir, subject_dir, subject_id):
         try:
             uncompress_file(archive_path)
         except Exception:
-            logger.log("Archive corrupted, trying to download it again.")
+            logger.log(
+                "Archive corrupted, trying to download it again.",
+                stack_level=2,
+            )
             return fetch_spm_multimodal_fmri(
                 data_dir=data_dir, data_name="", subject_id=subject_id
             )

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -21,7 +21,7 @@ from sklearn.utils import Bunch
 
 from nilearn.image import get_data
 
-from .._utils import check_niimg, fill_doc
+from .._utils import check_niimg, fill_doc, logger
 from .._utils.numpy_conversions import csv_to_array
 from ._utils import (
     fetch_files,
@@ -786,8 +786,7 @@ def fetch_localizer_contrasts(
 
     def _is_valid_path(path, index, verbose):
         if path not in index:
-            if verbose > 0:
-                print(f"Skipping path '{path}'...")
+            logger.log(f"Skipping path '{path}'...", verbose)
             return False
         return True
 
@@ -2691,7 +2690,7 @@ def fetch_localizer_first_level(data_dir=None, verbose=1):
 
 
 def _download_spm_auditory_data(data_dir, subject_dir, subject_id):
-    print("Data absent, downloading...")
+    logger.log("Data absent, downloading...")
     url = (
         "https://www.fil.ion.ucl.ac.uk/spm/download/data/MoAEpilot/"
         "MoAEpilot.zip"
@@ -2701,7 +2700,7 @@ def _download_spm_auditory_data(data_dir, subject_dir, subject_id):
     try:
         uncompress_file(archive_path)
     except Exception:
-        print("Archive corrupted, trying to download it again.")
+        logger.log("Archive corrupted, trying to download it again.")
         return fetch_spm_auditory(
             data_dir=data_dir, data_name="", subject_id=subject_id
         )
@@ -2734,7 +2733,7 @@ def _prepare_downloaded_spm_auditory_data(subject_dir):
         if os.path.exists(file_path):
             subject_data[file_name] = file_path
         else:
-            print(f"{file_name} missing from filelist!")
+            logger.log(f"{file_name} missing from filelist!")
             return None
 
     _subject_data = {
@@ -2879,7 +2878,7 @@ def _get_func_data_spm_multimodal(subject_dir, session, _subject_data):
         )
     )
     if len(session_func) < 390:
-        print(
+        logger.log(
             f"Missing {390 - len(session_func)} functional scans "
             f"for session {session}."
         )
@@ -2894,7 +2893,7 @@ def _get_session_trials_spm_multimodal(subject_dir, session, _subject_data):
         subject_dir, f"fMRI/trials_ses{int(session)}.mat"
     )
     if not os.path.isfile(sess_trials):
-        print(f"Missing session file: {sess_trials}")
+        logger.log(f"Missing session file: {sess_trials}")
         return None
 
     _subject_data[f"trials_ses{int(session)}"] = sess_trials
@@ -2904,7 +2903,7 @@ def _get_session_trials_spm_multimodal(subject_dir, session, _subject_data):
 def _get_anatomical_data_spm_multimodal(subject_dir, _subject_data):
     anat = os.path.join(subject_dir, "sMRI/smri.img")
     if not os.path.isfile(anat):
-        print("Missing structural image.")
+        logger.log("Missing structural image.")
         return None
 
     _subject_data["anat"] = anat
@@ -2951,7 +2950,7 @@ def _glob_spm_multimodal_fmri_data(subject_dir):
 
 
 def _download_data_spm_multimodal(data_dir, subject_dir, subject_id):
-    print("Data absent, downloading...")
+    logger.log("Data absent, downloading...")
     urls = [
         # fmri
         (
@@ -2971,7 +2970,7 @@ def _download_data_spm_multimodal(data_dir, subject_dir, subject_id):
         try:
             uncompress_file(archive_path)
         except Exception:
-            print("Archive corrupted, trying to download it again.")
+            logger.log("Archive corrupted, trying to download it again.")
             return fetch_spm_multimodal_fmri(
                 data_dir=data_dir, data_name="", subject_id=subject_id
             )
@@ -3098,7 +3097,7 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
             # glob func data for session
             session_func = os.path.join(subject_dir, f"run{int(run)}.nii.gz")
             if not os.path.isfile(session_func):
-                print(f"Missing functional scan for session {int(run)}.")
+                logger.log(f"Missing functional scan for session {int(run)}.")
                 return None
 
             _subject_data[f"func{int(run)}"] = session_func
@@ -3106,7 +3105,7 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
             # glob design matrix .npz file
             sess_dmtx = os.path.join(subject_dir, f"run{int(run)}_design.npz")
             if not os.path.isfile(sess_dmtx):
-                print(f"Missing run file: {sess_dmtx}")
+                logger.log(f"Missing run file: {sess_dmtx}")
                 return None
 
             _subject_data[f"design_matrix{int(run)}"] = sess_dmtx
@@ -3114,7 +3113,7 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
         # glob for mask data
         mask = os.path.join(subject_dir, "mask.nii.gz")
         if not os.path.isfile(mask):
-            print("Missing mask image.")
+            logger.log("Missing mask image.")
             return None
 
         _subject_data["mask"] = mask
@@ -3129,7 +3128,7 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
         return data
 
     # No. Download the data
-    print("Data absent, downloading...")
+    logger.log("Data absent, downloading...")
     url = "https://nipy.org/data-packages/nipy-data-0.2.tar.gz"
 
     archive_path = os.path.join(data_dir, os.path.basename(url))
@@ -3137,7 +3136,7 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
     try:
         uncompress_file(archive_path)
     except Exception:
-        print("Archive corrupted, trying to download it again.")
+        logger.log("Archive corrupted, trying to download it again.")
         data = fetch_fiac_first_level(data_dir=data_dir)
         data.description = description
         return data

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -16,12 +16,7 @@ import nibabel as nib
 import numpy as np
 import pandas as pd
 from scipy.io import loadmat
-
-try:
-    from scipy.io.matlab import MatReadError
-except ImportError:  # SciPy < 1.8
-    from scipy.io.matlab.miobase import MatReadError
-
+from scipy.io.matlab import MatReadError
 from sklearn.utils import Bunch
 
 from nilearn.image import get_data

--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -22,7 +22,12 @@ from sklearn.feature_extraction import DictVectorizer
 from sklearn.utils import Bunch
 
 from ..image import resample_img
-from ._utils import fetch_single_file, get_dataset_descr, get_dataset_dir
+from ._utils import (
+    fetch_single_file,
+    get_dataset_descr,
+    get_dataset_dir,
+    logger,
+)
 
 _NEUROVAULT_BASE_URL = "https://neurovault.org/api/"
 _NEUROVAULT_COLLECTIONS_URL = urljoin(_NEUROVAULT_BASE_URL, "collections/")
@@ -909,6 +914,8 @@ def _print_if(message, level, threshold_level, with_traceback=False):
         if `message` is printed, also print the last traceback.
 
     """
+    # TODO replace by the nileanr logger,
+    # that does almost exactly the same thing!
     if level > threshold_level:
         return
     print(message)
@@ -1525,7 +1532,7 @@ def _download_image_nii_file(image_info, collection, download_params):
         )
 
         # Resample here
-        print("Resampling...")
+        logger.log("Resampling...")
         # TODO switch to force_resample=True
         # when bumping to version > 0.13
         im_resampled = resample_img(

--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -894,35 +894,6 @@ class _TemporaryDirectory:
         self.temp_dir_ = None
 
 
-def _print_if(message, level, threshold_level, with_traceback=False):
-    """Print a message if its importance is above a threshold.
-
-    Parameters
-    ----------
-    message : str
-        the message to print if `level` is strictly above
-        `threshold_level`.
-
-    level : int
-        importance of the message.
-
-    threshold_level : int
-        the message is printed if `level` is strictly above
-        `threshold_level`.
-
-    with_traceback : bool, default=False
-        if `message` is printed, also print the last traceback.
-
-    """
-    # TODO replace by the nileanr logger,
-    # that does almost exactly the same thing!
-    if level > threshold_level:
-        return
-    print(message)
-    if with_traceback:
-        traceback.print_exc()
-
-
 def _append_filters_to_query(query, filters):
     """Encode dict or sequence of key-value pairs into a URL query string.
 
@@ -995,17 +966,23 @@ def _get_batch(query, prefix_msg="", timeout=10.0, verbose=3):
         method="GET", url=query, headers={"Connection": "Keep-Alive"}
     )
     prepped = session.prepare_request(req)
-    _print_if(f"{prefix_msg}getting new batch: {query}", _DEBUG, verbose)
+    logger.log(
+        f"{prefix_msg}getting new batch: {query}",
+        verbose=verbose,
+        msg_level=_DEBUG,
+        stack_level=8,
+    )
     try:
         resp = session.send(prepped, timeout=timeout)
         resp.raise_for_status()
         batch = resp.json()
     except Exception:
-        _print_if(
+        logger.log(
             f"Could not get batch from {query}",
-            _ERROR,
-            verbose,
+            msg_level=_ERROR,
+            verbose=verbose,
             with_traceback=True,
+            stack_level=4,
         )
         raise
     if "id" in batch:
@@ -1016,7 +993,7 @@ def _get_batch(query, prefix_msg="", timeout=10.0, verbose=3):
                 f'Could not find required key "{key}" '
                 f"in batch retrieved from {query}."
             )
-            _print_if(msg, _ERROR, verbose)
+            logger.log(msg, msg_level=_ERROR, verbose=verbose, stack_level=4)
             raise ValueError(msg)
 
     return batch
@@ -1090,7 +1067,12 @@ def _scroll_server_results(
         if batch is not None:
             batch_size = len(batch["results"])
             downloaded += batch_size
-            _print_if(f"{prefix_msg}batch size: {batch_size}", _DEBUG, verbose)
+            logger.log(
+                f"{prefix_msg}batch size: {batch_size}",
+                msg_level=_DEBUG,
+                verbose=verbose,
+                stack_level=4,
+            )
             if n_available is None:
                 n_available = batch["count"]
                 max_results = (
@@ -1170,17 +1152,30 @@ def _simple_download(url, target_file, temp_dir, verbose=3):
     nilearn.datasets._utils.fetch_single_file
 
     """
-    _print_if(f"Downloading file: {url}", _DEBUG, verbose)
+    logger.log(
+        f"Downloading file: {url}",
+        msg_level=_DEBUG,
+        verbose=verbose,
+        stack_level=9,
+    )
     try:
         downloaded = fetch_single_file(
             url, temp_dir, resume=False, overwrite=True, verbose=0
         )
     except Exception:
-        _print_if(f"Problem downloading file from {url}", _ERROR, verbose)
+        logger.log(
+            f"Problem downloading file from {url}",
+            msg_level=_ERROR,
+            verbose=verbose,
+            stack_level=9,
+        )
         raise
     shutil.move(downloaded, target_file)
-    _print_if(
-        f"Download succeeded, downloaded to: {target_file}", _DEBUG, verbose
+    logger.log(
+        f"Download succeeded, downloaded to: {target_file}",
+        msg_level=_DEBUG,
+        verbose=verbose,
+        stack_level=9,
     )
     return target_file
 
@@ -1223,7 +1218,7 @@ def neurosynth_words_vectorized(word_files, verbose=3, **kwargs):
     sklearn.feature_extraction.DictVectorizer
 
     """
-    _print_if("Computing word features.", _INFO, verbose)
+    logger.log("Computing word features.", msg_level=_INFO, verbose=verbose)
     words = []
     voc_empty = True
     for file_name in word_files:
@@ -1234,13 +1229,13 @@ def neurosynth_words_vectorized(word_files, verbose=3, **kwargs):
                 if info["data"]["values"] != {}:
                     voc_empty = False
         except Exception:
-            _print_if(
+            logger.log(
                 (
                     f"Could not load words from file {file_name}; "
                     f"error: {traceback.format_exc()}"
                 ),
-                _ERROR,
-                verbose,
+                msg_level=_ERROR,
+                verbose=verbose,
             )
             words.append({})
     if voc_empty:
@@ -1252,10 +1247,10 @@ def neurosynth_words_vectorized(word_files, verbose=3, **kwargs):
     vectorizer = DictVectorizer(**kwargs)
     frequencies = vectorizer.fit_transform(words).toarray()
     vocabulary = np.asarray(vectorizer.feature_names_)
-    _print_if(
+    logger.log(
         f"Computing word features done; vocabulary size: {vocabulary.size}",
-        _INFO,
-        verbose,
+        msg_level=_INFO,
+        verbose=verbose,
     )
     return frequencies, vocabulary
 
@@ -1532,7 +1527,7 @@ def _download_image_nii_file(image_info, collection, download_params):
         )
 
         # Resample here
-        logger.log("Resampling...", stack_level=4)
+        logger.log("Resampling...", stack_level=8)
         # TODO switch to force_resample=True
         # when bumping to version > 0.13
         im_resampled = resample_img(
@@ -1624,8 +1619,12 @@ def _download_image_terms(image_info, collection, download_params):
         message = f"Could not fetch words for image {image_info['id']}"
         if not download_params.get("allow_neurosynth_failure", True):
             raise RuntimeError(message)
-        _print_if(
-            message, _ERROR, download_params["verbose"], with_traceback=True
+        logger.log(
+            message,
+            msg_level=_ERROR,
+            verbose=download_params["verbose"],
+            with_traceback=True,
+            stack_level=2,
         )
 
     return image_info, collection
@@ -1740,8 +1739,11 @@ def _scroll_local(download_params):
         Metadata for the corresponding collection.
 
     """
-    _print_if(
-        "Reading local neurovault data.", _DEBUG, download_params["verbose"]
+    logger.log(
+        "Reading local neurovault data.",
+        msg_level=_DEBUG,
+        verbose=download_params["verbose"],
+        stack_level=4,
     )
 
     collections = glob(
@@ -1838,32 +1840,31 @@ def _scroll_collection(collection, download_params):
             yield image
         except Exception:
             fails_in_collection += 1
-            _print_if(
+            logger.log(
                 f"_scroll_collection: bad image: {image}",
-                _ERROR,
-                download_params["verbose"],
+                msg_level=_ERROR,
+                verbose=download_params["verbose"],
                 with_traceback=True,
+                stack_level=4,
             )
             yield None
         if fails_in_collection == download_params["max_fails_in_collection"]:
-            _print_if(
-                (
-                    f"Too many bad images in collection {collection['id']}:  "
-                    f"{fails_in_collection} bad images."
-                ),
-                _ERROR,
-                download_params["verbose"],
+            logger.log(
+                f"Too many bad images in collection {collection['id']}:  "
+                f"{fails_in_collection} bad images.",
+                msg_level=_ERROR,
+                verbose=download_params["verbose"],
+                stack_level=4,
             )
             return
-    _print_if(
-        (
-            "On neurovault.org: "
-            f"{n_im_in_collection or 'no'} "
-            f"image{'s' if n_im_in_collection > 1 else ''}"
-            f"matched query in collection {collection['id']}"
-        ),
-        _INFO,
-        download_params["verbose"],
+    logger.log(
+        "On neurovault.org: "
+        f"{n_im_in_collection or 'no'} "
+        f"image{'s' if n_im_in_collection > 1 else ''} "
+        f"matched query in collection {collection['id']}",
+        msg_level=_INFO,
+        verbose=download_params["verbose"],
+        stack_level=6,
     )
 
 
@@ -1894,8 +1895,11 @@ def _scroll_filtered(download_params):
     failed download.
 
     """
-    _print_if(
-        "Reading server neurovault data.", _DEBUG, download_params["verbose"]
+    logger.log(
+        "Reading server neurovault data.",
+        msg_level=_DEBUG,
+        verbose=download_params["verbose"],
+        stack_level=7,
     )
 
     download_params["collection_filter"] = ResultFilter(
@@ -1955,10 +1959,11 @@ def _scroll_collection_ids(download_params):
     ]
 
     if collection_urls:
-        _print_if(
+        logger.log(
             "Reading server neurovault data.",
-            _DEBUG,
-            download_params["verbose"],
+            msg_level=_DEBUG,
+            verbose=download_params["verbose"],
+            stack_level=5,
         )
 
     collections = _yield_from_url_list(
@@ -2061,10 +2066,11 @@ def _scroll_explicit(download_params):
 
 def _print_progress(found, download_params, level=_INFO):
     """Print number of images fetched so far."""
-    _print_if(
+    logger.log(
         f"Already fetched {found} image{'s' if found > 1 else ''}",
-        level,
-        download_params["verbose"],
+        msg_level=level,
+        verbose=download_params["verbose"],
+        stack_level=4,
     )
 
 
@@ -2110,14 +2116,13 @@ def _scroll(download_params):
             yield image, collection
             if found == download_params["max_images"]:
                 break
-        _print_if(
-            (
-                f"{found or 'No'} "
-                f"image{'s' if found > 1 else ''} "
-                "found on local disk."
-            ),
-            _INFO,
-            download_params["verbose"],
+        logger.log(
+            f"{found or 'No'} "
+            f"image{'s' if found > 1 else ''} "
+            "found on local disk.",
+            msg_level=_INFO,
+            verbose=download_params["verbose"],
+            stack_level=3,
         )
 
     if download_params["download_mode"] == "offline":
@@ -2655,16 +2660,14 @@ def fetch_neurovault(
         image_terms = basic_image_terms()
 
     if max_images == _DEFAULT_MAX_IMAGES:
-        _print_if(
-            (
-                "fetch_neurovault: "
-                f"using default value of {_DEFAULT_MAX_IMAGES} "
-                "for max_images. "
-                "Set max_images to another value or None "
-                "if you want more images."
-            ),
-            _INFO,
-            verbose,
+        logger.log(
+            "fetch_neurovault: "
+            f"using default value of {_DEFAULT_MAX_IMAGES} "
+            "for max_images. "
+            "Set max_images to another value or None "
+            "if you want more images.",
+            msg_level=_INFO,
+            verbose=verbose,
         )
     # Users may get confused if they write their image_filter function
     # and the default filters contained in image_terms still apply, so we

--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -1532,7 +1532,7 @@ def _download_image_nii_file(image_info, collection, download_params):
         )
 
         # Resample here
-        logger.log("Resampling...")
+        logger.log("Resampling...", stack_level=4)
         # TODO switch to force_resample=True
         # when bumping to version > 0.13
         im_resampled = resample_img(

--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -970,7 +970,7 @@ def _get_batch(query, prefix_msg="", timeout=10.0, verbose=3):
         f"{prefix_msg}getting new batch: {query}",
         verbose=verbose,
         msg_level=_DEBUG,
-        stack_level=8,
+        stack_level=7,
     )
     try:
         resp = session.send(prepped, timeout=timeout)
@@ -1071,7 +1071,7 @@ def _scroll_server_results(
                 f"{prefix_msg}batch size: {batch_size}",
                 msg_level=_DEBUG,
                 verbose=verbose,
-                stack_level=4,
+                stack_level=6,
             )
             if n_available is None:
                 n_available = batch["count"]
@@ -1156,7 +1156,7 @@ def _simple_download(url, target_file, temp_dir, verbose=3):
         f"Downloading file: {url}",
         msg_level=_DEBUG,
         verbose=verbose,
-        stack_level=9,
+        stack_level=8,
     )
     try:
         downloaded = fetch_single_file(
@@ -1175,7 +1175,7 @@ def _simple_download(url, target_file, temp_dir, verbose=3):
         f"Download succeeded, downloaded to: {target_file}",
         msg_level=_DEBUG,
         verbose=verbose,
-        stack_level=9,
+        stack_level=8,
     )
     return target_file
 
@@ -1864,7 +1864,7 @@ def _scroll_collection(collection, download_params):
         f"matched query in collection {collection['id']}",
         msg_level=_INFO,
         verbose=download_params["verbose"],
-        stack_level=6,
+        stack_level=5,
     )
 
 

--- a/nilearn/datasets/tests/test_func.py
+++ b/nilearn/datasets/tests/test_func.py
@@ -90,6 +90,15 @@ def _make_haxby_subject_data(match, response):
     return list_to_archive(Path(match.group(1), f) for f in sub_files)
 
 
+@pytest.mark.parametrize("subjects", [None, 7])
+def test_fetch_haxby_more_than_6(tmp_path, request_mocker, subjects):
+    """Test edge cases to extend coverage."""
+    request_mocker.url_mapping[re.compile(r".*(subj\d).*\.tar\.gz")] = (
+        _make_haxby_subject_data
+    )
+    func.fetch_haxby(data_dir=tmp_path, subjects=subjects, verbose=1)
+
+
 def test_fetch_haxby(tmp_path, request_mocker):
     request_mocker.url_mapping[re.compile(r".*(subj\d).*\.tar\.gz")] = (
         _make_haxby_subject_data
@@ -195,6 +204,17 @@ def _adhd_metadata():
     return dict_to_archive({tmp: subs.to_csv(index=False)})
 
 
+@pytest.mark.parametrize("subjects", [None, 9999])
+def test_fetch_adhd_edge_cases(tmp_path, request_mocker, subjects):
+    request_mocker.url_mapping["*metadata.tgz"] = _adhd_metadata()
+    request_mocker.url_mapping[re.compile(r".*adhd40_([0-9]+)\.tgz")] = (
+        _adhd_example_subject
+    )
+    func.fetch_adhd(
+        data_dir=tmp_path, n_subjects=subjects, verbose=0, url=None
+    )
+
+
 def test_fetch_adhd(tmp_path, request_mocker):
     request_mocker.url_mapping["*metadata.tgz"] = _adhd_metadata()
     request_mocker.url_mapping[re.compile(r".*adhd40_([0-9]+)\.tgz")] = (
@@ -219,6 +239,19 @@ def test_miyawaki2008(tmp_path, request_mocker):
     assert isinstance(dataset.background, str)
     assert request_mocker.url_count == 1
     assert dataset.description != ""
+
+
+@pytest.mark.parametrize("subjects", [None, 9999])
+def test_fetch_localizer_contrasts_edge_cases(
+    tmp_path, localizer_mocker, subjects
+):
+    func.fetch_localizer_contrasts(
+        ["checkerboard"],
+        n_subjects=subjects,
+        data_dir=tmp_path,
+        verbose=1,
+        legacy_format=True,
+    )
 
 
 def test_fetch_localizer_contrasts(tmp_path, localizer_mocker):
@@ -429,23 +462,25 @@ def test__load_mixed_gambles(rng, affine_eye):
         assert len(zmaps) == len(gain)
 
 
-def test_fetch_mixed_gambles(tmp_path):
-    for n_subjects in [1, 5, 16]:
-        mgambles = func.fetch_mixed_gambles(
-            n_subjects=n_subjects,
-            data_dir=tmp_path,
-            verbose=0,
-            return_raw_data=True,
-        )
-        datasetdir = tmp_path / "jimura_poldrack_2012_zmaps"
+@pytest.mark.parametrize("n_subjects", [1, 5, 16])
+def test_fetch_mixed_gambles(tmp_path, n_subjects):
 
-        assert mgambles["zmaps"][0] == str(
-            datasetdir / "zmaps" / "sub001_zmaps.nii.gz"
-        )
-        assert len(mgambles["zmaps"]) == n_subjects
+    mgambles = func.fetch_mixed_gambles(
+        n_subjects=n_subjects,
+        data_dir=tmp_path,
+        verbose=1,
+        return_raw_data=True,
+        url=None,
+    )
+    datasetdir = tmp_path / "jimura_poldrack_2012_zmaps"
 
-        assert isinstance(mgambles, Bunch)
-        assert mgambles.description != ""
+    assert mgambles["zmaps"][0] == str(
+        datasetdir / "zmaps" / "sub001_zmaps.nii.gz"
+    )
+    assert len(mgambles["zmaps"]) == n_subjects
+
+    assert isinstance(mgambles, Bunch)
+    assert mgambles.description != ""
 
 
 def test_check_parameters_megatrawls_datasets():
@@ -1031,32 +1066,30 @@ def test_fetch_spm_auditory(affine_eye, tmp_path):
     assert dataset.description != ""
 
 
-def test_fetch_spm_multimodal(tmp_path):
-    data_dir = str(tmp_path / "spm_multimodal_fmri")
-    os.mkdir(data_dir)
-    subject_dir = os.path.join(data_dir, "sub001")
-    os.mkdir(subject_dir)
-    os.mkdir(os.path.join(subject_dir, "fMRI"))
-    os.mkdir(os.path.join(subject_dir, "sMRI"))
-    open(os.path.join(subject_dir, "sMRI", "smri.img"), "a").close()
-    for session in [0, 1]:
+def _generate_spm_multimodal(path, nb_sessions=2, nb_vol=390):
+    data_dir = path / "spm_multimodal_fmri"
+    subject_dir = data_dir / "sub001"
+    (subject_dir / "fMRI").mkdir(exist_ok=True, parents=True)
+    (subject_dir / "sMRI").mkdir(exist_ok=True)
+    open(subject_dir / "sMRI" / "smri.img", "a").close()
+    for session in range(nb_sessions):
         open(
-            os.path.join(
-                subject_dir, "fMRI", f"trials_ses{int(session + 1)}.mat"
-            ),
+            subject_dir / "fMRI" / f"trials_ses{int(session + 1)}.mat",
             "a",
         ).close()
-        dir_ = os.path.join(subject_dir, "fMRI", f"Session{int(session + 1)}")
-        os.mkdir(dir_)
-        for i in range(390):
+        dir_ = subject_dir / "fMRI" / f"Session{int(session + 1)}"
+        dir_.mkdir(exist_ok=True)
+        for i in range(nb_vol):
             open(
-                os.path.join(
-                    dir_, f"fMETHODS-000{int(session + 5)}-{int(i)}-01.img"
-                ),
+                dir_ / f"fMETHODS-000{int(session + 5)}-{int(i)}-01.img",
                 "a",
             ).close()
 
-    dataset = func.fetch_spm_multimodal_fmri(data_dir=tmp_path)
+
+def test_fetch_spm_multimodal(tmp_path):
+    _generate_spm_multimodal(tmp_path)
+
+    dataset = func.fetch_spm_multimodal_fmri(data_dir=tmp_path, verbose=0)
 
     assert isinstance(dataset, Bunch)
     assert isinstance(dataset.anat, str)
@@ -1068,6 +1101,13 @@ def test_fetch_spm_multimodal(tmp_path):
     assert isinstance(dataset.trials_ses1, str)
     assert isinstance(dataset.trials_ses2, str)
     assert dataset.description != ""
+
+
+def test_fetch_spm_multimodal_missing_data(tmp_path):
+    _generate_spm_multimodal(tmp_path, nb_sessions=2, nb_vol=390)
+    func.fetch_spm_multimodal_fmri(
+        data_dir=tmp_path, verbose=1, subject_id="sub001"
+    )
 
 
 def test_fiac(tmp_path):

--- a/nilearn/datasets/tests/test_func.py
+++ b/nilearn/datasets/tests/test_func.py
@@ -23,6 +23,11 @@ from nilearn.datasets.tests._testing import dict_to_archive, list_to_archive
 from nilearn.image import load_img
 
 
+def test_is_valid_path():
+    assert func._is_valid_path(path="foo", index=["foo"], verbose=1)
+    assert not func._is_valid_path(path="bar", index=["foo"], verbose=1)
+
+
 @pytest.mark.parametrize(
     "fn",
     [

--- a/nilearn/decoding/_proximal_operators.py
+++ b/nilearn/decoding/_proximal_operators.py
@@ -225,10 +225,11 @@ def prox_tvl1(
         # on the input array
         t_new = 0.5 * (1.0 + sqrt(1.0 + 4.0 * t * t))
         t_factor = (t - 1.0) / t_new
+
+        grad_aux = grad_tmp
         if fista_step:
             grad_aux = (1 + t_factor) * grad_tmp - t_factor * grad_im
-        else:
-            grad_aux = grad_tmp
+
         grad_im = grad_tmp
         t = t_new
         gap = weight * divergence_id(grad_aux, l1_ratio=l1_ratio)
@@ -262,6 +263,7 @@ def prox_tvl1(
 
                 if dgap < dgap_tol:
                     break
+
                 if old_dgap < dgap:
                     # M-FISTA strategy: switch to an ISTA to have
                     # monotone convergence

--- a/nilearn/decoding/_proximal_operators.py
+++ b/nilearn/decoding/_proximal_operators.py
@@ -8,6 +8,8 @@ from math import sqrt
 
 import numpy as np
 
+from nilearn._utils import logger
+
 from ._objective_functions import (
     divergence_id,
     gradient_id,
@@ -246,10 +248,13 @@ def prox_tvl1(
                     weight,
                     l1_ratio=l1_ratio,
                 )
-                if verbose:
-                    print(
-                        f"\tProxTVl1: Iteration {i: 2}, dual gap: {dgap: 6.3e}"
-                    )
+
+                logger.log(
+                    f"\tProxTVl1: Iteration {i: 2}, "
+                    f"dual gap: {dgap: 6.3e}",
+                    verbose,
+                )
+
                 if dgap < dgap_tol:
                     break
                 if old_dgap < dgap:
@@ -262,16 +267,18 @@ def prox_tvl1(
                 # Stopping criterion based on x_tol
                 diff = np.max(np.abs(negated_output_old - negated_output))
                 diff /= np.max(np.abs(negated_output))
-                if verbose:
-                    gid = gradient_id(negated_output, l1_ratio=l1_ratio)
-                    energy = _objective_function_prox_tvl1(
-                        input_img, -negated_output, gid, weight
-                    )
-                    print(
-                        f"\tProxTVl1 iteration {i: 2}, "
-                        f"relative difference: {diff: 6.3e}, "
-                        f"energy: {energy: 6.3e}"
-                    )
+
+                gid = gradient_id(negated_output, l1_ratio=l1_ratio)
+                energy = _objective_function_prox_tvl1(
+                    input_img, -negated_output, gid, weight
+                )
+                logger.log(
+                    f"\tProxTVl1 iteration {i: 2}, "
+                    f"relative difference: {diff: 6.3e}, "
+                    f"energy: {energy: 6.3e}",
+                    verbose,
+                )
+
                 if diff < x_tol:
                     break
                 negated_output_old = negated_output

--- a/nilearn/decoding/_proximal_operators.py
+++ b/nilearn/decoding/_proximal_operators.py
@@ -91,7 +91,7 @@ def prox_tvl1(
     check_gap_frequency=4,
     val_min=None,
     val_max=None,
-    verbose=False,
+    verbose=0,
     fista=True,
     init=None,
 ):
@@ -131,8 +131,8 @@ def prox_tvl1(
     val_max : None or float, optional
         An optional upper bound constraint on the reconstructed image.
 
-    verbose : bool, optional
-        If True, print the dual gap of the optimization
+    verbose : int or bool, optional
+        If True or 1, print the dual gap of the optimization
 
     fista : bool, optional
         If True, uses a FISTA loop to perform the optimization.
@@ -173,6 +173,11 @@ def prox_tvl1(
     For details on implementing the bound constraints, read the aforementioned
     Beck and Teboulle paper.
     """
+    if verbose is False:
+        verbose = 0
+    if verbose is True:
+        verbose = 1
+
     weight = float(weight)
     input_img_flat = input_img.view()
     input_img_flat.shape = input_img.size
@@ -300,7 +305,7 @@ def prox_tvl1_with_intercept(
     dgap_tol,
     max_iter=5000,
     init=None,
-    verbose=False,
+    verbose=0,
 ):
     """Compute TV-L1 prox taking into account the intercept.
 
@@ -319,13 +324,18 @@ def prox_tvl1_with_intercept(
     max_iter : int
         Maximum number of iterations for the solver.
 
-    verbose : int, optional (default 0)
-        Verbosity level.
+    verbose : int or bool, optional
+        If True or 1, print the dual gap of the optimization
 
     dgap_tol : float
         Dual-gap tolerance for TV-L1 prox operator approximation loop.
 
     """
+    if verbose is False:
+        verbose = 0
+    if verbose is True:
+        verbose = 1
+
     init = init.reshape(shape) if init is not None else init
     out, prox_info = prox_tvl1(
         w[:-1].reshape(shape),

--- a/nilearn/decoding/fista.py
+++ b/nilearn/decoding/fista.py
@@ -16,6 +16,8 @@ from math import sqrt
 import numpy as np
 from scipy import linalg
 
+from nilearn._utils import logger
+
 
 def _check_lipschitz_continuous(
     f, ndim, lipschitz_constant, n_trials=10, random_state=42
@@ -189,16 +191,15 @@ def mfista(
         w_old[:] = w
 
         # invoke callback
-        if verbose:
-            print(
-                f"mFISTA: Iteration {i + 1: 2}/{max_iter:2}: "
-                f"E = {old_energy:7.4e}, dE {energy_delta: 4.4e}"
-            )
+        logger.log(
+            f"mFISTA: Iteration {i + 1: 2}/{max_iter:2}: "
+            f"E = {old_energy:7.4e}, dE {energy_delta: 4.4e}",
+            verbose,
+        )
         if callback and callback(locals()):
             break
         if np.abs(energy_delta) < tol:
-            if verbose:
-                print(f"\tConverged (|dE| < {tol:g})")
+            logger.log(f"\tConverged (|dE| < {tol:g})", verbose)
             break
 
         # forward (gradient) step
@@ -226,8 +227,7 @@ def mfista(
             # tolerance.
             dgap_factor *= 0.2
 
-            if verbose:
-                print("decreased dgap_tol")
+            logger.log("decreased dgap_tol", verbose)
         # energy house-keeping
         energy_delta = old_energy - energy
         old_energy = energy
@@ -238,8 +238,7 @@ def mfista(
             z[:] = w_old
             w[:] = w_old
             ista_step = True
-            if verbose:
-                print("Monotonous FISTA: Switching to ISTA")
+            logger.log("Monotonous FISTA: Switching to ISTA", verbose)
         else:
             if ista_step:
                 z = w

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -203,7 +203,8 @@ def _group_iter_search_light(
                 remaining = (100.0 - percent) / max(0.01, percent) * dt
                 logger.log(
                     f"Job #{thread_id}, processed {i}/{len(list_rows)} voxels "
-                    f"({percent:0.2f}%, {remaining} seconds remaining){crlf}"
+                    f"({percent:0.2f}%, {remaining} seconds remaining){crlf}",
+                    stack_level=2,
                 )
     return par_scores
 

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -8,7 +8,6 @@ in the neighborhood of each location of a domain."""
 #           Philippe Gervais (philippe.gervais@inria.fr)
 #
 
-import sys
 import time
 import warnings
 
@@ -22,7 +21,7 @@ from sklearn.model_selection import cross_val_score
 from nilearn.maskers.nifti_spheres_masker import _apply_mask_and_get_affinity
 
 from .. import masking
-from .._utils import check_niimg_4d, fill_doc
+from .._utils import check_niimg_4d, fill_doc, logger
 from ..image.resampling import coord_transform
 
 ESTIMATOR_CATALOG = dict(svc=svm.LinearSVC, svr=svm.SVR)
@@ -202,7 +201,7 @@ def _group_iter_search_light(
                 dt = time.time() - t0
                 # We use a max to avoid a division by zero
                 remaining = (100.0 - percent) / max(0.01, percent) * dt
-                sys.stderr.write(
+                logger.log(
                     f"Job #{thread_id}, processed {i}/{len(list_rows)} voxels "
                     f"({percent:0.2f}%, {remaining} seconds remaining){crlf}"
                 )

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -844,8 +844,8 @@ class BaseSpaceNet(LinearRegression, CacheMixin):
             )
         else:
             self.memory_ = self.memory
-        if self.verbose:
-            tic = time.time()
+
+        tic = time.time()
 
         masker_type = "nii"
         if isinstance(self.mask, SurfaceMasker):

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -998,11 +998,11 @@ class BaseSpaceNet(LinearRegression, CacheMixin):
         self.coef_img_ = self.masker_.inverse_transform(self.coef_)
 
         # report time elapsed
-        if self.verbose:
-            duration = time.time() - tic
-            print(
-                f"Time Elapsed: {duration} seconds, {duration / 60.0} minutes."
-            )
+        duration = time.time() - tic
+        logger.log(
+            f"Time Elapsed: {duration} seconds, {duration / 60.0} minutes.",
+            self.verbose,
+        )
 
         return self
 

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -11,7 +11,6 @@ For example: TV-L1, Graph-Net, etc
 #         THIRION Bertrand
 
 import collections
-import sys
 import time
 import warnings
 from functools import partial
@@ -34,7 +33,7 @@ from nilearn.experimental.surface import SurfaceMasker
 from nilearn.image import get_data
 from nilearn.masking import unmask_from_to_3d_array
 
-from .._utils import fill_doc
+from .._utils import fill_doc, logger
 from .._utils.cache_mixin import CacheMixin
 from .._utils.param_validation import adjust_screening_percentile
 from .space_net_solvers import (
@@ -240,18 +239,15 @@ class _EarlyStoppingCallback:
             len(self.test_scores) > 4
             and np.mean(np.diff(self.test_scores[-5:][::-1])) >= self.tol
         ):
+            message = "."
             if self.verbose:
-                if self.verbose > 1:
-                    print(
-                        "Early stopping. "
-                        f"Test score: {score:.8f} {40 * '-'}"
-                    )
-                else:
-                    sys.stderr.write(".")
+                message = (
+                    f"Early stopping. \n" f"Test score: {score:.8f} {40 * '-'}"
+                )
+            logger.log(message)
             return True
 
-        if self.verbose > 1:
-            print(f"Test score: {score:.8f}")
+        logger.log(f"Test score: {score:.8f}", verbose=self.verbose)
         return False
 
     def _debias(self, w):

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -240,14 +240,16 @@ class _EarlyStoppingCallback:
             and np.mean(np.diff(self.test_scores[-5:][::-1])) >= self.tol
         ):
             message = "."
-            if self.verbose:
+            if self.verbose > 1:
                 message = (
                     f"Early stopping. \n" f"Test score: {score:.8f} {40 * '-'}"
                 )
-            logger.log(message)
+            logger.log(message, verbose=self.verbose)
             return True
 
-        logger.log(f"Test score: {score:.8f}", verbose=self.verbose)
+        logger.log(
+            f"Test score: {score:.8f}", verbose=self.verbose, msg_level=1
+        )
         return False
 
     def _debias(self, w):

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -244,7 +244,7 @@ class _EarlyStoppingCallback:
                 message = (
                     f"Early stopping. \n" f"Test score: {score:.8f} {40 * '-'}"
                 )
-            logger.log(message, verbose=self.verbose)
+            logger.log(message, verbose=self.verbose, stack_level=2)
             return True
 
         logger.log(

--- a/nilearn/decoding/tests/test_fista.py
+++ b/nilearn/decoding/tests/test_fista.py
@@ -37,7 +37,7 @@ def test_squared_loss_lipschitz(rng, scaling, n_samples=4, n_features=2):
 
 
 @pytest.mark.parametrize("cb_retval", [0, 1])
-@pytest.mark.parametrize("verbose", [0, 1])
+@pytest.mark.parametrize("verbose", [0, 2])
 @pytest.mark.parametrize("dgap_factor", [1.0, None])
 def test_input_args_and_kwargs(cb_retval, verbose, dgap_factor, rng):
     p = 125

--- a/nilearn/decoding/tests/test_operators.py
+++ b/nilearn/decoding/tests/test_operators.py
@@ -24,7 +24,7 @@ def test_prox_l1_nonexpansiveness(rng, n_features=10):
 @pytest.mark.parametrize("ndim", range(3, 4))
 @pytest.mark.parametrize("weight", np.logspace(-10, 10, num=10))
 def test_prox_tvl1_approximates_prox_l1_for_lasso(
-    rng, ndim, weight, size=15, random_state=42, decimal=4, dgap_tol=1e-7
+    rng, ndim, weight, size=15, decimal=4, dgap_tol=1e-7
 ):
     l1_ratio = 1.0  # pure LASSO
 
@@ -38,7 +38,6 @@ def test_prox_tvl1_approximates_prox_l1_for_lasso(
         l1_ratio=l1_ratio,
         dgap_tol=dgap_tol,
         max_iter=10,
-        verbose=1,
     )[0][-1].ravel()
 
     # use exact closed-form soft shrinkage formula for prox_l1
@@ -46,3 +45,28 @@ def test_prox_tvl1_approximates_prox_l1_for_lasso(
 
     # results should be close in l-infinity norm
     assert_almost_equal(np.abs(a - b).max(), 0.0, decimal=decimal)
+
+
+@pytest.mark.parametrize("verbose", [True, False])
+def test_prox_tvl1_verbose(rng, verbose):
+    l1_ratio = 1.0  # pure LASSO
+
+    size = 15
+    dgap_tol = 1e-7
+    ndim = 3
+    weight = -10
+
+    shape = [size] * ndim
+    z = rng.standard_normal(shape)
+
+    prox_tvl1(
+        z.copy(),
+        weight=weight,
+        l1_ratio=l1_ratio,
+        dgap_tol=dgap_tol,
+        max_iter=10,
+        val_min=-np.inf,
+        val_max=np.inf,
+        verbose=verbose,
+        x_tol=1e-7,
+    )

--- a/nilearn/decoding/tests/test_operators.py
+++ b/nilearn/decoding/tests/test_operators.py
@@ -38,6 +38,7 @@ def test_prox_tvl1_approximates_prox_l1_for_lasso(
         l1_ratio=l1_ratio,
         dgap_tol=dgap_tol,
         max_iter=10,
+        verbose=1,
     )[0][-1].ravel()
 
     # use exact closed-form soft shrinkage formula for prox_l1

--- a/nilearn/decoding/tests/test_same_api.py
+++ b/nilearn/decoding/tests/test_same_api.py
@@ -140,7 +140,7 @@ def test_graph_net_and_tvl1_same_for_pure_l1(max_iter=100, decimal=2):
         mask=mask,
         loss="mse",
         max_iter=max_iter,
-        verbose=0,
+        verbose=1,
     )[0]
     b = graph_net_squared_loss(
         unmasked_X,
@@ -221,7 +221,7 @@ def test_graph_net_and_tvl1_same_for_pure_l1_logistic(max_iter=20, decimal=2):
         loss="logistic",
         mask=mask,
         max_iter=max_iter,
-        verbose=0,
+        verbose=1,
     )[0]
 
     assert_array_almost_equal(a, b, decimal=decimal)

--- a/nilearn/decoding/tests/test_space_net.py
+++ b/nilearn/decoding/tests/test_space_net.py
@@ -236,7 +236,6 @@ def test_tv_regression_simple(rng, l1_ratio, debias):
         is_classif=False,
         max_iter=10,
         debias=debias,
-        verbose=0,
     ).fit(X, y)
 
 
@@ -261,7 +260,6 @@ def test_tv_regression_3D_image_doesnt_crash(rng, l1_ratio):
         penalty="tv-l1",
         is_classif=False,
         max_iter=10,
-        verbose=0,
     ).fit(X, y)
 
 
@@ -277,7 +275,6 @@ def test_graph_net_classifier_score():
         l1_ratios=1.0,
         tol=1e-10,
         standardize=False,
-        verbose=0,
         screening_percentile=100.0,
     ).fit(X_, y)
 
@@ -305,7 +302,6 @@ def test_log_reg_vs_graph_net_two_classes_iris(
         alphas=1.0 / C / X.shape[0],
         l1_ratios=1.0,
         tol=tol,
-        verbose=0,
         max_iter=1000,
         penalty="tv-l1",
         standardize=False,
@@ -345,7 +341,6 @@ def test_lasso_vs_graph_net():
         is_classif=False,
         penalty="graph-net",
         max_iter=100,
-        verbose=0,
     )
     lasso.fit(X_, y)
     graph_net.fit(X, y)
@@ -465,9 +460,9 @@ def test_space_net_no_crash_not_fitted(model):
         RuntimeError,
         match=f"This {model.__name__} instance is not fitted yet",
     ):
-        model(verbose=0).predict(X)
+        model().predict(X)
 
-    model(mask=mask, alphas=1.0, verbose=0).fit(X, y).predict(X)
+    model(mask=mask, alphas=1.0).fit(X, y).predict(X)
 
 
 @pytest.mark.parametrize("model", [SpaceNetRegressor, SpaceNetClassifier])
@@ -477,8 +472,8 @@ def test_space_net_one_alpha_no_crash(model):
     X, y = iris.data, iris.target
     X, mask = to_niimgs(X, [2, 2, 2])
 
-    model(n_alphas=1, mask=mask, verbose=0).fit(X, y)
-    model(n_alphas=2, mask=mask, verbose=0, alphas=None).fit(X, y)
+    model(n_alphas=1, mask=mask).fit(X, y)
+    model(n_alphas=2, mask=mask, alphas=None).fit(X, y)
 
 
 @pytest.mark.parametrize("model", [SpaceNetRegressor, SpaceNetClassifier])
@@ -498,7 +493,6 @@ def test_checking_inputs_length(model):
             l1_ratios=1.0,
             tol=1e-10,
             screening_percentile=100.0,
-            verbose=0,
         ).fit(
             X_,
             y,
@@ -512,7 +506,7 @@ def test_targets_in_y_space_net_regressor():
     y = np.ones(iris.target.shape)
 
     imgs, mask = to_niimgs(X, (2, 2, 2))
-    regressor = SpaceNetRegressor(mask=mask, verbose=0)
+    regressor = SpaceNetRegressor(mask=mask)
 
     with pytest.raises(
         ValueError, match="The given input y must have at least 2 targets"

--- a/nilearn/decomposition/_base.py
+++ b/nilearn/decomposition/_base.py
@@ -19,7 +19,7 @@ import nilearn
 from nilearn._utils.masker_validation import check_embedded_masker
 from nilearn.maskers import NiftiMapsMasker
 
-from .._utils import fill_doc
+from .._utils import fill_doc, logger
 from .._utils.cache_mixin import CacheMixin, cache
 from .._utils.niimg import safe_get_data
 from .._utils.niimg_conversions import resolve_globbing
@@ -439,8 +439,7 @@ class _BaseDecomposition(BaseEstimator, CacheMixin, TransformerMixin):
 
         # _mask_and_reduce step for decomposition estimators i.e.
         # MultiPCA, CanICA and Dictionary Learning
-        if self.verbose:
-            print(f"[{self.__class__.__name__}] Loading data")
+        logger.log("Loading data", self.verbose)
         data = _mask_and_reduce(
             self.masker_,
             imgs,

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -286,14 +286,16 @@ class DictLearning(_BaseDecomposition):
 
         _, n_features = data.shape
 
-        logger.log("Computing initial loadings", verbose=self.verbose)
+        logger.log(
+            "Computing initial loadings", verbose=self.verbose, stack_level=2
+        )
         self._init_loadings(data)
 
         dict_init = self.loadings_init_
 
         max_iter = ((n_features - 1) // self.batch_size + 1) * self.n_epochs
 
-        logger.log(" Learning dictionary", verbose=self.verbose)
+        logger.log(" Learning dictionary", verbose=self.verbose, stack_level=2)
 
         # TODO: remove this when sklearn 1.0 not supported anymore;
         # replace kwargs with actual parameter name

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -15,7 +15,7 @@ from joblib import Memory
 from sklearn.decomposition import dict_learning_online
 from sklearn.linear_model import Ridge
 
-from nilearn._utils import fill_doc
+from nilearn._utils import fill_doc, logger
 from nilearn._utils.helpers import _transfer_deprecated_param_vals
 
 from ._base import _BaseDecomposition
@@ -281,22 +281,19 @@ class DictLearning(_BaseDecomposition):
             Shape (n_samples, n_features)
 
         """
-        if self.verbose:
-            print("[DictLearning] Learning initial components")
+        logger.log("Learning initial components", self.verbose)
         self._init_dict(data)
 
         _, n_features = data.shape
 
-        if self.verbose:
-            print("[DictLearning] Computing initial loadings")
+        logger.log("Computing initial loadings", verbose=self.verbose)
         self._init_loadings(data)
 
         dict_init = self.loadings_init_
 
         max_iter = ((n_features - 1) // self.batch_size + 1) * self.n_epochs
 
-        if self.verbose:
-            print("[DictLearning] Learning dictionary")
+        logger.log(" Learning dictionary", verbose=self.verbose)
 
         # TODO: remove this when sklearn 1.0 not supported anymore;
         # replace kwargs with actual parameter name

--- a/nilearn/experimental/surface/tests/test_datasets.py
+++ b/nilearn/experimental/surface/tests/test_datasets.py
@@ -1,6 +1,12 @@
 import pytest
 
-from nilearn.experimental.surface import load_fsaverage
+from nilearn.experimental.surface import (
+    SurfaceImage,
+    fetch_destrieux,
+    fetch_nki,
+    load_fsaverage,
+    load_fsaverage_data,
+)
 
 
 def test_load_fsaverage():
@@ -10,10 +16,22 @@ def test_load_fsaverage():
     assert result["pial"].parts["left"].n_vertices == 10242  # fsaverage5
 
 
-def test_load_fsaverage_wrong_mesh_name():
-    """Give incorrect value to mesh_name argument."""
+def test_load_fsaverage_errors():
+    """Give incorrect value argument."""
     with pytest.raises(ValueError, match="'mesh' should be one of"):
         load_fsaverage(mesh_name="foo")
+
+
+def test_load_fsaverage_data_smoke():
+    assert isinstance(load_fsaverage_data(), SurfaceImage)
+
+
+def test_load_fsaverage_data_errors():
+    """Give incorrect value argument."""
+    with pytest.raises(ValueError, match="'mesh_type' must be one of"):
+        load_fsaverage_data(mesh_type="foo")
+    with pytest.raises(ValueError, match="'data_type' must be one of"):
+        load_fsaverage_data(data_type="foo")
 
 
 def test_load_fsaverage_hemispheres_have_file():
@@ -27,3 +45,10 @@ def test_load_fsaverage_hemispheres_have_file():
         mesh for mesh in result.values() if "right" in mesh.parts
     ]
     assert right_hemisphere_meshes
+
+
+def test_dfetch_datasets_errors():
+    """Give incorrect value argument."""
+    with pytest.raises(ValueError, match="'mesh_type' must be one of"):
+        fetch_nki(mesh_type="foo")
+        fetch_destrieux(mesh_type="foo")

--- a/nilearn/glm/contrasts.py
+++ b/nilearn/glm/contrasts.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 import scipy.stats as sps
 
-from nilearn._utils import rename_parameters
+from nilearn._utils import logger, rename_parameters
 from nilearn.glm._utils import pad_contrast, z_score
 from nilearn.maskers import NiftiMasker
 
@@ -232,7 +232,9 @@ class Contrast:
         self.dof = float(dof)
         self.dim = effect.shape[0] if dim is None else dim
         if self.dim > 1 and stat_type == "t":
-            print("Automatically converted multi-dimensional t to F contrast")
+            logger.log(
+                "Automatically converted multi-dimensional t to F contrast"
+            )
             stat_type = "F"
         if stat_type not in ["t", "F"]:
             raise ValueError(

--- a/nilearn/glm/first_level/experimental_paradigm.py
+++ b/nilearn/glm/first_level/experimental_paradigm.py
@@ -152,7 +152,8 @@ def _handle_modulation(events):
     if "modulation" in events.columns:
         logger.log(
             "A 'modulation' column was found in "
-            "the given events data and is used."
+            "the given events data and is used.",
+            stack_level=2,
         )
     else:
         events["modulation"] = 1

--- a/nilearn/glm/first_level/experimental_paradigm.py
+++ b/nilearn/glm/first_level/experimental_paradigm.py
@@ -18,6 +18,8 @@ import warnings
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 
+from nilearn._utils import logger
+
 
 def check_events(events):
     """Test that the events data describes a valid experimental paradigm.
@@ -148,7 +150,7 @@ def _check_null_duration(events):
 def _handle_modulation(events):
     """Set the modulation column to 1 if it is not present."""
     if "modulation" in events.columns:
-        print(
+        logger.log(
             "A 'modulation' column was found in "
             "the given events data and is used."
         )

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -565,7 +565,7 @@ class FirstLevelModel(BaseGLM):
                 f"in {int(time_in_second)} seconds."
             )
 
-        logger.log(msg, verbose=self.verbose)
+        logger.log(msg, verbose=self.verbose, stack_level=2)
 
     def _report_progress(self, run_idx, n_runs, t0):
         remaining = "go take a coffee, a big one"
@@ -1704,11 +1704,12 @@ def _report_found_files(files, text, sub_label, filters, verbose):
 
     """
     logger.log(
-        f"Found the following {len(files)} {text} files\n",
-        f"for subject {sub_label}\n",
-        f"for filter: {filters}:\n",
-        f"{files}\n",
-        verbose,
+        f"\nFound the following {len(files)} {text} files\n"
+        f"- for subject {sub_label}\n"
+        f"- for filter: {filters}:\n"
+        f"\t- {'\n\t- '.join(files)}\n",
+        verbose=verbose,
+        stack_level=3,
     )
 
 

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1684,7 +1684,7 @@ def _list_valid_subjects(derivatives_path, sub_labels):
     return set(sub_labels_exist)
 
 
-def _report_found_files(files, text, sub_label, filters):
+def _report_found_files(files, text, sub_label, filters, verbose):
     """Print list of files found for a given subject and filter.
 
     Parameters
@@ -1703,11 +1703,12 @@ def _report_found_files(files, text, sub_label, filters):
         Only one filter per field allowed.
 
     """
-    print(
+    logger.log(
         f"Found the following {len(files)} {text} files\n",
         f"for subject {sub_label}\n",
         f"for filter: {filters}:\n",
         f"{files}\n",
+        verbose,
     )
 
 
@@ -1758,13 +1759,13 @@ def _get_processed_imgs(
         sub_label=sub_label,
         filters=filters,
     )
-    if verbose:
-        _report_found_files(
-            files=imgs,
-            text="preprocessed BOLD",
-            sub_label=sub_label,
-            filters=filters,
-        )
+    _report_found_files(
+        files=imgs,
+        text="preprocessed BOLD",
+        sub_label=sub_label,
+        filters=filters,
+        verbose=verbose,
+    )
     _check_bids_image_list(imgs, sub_label, filters)
     return imgs
 
@@ -1822,13 +1823,13 @@ def _get_events_files(
         sub_label=sub_label,
         filters=events_filters,
     )
-    if verbose:
-        _report_found_files(
-            files=events,
-            text="events",
-            sub_label=sub_label,
-            filters=events_filters,
-        )
+    _report_found_files(
+        files=events,
+        text="events",
+        sub_label=sub_label,
+        filters=events_filters,
+        verbose=verbose,
+    )
     _check_bids_events_list(
         events=events,
         imgs=imgs,
@@ -1895,13 +1896,13 @@ def _get_confounds(
         sub_label=sub_label,
         filters=filters,
     )
-    if verbose:
-        _report_found_files(
-            files=confounds,
-            text="confounds",
-            sub_label=sub_label,
-            filters=filters,
-        )
+    _report_found_files(
+        files=confounds,
+        text="confounds",
+        sub_label=sub_label,
+        filters=filters,
+        verbose=verbose,
+    )
     _check_confounds_list(confounds=confounds, imgs=imgs)
 
     if confounds:

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1706,8 +1706,8 @@ def _report_found_files(files, text, sub_label, filters, verbose):
     logger.log(
         f"\nFound the following {len(files)} {text} files\n"
         f"- for subject {sub_label}\n"
-        f"- for filter: {filters}:\n"
-        f"\t- {'\n\t- '.join(files)}\n",
+        f"- for filter: {filters}:\n\t"
+        f"- {'\n\t- '.join(files)}\n",
         verbose=verbose,
         stack_level=3,
     )

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1703,11 +1703,12 @@ def _report_found_files(files, text, sub_label, filters, verbose):
         Only one filter per field allowed.
 
     """
+    unordered_list_string = "\n\t- ".join(files)
     logger.log(
         f"\nFound the following {len(files)} {text} files\n"
         f"- for subject {sub_label}\n"
         f"- for filter: {filters}:\n\t"
-        f"- {'\n\t- '.join(files)}\n",
+        f"- {unordered_list_string}\n",
         verbose=verbose,
         stack_level=3,
     )

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -518,10 +518,8 @@ class SecondLevelModel(BaseGLM):
 
         # Report progress
         logger.log(
-            (
-                "\nComputation of second level model done in "
-                f"{time.time() - t0} seconds.\n"
-            ),
+            "\nComputation of second level model done in "
+            f"{time.time() - t0} seconds.\n",
             verbose=self.verbose,
         )
 
@@ -942,10 +940,8 @@ def non_parametric_inference(
 
     # Report progress
     logger.log(
-        (
-            "\nComputation of second level model done in "
-            f"{time.time() - t0} seconds\n"
-        ),
+        "\nComputation of second level model done in "
+        f"{time.time() - t0} seconds\n",
         verbose=verbose,
     )
 

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -4,7 +4,6 @@ first level contrasts or directly on fitted first level models.
 Author: Martin Perez-Guevara, 2016
 """
 
-import sys
 import time
 from warnings import warn
 
@@ -14,7 +13,7 @@ from joblib import Memory
 from nibabel import Nifti1Image
 from sklearn.base import clone
 
-from nilearn._utils import fill_doc, stringify_path
+from nilearn._utils import fill_doc, logger, stringify_path
 from nilearn._utils.niimg_conversions import check_niimg
 from nilearn.glm._base import BaseGLM
 from nilearn.glm.contrasts import (
@@ -483,10 +482,10 @@ class SecondLevelModel(BaseGLM):
 
         # Report progress
         t0 = time.time()
-        if self.verbose > 0:
-            sys.stderr.write(
-                "Fitting second level model. Take a deep breath.\r"
-            )
+        logger.log(
+            "Fitting second level model. Take a deep breath.\r",
+            verbose=self.verbose,
+        )
 
         # Create and set design matrix, if not given
         if design_matrix is None:
@@ -518,11 +517,13 @@ class SecondLevelModel(BaseGLM):
         self.masker_.fit(sample_map)
 
         # Report progress
-        if self.verbose > 0:
-            sys.stderr.write(
+        logger.log(
+            (
                 "\nComputation of second level model done in "
                 f"{time.time() - t0} seconds.\n"
-            )
+            ),
+            verbose=self.verbose,
+        )
 
         return self
 
@@ -919,8 +920,7 @@ def non_parametric_inference(
 
     # Report progress
     t0 = time.time()
-    if verbose > 0:
-        sys.stderr.write("Fitting second level model...")
+    logger.log("Fitting second level model...", verbose=verbose)
 
     # Learn the mask. Assume the first level imgs have been masked.
     if not isinstance(mask, NiftiMasker):
@@ -941,11 +941,13 @@ def non_parametric_inference(
     masker.fit(sample_map)
 
     # Report progress
-    if verbose > 0:
-        sys.stderr.write(
+    logger.log(
+        (
             "\nComputation of second level model done in "
             f"{time.time() - t0} seconds\n"
-        )
+        ),
+        verbose=verbose,
+    )
 
     # Check and obtain the contrast
     contrast = _get_con_val(second_level_contrast, design_matrix)

--- a/nilearn/glm/tests/test_thresholding.py
+++ b/nilearn/glm/tests/test_thresholding.py
@@ -221,7 +221,7 @@ def test_all_resolution_inference(data_norm_isf, affine_eye):
 
     # verbose mode
     th_map = cluster_level_inference(
-        stat_img, threshold=3, alpha=0.05, verbose=True
+        stat_img, threshold=3, alpha=0.05, verbose=1
     )
 
 

--- a/nilearn/glm/thresholding.py
+++ b/nilearn/glm/thresholding.py
@@ -16,7 +16,7 @@ from nilearn.image import get_data, math_img, threshold_img
 from nilearn.maskers import NiftiMasker
 
 
-def _compute_hommel_value(z_vals, alpha, verbose=False):
+def _compute_hommel_value(z_vals, alpha, verbose=0):
     """Compute the All-Resolution Inference hommel-value."""
     if alpha < 0 or alpha > 1:
         raise ValueError("alpha should be between 0 and 1")
@@ -33,7 +33,7 @@ def _compute_hommel_value(z_vals, alpha, verbose=False):
     slopes = (alpha - p_vals[:-1]) / np.arange(n_samples - 1, 0, -1)
     slope = np.max(slopes)
     hommel_value = np.trunc(alpha / slope)
-    if verbose:
+    if verbose > 0:
         try:
             from matplotlib import pyplot as plt
         except ImportError:
@@ -109,7 +109,7 @@ def fdr_threshold(z_vals, alpha):
 
 
 def cluster_level_inference(
-    stat_img, mask_img=None, threshold=3.0, alpha=0.05, verbose=False
+    stat_img, mask_img=None, threshold=3.0, alpha=0.05, verbose=0
 ):
     """Report the proportion of active voxels for all clusters \
     defined by the input threshold.
@@ -131,7 +131,7 @@ def cluster_level_inference(
         Level of control on the true positive rate, aka true discovery
         proportion.
 
-    verbose : bool, default=False
+    verbose : int or bool, default=0
         Verbosity mode.
 
     Returns
@@ -144,6 +144,11 @@ def cluster_level_inference(
     .. footbibliography::
 
     """
+    if verbose is False:
+        verbose = 0
+    if verbose is True:
+        verbose = 1
+
     if not isinstance(threshold, list):
         threshold = [threshold]
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -25,6 +25,7 @@ from .._utils import (
     check_niimg_3d,
     check_niimg_4d,
     fill_doc,
+    logger,
 )
 from .._utils.exceptions import DimensionError
 from .._utils.helpers import (
@@ -1591,13 +1592,10 @@ def concat_imgs(
             ),
         )
     ):
-        if verbose > 0:
-            nii_str = (
-                f"image {niimg}"
-                if isinstance(niimg, str)
-                else f"image #{index}"
-            )
-            print(f"Concatenating {index + 1}: {nii_str}")
+        nii_str = (
+            f"image {niimg}" if isinstance(niimg, str) else f"image #{index}"
+        )
+        logger.log(f"Concatenating {index + 1}: {nii_str}", verbose)
 
         data[..., cur_4d_index : cur_4d_index + size] = _get_data(niimg)
         cur_4d_index += size

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -1264,7 +1264,7 @@ def test_concat_niimgs(affine_eye, tmp_path):
     img1c = Nifti1Image(np.ones(shape3), affine_eye)
 
     # check basic concatenation with equal shape/affine
-    # versbose for coverage
+    # verbose for coverage
     concatenated = concat_imgs((img1, img2, img1), verbose=1)
 
     # smoke-test auto_resample

--- a/nilearn/interfaces/tests/test_bids.py
+++ b/nilearn/interfaces/tests/test_bids.py
@@ -205,7 +205,6 @@ def test_get_bids_files_inheritance_principle_sub_folder(tmp_path, json_file):
         metadata={"RepetitionTime": 1.5},
         json_file=json_file,
     )
-    print(new_json_file)
     assert new_json_file.exists()
 
     # make sure that get_bids_files finds the json file

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -12,9 +12,8 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from nilearn.image import high_variance_confounds
 
 from .. import _utils, image, masking, signal
-from .._utils import stringify_path
+from .._utils import logger, stringify_path
 from .._utils.cache_mixin import CacheMixin, cache
-from .._utils.class_inspect import enclosing_scope_name
 
 
 def _filter_and_extract(
@@ -55,21 +54,16 @@ def _filter_and_extract(
     """
     if memory is None:
         memory = Memory(location=None)
-    # Since the calling class can be any *Nifti*Masker, we look for exact type
-    if verbose > 0:
-        class_name = enclosing_scope_name(stack_level=10)
-
     # If we have a string (filename), we won't need to copy, as
     # there will be no side effect
     imgs = stringify_path(imgs)
     if isinstance(imgs, str):
         copy = False
 
-    if verbose > 0:
-        print(
-            f"[{class_name}] Loading data "
-            f"from {_utils._repr_niimgs(imgs, shorten=False)}"
-        )
+    logger.log(
+        f"Loading data " f"from {_utils._repr_niimgs(imgs, shorten=False)}",
+        verbose,
+    )
 
     # Convert input to niimg to check shape.
     # This must be repeated after the shape check because check_niimg will
@@ -93,8 +87,8 @@ def _filter_and_extract(
     target_shape = parameters.get("target_shape")
     target_affine = parameters.get("target_affine")
     if target_shape is not None or target_affine is not None:
-        if verbose > 0:
-            print(f"[{class_name}] Resampling images")
+        logger.log("Resampling images")
+
         imgs = cache(
             image.resample_img,
             memory,
@@ -112,8 +106,7 @@ def _filter_and_extract(
 
     smoothing_fwhm = parameters.get("smoothing_fwhm")
     if smoothing_fwhm is not None:
-        if verbose > 0:
-            print(f"[{class_name}] Smoothing images")
+        logger.log("Smoothing images")
         imgs = cache(
             image.smooth_img,
             memory,
@@ -121,8 +114,7 @@ def _filter_and_extract(
             memory_level=memory_level,
         )(imgs, parameters["smoothing_fwhm"])
 
-    if verbose > 0:
-        print(f"[{class_name}] Extracting region signals")
+    logger.log("Extracting region signals", verbose)
     region_signals, aux = cache(
         extraction_function,
         memory,
@@ -136,8 +128,7 @@ def _filter_and_extract(
     # Filtering
     # Confounds removing (from csv file or numpy array)
     # Normalizing
-    if verbose > 0:
-        print(f"[{class_name}] Cleaning extracted signals")
+    logger.log("Cleaning extracted signals", verbose)
     runs = parameters.get("runs", None)
     region_signals = cache(
         signal.clean,

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -62,7 +62,8 @@ def _filter_and_extract(
 
     logger.log(
         f"Loading data " f"from {_utils._repr_niimgs(imgs, shorten=False)}",
-        verbose,
+        verbose=verbose,
+        stack_level=2,
     )
 
     # Convert input to niimg to check shape.
@@ -87,7 +88,7 @@ def _filter_and_extract(
     target_shape = parameters.get("target_shape")
     target_affine = parameters.get("target_affine")
     if target_shape is not None or target_affine is not None:
-        logger.log("Resampling images")
+        logger.log("Resampling images", stack_level=2)
 
         imgs = cache(
             image.resample_img,
@@ -106,7 +107,7 @@ def _filter_and_extract(
 
     smoothing_fwhm = parameters.get("smoothing_fwhm")
     if smoothing_fwhm is not None:
-        logger.log("Smoothing images")
+        logger.log("Smoothing images", verbose=verbose, stack_level=2)
         imgs = cache(
             image.smooth_img,
             memory,
@@ -114,7 +115,7 @@ def _filter_and_extract(
             memory_level=memory_level,
         )(imgs, parameters["smoothing_fwhm"])
 
-    logger.log("Extracting region signals", verbose)
+    logger.log("Extracting region signals", verbose=verbose, stack_level=2)
     region_signals, aux = cache(
         extraction_function,
         memory,
@@ -128,7 +129,7 @@ def _filter_and_extract(
     # Filtering
     # Confounds removing (from csv file or numpy array)
     # Normalizing
-    logger.log("Cleaning extracted signals", verbose)
+    logger.log("Cleaning extracted signals", verbose=verbose, stack_level=2)
     runs = parameters.get("runs", None)
     region_signals = cache(
         signal.clean,

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -11,6 +11,7 @@ from functools import partial
 from joblib import Memory, Parallel, delayed
 
 from nilearn import _utils, image, masking
+from nilearn._utils import logger
 from nilearn.maskers._utils import compute_middle_image
 from nilearn.maskers.nifti_masker import NiftiMasker, _filter_and_mask
 
@@ -198,16 +199,15 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
 
         """
         # Load data (if filenames are given, load them)
-        if self.verbose > 0:
-            print(
-                f"[{self.__class__.__name__}.fit] Loading data from "
-                f"{_utils._repr_niimgs(imgs, shorten=False)}."
-            )
+        logger.log(
+            f"[{self.__class__.__name__}.fit] Loading data from "
+            f"{_utils._repr_niimgs(imgs, shorten=False)}.",
+            self.verbose,
+        )
 
         # Compute the mask if not given by the user
         if self.mask_img is None:
-            if self.verbose > 0:
-                print("[{self.__class__.__name__}.fit] Computing mask")
+            logger.log("Computing mask", self.verbose)
 
             imgs = _utils.helpers.stringify_path(imgs)
             if not isinstance(imgs, collections.abc.Iterable) or isinstance(
@@ -260,8 +260,7 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
 
         # If resampling is requested, resample the mask as well.
         # Resampling: allows the user to change the affine, the shape or both.
-        if self.verbose > 0:
-            print(f"[{self.__class__.__name__}.transform] Resampling mask")
+        logger.log("Resampling mask")
 
         # TODO switch to force_resample=True
         # when bumping to version > 0.13

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -200,7 +200,7 @@ class MultiNiftiMasker(NiftiMasker, _utils.CacheMixin):
         """
         # Load data (if filenames are given, load them)
         logger.log(
-            f"[{self.__class__.__name__}.fit] Loading data from "
+            f"Loading data from "
             f"{_utils._repr_niimgs(imgs, shorten=False)}.",
             self.verbose,
         )

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -504,14 +504,14 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
         """
         repr = _utils._repr_niimgs(self.labels_img, shorten=(not self.verbose))
         msg = f"loading data from {repr}"
-        _utils.logger.log(msg=msg, verbose=self.verbose)
+        logger.log(msg=msg, verbose=self.verbose)
         self.labels_img_ = _utils.check_niimg_3d(self.labels_img)
         if self.mask_img is not None:
             repr = _utils._repr_niimgs(
                 self.mask_img, shorten=(not self.verbose)
             )
             msg = f"loading data from {repr}"
-            _utils.logger.log(msg=msg, verbose=self.verbose)
+            logger.log(msg=msg, verbose=self.verbose)
             self.mask_img_ = _utils.check_niimg_3d(self.mask_img)
 
         else:
@@ -546,7 +546,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
                     )
 
             elif self.resampling_target == "labels":
-                _utils.logger.log("resampling the mask", verbose=self.verbose)
+                logger.log("resampling the mask", verbose=self.verbose)
                 # TODO switch to force_resample=True
                 # when bumping to version > 0.13
                 self.mask_img_ = image.resample_img(
@@ -793,7 +793,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
 
     def _resample_labels(self, imgs_):
 
-        logger.log("Resampling labels", self.verbose)
+        logger.log("Resampling labels", self.verbose, stack_level=2)
         labels_before_resampling = set(
             np.unique(_utils.niimg.safe_get_data(self._resampled_labels_img_))
         )
@@ -852,7 +852,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
 
         self._check_fitted()
 
-        _utils.logger.log("computing image from signals", verbose=self.verbose)
+        logger.log("computing image from signals", verbose=self.verbose)
         return signal_extraction.signals_to_img_labels(
             signals,
             self._resampled_labels_img_,

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -6,6 +6,7 @@ import numpy as np
 from joblib import Memory
 
 from nilearn import _utils, image, masking
+from nilearn._utils import logger
 from nilearn.maskers._utils import compute_middle_image
 from nilearn.maskers.base_masker import BaseMasker, _filter_and_extract
 
@@ -699,8 +700,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
                     self._resampled_mask_img,
                 )
             ):
-                if self.verbose > 0:
-                    print("Resampling mask")
+                logger.log("Resampling mask", self.verbose)
                 self._resampled_mask_img = self._cache(
                     image.resample_img, func_memory_level=2
                 )(
@@ -792,8 +792,8 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
         return region_signals
 
     def _resample_labels(self, imgs_):
-        if self.verbose > 0:
-            print("Resampling labels")
+
+        logger.log("Resampling labels", self.verbose)
         labels_before_resampling = set(
             np.unique(_utils.niimg.safe_get_data(self._resampled_labels_img_))
         )

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -391,7 +391,7 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
         # Load images
         repr = _utils._repr_niimgs(self.mask_img, shorten=(not self.verbose))
         msg = f"loading regions from {repr}"
-        _utils.logger.log(msg=msg, verbose=self.verbose)
+        logger.log(msg=msg, verbose=self.verbose)
         self.maps_img_ = _utils.check_niimg(
             self.maps_img, dtype=self.dtype, atleast_4d=True
         )
@@ -407,7 +407,7 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
                 self.mask_img, shorten=(not self.verbose)
             )
             msg = f"loading mask from {repr}"
-            _utils.logger.log(msg=msg, verbose=self.verbose)
+            logger.log(msg=msg, verbose=self.verbose)
             self.mask_img_ = _utils.check_niimg_3d(self.mask_img)
         else:
             self.mask_img_ = None
@@ -672,7 +672,7 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
 
         self._check_fitted()
 
-        _utils.logger.log("computing image from signals", verbose=self.verbose)
+        logger.log("computing image from signals", verbose=self.verbose)
         return signal_extraction.signals_to_img_maps(
             region_signals, self.maps_img_, mask_img=self.mask_img_
         )

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -6,6 +6,7 @@ import numpy as np
 from joblib import Memory
 
 from nilearn import _utils, image
+from nilearn._utils import logger
 from nilearn.maskers._utils import compute_middle_image
 from nilearn.maskers.base_masker import BaseMasker, _filter_and_extract
 
@@ -420,8 +421,8 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
             )
 
         elif self.resampling_target == "mask" and self.mask_img_ is not None:
-            if self.verbose > 0:
-                print("Resampling maps")
+
+            logger.log("Resampling maps", self.verbose)
 
             # TODO switch to force_resample=True
             # when bumping to version > 0.13
@@ -436,8 +437,8 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
             )
 
         elif self.resampling_target == "maps" and self.mask_img_ is not None:
-            if self.verbose > 0:
-                print("Resampling mask")
+
+            logger.log("Resampling mask", self.verbose)
 
             # TODO switch to force_resample=True
             # when bumping to version > 0.13
@@ -556,8 +557,8 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
                 ref_img,
                 self._resampled_maps_img_,
             ):
-                if self.verbose > 0:
-                    print("Resampling maps")
+
+                logger.log("Resampling maps", self.verbose)
                 # TODO switch to force_resample=True
                 # when bumping to version > 0.13
                 self._resampled_maps_img_ = self._cache(image.resample_img)(
@@ -576,8 +577,8 @@ class NiftiMapsMasker(BaseMasker, _utils.CacheMixin):
                     self.mask_img_,
                 )
             ):
-                if self.verbose > 0:
-                    print("Resampling mask")
+
+                logger.log("Resampling mask", self.verbose)
                 # TODO switch to force_resample=True
                 # when bumping to version > 0.13
                 self._resampled_mask_img_ = self._cache(image.resample_img)(

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -8,7 +8,8 @@ from functools import partial
 
 from joblib import Memory
 
-from nilearn import _utils, image, logger, masking
+from nilearn import _utils, image, masking
+from nilearn._utils import logger
 from nilearn.maskers._utils import compute_middle_image
 from nilearn.maskers.base_masker import BaseMasker, _filter_and_extract
 

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -8,7 +8,7 @@ from functools import partial
 
 from joblib import Memory
 
-from nilearn import _utils, image, masking
+from nilearn import _utils, image, logger, masking
 from nilearn.maskers._utils import compute_middle_image
 from nilearn.maskers.base_masker import BaseMasker, _filter_and_extract
 
@@ -423,11 +423,10 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
 
         """
         # Load data (if filenames are given, load them)
-        if self.verbose > 0:
-            print(
-                f"[{self.__class__.__name__}.fit] "
-                f"Loading data from {_utils._repr_niimgs(imgs, shorten=False)}"
-            )
+        logger.log(
+            f"Loading data from {_utils._repr_niimgs(imgs, shorten=False)}",
+            verbose=self.verbose,
+        )
 
         # Compute the mask if not given by the user
         if self.mask_img is None:
@@ -439,8 +438,8 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
                 )
             mask_args = self.mask_args if self.mask_args is not None else {}
             compute_mask = _get_mask_strategy(self.mask_strategy)
-            if self.verbose > 0:
-                print(f"[{self.__class__.__name__}.fit] Computing the mask")
+
+            logger.log("Computing the mask", verbose=self.verbose)
             self.mask_img_ = self._cache(compute_mask, ignore=["verbose"])(
                 imgs, verbose=max(0, self.verbose - 1), **mask_args
             )
@@ -462,8 +461,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
 
         # If resampling is requested, resample also the mask
         # Resampling: allows the user to change the affine, the shape or both
-        if self.verbose > 0:
-            print(f"[{self.__class__.__name__}.fit] Resampling mask")
+        logger.log("Resampling mask", verbose=self.verbose)
 
         # TODO switch to force_resample=True
         # when bumping to version > 0.13
@@ -488,8 +486,7 @@ class NiftiMasker(BaseMasker, _utils.CacheMixin):
         # Infer the number of elements (voxels) in the mask
         self.n_elements_ = int(data.sum())
 
-        if self.verbose > 0:
-            print(f"[{self.__class__.__name__}.fit] Finished fit")
+        logger.log("Finished fit", verbose=self.verbose)
 
         if (
             (self.target_shape is not None)

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -9,7 +9,7 @@ from joblib import Parallel, delayed
 from scipy.ndimage import binary_dilation, binary_erosion
 
 from . import _utils
-from ._utils import fill_doc
+from ._utils import fill_doc, logger
 from ._utils.cache_mixin import cache
 from ._utils.ndimage import get_border_data, largest_connected_component
 from ._utils.niimg import safe_get_data
@@ -291,8 +291,7 @@ def compute_epi_mask(
     mask : :class:`nibabel.nifti1.Nifti1Image`
         The brain mask (3D image).
     """
-    if verbose > 0:
-        print("EPI mask computation")
+    logger.log("EPI mask computation", verbose)
 
     # Delayed import to avoid circular imports
     from .image.image import _compute_mean
@@ -480,8 +479,7 @@ def compute_background_mask(
     mask : :class:`nibabel.nifti1.Nifti1Image`
         The brain mask (3D image).
     """
-    if verbose > 0:
-        print("Background mask computation")
+    logger.log("Background mask computation", verbose)
 
     data_imgs = _utils.check_niimg(data_imgs)
 
@@ -633,8 +631,7 @@ def compute_brain_mask(
     mask : :class:`nibabel.nifti1.Nifti1Image`
         The whole-brain mask (3D image).
     """
-    if verbose > 0:
-        print("Template", mask_type, "mask computation")
+    logger.log("Template", mask_type, "mask computation", verbose)
 
     target_img = _utils.check_niimg(target_img)
 

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -631,7 +631,7 @@ def compute_brain_mask(
     mask : :class:`nibabel.nifti1.Nifti1Image`
         The whole-brain mask (3D image).
     """
-    logger.log("Template", mask_type, "mask computation", verbose)
+    logger.log(f"Template {mask_type} mask computation", verbose)
 
     target_img = _utils.check_niimg(target_img)
 

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -284,7 +284,8 @@ def _permuted_ols_on_chunk(
                 logger.log(
                     f"Job #{thread_id}, processed {i_perm}/{n_perm_chunk} "
                     f"permutations ({percent:0.2f}%, {remaining} seconds "
-                    f"remaining){crlf}"
+                    f"remaining){crlf}",
+                    stack_level=2,
                 )
 
     return (

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -3,7 +3,6 @@ with OLS and permutation test."""
 
 # Author: Benoit Da Mota, <benoit.da_mota@inria.fr>, sept. 2011
 #         Virgile Fritsch, <virgile.fritsch@inria.fr>, jan. 2014
-import sys
 import time
 import warnings
 
@@ -15,6 +14,7 @@ from scipy.ndimage import generate_binary_structure, label
 from sklearn.utils import check_random_state
 
 from nilearn import image
+from nilearn._utils import logger
 from nilearn.masking import apply_mask
 from nilearn.mass_univariate._utils import (
     calculate_cluster_measures,
@@ -280,7 +280,8 @@ def _permuted_ols_on_chunk(
                 percent = round(percent * 100, 2)
                 dt = time.time() - t0
                 remaining = (100.0 - percent) / max(0.01, percent) * dt
-                sys.stderr.write(
+
+                logger.log(
                     f"Job #{thread_id}, processed {i_perm}/{n_perm_chunk} "
                     f"permutations ({percent:0.2f}%, {remaining} seconds "
                     f"remaining){crlf}"

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -278,6 +278,7 @@ def test_permuted_ols_no_covar(design):
         n_perm=0,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
     compare_to_ref_score(output["t"], tested_var, target_var)
 
@@ -292,6 +293,7 @@ def test_permuted_ols_no_covar_with_ravelized_tested_var(design):
         n_perm=0,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
     compare_to_ref_score(output["t"], tested_var, target_var)
 
@@ -307,6 +309,7 @@ def test_permuted_ols_no_covar_with_intercept(design):
         n_perm=0,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
     target_var -= target_var.mean(0)
     tested_var -= tested_var.mean(0)
@@ -328,6 +331,7 @@ def test_permuted_ols_no_covar_warning(rng):
         n_perm=N_PERM,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
 
     # test with ravelized tested_var
@@ -375,6 +379,7 @@ def test_permuted_ols_with_covar(design, confounding_vars):
         n_perm=0,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
 
     ref_score = compare_to_ref_score(
@@ -395,6 +400,7 @@ def test_permuted_ols_with_covar_with_intercept(design, confounding_vars):
         n_perm=0,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
 
     confounding_vars = np.hstack((confounding_vars, np.ones((N_SAMPLES, 1))))
@@ -420,6 +426,7 @@ def test_permuted_ols_with_covar_with_intercept_in_confonding_vars(
         n_perm=0,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
     assert output["t"].shape == (n_regressors, n_descriptors)
 
@@ -440,6 +447,7 @@ def test_permuted_ols_with_multiple_constants_and_covars(design, rng):
         n_perm=0,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
     assert output["t"].shape == (n_regressors, n_descriptors)
 
@@ -494,6 +502,7 @@ def test_permuted_ols_nocovar_multivariate(rng):
         n_perm=n_perm,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
 
     compare_to_ref_score(output["t"], tested_var, target_vars)
@@ -509,6 +518,7 @@ def test_permuted_ols_nocovar_multivariate(rng):
         n_perm=0,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
 
     target_vars -= target_vars.mean(0)
@@ -534,6 +544,7 @@ def test_permuted_ols_intercept_nocovar(rng):
         n_perm=N_PERM,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
 
     ref_score = compare_to_ref_score(output["t"], tested_var, target_var)
@@ -553,6 +564,7 @@ def test_permuted_ols_intercept_nocovar(rng):
         n_perm=0,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
     compare_to_ref_score(output_addintercept["t"], tested_var, target_var)
     assert output_addintercept["t"].shape == (n_regressors, n_descriptors)
@@ -575,6 +587,7 @@ def test_permuted_ols_intercept_statsmodels_withcovar(
         n_perm=0,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
     ref_score = compare_to_ref_score(
         output["t"], tested_var, target_var, confounding_vars
@@ -591,6 +604,7 @@ def test_permuted_ols_intercept_statsmodels_withcovar(
         n_perm=0,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
     compare_to_ref_score(
         output_intercept["t"], tested_var, target_var, confounding_vars
@@ -615,6 +629,7 @@ def test_one_sided_versus_two_test(rng):
         n_perm=N_PERM,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
     assert output_1_sided["logp_max_t"].shape == (n_regressors, n_descriptors)
 
@@ -627,6 +642,7 @@ def test_one_sided_versus_two_test(rng):
         n_perm=N_PERM,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
     assert output_2_sided["logp_max_t"].shape == (n_regressors, n_descriptors)
 
@@ -657,6 +673,7 @@ def test_two_sided_recover_positive_and_negative_effects():
         n_perm=N_PERM,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
     output_1_sided_1["logp_max_t"]
 
@@ -669,6 +686,7 @@ def test_two_sided_recover_positive_and_negative_effects():
         n_perm=N_PERM,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
 
     # two-sided
@@ -680,6 +698,7 @@ def test_two_sided_recover_positive_and_negative_effects():
         n_perm=N_PERM,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
     output_2_sided["logp_max_t"]
 
@@ -765,6 +784,7 @@ def test_tfce_smoke_legacy_smoke():
         masker=masker,
         tfce=True,
         output_type="dict",
+        verbose=1,
     )
 
     assert isinstance(out, dict)
@@ -786,6 +806,7 @@ def test_tfce_smoke_legacy_smoke():
         masker=masker,
         tfce=True,
         output_type="dict",
+        verbose=1,
     )
 
     assert isinstance(out, dict)
@@ -888,6 +909,7 @@ def test_cluster_level_parameters_smoke(cluster_level_design, masker):
         n_perm=0,
         random_state=0,
         output_type="dict",
+        verbose=1,
     )
 
     assert isinstance(out, dict)
@@ -906,6 +928,7 @@ def test_cluster_level_parameters_smoke(cluster_level_design, masker):
         threshold=0.001,
         masker=masker,
         output_type="dict",
+        verbose=1,
     )
 
     assert isinstance(out, dict)

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -28,7 +28,7 @@ from nilearn.plotting.displays import get_projector, get_slicer
 from nilearn.plotting.displays._slicers import _get_cbar_ticks
 
 from .. import _utils
-from .._utils import compare_version, fill_doc
+from .._utils import compare_version, fill_doc, logger
 from .._utils.extmath import fast_abs_percentile
 from .._utils.ndimage import get_border_data
 from .._utils.niimg import safe_get_data
@@ -1934,7 +1934,7 @@ def plot_carpet(
         if mask_labels:
             label_dtype = type(list(mask_labels.values())[0])
             if label_dtype != atlas_values.dtype:
-                print(f"Coercing atlas_values to {label_dtype}")
+                logger.log(f"Coercing atlas_values to {label_dtype}")
                 atlas_values = atlas_values.astype(label_dtype)
 
         # Sort data and atlas by atlas values

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -9,7 +9,7 @@ from sklearn.feature_extraction import image
 
 from nilearn.maskers import NiftiLabelsMasker
 
-from .._utils import fill_doc, stringify_path
+from .._utils import fill_doc, logger, stringify_path
 from .._utils.niimg import safe_get_data
 from .._utils.niimg_conversions import iter_check_niimg
 from ..decomposition._multi_pca import _MultiPCA
@@ -359,8 +359,8 @@ class Parcellations(_MultiPCA):
         components = _MultiPCA._raw_fit(self, data)
 
         mask_img_ = self.masker_.mask_img_
-        if self.verbose:
-            print(f"[{self.__class__.__name__}] computing {self.method}")
+
+        logger.log(f"computing {self.method}", verbose=self.verbose)
 
         if self.method == "kmeans":
             from sklearn.cluster import MiniBatchKMeans

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -360,7 +360,9 @@ class Parcellations(_MultiPCA):
 
         mask_img_ = self.masker_.mask_img_
 
-        logger.log(f"computing {self.method}", verbose=self.verbose)
+        logger.log(
+            f"computing {self.method}", verbose=self.verbose, stack_level=3
+        )
 
         if self.method == "kmeans":
             from sklearn.cluster import MiniBatchKMeans

--- a/nilearn/regions/rena_clustering.py
+++ b/nilearn/regions/rena_clustering.py
@@ -15,7 +15,7 @@ from sklearn.base import BaseEstimator, ClusterMixin, TransformerMixin
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
 
-from nilearn._utils import fill_doc
+from nilearn._utils import fill_doc, logger
 from nilearn.image import get_data
 from nilearn.masking import unmask_from_to_3d_array
 
@@ -416,9 +416,10 @@ def recursive_neighbor_agglomeration(
         n_components = connectivity.shape[0]
 
         if verbose > 0:
-            print(
+            logger.log(
                 f"After iteration number {i + 1}, features are "
-                f" grouped into {n_components} clusters"
+                f" grouped into {n_components} clusters",
+                verbose,
             )
 
         if n_components <= n_clusters:

--- a/nilearn/regions/rena_clustering.py
+++ b/nilearn/regions/rena_clustering.py
@@ -415,12 +415,11 @@ def recursive_neighbor_agglomeration(
         labels = reduced_labels[labels]
         n_components = connectivity.shape[0]
 
-        if verbose > 0:
-            logger.log(
-                f"After iteration number {i + 1}, features are "
-                f" grouped into {n_components} clusters",
-                verbose,
-            )
+        logger.log(
+            f"After iteration number {i + 1}, features are "
+            f" grouped into {n_components} clusters",
+            verbose,
+        )
 
         if n_components <= n_clusters:
             break


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4443 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- use nilearn logger instead of "simple" `print`

### TODO

- [x] use the stack level parameter of the nilearn logger to check that messages are not displayed as being sent from a private function / method
