### PR TITLE
[MAINT] Optimize `_resample_one_img` logic check for nearest interpolation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -323,6 +323,10 @@ authors:
     family-names: Gors
     website: http://jgors.com/
     affiliation: Insight Data Science, Mountain View, California, USA
+  - given-names: Jason
+    family-names: Kai
+    website: https://github.com/kaitj
+    affiliation: Child Mind Institute
   - given-names: Javier
     family-names: Rasero
     website: https://jrasero.github.io/

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -71,6 +71,6 @@ Changes
 
 - :bdg-danger:`Deprecation` The parameter ``ax`` will be replaced by ``axes`` in :func:`nilearn.plotting.plot_contrast_matrix` and :func:`nilearn.plotting.plot_design_matrix` in release 0.13.0. (:gh:`4476` by `Mudassir Chapra`_)
 
-- :bdg-dark:`Code` Skip check of array values if interpolation order is ``0`` in :func:`nilearn.image._resample_one_img` by reordering condition (:gh:`4571` by `Jason Kai`_).
+- :bdg-dark:`Code` Reorder condition in internal call of :func:`nilearn.image.resample_img` to skip checking of array values if interpolation is ``nearest`` (:gh:`4571` by `Jason Kai`_).
 
-- :bdg-dark:`Code` Remove redundant sorting of ``np.unique(data)`` in :func:`nilearn.image._resample_one_img` (:gh:`4571` by `Jason Kai`_) when checking array values.
+- :bdg-dark:`Code` Remove redundant sorting of ``np.unique(data)`` in internal call of :func:`nilearn.image.resample_img` when checking array values (:gh:`4571` by `Jason Kai`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -70,3 +70,7 @@ Changes
 - :bdg-dark:`Code` Extend coverage for data generating utility functions (:gh:`4465` by `Sin Kim`_).
 
 - :bdg-danger:`Deprecation` The parameter ``ax`` will be replaced by ``axes`` in :func:`nilearn.plotting.plot_contrast_matrix` and :func:`nilearn.plotting.plot_design_matrix` in release 0.13.0. (:gh:`4476` by `Mudassir Chapra`_)
+
+- :bdg-dark:`Code` Skip check of array values if interpolation order is ``0`` in :func:`nilearn.image._resample_one_img` by reordering condition (:gh:`4571` by `Jason Kai`_).
+
+- :bdg-dark:`Code` Remove redundant sorting of ``np.unique(data)`` in :func:`nilearn.image._resample_one_img` (:gh:`4571` by `Jason Kai`_) when checking array values.

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -289,7 +289,7 @@ def _resample_one_img(
 
     # If data is binary and interpolation is continuous or linear,
     # warn the user as this might be unintentional
-    if sorted(list(np.unique(data))) == [0, 1] and interpolation_order != 0:
+    if interpolation_order != 0 and np.array_equal(np.unique(data), [0, 1]):
         warnings.warn(
             "Resampling binary images with continuous or "
             "linear interpolation. This might lead to "


### PR DESCRIPTION
- Closes #4563 

Changes proposed in this pull request:
- Reorder condition checking for internal [`_resample_one_img`](https://github.com/nilearn/nilearn/blob/4c209b49b42ad2093ee3c2ce268b4d87d18a5ee2/nilearn/image/resampling.py#L292), first checking interpolation order before checking array values, improving performance by skipping the value checks when `nearest` interpolation is selected for [`resample_img`](https://github.com/nilearn/nilearn/blob/4c209b49b42ad2093ee3c2ce268b4d87d18a5ee2/nilearn/image/resampling.py#L349).
- Update the check of array values to call `np.array_equal` to assert values are `[0, 1]`, avoiding redundant sorting and typecasting from `np.array` to `list`
