### PR TITLE
[MAINT] drop python 3.8

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -54,7 +54,6 @@ body:
         -   label: '3.11'
         -   label: '3.10'
         -   label: '3.9'
-        -   label: '3.8'
 
 -   type: textarea
     attributes:

--- a/.github/workflows/test_with_tox.yml
+++ b/.github/workflows/test_with_tox.yml
@@ -26,7 +26,7 @@ jobs:
             fail-fast: false
             matrix:
                 description: [latest dependencies]
-                py: ['3.12', '3.11', '3.10', '3.9', '3.8']
+                py: ['3.12', '3.11', '3.10', '3.9']
                 os: [ubuntu-latest, macos-latest, windows-latest]
                 env: [test_plotting]
                 include:
@@ -35,11 +35,11 @@ jobs:
                     os: ubuntu-latest
                     env: test_pre
                 -   description: oldest dependencies - no plotting
-                    py: '3.8'
+                    py: '3.9'
                     os: ubuntu-latest
                     env: test_min
                 -   description: oldest dependencies - no plotly
-                    py: '3.8'
+                    py: '3.9'
                     os: ubuntu-latest
                     env: test_plot_min
         steps:

--- a/.github/workflows/testing_install.yml
+++ b/.github/workflows/testing_install.yml
@@ -21,7 +21,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: ['3.8']
+                python-version: ['3.9']
         name: ${{ matrix.os }} with Python ${{ matrix.python-version }} and latest package versions
         defaults:
             run:

--- a/.github/workflows/testing_minimum.yml
+++ b/.github/workflows/testing_minimum.yml
@@ -48,7 +48,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
                 python-version: ['3.9']
-                min_dep: [joblib==1.0.0, nibabel==5.2.0, numpy==1.20.0, pandas==1.1.5, scikit-learn==1.4.0, scipy==1.8.0]
+                min_dep: [joblib==1.2.0, nibabel==5.2.0, numpy==1.20.0, pandas==1.1.5, scikit-learn==1.4.0, scipy==1.8.0]
         name: ${{ matrix.os }} with Python ${{ matrix.python-version }} and ${{ matrix.min_dep }}
         steps:
         -   name: Checkout nilearn

--- a/.github/workflows/testing_minimum.yml
+++ b/.github/workflows/testing_minimum.yml
@@ -8,7 +8,9 @@ name: test minimal version of each dependency
 # see https://github.com/nilearn/nilearn/issues/4069
 
 on:
-
+    pull_request:
+        branches:
+        -   '*'
     # Uses the cron schedule for github actions
     #
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events
@@ -46,7 +48,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
                 python-version: ['3.9']
-                min_dep: [joblib==1.0.0, nibabel==4.0.0, numpy==1.19.0, pandas==1.1.5, scikit-learn==1.0.0, scipy==1.8.0]
+                min_dep: [joblib==1.0.0, nibabel==4.0.0, numpy==1.20.0, pandas==1.1.5, scikit-learn==1.0.0, scipy==1.8.0]
         name: ${{ matrix.os }} with Python ${{ matrix.python-version }} and ${{ matrix.min_dep }}
         steps:
         -   name: Checkout nilearn

--- a/.github/workflows/testing_minimum.yml
+++ b/.github/workflows/testing_minimum.yml
@@ -48,7 +48,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
                 python-version: ['3.9']
-                min_dep: [joblib==1.2.0, nibabel==5.2.0, numpy==1.20.0, pandas==2.2.0, scikit-learn==1.4.0, scipy==1.8.0, matplotlib==3.3.0]
+                min_dep: [joblib==1.2.0, nibabel==5.2.0, numpy==1.22.4, pandas==2.2.0, scikit-learn==1.4.0, scipy==1.8.0, matplotlib==3.3.0]
         name: ${{ matrix.os }} with Python ${{ matrix.python-version }} and ${{ matrix.min_dep }}
         steps:
         -   name: Checkout nilearn

--- a/.github/workflows/testing_minimum.yml
+++ b/.github/workflows/testing_minimum.yml
@@ -48,7 +48,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
                 python-version: ['3.9']
