### PR TITLE
[DOC] Demonstrate how to compute & plot functional connectivity for each hemisphere separately with Yeo 17 networks

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -43,6 +43,8 @@ Fixes
 Enhancements
 ------------
 
+- :bdg-primary:`Doc` Add example showing how to compute hemisphere-wise connectivity for Yeo 17 networks (:gh:`4585` by `Victoria Shevchenko`_).
+
 - :bdg-primary:`Doc` Add an option in :func:`nilearn.datasets.fetch_atlas_aal` to fetch the latest AAL version, 3v2 (:gh:`4554` by `Jeremy Lefort-Besnard`_ and `Rémi Gau`_).
 
 - :bdg-dark:`Code` Improve input/output for ``SurfaceImage`` by loading meshes from files on disk, loading data from files or Nifti object, and saving meshes to file (:gh:`4446` by `Rémi Gau`_).

--- a/examples/03_connectivity/plot_atlas_comparison.py
+++ b/examples/03_connectivity/plot_atlas_comparison.py
@@ -108,7 +108,7 @@ left_connectome = plotting.plot_connectome(
 import nibabel as nb
 import numpy as np
 
-from nilearn.image import get_data
+from nilearn.image import get_data, new_img_like
 from nilearn.image.resampling import coord_transform
 
 # load the atlas image first
@@ -124,12 +124,12 @@ x, y, z = coord_transform(0, 0, 0, np.linalg.inv(labels_affine))
 # left/right split is done along x-axis
 left_hemi = get_data(label_image).copy()
 left_hemi[: int(x)] = 0
-label_image_left = nb.Nifti1Image(left_hemi, labels_affine)
+label_image_left = new_img_like(label_image, left_hemi, labels_affine)
 
 # same for the right hemisphere
 right_hemi = get_data(label_image).copy()
 right_hemi[int(x) :] = 0
-label_image_right = nb.Nifti1Image(right_hemi, labels_affine)
+label_image_right = new_img_like(label_image, right_hemi, labels_affine)
 
 # %%
 # Then, create a masker object, compute a connectivity matrix and


### PR DESCRIPTION
Closes #4473

* Emphasized that connectivity is computed for both hemispheres as default behavior.
* Added an example where Yeo 17 networks is divided into two separate images & connectivity analysis is run on them separately.

In the future however it would be nice if the plotting function displayed both hemispheres by default for Yeo so as to align with the default connectome computation.