### PR TITLE
[FIX] Reduce `dtype` of mask from `int64` to `int8` in `image.binarize_img`

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -16,7 +16,7 @@ Fixes
 
 - :bdg-dark:`Code` Fix previous Glover HRF implementation to fit the original paper (Glover, 1999) (:gh:`4452` by `Kun CHEN`_).
 
-- :bdg-dark:`Code` Avoid triggering ``UserWarning`` by :func:`nilearn.image.binarize_img` (:gh:`4498` by `Patrick Sadil`_).
+- :bdg-dark:`Code` :func:`nilearn.image.binarize_img` explicitly cast images to ``int8`` to avoid warnings about ``int64`` when working with ``float64`` images (:gh:`4498` by `Patrick Sadil`_).
 
 Enhancements
 ------------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -16,6 +16,8 @@ Fixes
 
 - :bdg-dark:`Code` Fix previous Glover HRF implementation to fit the original paper (Glover, 1999) (:gh:`4452` by `Kun CHEN`_).
 
+- :bdg-dark:`Code` Avoid triggering ``UserWarning`` by :func:`nilearn.image.binarize_img` (:gh:`4498` by `Patrick Sadil`_).
+
 Enhancements
 ------------
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1242,7 +1242,7 @@ def binarize_img(
     )
 
     return math_img(
-        "img.astype(bool).astype(np.int8)",
+        "img.astype(bool).astype('int8')",
         img=threshold_img(
             img,
             threshold,

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1242,7 +1242,7 @@ def binarize_img(
     )
 
     return math_img(
-        "img.astype(bool).astype(int)",
+        "img.astype(bool).astype(np.int8)",
         img=threshold_img(
             img,
             threshold,

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -1024,6 +1024,13 @@ def test_binarize_img_copied_header(img_4d_mni_tr2):
     assert result.header["cal_max"] == 1
 
 
+def test_binarize_img_no_userwarning(img_4d_rand_eye):
+    # Test that a UserWarning is not thrown for a float64 img
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=UserWarning)
+        binarize_img(img_4d_rand_eye)
+
+
 @pytest.mark.parametrize(
     "func, input_img",
     [


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4498

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Avoids the warning by casting the mask to `np.int8` instead of `int`(64)