-                min_dep: [joblib==1.0.0, nibabel==4.0.0, numpy==1.20.0, pandas==1.1.5, scikit-learn==1.0.0, scipy==1.8.0]
+                min_dep: [joblib==1.0.0, nibabel==5.2.0, numpy==1.20.0, pandas==1.1.5, scikit-learn==1.4.0, scipy==1.8.0]
         name: ${{ matrix.os }} with Python ${{ matrix.python-version }} and ${{ matrix.min_dep }}
         steps:
         -   name: Checkout nilearn

--- a/.github/workflows/testing_minimum.yml
+++ b/.github/workflows/testing_minimum.yml
@@ -48,7 +48,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
                 python-version: ['3.9']
-                min_dep: [joblib==1.2.0, nibabel==5.2.0, numpy==1.20.0, pandas==1.1.5, scikit-learn==1.4.0, scipy==1.8.0]
+                min_dep: [joblib==1.2.0, nibabel==5.2.0, numpy==1.20.0, pandas==2.2.0, scikit-learn==1.4.0, scipy==1.8.0, matplotlib==3.3.0]
         name: ${{ matrix.os }} with Python ${{ matrix.python-version }} and ${{ matrix.min_dep }}
         steps:
         -   name: Checkout nilearn

--- a/.github/workflows/testing_minimum.yml
+++ b/.github/workflows/testing_minimum.yml
@@ -45,7 +45,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: ['3.8']
+                python-version: ['3.9']
                 min_dep: [joblib==1.0.0, nibabel==4.0.0, numpy==1.19.0, pandas==1.1.5, scikit-learn==1.0.0, scipy==1.8.0]
         name: ${{ matrix.os }} with Python ${{ matrix.python-version }} and ${{ matrix.min_dep }}
         steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     rev: v3.17.0
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
 
 # Checks for .rst files
 -   repo: https://github.com/pre-commit/pygrep-hooks

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -5,6 +5,15 @@
 0.11.0.dev
 ==========
 
+HIGHLIGHTS
+----------
+
+.. warning::
+
+ | **Support for Python 3.8 has been dropped.**
+ | **We recommend upgrading to Python 3.11 or above.**
+
+
 NEW
 ---
 

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -12,7 +12,9 @@ HIGHLIGHTS
 
  | **Support for Python 3.8 has been dropped.**
  | **We recommend upgrading to Python 3.11 or above.**
-
+ |
+ | **Minimum supported versions of the following packages have been bumped up:**
+ | - Numpy -- v1.20.0
 
 NEW
 ---

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -14,7 +14,9 @@ HIGHLIGHTS
  | **We recommend upgrading to Python 3.11 or above.**
  |
  | **Minimum supported versions of the following packages have been bumped up:**
- | - Numpy -- v1.20.0
+ | - numpy -- v1.20.0
+ | - nibabel -- v5.2.0
+ | - scikit-learn -- v1.4.0
 
 NEW
 ---

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -14,7 +14,7 @@ HIGHLIGHTS
  | **We recommend upgrading to Python 3.11 or above.**
  |
  | **Minimum supported versions of the following packages have been bumped up:**
- | - numpy -- 1.20.0
+ | - numpy -- 1.22.4
  | - nibabel -- 5.2.0
  | - scikit-learn -- 1.4.0
  | - joblib -- 1.2.0

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -14,10 +14,11 @@ HIGHLIGHTS
  | **We recommend upgrading to Python 3.11 or above.**
  |
  | **Minimum supported versions of the following packages have been bumped up:**
- | - numpy -- v1.20.0
- | - nibabel -- v5.2.0
- | - scikit-learn -- v1.4.0
- | - joblib -- v1.2.0
+ | - numpy -- 1.20.0
+ | - nibabel -- 5.2.0
+ | - scikit-learn -- 1.4.0
+ | - joblib -- 1.2.0
+ | - pandas -- 2.2.0
 
 NEW
 ---

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -17,6 +17,7 @@ HIGHLIGHTS
  | - numpy -- v1.20.0
  | - nibabel -- v5.2.0
  | - scikit-learn -- v1.4.0
+ | - joblib -- v1.2.0
 
 NEW
 ---

--- a/nilearn/_utils/segmentation.py
+++ b/nilearn/_utils/segmentation.py
@@ -11,11 +11,9 @@ sub functions in skimage.segmentation
 import warnings
 
 import numpy as np
