### PR TITLE
[MAINT] raise stacklevel of `copy_header` warning

### DIFF
--- a/examples/06_manipulating_images/plot_affine_transformation.py
+++ b/examples/06_manipulating_images/plot_affine_transformation.py
@@ -124,6 +124,7 @@ img_4d_affine_in_mm_space = resample_img(
     img_4d_affine,
     target_affine=np.eye(4),
     target_shape=(np.array(img_4d_affine.shape) * 2).astype(int),
+    copy_header=True,
 )
 
 # %%

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -251,6 +251,5 @@ def check_copy_header(copy_header):
             "`copy_header=True`."
         )
         warnings.warn(
-            category=FutureWarning,
-            message=copy_header_default,
+            category=FutureWarning, message=copy_header_default, stacklevel=3
         )


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- raise stacklevel of `copy_header` warning to allow user to know which function call triggered the warning so they can act on it.
