### PR TITLE
[FIX] avoid warning when creating int64 images

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -59,7 +59,7 @@ Changes
 
 - :bdg-dark:`Code` Improve logging by relying only on the Nilearn logger and adding optional support for rich printing if `rich <https://github.com/Textualize/rich>`_ is installed (:gh:`4469` and :gh:`4544` by `Rémi Gau`_).
 
-- :bdg-dark:`Code` Parcellations returned by :class:`nilearn.regions.Parcellations` will now be of type ``np.int32`` to avoid unnecessary warnings (:gh:`4555` by `Rémi Gau`).
+- :bdg-dark:`Code` Parcellations returned by :class:`nilearn.regions.Parcellations` will now be of type ``np.int32`` to avoid unnecessary warnings (:gh:`4555` by `Rémi Gau`_).
 
 - :bdg-danger:`Deprecation` The parameter ``tr`` for :term:`Repetition time<TR>` will be replaced by ``t_r`` in the "HRF" functions in version 0.13.0. The affected functions are :func:`nilearn.glm.first_level.glover_dispersion_derivative`, :func:`nilearn.glm.first_level.glover_hrf`, :func:`nilearn.glm.first_level.glover_time_derivative`, :func:`nilearn.glm.first_level.spm_dispersion_derivative`, :func:`nilearn.glm.first_level.spm_hrf`, :func:`nilearn.glm.first_level.spm_time_derivative` (:gh:`4470` by `Rémi Gau`_).
 

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -59,6 +59,8 @@ Changes
 
 - :bdg-dark:`Code` Improve logging by relying only on the Nilearn logger and adding optional support for rich printing if `rich <https://github.com/Textualize/rich>`_ is installed (:gh:`4469` and :gh:`4544` by `Rémi Gau`_).
 
+- :bdg-dark:`Code` Parcellations returned by :class:`nilearn.regions.Parcellations` will now be of type ``np.int32`` to avoid unnecessary warnings (:gh:`4555` by `Rémi Gau`).
+
 - :bdg-danger:`Deprecation` The parameter ``tr`` for :term:`Repetition time<TR>` will be replaced by ``t_r`` in the "HRF" functions in version 0.13.0. The affected functions are :func:`nilearn.glm.first_level.glover_dispersion_derivative`, :func:`nilearn.glm.first_level.glover_hrf`, :func:`nilearn.glm.first_level.glover_time_derivative`, :func:`nilearn.glm.first_level.spm_dispersion_derivative`, :func:`nilearn.glm.first_level.spm_hrf`, :func:`nilearn.glm.first_level.spm_time_derivative` (:gh:`4470` by `Rémi Gau`_).
 
 - :bdg-primary:`Doc` Refactor design matrix and contrast formula for the two-sample T-test example in :ref:`sphx_glr_auto_examples_05_glm_second_level_plot_second_level_two_sample_test.py` (:gh:`4407` by `Yichun Huang`_).

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -808,7 +808,7 @@ def _plot_roi_contours(display, roi_img, cmap, alpha, linewidths):
         if label == 0:
             continue
         data = roi_data == label
-        data = data.astype(int)
+        data = data.astype(np.int32)
         img = new_img_like(roi_img, data, affine=roi_img.affine)
         display.add_contours(
             img,

--- a/nilearn/plotting/tests/test_img_plotting/test_plot_roi.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_plot_roi.py
@@ -35,7 +35,7 @@ def demo_plot_roi(**kwargs):
     "display_mode,cut_coords", [("ortho", None), ("z", 3), ("x", [2.0, 10])]
 )
 def test_plot_roi_view_types(
-    view_type, black_bg, threshold, alpha, display_mode, cut_coords, recwarn
+    view_type, black_bg, threshold, alpha, display_mode, cut_coords
 ):
     """Smoke-test for plot_roi.
 

--- a/nilearn/plotting/tests/test_img_plotting/test_plot_roi.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_plot_roi.py
@@ -24,8 +24,8 @@ def demo_plot_roi(**kwargs):
         int(z_map) - 10 : int(z_map) + 10,
     ] = 1
     img = Nifti1Image(data, _affine_mni())
-    return plot_roi(img, title="Broca's area", **kwargs)
-
+    plot_roi(img, title="Broca's area", **kwargs)
+ 
 
 @pytest.mark.parametrize("view_type", ["contours", "continuous"])
 @pytest.mark.parametrize("black_bg", [True, False])
@@ -35,7 +35,7 @@ def demo_plot_roi(**kwargs):
     "display_mode,cut_coords", [("ortho", None), ("z", 3), ("x", [2.0, 10])]
 )
 def test_plot_roi_view_types(
-    view_type, black_bg, threshold, alpha, display_mode, cut_coords
+    view_type, black_bg, threshold, alpha, display_mode, cut_coords, recwarn
 ):
     """Smoke-test for plot_roi.
 
