### PR TITLE
[FIX] fix name of parameter in the "extract_type" definition

### DIFF
--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -342,8 +342,9 @@ extractor : {"local_regions", "connected_components"}, default="local_regions"
           on these markers for region separation.
 
 """
-docdict["extract_type"] = docdict["extractor"]
-
+docdict["extract_type"] = docdict["extractor"].replace(
+    "extractor", "extract_type"
+)
 # figure
 docdict[
     "figure"


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- make sure the name of the extract_type parameter matches that of the key in the doc dictionary to avoid mismatch in the rendered doc (see example in image below where parameter name 'extract_type' in the function signature does not match the name of the parameter in the doc string 'extractor')

![Screenshot_20240924_160042_Firefox](https://github.com/user-attachments/assets/f987b173-4777-4a44-b2b9-ddeb0d595fe3)