-from scipy import __version__, ndimage as ndi, sparse
+from scipy import ndimage as ndi, sparse
 from scipy.sparse.linalg import cg
 from sklearn.utils import as_float_array
-
-from nilearn._utils.helpers import compare_version
 
 
 def _make_graph_edges_3d(n_x, n_y, n_z):
@@ -357,14 +355,7 @@ def _solve_cg(lap_sparse, B, tol):
     lap_sparse = lap_sparse.tocsc()
     X = []
     for i in range(len(B)):
-        # TODO Python 3.8
-        # consider remove if/else block when dropping support for 3.8
-        # would require pinning scipy to >= 1.12
-        # See https://github.com/nilearn/nilearn/pull/4394
-        if compare_version(__version__, ">=", "1.12"):
-            x0 = cg(lap_sparse, -B[i].todense(), rtol=tol, atol=0)[0]
-        else:
-            x0 = cg(lap_sparse, -B[i].todense(), tol=tol, atol="legacy")[0]
+        x0 = cg(lap_sparse, -B[i].todense(), rtol=tol, atol=0)[0]
         X.append(x0)
 
     X = np.array(X)

--- a/nilearn/_utils/segmentation.py
+++ b/nilearn/_utils/segmentation.py
@@ -11,9 +11,11 @@ sub functions in skimage.segmentation
 import warnings
 
 import numpy as np
-from scipy import ndimage as ndi, sparse
+from scipy import __version__, ndimage as ndi, sparse
 from scipy.sparse.linalg import cg
 from sklearn.utils import as_float_array
+
+from nilearn._utils.helpers import compare_version
 
 
 def _make_graph_edges_3d(n_x, n_y, n_z):
@@ -355,7 +357,13 @@ def _solve_cg(lap_sparse, B, tol):
     lap_sparse = lap_sparse.tocsc()
     X = []
     for i in range(len(B)):
-        x0 = cg(lap_sparse, -B[i].todense(), rtol=tol, atol=0)[0]
+        # TODO
+        # when support scipy to >= 1.12
+        # See https://github.com/nilearn/nilearn/pull/4394
+        if compare_version(__version__, ">=", "1.12"):
+            x0 = cg(lap_sparse, -B[i].todense(), rtol=tol, atol=0)[0]
+        else:
+            x0 = cg(lap_sparse, -B[i].todense(), tol=tol, atol="legacy")[0]
         X.append(x0)
 
     X = np.array(X)

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -18,7 +18,7 @@ ensembling to achieve state of the art performance
 
 import itertools
 import warnings
-from typing import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 from joblib import Parallel, delayed

--- a/nilearn/experimental/surface/_datasets.py
+++ b/nilearn/experimental/surface/_datasets.py
@@ -5,7 +5,7 @@ eventually nilearn.datasets would be updated
 
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 from nilearn import datasets
 from nilearn.experimental.surface import _io

--- a/nilearn/experimental/surface/_io.py
+++ b/nilearn/experimental/surface/_io.py
@@ -1,7 +1,7 @@
 """Input/output for surface data and meshes."""
 
 import pathlib
-from typing import Dict, Union
+from typing import Union
 
 import numpy as np
 from nibabel import gifti
@@ -14,7 +14,7 @@ def read_array(array_file: Union[pathlib.Path, str]) -> np.ndarray:
     return old_surface.load_surf_data(array_file)
 
 
-def read_mesh(mesh_file: Union[pathlib.Path, str]) -> Dict[str, np.ndarray]:
+def read_mesh(mesh_file: Union[pathlib.Path, str]) -> dict[str, np.ndarray]:
     """Load surface mesh geometry into Numpy arrays."""
     loaded = old_surface.load_surf_mesh(mesh_file)
     return {"coordinates": loaded.coordinates, "faces": loaded.faces}

--- a/nilearn/experimental/surface/_surface_image.py
+++ b/nilearn/experimental/surface/_surface_image.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import abc
 import pathlib
-import sys
 from pathlib import Path
 
 import numpy as np
@@ -270,17 +269,9 @@ class SurfaceImage:
 
         if "hemi-L" not in filename.stem and "hemi-R" not in filename.stem:
             for hemi in ["L", "R"]:
