### PR TITLE
[FIX] check type compatibility of GLM mask and input data

### DIFF
--- a/nilearn/_utils/masker_validation.py
+++ b/nilearn/_utils/masker_validation.py
@@ -1,9 +1,11 @@
 import warnings
+from pathlib import Path
 from string import Template
 
 import numpy as np
+from nibabel import Nifti1Image
 
-from nilearn.experimental.surface import SurfaceMasker
+from nilearn.experimental.surface import SurfaceImage, SurfaceMasker
 from nilearn.maskers import MultiNiftiMasker, NiftiMasker
 
 from .cache_mixin import _check_memory
@@ -119,3 +121,39 @@ def check_embedded_masker(estimator, masker_type="multi_nii"):
         masker.mask_img = mask.mask_img_
 
     return masker
+
+
+def check_compatibility_mask_and_images(mask_img, run_imgs):
+    """Check that mask type and image types are compatible.
+
+    Images to fit should be a Niimg-Like
+    if the mask is a NiftiImage, NiftiMasker or a path.
+    Similarly, only SurfaceImages can be fitted
+    with a SurfaceImage or a SrufaceMasked as mask.
+    """
+    if mask_img is None:
+        return None
+
+    msg = (
+        "Mask and images to fit must be of compatible types.\n"
+        f"Got mask of type: {type(mask_img)}, "
+        f"and images of type: {[type(x) for x in run_imgs]}"
+    )
+
+    volumetric_type = (Nifti1Image, NiftiMasker, str, Path)
+    if isinstance(mask_img, volumetric_type) and any(
+        not isinstance(x, (Nifti1Image, str, Path)) for x in run_imgs
+    ):
+        raise TypeError(
+            f"{msg} "
+            f"where images should be NiftiImage-like instances "
+            f"(Nifti1Image or str or Path)."
+        )
+
+    surface_type = (SurfaceImage, SurfaceMasker)
+    if isinstance(mask_img, surface_type) and any(
+        not isinstance(x, SurfaceImage) for x in run_imgs
+    ):
+        raise TypeError(
+            f"{msg} where SurfaceImage instances would be expected."
+        )

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -325,10 +325,11 @@ class FirstLevelModel(BaseGLM):
 
     mask_img : Niimg-like, NiftiMasker, SurfaceImage, SurfaceMasker, False or \
                None, default=None
-        Mask to be used on data. If an instance of masker is passed,
-        then its mask will be used. If None is passed, the mask
-        will be computed automatically by a NiftiMasker with default
-        parameters. If False is given then the data will not be masked.
+        Mask to be used on data.
+        If an instance of masker is passed, then its mask will be used.
+        If None is passed, the mask will be computed automatically
+        by a NiftiMasker or SurfaceMasker with default parameters.
+        If False is given then the data will not be masked.
         In the case of surface analysis, passing None or False will lead to
         no masking.
 
@@ -715,8 +716,24 @@ class FirstLevelModel(BaseGLM):
                    :obj:`list` or :obj:`tuple` of Niimg-like objects, \
                    SurfaceImage object, \
                    or :obj:`list` or :obj:`tuple` of SurfaceImage
