### PR TITLE
Change default `clustering_percentile` in `_BaseDecoder` docstring

### DIFF
--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -495,7 +495,7 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
         than 100, a ReNA clustering is performed as a first step of fit
         to agglomerate similar features together. ReNA is typically efficient
         for clustering_percentile equal to 10. Only used with
-        :class:`nilearn.decoding.FREMClassifier` and 
+        :class:`nilearn.decoding.FREMClassifier` and
         :class:`nilearn.decoding.FREMRegressor`.
 
     screening_percentile: int, float, \

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -490,7 +490,7 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
 
         For Dummy estimators, parameter grid defaults to empty dictionary.
 
-    clustering_percentile: int, float, in the [0, 100], default=10
+    clustering_percentile: int, float, in the [0, 100], default=100
         Percentile of features to keep after clustering. If it is lower
         than 100, a ReNA clustering is performed as a first step of fit
         to agglomerate similar features together. ReNA is typically efficient

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -494,7 +494,9 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
         Percentile of features to keep after clustering. If it is lower
         than 100, a ReNA clustering is performed as a first step of fit
         to agglomerate similar features together. ReNA is typically efficient
-        for clustering_percentile equal to 10.
+        for clustering_percentile equal to 10. Only used with
+        :class:`nilearn.decoding.FREMClassifier` and 
+        :class:`nilearn.decoding.FREMRegressor`.
 
     screening_percentile: int, float, \
                           in the closed interval [0, 100], \


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4488

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- changing the default value of `clustering_percentile` in `_BaseDecoder` docstring from 10 to 100