@@ -54,6 +54,11 @@ def test_plot_roi_view_types(
         cut_coords=cut_coords,
         **kwargs,
     )
+    for _ in range(len(recwarn)):
+        x = recwarn.pop()
+        if issubclass(x.category, UserWarning):
+            assert "image contains 64-bit ints" not in x.message
+
     plt.close()
 
 

--- a/nilearn/plotting/tests/test_img_plotting/test_plot_roi.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_plot_roi.py
@@ -54,13 +54,16 @@ def test_plot_roi_view_types(
         cut_coords=cut_coords,
         **kwargs,
     )
+    plt.close()
 
+
+def test_plot_roi_no_int_64_warning(recwarn):
+    """Make sure that no int64 warning is thrown."""
+    demo_plot_roi()
     for _ in range(len(recwarn)):
         x = recwarn.pop()
         if issubclass(x.category, UserWarning):
             assert "image contains 64-bit ints" not in str(x.message)
-
-    plt.close()
 
 
 def test_plot_roi_view_type_error():

--- a/nilearn/plotting/tests/test_img_plotting/test_plot_roi.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_plot_roi.py
@@ -25,7 +25,7 @@ def demo_plot_roi(**kwargs):
     ] = 1
     img = Nifti1Image(data, _affine_mni())
     plot_roi(img, title="Broca's area", **kwargs)
- 
+
 
 @pytest.mark.parametrize("view_type", ["contours", "continuous"])
 @pytest.mark.parametrize("black_bg", [True, False])

--- a/nilearn/plotting/tests/test_img_plotting/test_plot_roi.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_plot_roi.py
@@ -54,10 +54,11 @@ def test_plot_roi_view_types(
         cut_coords=cut_coords,
         **kwargs,
     )
+
     for _ in range(len(recwarn)):
         x = recwarn.pop()
         if issubclass(x.category, UserWarning):
-            assert "image contains 64-bit ints" not in x.message
+            assert "image contains 64-bit ints" not in str(x.message)
 
     plt.close()
 

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -441,7 +441,9 @@ class Parcellations(_MultiPCA):
             warnings.warn(
                 message=n_parcels_warning, category=UserWarning, stacklevel=3
             )
-        self.labels_img_ = self.masker_.inverse_transform(labels)
+        self.labels_img_ = self.masker_.inverse_transform(
+            labels.astype(np.int32)
+        )
 
         return self
 

--- a/nilearn/regions/tests/test_parcellations.py
+++ b/nilearn/regions/tests/test_parcellations.py
@@ -97,7 +97,7 @@ def test_parcellations_no_int64_warnings(img_4d_zeros_eye):
     with warnings.catch_warnings(record=True) as record:
         parcellator.fit(img_4d_zeros_eye)
     for r in record:
-        if issubclass(x.category, UserWarning):
+        if issubclass(r.category, UserWarning):
             assert "image contains 64-bit ints" not in str(r.message)
 
 

--- a/nilearn/regions/tests/test_parcellations.py
+++ b/nilearn/regions/tests/test_parcellations.py
@@ -92,6 +92,15 @@ def test_parcellations_no_warnings(img_4d_zeros_eye):
     assert all([r.category is not UserWarning for r in record])
 
 
+def test_parcellations_no_int64_warnings(img_4d_zeros_eye):
+    parcellator = Parcellations(method="kmeans", n_parcels=1, verbose=0)
+    with warnings.catch_warnings(record=True) as record:
+        parcellator.fit(img_4d_zeros_eye)
+    for r in record:
+        if issubclass(x.category, UserWarning):
+            assert "image contains 64-bit ints" not in str(r.message)
+
+
 @pytest.mark.parametrize("method", METHODS)
 def test_parcellations_fit_on_multi_nifti_images(
     method, test_image, affine_eye


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- fix plotting_roi and Parcellations that threw the warning even if users data with a type different from int64:

> Data array used to create a new image contains 64-bit ints. This is likely due to creating the array with numpy and passing `int` as the `dtype`. Many tools such as FSL and SPM cannot deal with int64 in Nifti images, so for compatibility the data has been converted to int32.
 
- Should remove > 80 warnings from the test suite
- warnings in the example:

https://nilearn.github.io/stable/auto_examples/03_connectivity/plot_data_driven_parcellations.html

![image](https://github.com/user-attachments/assets/4514c3f7-bbc7-4f69-b60e-d903943e3cf9)

https://nilearn.github.io/stable/auto_examples/01_plotting/plot_atlas.html#visualizing-the-juelich-atlas-with-contours

![image](https://github.com/user-attachments/assets/b9386838-7002-4f68-8a43-6c202dc409d8)