-            Data on which the :term:`GLM` will be fitted. If this is a list,
-            the affine is considered the same for all.
+            Data on which the :term:`GLM` will be fitted.
+            If this is a list, the affine is considered the same for all.
+
+            .. warning::
+
+                If the FirstLevelModel object was instantiated
+                with a ``mask_img``,
+                then ``run_imgs`` must be compatible with ``mask_img``.
+                For example, if ``mask_img`` is
+                a :class:`nilearn.maskers.NiftiMasker` instance
+                or a Niimng-like object, then ``run_imgs`` must be a
+                Niimg-like object, \
+                a :obj:`list` or a :obj:`tuple` of Niimg-like objects.
+                If ``mask_img`` is
+                a ``SurfaceMasker`` or ``SurfaceImage`` instance,
+                then ``run_imgs`` mustr be a
+                ``SurfaceImage`` object, \
+                a :obj:`list` or a :obj:`tuple` of ``SurfaceImage`` objects.
 
         events : :class:`pandas.DataFrame` or :obj:`str` or :obj:`list` of \
                  :class:`pandas.DataFrame` or :obj:`str`, default=None

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1077,15 +1077,16 @@ def _check_compatibility_mask_and_images(mask_img, run_imgs):
     Similarly, only SurfaceImages can be fitted
     with a SurfaceImage or a SrufaceMasked as mask.
     """
-    volumetric_type = (Nifti1Image, NiftiMasker, str, Path)
-    surface_type = (SurfaceImage, SurfaceMasker)
+    if mask_img is None:
+        return None
+
     msg = (
         "Mask and images to fit must be of compatible types.\n"
         f"Got mask of type: {type(mask_img)}, "
         f"and images of type: {[type(x) for x in run_imgs]} "
     )
-    if mask_img is None:
-        return None
+
+    volumetric_type = (Nifti1Image, NiftiMasker, str, Path)
     if isinstance(mask_img, volumetric_type) and any(
         not isinstance(x, (Nifti1Image, str, Path)) for x in run_imgs
     ):
@@ -1094,6 +1095,8 @@ def _check_compatibility_mask_and_images(mask_img, run_imgs):
             f"where images should be NiftiImage-like instances "
             f"(Nifti1Image or str or Path)."
         )
+
+    surface_type = (SurfaceImage, SurfaceMasker)
     if isinstance(mask_img, surface_type) and any(
         not isinstance(x, SurfaceImage) for x in run_imgs
     ):

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -731,7 +731,7 @@ class FirstLevelModel(BaseGLM):
                 a :obj:`list` or a :obj:`tuple` of Niimg-like objects.
                 If ``mask_img`` is
                 a ``SurfaceMasker`` or ``SurfaceImage`` instance,
-                then ``run_imgs`` mustr be a
+                then ``run_imgs`` must be a
                 ``SurfaceImage`` object, \
                 a :obj:`list` or a :obj:`tuple` of ``SurfaceImage`` objects.
 

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1083,7 +1083,7 @@ def _check_compatibility_mask_and_images(mask_img, run_imgs):
     msg = (
         "Mask and images to fit must be of compatible types.\n"
         f"Got mask of type: {type(mask_img)}, "
-        f"and images of type: {[type(x) for x in run_imgs]} "
+        f"and images of type: {[type(x) for x in run_imgs]}"
     )
 
     volumetric_type = (Nifti1Image, NiftiMasker, str, Path)
@@ -1091,7 +1091,7 @@ def _check_compatibility_mask_and_images(mask_img, run_imgs):
         not isinstance(x, (Nifti1Image, str, Path)) for x in run_imgs
     ):
         raise TypeError(
-            f"{msg}"
+            f"{msg} "
             f"where images should be NiftiImage-like instances "
             f"(Nifti1Image or str or Path)."
         )
@@ -1101,7 +1101,7 @@ def _check_compatibility_mask_and_images(mask_img, run_imgs):
         not isinstance(x, SurfaceImage) for x in run_imgs
     ):
         raise TypeError(
-            f"{msg}" f"where SurfaceImage instances would be expected."
+            f"{msg} where SurfaceImage instances would be expected."
         )
 
 

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1070,7 +1070,13 @@ class FirstLevelModel(BaseGLM):
 
 
 def _check_compatibility_mask_and_images(mask_img, run_imgs):
-    # check that mask type and image types are compatible
+    """Check that mask type and image types are compatible.
+
+    Images to fit should be a Niimg-Like
+    if the mask is a NiftiImage, NiftiMasker or a path.
+    Similarly, only SurfaceImages can be fitted
+    with a SurfaceImage or a SrufaceMasked as mask.
+    """
     volumetric_type = (Nifti1Image, NiftiMasker, str, Path)
     surface_type = (SurfaceImage, SurfaceMasker)
     msg = (
@@ -1078,15 +1084,16 @@ def _check_compatibility_mask_and_images(mask_img, run_imgs):
         f"Got mask of type: {type(mask_img)}, "
         f"and images of type: {[type(x) for x in run_imgs]} "
     )
-    if mask_img is not None:
-        if isinstance(mask_img, volumetric_type) and any(
-            not isinstance(x, (Nifti1Image, str, Path)) for x in run_imgs
-        ):
-            raise TypeError(
-                f"{msg}"
-                f"where images should be NiftiImage-like instances "
-                f"(Nifti1Image or str or Path)."
-            )
+    if mask_img is None:
+        return None
+    if isinstance(mask_img, volumetric_type) and any(
+        not isinstance(x, (Nifti1Image, str, Path)) for x in run_imgs
+    ):
+        raise TypeError(
+            f"{msg}"
+            f"where images should be NiftiImage-like instances "
+            f"(Nifti1Image or str or Path)."
+        )
     if isinstance(mask_img, surface_type) and any(
         not isinstance(x, SurfaceImage) for x in run_imgs
     ):

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -2077,6 +2077,45 @@ def test_flm_fit_surface_image_with_mask(_make_surface_glm_data, mini_mask):
     assert isinstance(model.masker_, SurfaceMasker)
 
 
+def test_error_flm_surface_mask_volume_image(
+    _make_surface_glm_data, mini_mask, img_4d_rand_eye
+):
+    """Test error is raised when mask is a surface and data is in volume."""
+    mini_img, des = _make_surface_glm_data(5)
+    model = FirstLevelModel(mask_img=mini_mask)
+    with pytest.raises(
+        TypeError, match="Mask and images to fit must be of the same type."
+    ):
+        model.fit(img_4d_rand_eye, design_matrices=des)
+
+    masker = SurfaceMasker().fit(mini_img)
+    model = FirstLevelModel(mask_img=masker)
+    with pytest.raises(
+        TypeError, match="Mask and images to fit must be of the same type."
+    ):
+        model.fit(img_4d_rand_eye, design_matrices=des)
+
+
+def test_error_flm_volume_mask_surface_image(_make_surface_glm_data):
+    """Test error is raised when mask is a volume and data is in surface."""
+    shapes, rk = [(7, 8, 9, 15)], 3
+    mask, _, _ = generate_fake_fmri_data_and_design(shapes, rk)
+
+    mini_img, des = _make_surface_glm_data(5)
+    model = FirstLevelModel(mask_img=mask)
+    with pytest.raises(
+        TypeError, match="Mask and images to fit must be of the same type."
+    ):
+        model.fit(mini_img, design_matrices=des)
+
+    masker = NiftiMasker().fit(mask)
+    model = FirstLevelModel(mask_img=masker)
+    with pytest.raises(
+        TypeError, match="Mask and images to fit must be of the same type."
+    ):
+        model.fit(mini_img, design_matrices=des)
+
+
 def test_flm_with_surface_image_with_surface_masker(_make_surface_glm_data):
     """Test FirstLevelModel with SurfaceMasker."""
     mini_img, des = _make_surface_glm_data(5)

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -2084,14 +2084,14 @@ def test_error_flm_surface_mask_volume_image(
     mini_img, des = _make_surface_glm_data(5)
     model = FirstLevelModel(mask_img=mini_mask)
     with pytest.raises(
-        TypeError, match="Mask and images to fit must be of the same type."
+        TypeError, match="Mask and images to fit must be of compatible types."
     ):
         model.fit(img_4d_rand_eye, design_matrices=des)
 
     masker = SurfaceMasker().fit(mini_img)
     model = FirstLevelModel(mask_img=masker)
     with pytest.raises(
-        TypeError, match="Mask and images to fit must be of the same type."
+        TypeError, match="Mask and images to fit must be of compatible types."
     ):
         model.fit(img_4d_rand_eye, design_matrices=des)
 
@@ -2104,14 +2104,14 @@ def test_error_flm_volume_mask_surface_image(_make_surface_glm_data):
     mini_img, des = _make_surface_glm_data(5)
     model = FirstLevelModel(mask_img=mask)
     with pytest.raises(
-        TypeError, match="Mask and images to fit must be of the same type."
+        TypeError, match="Mask and images to fit must be of compatible types."
     ):
         model.fit(mini_img, design_matrices=des)
 
     masker = NiftiMasker().fit(mask)
     model = FirstLevelModel(mask_img=masker)
     with pytest.raises(
-        TypeError, match="Mask and images to fit must be of the same type."
+        TypeError, match="Mask and images to fit must be of compatible types."
     ):
         model.fit(mini_img, design_matrices=des)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4586

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- check that mask and input data are of compatible types (that is for volumetric or surface based analysis) and raise an error when that's not possible
