### PR TITLE
Return signals if standardisation was not applied, and change the condition when adding signal mean back for psc method

### DIFF
--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -810,7 +810,8 @@ def clean(
         return signals
 
     # detect if mean is close to zero; This can obscure the scale of the signal
-    # with percent signal change standardization
+    # with percent signal change standardization. This should happen when the
+    # data was 1. detrended 2. high pass filtered.
     filtered_mean_check = (
         np.abs(signals.mean(0)).mean() / np.abs(original_mean_signals).mean()
         < 1e-1

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -808,9 +808,12 @@ def clean(
     # Standardize
     if not standardize:
         return signals
-    if standardize == "psc" and (detrend or (filter_type == "butterworth" and high_pass is not None)):
-        # If the signal is detrended or high pass filtered with butterworth,
-        # the mean signal will be zero or close to zero. In this case,
+    if standardize == "psc" and (
+        detrend or (filter_type == "butterworth" and high_pass is not None)
+    ):
+        # If the signal is detrended, the mean signal will be zero or close to
+        # zero. If signal is high pass filtered with butterworth, the constant
+        # (mean) will be removed. In this case,
         # we have to know the original mean signal to calculate the psc.
         signals = standardize_signal(
             signals + mean_signals,

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -806,8 +806,10 @@ def clean(
         signals -= Q.dot(Q.T).dot(signals)
 
     # Standardize
-    if (detrend and standardize == "psc") or (filter_type == "butterworth"):
-        # If the signal is detrended or filtered,
+    if not standardize:
+        return signals
+    if standardize == "psc" and (detrend or (filter_type == "butterworth" and high_pass is not None)):
+        # If the signal is detrended or high pass filtered with butterworth,
         # the mean signal will be zero or close to zero. In this case,
         # we have to know the original mean signal to calculate the psc.
         signals = standardize_signal(

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -808,6 +808,9 @@ def clean(
     # Standardize
     if not standardize:
         return signals
+
+    # detect if mean is close to zero; This can obscure the scale of the signal
+    # with percent signal change standardization
     filtered_mean_check = (
         np.abs(signals.mean(0)).mean() / np.abs(original_mean_signals).mean()
         < 1e-1
@@ -819,15 +822,6 @@ def clean(
         # difference of the original mean and filtered mean signal. When the
         # mean is too small, we have to know the original mean signal to
         # calculate the psc to avoid weird scaling.
-        warnings.warn(
-            "After cleaning, the new mean of the signal is 1 factor of 10 "
-            "smaller than the original signal. This can obscure the scale of "
-            "the signal with percent signal change standardization. To avoid "
-            "the scale of the signal being obscured drassically, the original "
-            "signal mean has been added back for percent signal change "
-            "standardization. Please note that this might not always solve "
-            "the scale issue if the original signal has a small mean."
-        )
         signals = standardize_signal(
             signals + original_mean_signals,
             standardize=standardize,

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -820,10 +820,13 @@ def clean(
         # mean is too small, we have to know the original mean signal to
         # calculate the psc to avoid weird scaling.
         warnings.warn(
-            "After cleaning, the mean of the signal is 1 factor of 10 smaller "
-            "than the original signal. To avoid the scale of the signal being "
-            "obscured drassically, the original signal mean has been added "
-            "back for percent signal change standardization. "
+            "After cleaning, the new mean of the signal is 1 factor of 10 "
+            "smaller than the original signal. This can obscure the scale of "
+            "the signal with percent signal change standardization. To avoid "
+            "the scale of the signal being obscured drassically, the original "
+            "signal mean has been added back for percent signal change "
+            "standardization. Please note that this might not always solve "
+            "the scale issue if the original signal has a small mean."
         )
         signals = standardize_signal(
             signals + original_mean_signals,

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -1036,7 +1036,6 @@ def test_clean_psc(rng):
             0.99999,
             decimal=5,
         )
-        # assert hp_butterworth_signals.max() < 10
 
     # leave out the last 3 columns with a mean of zero to test user warning
     signals_w_zero = signals + np.append(means[:, :-3], np.zeros((1, 3)))

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -988,15 +988,7 @@ def test_clean_psc(rng):
             decimal=5,
         )
 
-        # detrend; expect this to always trigger warning
-        with pytest.warns(UserWarning) as records:
-            cleaned_signals = clean(s, standardize="psc", detrend=True)
-        psc_scale_warning = sum(
-            "the signal is 1 factor of 10 smaller than the original signal"
-            in str(r.message)
-            for r in records
-        )
-        assert psc_scale_warning == 1
+        cleaned_signals = clean(s, standardize="psc", detrend=True)
         z_signals = clean(s, standardize="zscore_sample", detrend=True)
         np.testing.assert_almost_equal(cleaned_signals.mean(0), 0)
         np.testing.assert_almost_equal(
@@ -1006,20 +998,14 @@ def test_clean_psc(rng):
         )
 
         # test with high pass with butterworth
-        with pytest.warns(UserWarning) as records:
-            hp_butterworth_signals = clean(
-                s,
-                detrend=False,
-                filter="butterworth",
-                high_pass=0.01,
-                t_r=2,
-                standardize="psc",
-            )
-        psc_scale_warning = sum(
-            "factor of 10 smaller than the original signal" in str(r.message)
-            for r in records
+        hp_butterworth_signals = clean(
+            s,
+            detrend=False,
+            filter="butterworth",
+            high_pass=0.01,
+            t_r=2,
+            standardize="psc",
         )
-        assert psc_scale_warning == 1
         z_butterworth_signals = clean(
             s,
             detrend=False,


### PR DESCRIPTION
This ended up being a pretty chunky PR.

<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4466 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Return signals if standardization was not applied. This is straight forward.
- Extra tests for PSC - make sure at least the output is correlated with those created by other linear scaling method (z score).
- Tighten the logic for adding back mean to signals.

Instead of checking user supplied strategy, I check if the original signal mean has a factor of 10 difference after filtering / detrending / regressing confounds. This absolutely would be triggered by `detrend` as the mean is usually 1-e16. And for high-pass filtered signal, the mean is usually 1-e2 - 1-e3, so it get triggers too. I added a warning when this is happening, and also inform users that if the original signal mean is too small, the scale would be weird.

Let me know if you think this is a good solution before I add things to the change log.