-                # TODO simplify when dropping python 3.8
-                if sys.version_info.minor >= 9:
-                    self.to_filename(
-                        filename.with_stem(f"{filename.stem}_hemi-{hemi}")
-                    )
-                else:
-                    self.to_filename(
-                        _with_stem_compat(
-                            filename, new_stem=f"{filename.stem}_hemi-{hemi}"
-                        )
-                    )
+                self.to_filename(
+                    filename.with_stem(f"{filename.stem}_hemi-{hemi}")
+                )
 
             return None
 
@@ -289,11 +280,3 @@ class SurfaceImage:
         if "hemi-R" in filename.stem:
             mesh = self.mesh.parts["right"]
         mesh.to_gifti(filename)
-
-
-def _with_stem_compat(path: Path, new_stem: str) -> Path:
-    """Provide equivalent of `with_stem` for Python < 3.9.
-
-    TODO remove when dropping python 3.8
-    """
-    return path.with_name(new_stem + path.suffix)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "joblib>=1.0.0",
     "lxml",
     "nibabel>=4.0.0",
-    "numpy>=1.19.0",
+    "numpy>=1.20.0",
     "pandas>=1.1.5",
     "requests>=2.25.0",
     "scikit-learn>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "Operating System :: POSIX",
     "Operating System :: Unix",
     "Operating System :: MacOS",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -40,7 +39,7 @@ license = {text = "new BSD"}
 maintainers = [{name = "Bertrand Thirion", email = "bertrand.thirion@inria.fr"}]
 name = "nilearn"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 # A combination of dependencies useful for developers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "lxml",
     "nibabel>=5.2.0",
     "numpy>=1.20.0",
-    "pandas>=1.1.5",
+    "pandas>=2.2.0",
     "requests>=2.25.0",
     "scikit-learn>=1.4.0",
     "scipy>=1.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "joblib>=1.2.0",
     "lxml",
     "nibabel>=5.2.0",
-    "numpy>=1.20.0",
+    "numpy>=1.22.4",
     "pandas>=2.2.0",
     "requests>=2.25.0",
     "scikit-learn>=1.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12"
 ]
 dependencies = [
-    "joblib>=1.0.0",
+    "joblib>=1.2.0",
     "lxml",
     "nibabel>=5.2.0",
     "numpy>=1.20.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,11 @@ classifiers = [
 dependencies = [
     "joblib>=1.0.0",
     "lxml",
-    "nibabel>=4.0.0",
+    "nibabel>=5.2.0",
     "numpy>=1.20.0",
     "pandas>=1.1.5",
     "requests>=2.25.0",
-    "scikit-learn>=1.0.0",
+    "scikit-learn>=1.4.0",
     "scipy>=1.8.0",
     "packaging"
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ skip_install = false
 deps =
     joblib==1.0.0
     nibabel==4.0.0
-    numpy==1.19.0
+    numpy==1.20.0
     pandas==1.1.5
     scikit-learn==1.0.0
     scipy==1.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     joblib==1.2.0
     nibabel==5.2.0
     numpy==1.20.0
-    pandas==1.1.5
+    pandas==2.2.0
     scikit-learn==1.4.0
     scipy==1.8.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
 description = environment with minimum versions of all dependencies (plotting not included)
 skip_install = false
 deps =
-    joblib==1.0.0
+    joblib==1.2.0
     nibabel==5.2.0
     numpy==1.20.0
     pandas==1.1.5

--- a/tox.ini
+++ b/tox.ini
@@ -20,10 +20,10 @@ description = environment with minimum versions of all dependencies (plotting no
 skip_install = false
 deps =
     joblib==1.0.0
-    nibabel==4.0.0
+    nibabel==5.2.0
     numpy==1.20.0
     pandas==1.1.5
-    scikit-learn==1.0.0
+    scikit-learn==1.4.0
     scipy==1.8.0
 
 [plotmin]

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ skip_install = false
 deps =
     joblib==1.2.0
     nibabel==5.2.0
-    numpy==1.20.0
+    numpy==1.22.4
     pandas==2.2.0
     scikit-learn==1.4.0
     scipy==1.8.0


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4399
- Closes #4521 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- drop python 3.8
- run minimal install with python 3.9
- adapt dependencies version so all tests pass