### PR TITLE
[MAINT] Handle 2 numpy and matplolib deprecation warnings

### DIFF
--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -211,6 +211,16 @@ def compare_version(version_a, operator, version_b):
     return VERSION_OPERATORS[operator](parse(version_a), parse(version_b))
 
 
+def is_matplotlib_installed():
+    """Check if matplotlib is installed."""
+    try:
+        import matplotlib  # noqa: F401
+    except ImportError:
+        return False
+    else:
+        return True
+
+
 def is_plotly_installed():
     """Check if plotly is installed."""
     try:

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -211,16 +211,6 @@ def compare_version(version_a, operator, version_b):
     return VERSION_OPERATORS[operator](parse(version_a), parse(version_b))
 
 
-def is_matplotlib_installed():
-    """Check if matplotlib is installed."""
-    try:
-        import matplotlib  # noqa: F401
-    except ImportError:
-        return False
-    else:
-        return True
-
-
 def is_plotly_installed():
     """Check if plotly is installed."""
     try:

--- a/nilearn/interfaces/bids/glm.py
+++ b/nilearn/interfaces/bids/glm.py
@@ -237,8 +237,17 @@ def save_glm_to_bids(
 
     """
     # Import here to avoid circular imports
-    from matplotlib import __version__ as mpl_version
 
+    # TODO this entire version check can be removed
+    # when bumlping matplotlib to >= 3.6
+    from nilearn._utils.helpers import is_matplotlib_installed
+
+    if is_matplotlib_installed():
+        from matplotlib import __version__ as mpl_version
+    else:
+        from nilearn.plotting import (
+            OPTIONAL_MATPLOTLIB_MIN_VERSION as mpl_version,
+        )
     from nilearn._utils import compare_version
     from nilearn.plotting.matrix_plotting import (
         plot_contrast_matrix,
@@ -345,6 +354,7 @@ def save_glm_to_bids(
             )
             contrast_plot.set_xlabel(contrast_name)
             contrast_plot.figure.set_figheight(2)
+            # TODO remove if block when bumlping matplotlib to >= 3.6
             if compare_version(mpl_version, ">=", "3.6.0"):
                 contrast_plot.figure.set_layout_engine("tight")
             else:

--- a/nilearn/interfaces/bids/glm.py
+++ b/nilearn/interfaces/bids/glm.py
@@ -237,6 +237,9 @@ def save_glm_to_bids(
 
     """
     # Import here to avoid circular imports
+    from matplotlib import __version__ as mpl_version
+
+    from nilearn._utils import compare_version
     from nilearn.plotting.matrix_plotting import (
         plot_contrast_matrix,
         plot_design_matrix,
@@ -342,7 +345,10 @@ def save_glm_to_bids(
             )
             contrast_plot.set_xlabel(contrast_name)
             contrast_plot.figure.set_figheight(2)
-            contrast_plot.figure.set_tight_layout(True)
+            if compare_version(mpl_version, ">=", "3.6.0"):
+                contrast_plot.figure.set_layout_engine("tight")
+            else:
+                contrast_plot.figure.set_tight_layout(True)
             contrast_name = _clean_contrast_name(contrast_name)
             constrast_fig_file = (
                 out_dir

--- a/nilearn/interfaces/bids/glm.py
+++ b/nilearn/interfaces/bids/glm.py
@@ -237,18 +237,6 @@ def save_glm_to_bids(
 
     """
     # Import here to avoid circular imports
-
-    # TODO this entire version check can be removed
-    # when bumlping matplotlib to >= 3.6
-    from nilearn._utils.helpers import is_matplotlib_installed
-
-    if is_matplotlib_installed():
-        from matplotlib import __version__ as mpl_version
-    else:
-        from nilearn.plotting import (
-            OPTIONAL_MATPLOTLIB_MIN_VERSION as mpl_version,
-        )
-    from nilearn._utils import compare_version
     from nilearn.plotting.matrix_plotting import (
         plot_contrast_matrix,
         plot_design_matrix,
@@ -354,11 +342,7 @@ def save_glm_to_bids(
             )
             contrast_plot.set_xlabel(contrast_name)
             contrast_plot.figure.set_figheight(2)
-            # TODO remove if block when bumlping matplotlib to >= 3.6
-            if compare_version(mpl_version, ">=", "3.6.0"):
-                contrast_plot.figure.set_layout_engine("tight")
-            else:
-                contrast_plot.figure.set_tight_layout(True)
+            contrast_plot.figure.tight_layout()
             contrast_name = _clean_contrast_name(contrast_name)
             constrast_fig_file = (
                 out_dir

--- a/nilearn/plotting/matrix_plotting.py
+++ b/nilearn/plotting/matrix_plotting.py
@@ -368,7 +368,7 @@ def plot_contrast_matrix(
 
     """
     contrast_def = pad_contrast_matrix(contrast_def, design_matrix)
-    con_matrix = np.asmatrix(contrast_def)
+    con_matrix = np.array(contrast_def, ndmin=2)
 
     design_column_names = design_matrix.columns.tolist()
     max_len = np.max([len(str(name)) for name in design_column_names])

--- a/nilearn/reporting/glm_reporter.py
+++ b/nilearn/reporting/glm_reporter.py
@@ -19,9 +19,8 @@ from html import escape
 
 import numpy as np
 import pandas as pd
-from matplotlib import __version__ as mpl_version, pyplot as plt
+from matplotlib import pyplot as plt
 
-from nilearn._utils import compare_version
 from nilearn.plotting import plot_glass_brain, plot_roi, plot_stat_map
 from nilearn.plotting.cm import _cmap_d as nilearn_cmaps
 from nilearn.plotting.img_plotting import MNI152TEMPLATE
@@ -395,10 +394,7 @@ def _plot_contrasts(contrasts, design_matrices):
             )
             contrast_plot.set_xlabel(contrast_name)
             contrast_plot.figure.set_figheight(2)
-            if compare_version(mpl_version, ">=", "3.6.0"):
-                contrast_plot.figure.set_layout_engine("tight")
-            else:
-                contrast_plot.figure.set_tight_layout(True)
+            contrast_plot.figure.tight_layout()
             url_contrast_plot_svg = _plot_to_svg(contrast_plot)
             # prevents sphinx-gallery & jupyter
             # from scraping & inserting plots

--- a/nilearn/reporting/glm_reporter.py
+++ b/nilearn/reporting/glm_reporter.py
@@ -19,8 +19,9 @@ from html import escape
 
 import numpy as np
 import pandas as pd
-from matplotlib import pyplot as plt
+from matplotlib import __version__ as mpl_version, pyplot as plt
 
+from nilearn._utils import compare_version
 from nilearn.plotting import plot_glass_brain, plot_roi, plot_stat_map
 from nilearn.plotting.cm import _cmap_d as nilearn_cmaps
 from nilearn.plotting.img_plotting import MNI152TEMPLATE
@@ -394,7 +395,10 @@ def _plot_contrasts(contrasts, design_matrices):
             )
             contrast_plot.set_xlabel(contrast_name)
             contrast_plot.figure.set_figheight(2)
-            contrast_plot.figure.set_tight_layout(True)
+            if compare_version(mpl_version, ">=", "3.6.0"):
+                contrast_plot.figure.set_layout_engine("tight")
+            else:
+                contrast_plot.figure.set_tight_layout(True)
             url_contrast_plot_svg = _plot_to_svg(contrast_plot)
             # prevents sphinx-gallery & jupyter
             # from scraping & inserting plots


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- deal with one deprecation warning from matplotlib to set figure layout to "tight"
- deal with one warnings from numpy about using matrix instead of array

Should remove about 100 warnings from the test run.

