### PR TITLE
[FIX] force np.float64 format for second level matrix dataframe

### DIFF
--- a/.github/workflows/nightly_dependencies.yml
+++ b/.github/workflows/nightly_dependencies.yml
@@ -19,6 +19,10 @@ on:
 
     workflow_dispatch:
 
+# Force to use color
+env:
+    FORCE_COLOR: true
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true

--- a/nilearn/glm/first_level/design_matrix.py
+++ b/nilearn/glm/first_level/design_matrix.py
@@ -488,7 +488,7 @@ def make_second_level_design_matrix(subjects_label, confounds=None):
         raise ValueError("Design matrix columns do not have unique names")
 
     # float dtype necessary for linalg
-    design_matrix = pd.DataFrame(columns=design_columns, dtype=np.float64)
+    design_matrix = pd.DataFrame(columns=design_columns, dtype="float64")
     for ridx, subject_label in enumerate(subjects_label):
         design_matrix.loc[ridx] = [0.0] * len(design_columns)
         design_matrix.loc[ridx, "intercept"] = 1.0

--- a/nilearn/glm/first_level/design_matrix.py
+++ b/nilearn/glm/first_level/design_matrix.py
@@ -488,10 +488,10 @@ def make_second_level_design_matrix(subjects_label, confounds=None):
         raise ValueError("Design matrix columns do not have unique names")
 
     # float dtype necessary for linalg
-    design_matrix = pd.DataFrame(columns=design_columns, dtype=float)
+    design_matrix = pd.DataFrame(columns=design_columns, dtype=np.float64)
     for ridx, subject_label in enumerate(subjects_label):
-        design_matrix.loc[ridx] = [0] * len(design_columns)
-        design_matrix.loc[ridx, "intercept"] = 1
+        design_matrix.loc[ridx] = [0.0] * len(design_columns)
+        design_matrix.loc[ridx, "intercept"] = 1.0
         if confounds is not None:
             conrow = confounds["subject_label"] == subject_label
             if np.sum(conrow) > 1:

--- a/nilearn/glm/tests/test_dmtx.py
+++ b/nilearn/glm/tests/test_dmtx.py
@@ -453,7 +453,7 @@ def test_create_second_level_design():
     regressors = [["01", 0.1], ["02", 0.75]]
     regressors = pd.DataFrame(regressors, columns=["subject_label", "f1"])
     design = make_second_level_design_matrix(subjects_label, regressors)
-    expected_design = np.array([[0.75, 1], [0.1, 1]])
+    expected_design = np.array([[0.75, 1.0], [0.1, 1.0]])
     assert_array_equal(design, expected_design)
     assert len(design.columns) == 2
     assert len(design) == 2


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4495 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- force np.float64 format to make sure compatibility with pandas 3.0 

