### PR TITLE
[MAINT] reduce occurence of resampling related warnings

### DIFF
--- a/doc/visual_testing/reporter_visual_inspection_suite.py
+++ b/doc/visual_testing/reporter_visual_inspection_suite.py
@@ -251,6 +251,7 @@ def report_slm_oasis():
         oasis_dataset.gray_matter_maps[0],
         interpolation="nearest",
         copy_header=True,
+        force_resample=True,
     )
 
     design_matrix = _make_design_matrix_slm_oasis(oasis_dataset, n_subjects)

--- a/examples/04_glm_first_level/plot_first_level_details.py
+++ b/examples/04_glm_first_level/plot_first_level_details.py
@@ -560,7 +560,11 @@ plt.show()
 from nilearn.image import resample_to_img
 
 resampled_icbm_mask = resample_to_img(
-    icbm_mask, data_mask, interpolation="nearest", copy_header=True
+    icbm_mask,
+    data_mask,
+    interpolation="nearest",
+    copy_header=True,
+    force_resample=True,
 )
 
 # %%

--- a/examples/04_glm_first_level/plot_spm_multimodal_faces.py
+++ b/examples/04_glm_first_level/plot_spm_multimodal_faces.py
@@ -55,7 +55,9 @@ with warnings.catch_warnings():
     ]
 affine, shape = fmri_img[0].affine, fmri_img[0].shape
 print("Resampling the second image (this takes time)...")
-fmri_img[1] = resample_img(fmri_img[1], affine, shape[:3], copy_header=True)
+fmri_img[1] = resample_img(
+    fmri_img[1], affine, shape[:3], copy_header=True, force_resample=True
+)
 
 # %%
 # Let's create mean image for display purposes.

--- a/examples/05_glm_second_level/plot_oasis.py
+++ b/examples/05_glm_second_level/plot_oasis.py
@@ -75,6 +75,7 @@ mask_img = resample_to_img(
     gray_matter_map_filenames[0],
     interpolation="nearest",
     copy_header=True,
+    force_resample=True,
 )
 
 # %%

--- a/examples/06_manipulating_images/plot_affine_transformation.py
+++ b/examples/06_manipulating_images/plot_affine_transformation.py
@@ -52,18 +52,22 @@ from nilearn.plotting import show
 
 grid = np.mgrid[0:192, 0:128]
 circle = (
-    np.sum((grid - np.array([32, 32])[:, np.newaxis, np.newaxis]) ** 2, axis=0)
+    np.sum(
+        (grid - np.array([32.0, 32.0])[:, np.newaxis, np.newaxis]) ** 2, axis=0
+    )
     < 256
 )
 diamond = (
     np.sum(
-        np.abs(grid - np.array([128, 80])[:, np.newaxis, np.newaxis]), axis=0
+        np.abs(grid - np.array([128.0, 80.0])[:, np.newaxis, np.newaxis]),
+        axis=0,
     )
     < 16
 )
 rectangle = (
     np.max(
-        np.abs(grid - np.array([64, 96])[:, np.newaxis, np.newaxis]), axis=0
+        np.abs(grid - np.array([64.0, 96.0])[:, np.newaxis, np.newaxis]),
+        axis=0,
     )
     < 16
 )
@@ -90,7 +94,7 @@ source_affine[:2, :2] = rotation_matrix * 2.0  # 2.0mm voxel size
 from nibabel import Nifti1Image
 
 img = Nifti1Image(
-    image[:, :, np.newaxis].astype("int32"), affine=source_affine
+    image[:, :, np.newaxis].astype("float32"), affine=source_affine
 )
 
 # %%
