### PR TITLE
 [ENH] Add last version of the AAL atlas to its fetcher

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -747,6 +747,3 @@ authors:
     family-names: Nájera
     website: https://github.com/Titan-C
     affiliation: Checkmk
-  - given-names: Jeremy
-    family-names: LefortBesnard
-    website: https://jlefortbesnard.github.io

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -747,3 +747,6 @@ authors:
     family-names: Nájera
     website: https://github.com/Titan-C
     affiliation: Checkmk
+  - given-names: Jeremy
+    family-names: LefortBesnard
+    website: https://jlefortbesnard.github.io

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -25,6 +25,8 @@ Fixes
 Enhancements
 ------------
 
+- :bdg-primary:`Doc` Add an option in :func:`nilearn.datasets.fetch_atlas_aal` to fetch the latest AAL version, 3v2 (:gh:`4554` by `Jeremy LefortBesnard`_ and `Rémi Gau`_).
+
 - :bdg-dark:`Code` Improve input/output for ``SurfaceImage`` by loading meshes from files on disk, loading data from files or Nifti object, and saving meshes to file (:gh:`4446` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Add a new function :func:`nilearn.plotting.plot_design_matrix_correlation` to plot the correlation between regressors of a GLM design matrix (:gh:`4467` by `Rémi Gau`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -25,7 +25,7 @@ Fixes
 Enhancements
 ------------
 
-- :bdg-primary:`Doc` Add an option in :func:`nilearn.datasets.fetch_atlas_aal` to fetch the latest AAL version, 3v2 (:gh:`4554` by `Jeremy LefortBesnard`_ and `Rémi Gau`_).
+- :bdg-primary:`Doc` Add an option in :func:`nilearn.datasets.fetch_atlas_aal` to fetch the latest AAL version, 3v2 (:gh:`4554` by `Jeremy Lefort-Besnard`_ and `Rémi Gau`_).
 
 - :bdg-dark:`Code` Improve input/output for ``SurfaceImage`` by loading meshes from files on disk, loading data from files or Nifti object, and saving meshes to file (:gh:`4446` by `Rémi Gau`_).
 

--- a/doc/modules/datasets.rst
+++ b/doc/modules/datasets.rst
@@ -79,7 +79,7 @@ Atlases descriptions
 .. toctree::
     :titlesonly:
 
-    description/aal_SPM12.rst
+    description/aal.rst
     description/allen_rsn_2011.rst
     description/basc_multiscale_2015.rst
     description/craddock_2012.rst

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1221,15 +1221,21 @@ def fetch_atlas_aal(
 
     .. warning::
 
-        The maps image (``data.maps``) contains 117 unique integer values
-        defining the parcellation. However, these values are not consecutive
-        integers from 0 to 116 as is usually the case in Nilearn.
-        Therefore, these values shouldn't be interpreted as indices for the
-        list of label names. In addition, the region IDs are provided as
+        For the AAL version SPM 5, 8, and 12, the map image (data.maps) 
+        contains 117 unique integer values that define the parcellation.
+        However, these values are not consecutive integers from 0 to 116, as is 
+        usually the case in Nilearn. Therefore, they should not be interpreted 
+        as indices for the list of label names. 
+        In contrast, the total number of parcellations in AAL 3v2 is 167. The 
+        3v2 atlas contains 171 unique integer values that define the
+        parcellation. These values are consecutive integers from 0 to 170, 
+        except for the anterior cingulate cortex (35, 36) and thalamus (81, 
+        82), which are left empty in AAL 3v2.
+        In addition, for all AAL versions, the region IDs are provided as 
         strings, so it is necessary to cast them to integers when indexing.
 
-    For example, to get the name of the region corresponding to the region
-    ID 5021 in the image, you should do:
+    For example, with version SPM 5, 8 and 12, to get the name of the region 
+    corresponding to the region ID 5021 in the image, you should do:
 
     .. code-block:: python
 
@@ -1246,8 +1252,9 @@ def fetch_atlas_aal(
 
     Parameters
     ----------
-    version : {'SPM12', 'SPM5', 'SPM8'}, default='SPM12'
-        The version of the AAL atlas. Must be 'SPM5', 'SPM8', or 'SPM12'.
+    version : {'3v2', 'SPM12', 'SPM5', 'SPM8'}, default='SPM12'
+        The version of the AAL atlas. Must be 'SPM5', 'SPM8', 'SPM12', or '3v2' 
+        for the latest SPM12 version of AAL3 software.
     %(data_dir)s
     %(url)s
     %(resume)s
@@ -1260,15 +1267,18 @@ def fetch_atlas_aal(
 
             - 'maps': :obj:`str`, path to nifti file containing the
               regions. The image has shape ``(91, 109, 91)`` and contains
-              117 unique integer values defining the parcellation. Please
-              refer to the main description to see how to link labels to
-              regions IDs.
-            - 'labels': :obj:`list` of :obj:`str`, list of the names of the
-              regions. This list has 116 names as 'Background' (label 0) is
-              not included in this list. Please refer to the main description
+              117 unique integer values defining the parcellation in version 
+              SPM 5, 8 and 12, and 167 unique integer values defining the 
+              parcellation in version 3v2. Please refer to the main description 
               to see how to link labels to regions IDs.
+            - 'labels': :obj:`list` of :obj:`str`, list of the names of the
+              regions. As 'Background' (label 0) is not included in this list, 
+              there are 116 names in version SPM 5, 8, and 12, and 166 names in
+              version 3v2. Please refer to the main description to see how to
+              link labels to regions IDs.
             - 'indices': :obj:`list` of :obj:`str`, indices mapping 'labels'
-              to values in the 'maps' image. This list has 116 elements.
+              to values in the 'maps' image. This list has 116 elements in 
+              version SPM 5, 8 and 12, and 166 elements in version 3v2.
               Since the values in the 'maps' image do not correspond to
               indices in ``labels``, but rather to values in ``indices``, the
               location of a label in the ``labels`` list does not necessary
@@ -1276,6 +1286,11 @@ def fetch_atlas_aal(
               list to identify the appropriate image value for a given label
               (See main description above).
             - 'description': :obj:`str`, description of the atlas.
+
+    Warns
+    -----
+    DeprecationWarning
+        Starting in version 0.13, the default fetched mask will be AAL 3v2.
 
     References
     ----------
@@ -1304,11 +1319,17 @@ def fetch_atlas_aal(
             filenames = [
                 (os.path.join("aal", "atlas", f), url, opts) for f in basenames
             ]
+            message = (
+                "Starting in version 0.13, the default fetched mask will be"
+                "AAL 3v2 instead."
+            )
+            warnings.warn(message, DeprecationWarning)
+
         elif version == "3v2":
-            url = f"{base_url}AAL_files/AAL3v2_for_SPM12.tar.gz"
+            url = f"{base_url}wp-content/uploads/AAL3v2_for_SPM12.tar.gz"
             basenames = ("AAL3v1.nii", "AAL3v1.xml")
             filenames = [
-                (os.path.join("AAL3", f), url, opts) for f in basenames
+                (os.path.join(f"AAL3", f), url, opts) for f in basenames
             ]
         else:
             url = f"{base_url}wp-content/uploads/aal_for_{version}.zip"
@@ -1327,7 +1348,7 @@ def fetch_atlas_aal(
     fdescr = get_dataset_descr("aal_SPM12")
     labels = []
     indices = []
-    if version == "SPM12":
+    if version in ("SPM12", "3v2"):
         xml_tree = xml.etree.ElementTree.parse(labels_file)
         root = xml_tree.getroot()
         for label in root.iter("label"):

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1286,7 +1286,7 @@ def fetch_atlas_aal(
     Licence: unknown.
 
     """
-    versions = ["SPM5", "SPM8", "SPM12"]
+    versions = ["SPM5", "SPM8", "SPM12", "3v2"]
     if version not in versions:
         raise ValueError(
             f"The version of AAL requested '{version}' does not exist."
@@ -1303,6 +1303,12 @@ def fetch_atlas_aal(
             basenames = ("AAL.nii", "AAL.xml")
             filenames = [
                 (os.path.join("aal", "atlas", f), url, opts) for f in basenames
+            ]
+        elif version == "3v2":
+            url = f"{base_url}AAL_files/AAL3v2_for_SPM12.tar.gz"
+            basenames = ("AAL3v1.nii", "AAL3v1.xml")
+            filenames = [
+                (os.path.join("AAL3", f), url, opts) for f in basenames
             ]
         else:
             url = f"{base_url}wp-content/uploads/aal_for_{version}.zip"

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -1221,39 +1221,24 @@ def fetch_atlas_aal(
 
     .. warning::
 
-        For the AAL version SPM 5, 8, and 12, the map image (data.maps) 
-        contains 117 unique integer values that define the parcellation.
-        However, these values are not consecutive integers from 0 to 116, as is 
-        usually the case in Nilearn. Therefore, they should not be interpreted 
-        as indices for the list of label names. 
-        In contrast, the total number of parcellations in AAL 3v2 is 167. The 
-        3v2 atlas contains 171 unique integer values that define the
-        parcellation. These values are consecutive integers from 0 to 170, 
-        except for the anterior cingulate cortex (35, 36) and thalamus (81, 
-        82), which are left empty in AAL 3v2.
-        In addition, for all AAL versions, the region IDs are provided as 
-        strings, so it is necessary to cast them to integers when indexing.
+        The integers in the map image (data.maps) that define the parcellation
+        are not always consecutive, as is usually the case in Nilearn, and
+        should not be interpreted as indices for the list of label names.
+        In addition, the region IDs are provided as strings, so it is necessary
+        to cast them to integers when indexing.
+        For more information, refer to the fetcher’s description:
 
-    For example, with version SPM 5, 8 and 12, to get the name of the region 
-    corresponding to the region ID 5021 in the image, you should do:
+        .. code-block:: python
 
-    .. code-block:: python
+            from nilearn.datasets import fetch_atlas_aal
 
-        # This should print 'Lingual_L'
-        data.labels[data.indices.index("5021")]
-
-    Conversely, to get the region ID corresponding to the label
-    "Precentral_L", you should do:
-
-    .. code-block:: python
-
-        # This should print '2001'
-        data.indices[data.labels.index("Precentral_L")]
+            atlas = fetch_atlas_aal()
+            print(atlas.description)
 
     Parameters
     ----------
     version : {'3v2', 'SPM12', 'SPM5', 'SPM8'}, default='SPM12'
-        The version of the AAL atlas. Must be 'SPM5', 'SPM8', 'SPM12', or '3v2' 
+        The version of the AAL atlas. Must be 'SPM5', 'SPM8', 'SPM12', or '3v2'
         for the latest SPM12 version of AAL3 software.
     %(data_dir)s
     %(url)s
@@ -1267,17 +1252,17 @@ def fetch_atlas_aal(
 
             - 'maps': :obj:`str`, path to nifti file containing the
               regions. The image has shape ``(91, 109, 91)`` and contains
-              117 unique integer values defining the parcellation in version 
-              SPM 5, 8 and 12, and 167 unique integer values defining the 
-              parcellation in version 3v2. Please refer to the main description 
+              117 unique integer values defining the parcellation in version
+              SPM 5, 8 and 12, and 167 unique integer values defining the
+              parcellation in version 3v2. Please refer to the main description
               to see how to link labels to regions IDs.
             - 'labels': :obj:`list` of :obj:`str`, list of the names of the
-              regions. As 'Background' (label 0) is not included in this list, 
+              regions. As 'Background' (label 0) is not included in this list,
               there are 116 names in version SPM 5, 8, and 12, and 166 names in
               version 3v2. Please refer to the main description to see how to
               link labels to regions IDs.
             - 'indices': :obj:`list` of :obj:`str`, indices mapping 'labels'
-              to values in the 'maps' image. This list has 116 elements in 
+              to values in the 'maps' image. This list has 116 elements in
               version SPM 5, 8 and 12, and 166 elements in version 3v2.
               Since the values in the 'maps' image do not correspond to
               indices in ``labels``, but rather to values in ``indices``, the
@@ -1329,7 +1314,7 @@ def fetch_atlas_aal(
             url = f"{base_url}wp-content/uploads/AAL3v2_for_SPM12.tar.gz"
             basenames = ("AAL3v1.nii", "AAL3v1.xml")
             filenames = [
-                (os.path.join(f"AAL3", f), url, opts) for f in basenames
+                (os.path.join("AAL3", f), url, opts) for f in basenames
             ]
         else:
             url = f"{base_url}wp-content/uploads/aal_for_{version}.zip"
@@ -1345,7 +1330,7 @@ def fetch_atlas_aal(
     atlas_img, labels_file = fetch_files(
         data_dir, filenames, resume=resume, verbose=verbose
     )
-    fdescr = get_dataset_descr("aal_SPM12")
+    fdescr = get_dataset_descr("aal")
     labels = []
     indices = []
     if version in ("SPM12", "3v2"):

--- a/nilearn/datasets/description/aal.rst
+++ b/nilearn/datasets/description/aal.rst
@@ -20,6 +20,26 @@ of functional studies are proposed:
 (2) percentage of voxels belonging to each of the AVOI intersected by a sphere centered by a set of coordinates, and
 (3) percentage of voxels belonging to each of the AVOI intersected by an activated cluster.
 
+For the AAL version SPM 5, 8, and 12, the map image (data.maps) contains 117 unique integer values that define the parcellation. However, these values are not consecutive integers from 0 to 116, as is usually the case in Nilearn. Therefore, they should not be interpreted as indices for the list of label names.
+In contrast, the total number of parcellations in AAL 3v2 is 167. The 3v2 atlas contains 171 unique integer values that define the parcellation. These values are consecutive integers from 0 to 170, except for the anterior cingulate cortex (35, 36) and thalamus (81, 82), which are left empty in AAL 3v2.
+In addition, the region IDs are provided as strings, so it is necessary to cast them to integers when indexing.
+
+For example, with version SPM 5, 8 and 12, to get the name of the region
+corresponding to the region ID 5021 in the image, you should do:
+
+.. code-block:: python
+
+    # This should print 'Lingual_L'
+    data.labels[data.indices.index("5021")]
+
+Conversely, to get the region ID corresponding to the label
+"Precentral_L", you should do:
+
+.. code-block:: python
+
+    # This should print '2001'
+    data.indices[data.labels.index("Precentral_L")]
+
 For more information on this atlas,
 see :footcite:t:`AAL_atlas`,
 and :footcite:t:`Tzourio-Mazoyer2002`.

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -17,7 +17,7 @@ from sklearn.utils import Bunch
 from nilearn._utils import data_gen
 from nilearn._utils.testing import serialize_niimg
 from nilearn.conftest import _rng
-from nilearn.datasets import atlas
+from nilearn.datasets import atlas, fetch_atlas_aal
 from nilearn.datasets._utils import fetch_files
 from nilearn.datasets.tests._testing import dict_to_archive
 from nilearn.image import get_data
@@ -824,3 +824,10 @@ def test_fetch_atlas_schaefer_2018(tmp_path, request_mocker):
 
         assert img.header.get_zooms()[0] == resolution_mm
         assert np.array_equal(np.unique(img.dataobj), np.arange(n_rois + 1))
+
+
+def test_all_version_deprecation():
+    with pytest.deprecated_call(
+        match=r"Starting in version 0\.13, the default fetched mask"
+    ):
+        fetch_atlas_aal()

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -826,7 +826,13 @@ def test_fetch_atlas_schaefer_2018(tmp_path, request_mocker):
         assert np.array_equal(np.unique(img.dataobj), np.arange(n_rois + 1))
 
 
-def test_all_version_deprecation():
+def test_aal_version_deprecation(request_mocker):
+
+    img_pattern = re.compile("https://www.gin.cnrs.fr/*")
+    request_mocker.url_mapping[img_pattern] = (
+        data_gen.generate_labeled_regions((7, 6, 5), 16)
+    )
+
     with pytest.deprecated_call(
         match=r"Starting in version 0\.13, the default fetched mask"
     ):

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -22,7 +22,7 @@ currdir = os.path.dirname(os.path.abspath(__file__))
 datadir = os.path.join(currdir, "data")
 
 DATASET_NAMES = {
-    "aal_SPM12",
+    "aal",
     "ABIDE_pcp",
     "adhd",
     "allen_rsn_2011",


### PR DESCRIPTION
- Closes #4551 

Changes proposed in this pull request:

- Added an option in `fetch_atlas_aal(version="3v2")` to fetch the latest AAL version.
- Updated the documentation accordingly.
- Added a _DeprecationWarning_ when the default AAL atlas is fetched, notifying users that version 3v2 will become the default instead of SPM12 starting from version 0.13.
