### PR TITLE
[ENH] use fsaverage mesh as default for the SurfaceImage

### DIFF
--- a/nilearn/experimental/surface/_surface_image.py
+++ b/nilearn/experimental/surface/_surface_image.py
@@ -11,7 +11,7 @@ import numpy as np
 from nibabel import Nifti1Image
 
 from nilearn._utils.niimg_conversions import check_niimg
-from nilearn.experimental.surface import _io, load_fsaverage
+from nilearn.experimental.surface import _io
 from nilearn.surface import vol_to_surf
 
 
@@ -204,6 +204,8 @@ class SurfaceImage:
         data : PolyData | dict[str, Mesh  |  str  |  Path] | Niimg-like object
         """
         if mesh is None:
+            from nilearn.experimental.surface._datasets import load_fsaverage
+
             fsaverage5 = load_fsaverage("fsaverage5")
             mesh = fsaverage5["pial"]
         self.mesh = mesh if isinstance(mesh, PolyMesh) else PolyMesh(**mesh)

--- a/nilearn/experimental/surface/_surface_image.py
+++ b/nilearn/experimental/surface/_surface_image.py
@@ -11,7 +11,7 @@ import numpy as np
 from nibabel import Nifti1Image
 
 from nilearn._utils.niimg_conversions import check_niimg
-from nilearn.experimental.surface import _io
+from nilearn.experimental.surface import _io, load_fsaverage
 from nilearn.surface import vol_to_surf
 
 
@@ -190,7 +190,7 @@ class SurfaceImage:
 
     def __init__(
         self,
-        mesh: PolyMesh | dict[str, Mesh | str | Path],
+        mesh: PolyMesh | dict[str, Mesh | str | Path] | None,
         data: (
             PolyData | dict[str, Mesh | str | Path] | Nifti1Image | str | Path
         ),
@@ -199,9 +199,13 @@ class SurfaceImage:
 
         Parameters
         ----------
-        mesh : PolyMesh | dict[str, Mesh  |  str  |  Path]
+        mesh : PolyMesh | dict[str, Mesh  |  str  |  Path] | None
+            Defaults to fsaverage if None is passed.
         data : PolyData | dict[str, Mesh  |  str  |  Path] | Niimg-like object
         """
+        if mesh is None:
+            fsaverage5 = load_fsaverage("fsaverage5")
+            mesh = fsaverage5["pial"]
         self.mesh = mesh if isinstance(mesh, PolyMesh) else PolyMesh(**mesh)
 
         if not isinstance(data, (PolyData, dict, str, Path, Nifti1Image)):


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but relates to https://github.com/nilearn/nilearn/issues/4027#issuecomment-2368892520

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- uses fsaverage5 pial mesh as default when no mesh is passed to the SurfaceImage constructor
-