@@ -98,17 +102,21 @@ img = Nifti1Image(
 from nilearn.image import resample_img
 
 img_in_mm_space = resample_img(
-    img, target_affine=np.eye(4), target_shape=(512, 512, 1), copy_header=True
+    img,
+    target_affine=np.eye(4),
+    target_shape=(512, 512, 1),
+    copy_header=True,
+    force_resample=True,
 )
 
 target_affine_3x3 = np.eye(3) * 2
 target_affine_4x4 = np.eye(4) * 2
 target_affine_4x4[3, 3] = 1.0
 img_3d_affine = resample_img(
-    img, target_affine=target_affine_3x3, copy_header=True
+    img, target_affine=target_affine_3x3, copy_header=True, force_resample=True
 )
 img_4d_affine = resample_img(
-    img, target_affine=target_affine_4x4, copy_header=True
+    img, target_affine=target_affine_4x4, copy_header=True, force_resample=True
 )
 target_affine_mm_space_offset_changed = np.eye(4)
 target_affine_mm_space_offset_changed[:3, 3] = img_3d_affine.affine[:3, 3]
@@ -118,12 +126,14 @@ img_3d_affine_in_mm_space = resample_img(
     target_affine=target_affine_mm_space_offset_changed,
     target_shape=(np.array(img_3d_affine.shape) * 2).astype(int),
     copy_header=True,
+    force_resample=True,
 )
 
 img_4d_affine_in_mm_space = resample_img(
     img_4d_affine,
     target_affine=np.eye(4),
     target_shape=(np.array(img_4d_affine.shape) * 2).astype(int),
+    force_resample=True,
 )
 
 # %%

--- a/examples/06_manipulating_images/plot_resample_to_template.py
+++ b/examples/06_manipulating_images/plot_resample_to_template.py
@@ -24,7 +24,9 @@ stat_img = load_sample_motor_activation_image()
 # to the :term:`MNI` template image.
 from nilearn.image import resample_to_img
 
-resampled_stat_img = resample_to_img(stat_img, template, copy_header=True)
+resampled_stat_img = resample_to_img(
+    stat_img, template, copy_header=True, force_resample=True
+)
 
 # %%
 # Let's check the shape and affine have been correctly updated.

--- a/nilearn/_utils/niimg_conversions.py
+++ b/nilearn/_utils/niimg_conversions.py
@@ -173,6 +173,7 @@ def iter_check_niimg(
                         target_affine=ref_fov[0],
                         target_shape=ref_fov[1],
                         copy_header=True,
+                        force_resample=False,  # TODO update to True in 0.13.0
                     )
                 else:
                     raise ValueError(

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -341,7 +341,7 @@ def _check_force_resample(force_resample):
                 "Use 'force_resample=True' to suppress this warning."
             ),
             FutureWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
     return force_resample
 

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -19,7 +19,6 @@ from numpy.testing import (
 
 from nilearn import _utils
 from nilearn._utils import testing
-from nilearn.conftest import _affine_eye, _rng
 from nilearn.image import get_data
 from nilearn.image.image import _pad_array, crop_img
 from nilearn.image.resampling import (
@@ -36,15 +35,6 @@ from nilearn.image.tests._testing import match_headers_keys
 ANGLES_TO_TEST = (0, np.pi, np.pi / 2.0, np.pi / 4.0, np.pi / 3.0)
 
 SHAPE = (3, 2, 5, 2)
-
-
-def _make_resampling_test_data():
-    rng = _rng()
-    shape = SHAPE
-    affine = _affine_eye()
-    data = rng.integers(0, 10, shape, dtype="int32")
-    img = Nifti1Image(data, affine)
-    return img, affine, data
 
 
 def rotation(theta, phi):
@@ -65,9 +55,13 @@ def shape():
     return SHAPE
 
 
-def test_resample_deprecation_force_resample(shape, affine_eye, rng):
+@pytest.fixture
+def data(rng, shape):
+    return rng.random(shape)
+
+
+def test_resample_deprecation_force_resample(data, shape, affine_eye):
     """Test change of value of force_resample."""
-    data = rng.integers(0, 10, shape, dtype="int32")
     affine_eye[:3, -1] = 0.5 * np.array(shape[:3])
 
     with pytest.warns(FutureWarning, match="force_resample"):
@@ -80,9 +74,8 @@ def test_resample_deprecation_force_resample(shape, affine_eye, rng):
 
 
 @pytest.mark.parametrize("force_resample", [False, True])
-def test_identity_resample(force_resample, shape, affine_eye, rng):
+def test_identity_resample(data, force_resample, shape, affine_eye):
     """Test resampling with an identity affine."""
-    data = rng.integers(0, 10, shape, dtype="int32")
     affine_eye[:3, -1] = 0.5 * np.array(shape[:3])
 
     rot_img = resample_img(
@@ -120,14 +113,13 @@ def test_identity_resample(force_resample, shape, affine_eye, rng):
 @pytest.mark.parametrize("endian_type", [">f8", "<f8"])
 @pytest.mark.parametrize("interpolation", ["nearest", "linear", "continuous"])
 def test_identity_resample_non_native_endians(
-    force_resample, shape, affine_eye, endian_type, interpolation, rng
+    data, force_resample, shape, affine_eye, endian_type, interpolation
 ):
     """Test resampling with an identity affine with non native endians.
 
     with big endian data ('>f8')
     with little endian data ('<f8')
     """
-    data = rng.integers(0, 10, shape, dtype="int32")
     affine_eye[:3, -1] = 0.5 * np.array(shape[:3])
 
     rot_img = resample_img(
@@ -142,10 +134,8 @@ def test_identity_resample_non_native_endians(
 
 
 @pytest.mark.parametrize("force_resample", [False, True])
-def test_downsample(force_resample, shape, affine_eye, rng):
+def test_downsample(data, force_resample, affine_eye):
     """Test resampling with a 1/2 down-sampling affine."""
-    data = rng.random(shape)
-
     rot_img = resample_img(
         Nifti1Image(data, affine_eye),
         target_affine=2 * affine_eye,
@@ -174,7 +164,7 @@ def test_downsample(force_resample, shape, affine_eye, rng):
 @pytest.mark.parametrize("copy_data", [True, False])
 @pytest.mark.parametrize("force_resample", [True, False])
 def test_downsample_non_native_endian_data(
-    shape, affine_eye, endian_type, copy_data, force_resample, rng
+    data, affine_eye, endian_type, copy_data, force_resample
 ):
     """Test resampling with a 1/2 down-sampling affine with non native endians.
 
@@ -184,8 +174,6 @@ def test_downsample_non_native_endian_data(
     Big endian data ">f8"
     Little endian data "<f8"
     """
-    data = rng.random(shape)
-
     rot_img = resample_img(
         Nifti1Image(data, affine_eye),
         target_affine=2 * affine_eye,
@@ -214,13 +202,11 @@ def test_downsample_non_native_endian_data(
 @pytest.mark.parametrize("force_resample", [False, True])
 @pytest.mark.parametrize("shape", [(1, 4, 4), (1, 4, 4, 3)])
 @pytest.mark.parametrize("value", [-3.75, 0])
-def test_resampling_fill_value(affine_eye, shape, value, rng, force_resample):
+def test_resampling_fill_value(data, affine_eye, value, force_resample):
     """Test resampling with a non-zero fill value.
 
     Check on 3D and 4D data.
     """
-    data = rng.uniform(size=shape)
-
     angle = np.pi / 4
     rot = rotation(0, angle)
 
@@ -261,12 +247,11 @@ def test_resampling_fill_value(affine_eye, shape, value, rng, force_resample):
 @pytest.mark.parametrize("force_resample", [False, True])
 @pytest.mark.parametrize("shape", [(1, 4, 4), (1, 4, 4, 3)])
 @pytest.mark.parametrize("angle", ANGLES_TO_TEST)
-def test_resampling_with_affine(affine_eye, shape, angle, rng, force_resample):
+def test_resampling_with_affine(data, affine_eye, angle, force_resample):
     """Test resampling with a given rotation part of the affine.
 
     Check on 3D and 4D data.
     """
-    data = rng.integers(4, size=shape, dtype="int32")
     rot = rotation(0, angle)
 
     rot_img = resample_img(
@@ -300,9 +285,8 @@ def test_resampling_with_affine(affine_eye, shape, angle, rng, force_resample):
 @pytest.mark.parametrize("shape", [(1, 10, 10), (1, 10, 10, 3)])
 @pytest.mark.parametrize("angle", (0, np.pi / 2.0, np.pi, 3 * np.pi / 2.0))
 def test_resampling_continuous_with_affine(
-    affine_eye, shape, angle, rng, force_resample
+    data, affine_eye, angle, force_resample
 ):
-    data = rng.integers(1, 4, size=shape, dtype="int32")
     rot = rotation(0, angle)
     img = Nifti1Image(data, affine_eye)
 
@@ -332,21 +316,21 @@ def test_resampling_continuous_with_affine(
 
 
 @pytest.mark.parametrize("force_resample", [False, True])
-def test_resampling_error_checks(tmp_path, force_resample):
-    img, affine, _ = _make_resampling_test_data()
+def test_resampling_error_checks(tmp_path, force_resample, data, affine_eye):
+    img = Nifti1Image(data, affine_eye)
     target_shape = (5, 3, 2)
 
     # Correct parameters: no exception
     resample_img(
         img,
         target_shape=target_shape,
-        target_affine=affine,
+        target_affine=affine_eye,
         force_resample=force_resample,
         copy_header=True,
     )
     resample_img(
         img,
-        target_affine=affine,
+        target_affine=affine_eye,
         force_resample=force_resample,
         copy_header=True,
     )
@@ -355,7 +339,7 @@ def test_resampling_error_checks(tmp_path, force_resample):
     resample_img(
         filename,
         target_shape=target_shape,
-        target_affine=affine,
+        target_affine=affine_eye,
         force_resample=force_resample,
         copy_header=True,
     )
@@ -374,7 +358,7 @@ def test_resampling_error_checks(tmp_path, force_resample):
         resample_img(
             img,
             target_shape=(2, 3),
-            target_affine=affine,
+            target_affine=affine_eye,
             force_resample=force_resample,
             copy_header=True,
         )
@@ -384,7 +368,7 @@ def test_resampling_error_checks(tmp_path, force_resample):
         resample_img(
             img,
             target_shape=target_shape,
-            target_affine=affine,
+            target_affine=affine_eye,
             interpolation="an_invalid_interpolation",
             force_resample=force_resample,
             copy_header=True,
@@ -393,10 +377,12 @@ def test_resampling_error_checks(tmp_path, force_resample):
 
 @pytest.mark.parametrize("force_resample", [False, True])
 @pytest.mark.parametrize("target_shape", [None, (3, 2, 5)])
-def test_resampling_copy_has_no_shared_memory(target_shape, force_resample):
+def test_resampling_copy_has_no_shared_memory(
+    target_shape, force_resample, data, affine_eye
+):
     """copy=true guarantees output array shares no memory with input array."""
-    img, affine, _ = _make_resampling_test_data()
-    target_affine = None if target_shape is None else affine
+    img = Nifti1Image(data, affine_eye)
+    target_affine = None if target_shape is None else affine_eye
 
     img_r = resample_img(
         img,
@@ -427,8 +413,7 @@ def test_resampling_copy_has_no_shared_memory(target_shape, force_resample):
     "force_resample",
     [False, True],
 )
-def test_resampling_warning_s_form(affine_eye, shape, rng, force_resample):
-    data = rng.integers(0, 10, shape, dtype="int32")
+def test_resampling_warning_s_form(data, affine_eye, force_resample):
     img_no_sform = Nifti1Image(data, affine_eye)
     img_no_sform.set_sform(None)
 
@@ -807,9 +792,7 @@ def test_resampling_nan_big(affine_eye, force_resample):
 
 
 @pytest.mark.parametrize("force_resample", [False, True])
-def test_resample_to_img(affine_eye, shape, rng, force_resample):
-    data = rng.random(shape)
-
+def test_resample_to_img(data, affine_eye, force_resample):
     source_affine = affine_eye
     source_img = Nifti1Image(data, source_affine)
 

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -103,6 +103,7 @@ def _filter_and_extract(
             target_affine=target_affine,
             copy=copy,
             copy_header=True,
+            force_resample=False,  # set to True in 0.13.0
         )
 
     smoothing_fwhm = parameters.get("smoothing_fwhm")

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -744,6 +744,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
                     target_shape=imgs_.shape[:3],
                     target_affine=imgs_.affine,
                     copy_header=True,
+                    force_resample=False,
                 )
 
             # Remove imgs_ from memory before loading the same image
@@ -830,6 +831,7 @@ class NiftiLabelsMasker(BaseMasker, _utils.CacheMixin):
             target_shape=imgs_.shape[:3],
             target_affine=imgs_.affine,
             copy_header=True,
+            force_resample=False,
         )
         labels_after_resampling = set(
             np.unique(_utils.niimg.safe_get_data(self._resampled_labels_img_))

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -648,7 +648,10 @@ def compute_brain_mask(
         )
 
     resampled_template = cache(resampling.resample_to_img, memory)(
-        template, target_img, copy_header=True
+        template,
+        target_img,
+        copy_header=True,
+        force_resample=False,  # TODO set to True in 0.13.0
     )
 
     mask = (get_data(resampled_template) >= threshold).astype("int8")

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -251,6 +251,7 @@ def _resample_stat_map(
         bg_img,
         interpolation=resampling_interpolation,
         copy_header=True,
+        force_resample=False,  # TODO set to True in 0.13.0
     )
     mask_img = resample_to_img(
         mask_img,
@@ -258,6 +259,7 @@ def _resample_stat_map(
         fill_value=1,
         interpolation="nearest",
         copy_header=True,
+        force_resample=False,  # TODO set to True in 0.13.0
     )
 
     return stat_map_img, mask_img

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -1919,7 +1919,11 @@ def plot_carpet(
         background_label = 0
 
         atlas_img_res = resample_to_img(
-            mask_img, img, interpolation="nearest", copy_header=True
+            mask_img,
+            img,
+            interpolation="nearest",
+            copy_header=True,
+            force_resample=False,  # TODO change to True in 0.13.0
         )
         atlas_bin = math_img(
             f"img != {background_label}",

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -636,6 +636,7 @@ def vol_to_surf(img, surf_mesh,
         mask_img = _utils.check_niimg(mask_img)
         mask = get_data(resampling.resample_to_img(
             mask_img, img, interpolation='nearest', copy=False,
+            force_resample=False,  # TODO update to True in 0.13.0
             copy_header=True))
     else:
         mask = None

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -635,7 +635,10 @@ def vol_to_surf(img, surf_mesh,
     if mask_img is not None:
         mask_img = _utils.check_niimg(mask_img)
         mask = get_data(resampling.resample_to_img(
-            mask_img, img, interpolation='nearest', copy=False,
+            mask_img,
+            img,
+            interpolation='nearest',
+            copy=False,
             force_resample=False,  # TODO update to True in 0.13.0
             copy_header=True))
     else:


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but relates to #4412, #4441, #4450

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- some internal occurrence of force `resample_img` and `resample_to_img` were not set with `force_resample=False` leading to extra warnings that users cannot act on despite the warning message implying that they can.
- change dtype of some of the data used to test resample_img to reduce occurences of "casting to float" warnings in tests

