### PR TITLE
[MAINT] Clean up some warnings from the tests

### DIFF
--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -16,7 +16,7 @@ from joblib import Parallel, cpu_count, delayed
 from sklearn import svm
 from sklearn.base import BaseEstimator
 from sklearn.exceptions import ConvergenceWarning
-from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import KFold, cross_val_score
 
 from nilearn.maskers.nifti_spheres_masker import _apply_mask_and_get_affinity
 
@@ -186,7 +186,11 @@ def _group_iter_search_light(
     par_scores = np.zeros(len(list_rows))
     t0 = time.time()
     for i, row in enumerate(list_rows):
+
         kwargs = {"scoring": scoring, "groups": groups}
+        if isinstance(cv, KFold):
+            kwargs = {"scoring": scoring}
+
         par_scores[i] = np.mean(
             cross_val_score(estimator, X[:, row], y, cv=cv, n_jobs=1, **kwargs)
         )

--- a/nilearn/decoding/tests/test_space_net.py
+++ b/nilearn/decoding/tests/test_space_net.py
@@ -38,7 +38,7 @@ PENALTY = ["graph-net", "tv-l1"]
 
 
 @pytest.mark.parametrize("is_classif", IS_CLASSIF)
-@pytest.mark.parametrize("l1_ratio", [0.5, 1.0])
+@pytest.mark.parametrize("l1_ratio", [0.5, 0.99])
 @pytest.mark.parametrize("n_alphas", range(1, 10))
 def test_space_net_alpha_grid(
     rng, is_classif, l1_ratio, n_alphas, n_samples=4, n_features=3
@@ -101,7 +101,7 @@ def test_early_stopping_callback_object(rng, n_samples=10, n_features=30):
 @pytest.mark.parametrize("penalty", PENALTY)
 @pytest.mark.parametrize("is_classif", IS_CLASSIF)
 @pytest.mark.parametrize("n_alphas", [0.1, 0.01])
-@pytest.mark.parametrize("l1_ratio", [0.5, 1.0])
+@pytest.mark.parametrize("l1_ratio", [0.5, 0.99])
 @pytest.mark.parametrize("n_jobs", [1, -1])
 @pytest.mark.parametrize("cv", [2, 3])
 @pytest.mark.parametrize("perc", [5, 10])
@@ -129,7 +129,7 @@ def test_params_correctly_propagated_in_constructors(
 @pytest.mark.parametrize("penalty", PENALTY)
 @pytest.mark.parametrize("is_classif", IS_CLASSIF)
 @pytest.mark.parametrize("alpha", [0.4, 0.01])
-@pytest.mark.parametrize("l1_ratio", [0.5, 1.0])
+@pytest.mark.parametrize("l1_ratio", [0.5, 0.99])
 def test_params_correctly_propagated_in_constructors_biz(
     penalty, is_classif, alpha, l1_ratio
 ):
@@ -213,7 +213,7 @@ def test_squared_loss_path_scores():
     assert X.shape[1] + 1 == len(best_w)
 
 
-@pytest.mark.parametrize("l1_ratio", [1])
+@pytest.mark.parametrize("l1_ratio", [0.99])
 @pytest.mark.parametrize("debias", [True])
 def test_tv_regression_simple(rng, l1_ratio, debias):
     dim = (4, 4, 4)
@@ -239,7 +239,7 @@ def test_tv_regression_simple(rng, l1_ratio, debias):
     ).fit(X, y)
 
 
-@pytest.mark.parametrize("l1_ratio", [0.0, 0.5, 1.0])
+@pytest.mark.parametrize("l1_ratio", [0.01, 0.5, 0.99])
 def test_tv_regression_3D_image_doesnt_crash(rng, l1_ratio):
     dim = (3, 4, 5)
     W_init = np.zeros(dim)
@@ -393,7 +393,7 @@ def test_univariate_feature_screening(
 
 @pytest.mark.parametrize("penalty", PENALTY)
 @pytest.mark.parametrize("alpha", [0.4, 0.01])
-@pytest.mark.parametrize("l1_ratio", [0.5, 1.0])
+@pytest.mark.parametrize("l1_ratio", [0.5, 0.99])
 @pytest.mark.parametrize("verbose", [True, False])
 def test_space_net_classifier_subclass(penalty, alpha, l1_ratio, verbose):
     cvobj = SpaceNetClassifier(
@@ -410,7 +410,7 @@ def test_space_net_classifier_subclass(penalty, alpha, l1_ratio, verbose):
 
 @pytest.mark.parametrize("penalty", PENALTY)
 @pytest.mark.parametrize("alpha", [0.4, 0.01])
-@pytest.mark.parametrize("l1_ratio", [0.5, 1.0])
+@pytest.mark.parametrize("l1_ratio", [0.5, 0.99])
 @pytest.mark.parametrize("verbose", [True, False])
 def test_space_net_regressor_subclass(penalty, alpha, l1_ratio, verbose):
     cvobj = SpaceNetRegressor(

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1811,6 +1811,10 @@ def _get_events_files(
     events : :obj:`list` of :obj:`str`
         List of fullpath to the events files
     """
+    # pop the 'desc' filter
+    # it would otherwise trigger some meaningless warnings
+    # as desc entity are not supported in BIDS raw datasets
+    img_filters = [x for x in img_filters if x[0] != "desc"]
     events_filters = _make_bids_files_filter(
         task_label=task_label,
         supported_filters=bids_entities()["raw"],
@@ -1884,6 +1888,10 @@ def _get_confounds(
     confounds : :obj:`list` of :class:`pandas.DataFrame`
 
     """
+    # pop the 'desc' filter
+    # it would otherwise trigger some meaningless warnings
+    # as desc entity are not supported in BIDS raw datasets
+    img_filters = [x for x in img_filters if x[0] != "desc"]
     filters = _make_bids_files_filter(
         task_label=task_label,
         supported_filters=bids_entities()["raw"],

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1811,10 +1811,12 @@ def _get_events_files(
     events : :obj:`list` of :obj:`str`
         List of fullpath to the events files
     """
-    # pop the 'desc' filter
+    # pop the derivatives filter
     # it would otherwise trigger some meaningless warnings
-    # as desc entity are not supported in BIDS raw datasets
-    img_filters = [x for x in img_filters if x[0] != "desc"]
+    # as the derivatives entity are not supported in BIDS raw datasets
+    img_filters = [
+        x for x in img_filters if x[0] in bids_entities()["derivatives"]
+    ]
     events_filters = _make_bids_files_filter(
         task_label=task_label,
         supported_filters=bids_entities()["raw"],
@@ -1891,6 +1893,7 @@ def _get_confounds(
     # pop the 'desc' filter
     # it would otherwise trigger some meaningless warnings
     # as desc entity are not supported in BIDS raw datasets
+    # and we add a desc-confounds 'filter' later on
     img_filters = [x for x in img_filters if x[0] != "desc"]
     filters = _make_bids_files_filter(
         task_label=task_label,

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1815,7 +1815,7 @@ def _get_events_files(
     # it would otherwise trigger some meaningless warnings
     # as the derivatives entity are not supported in BIDS raw datasets
     img_filters = [
-        x for x in img_filters if x[0] in bids_entities()["derivatives"]
+        x for x in img_filters if x[0] not in bids_entities()["derivatives"]
     ]
     events_filters = _make_bids_files_filter(
         task_label=task_label,

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -1337,7 +1337,7 @@ def test_first_level_from_bids(
         task_label=tasks[task_index],
         space_label=space_label,
         img_filters=[("desc", "preproc")],
-        slice_time_ref=None,
+        slice_time_ref=0.0,  # set to 0.0 to avoid warnings
     )
 
     _check_output_first_level_from_bids(n_sub, models, imgs, events, confounds)
@@ -1365,7 +1365,7 @@ def test_first_level_from_bids_select_one_run_per_session(bids_dataset):
         task_label="main",
         space_label="MNI",
         img_filters=[("run", "01"), ("desc", "preproc")],
-        slice_time_ref=None,
+        slice_time_ref=0.0,  # set to 0.0 to avoid warnings
     )
 
     _check_output_first_level_from_bids(n_sub, models, imgs, events, confounds)
@@ -1382,7 +1382,7 @@ def test_first_level_from_bids_select_all_runs_of_one_session(bids_dataset):
         task_label="main",
         space_label="MNI",
         img_filters=[("ses", "01"), ("desc", "preproc")],
-        slice_time_ref=None,
+        slice_time_ref=0.0,  # set to 0.0 to avoid warnings
     )
 
     _check_output_first_level_from_bids(n_sub, models, imgs, events, confounds)
@@ -1401,7 +1401,7 @@ def test_first_level_from_bids_smoke_test_for_verbose_argument(
         space_label="MNI",
         img_filters=[("desc", "preproc")],
         verbose=verbose,
-        slice_time_ref=None,
+        slice_time_ref=0.0,  # set to 0.0 to avoid warnings
     )
 
 
@@ -1432,7 +1432,7 @@ def test_first_level_from_bids_several_labels_per_entity(tmp_path, entity):
         task_label="main",
         space_label="MNI",
         img_filters=[("desc", "preproc"), (entity, "A")],
-        slice_time_ref=None,
+        slice_time_ref=0.0,  # set to 0.0 to avoid warnings
     )
 
     _check_output_first_level_from_bids(n_sub, models, imgs, events, confounds)
@@ -1474,7 +1474,7 @@ def test_first_level_from_bids_with_subject_labels(bids_dataset):
             sub_labels=["foo", "01"],
             space_label="MNI",
             img_filters=[("desc", "preproc")],
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
         )
 
         assert models[0].subject_label == "01"
@@ -1492,7 +1492,7 @@ def test_first_level_from_bids_no_duplicate_sub_labels(bids_dataset):
         sub_labels=["01", "01"],
         space_label="MNI",
         img_filters=[("desc", "preproc")],
-        slice_time_ref=None,
+        slice_time_ref=0.0,  # set to 0.0 to avoid warnings
     )
 
     assert len(models) == 1
@@ -1504,14 +1504,14 @@ def test_first_level_from_bids_validation_input_dataset_path():
             dataset_path=2,
             task_label="main",
             space_label="MNI",
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
         )
     with pytest.raises(ValueError, match="'dataset_path' does not exist"):
         first_level_from_bids(
             dataset_path="lolo",
             task_label="main",
             space_label="MNI",
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
         )
     with pytest.raises(TypeError, match="derivatives_.* must be a string"):
         first_level_from_bids(
@@ -1519,7 +1519,7 @@ def test_first_level_from_bids_validation_input_dataset_path():
             task_label="main",
             space_label="MNI",
             derivatives_folder=1,
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
         )
 
 
@@ -1552,7 +1552,7 @@ def test_first_level_from_bids_validation_sub_labels(
             dataset_path=bids_dataset,
             task_label="main",
             sub_labels=sub_labels,
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
         )
 
 
@@ -1568,7 +1568,7 @@ def test_first_level_from_bids_validation_space_label(
             dataset_path=bids_dataset,
             task_label="main",
             space_label=space_label,
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
         )
 
 
@@ -1589,7 +1589,7 @@ def test_first_level_from_bids_validation_img_filter(
             dataset_path=bids_dataset,
             task_label="main",
             img_filters=img_filters,
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
         )
 
 
@@ -1604,7 +1604,7 @@ def test_first_level_from_bids_too_many_bold_files(bids_dataset):
             dataset_path=bids_dataset,
             task_label="main",
             space_label="T1w",
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
         )
 
 
@@ -1620,7 +1620,7 @@ def test_first_level_from_bids_with_missing_events(tmp_path_factory):
             dataset_path=bids_dataset,
             task_label="main",
             space_label="MNI",
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
         )
 
 
@@ -1641,7 +1641,7 @@ def test_first_level_from_bids_no_tr(tmp_path_factory):
             dataset_path=bids_dataset,
             task_label="main",
             space_label="MNI",
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
             t_r=None,
         )
 
@@ -1661,7 +1661,7 @@ def test_first_level_from_bids_no_bold_file(tmp_path_factory):
             dataset_path=bids_dataset,
             task_label="main",
             space_label="MNI",
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
         )
 
 
@@ -1678,7 +1678,7 @@ def test_first_level_from_bids_with_one_events_missing(tmp_path_factory):
             dataset_path=bids_dataset,
             task_label="main",
             space_label="MNI",
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
         )
 
 
@@ -1701,7 +1701,7 @@ def test_first_level_from_bids_one_confound_missing(tmp_path_factory):
             dataset_path=bids_dataset,
             task_label="main",
             space_label="MNI",
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
         )
 
 
@@ -1722,7 +1722,7 @@ def test_first_level_from_bids_all_confounds_missing(tmp_path_factory):
         space_label="MNI",
         img_filters=[("desc", "preproc")],
         verbose=0,
-        slice_time_ref=None,
+        slice_time_ref=0.0,  # set to 0.0 to avoid warnings
     )
 
     assert len(models) == len(imgs)
@@ -1747,7 +1747,7 @@ def test_first_level_from_bids_no_derivatives(tmp_path):
             dataset_path=bids_path,
             task_label="main",
             space_label="MNI",
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
         )
 
 
@@ -1764,7 +1764,7 @@ def test_first_level_from_bids_no_session(tmp_path):
             dataset_path=bids_path,
             task_label="main",
             space_label="T1w",
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
         )
 
 
@@ -1788,7 +1788,7 @@ def test_first_level_from_bids_mismatch_run_index(tmp_path_factory):
             task_label="main",
             space_label="MNI",
             img_filters=[("desc", "preproc")],
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
         )
 
 
@@ -1955,7 +1955,7 @@ def test_first_level_from_bids_no_subject(tmp_path):
             dataset_path=bids_path,
             task_label="main",
             space_label="MNI",
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
         )
 
 
@@ -1971,7 +1971,7 @@ def test_first_level_from_bids_unused_kwargs(tmp_path):
             dataset_path=bids_path,
             task_label="main",
             space_label="MNI",
-            slice_time_ref=None,
+            slice_time_ref=0.0,  # set to 0.0 to avoid warnings
             confound_strategy="motion",
         )
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- change some tested value in space_net to avoid warnings
- update first_level_from bids to reduce amount of meaningless warnings
- update searchlight to no pass groups to KFold CVs as it does not use it anyway (would trigger a warning otherwise)
