### PR TITLE
Test for screening adjustment

### DIFF
--- a/nilearn/conftest.py
+++ b/nilearn/conftest.py
@@ -21,6 +21,7 @@ from nilearn.datasets.tests._testing import (
 from nilearn.experimental.conftest import (  # noqa: F401
     drop_img_part,
     make_mini_img,
+    make_mini_mask,
     mini_img,
     mini_mask,
     mini_mesh,

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -1160,9 +1160,10 @@ def test_decoder_screening_percentile_surface(perc, _make_surface_class_data):
 def test_decoder_screening_percentile_adjustment_surface(
     _make_surface_mask, _make_surface_class_data, screening_percentile
 ):
-    """Test adjustment of screening percentile, such that if mask size is
-    smaller than screening percentile wrt to the mesh size, use whole mask or
-    if mask size is greater than screening percentile wrt to the mesh size,
+    """Test adjustment of screening percentile, such that:
+    - if mask size is smaller than screening percentile wrt to the mesh size,
+    use whole mask.
+    - if mask size is greater than screening percentile wrt to the mesh size,
     adjust the screening percentile for that mask size.
     """
     mask = _make_surface_mask()

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -1167,7 +1167,7 @@ def test_decoder_adjust_screening_lessthan_mask_surface(
     mask_n_vertices = get_mask_volume(mask)
     mesh_n_vertices = img.mesh.n_vertices
     mask_to_mesh_ratio = (mask_n_vertices / mesh_n_vertices) * 100
-    assert mask_to_mesh_ratio <= screening_percentile
+    assert screening_percentile <= mask_to_mesh_ratio
     decoder = Decoder(
         mask=mask,
         param_grid={"C": [0.01, 0.1]},
@@ -1193,7 +1193,7 @@ def test_decoder_adjust_screening_greaterthan_mask_surface(
     mask_n_vertices = get_mask_volume(mask)
     mesh_n_vertices = img.mesh.n_vertices
     mask_to_mesh_ratio = (mask_n_vertices / mesh_n_vertices) * 100
-    assert mask_to_mesh_ratio > screening_percentile
+    assert screening_percentile > mask_to_mesh_ratio
     decoder = Decoder(
         mask=mask,
         param_grid={"C": [0.01, 0.1]},

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -48,7 +48,10 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVR, LinearSVC
 
 from nilearn._utils import compare_version
-from nilearn._utils.param_validation import check_feature_screening
+from nilearn._utils.param_validation import (
+    check_feature_screening,
+    get_mask_volume,
+)
 from nilearn.conftest import _rng
 from nilearn.decoding.decoder import (
     Decoder,
@@ -1097,6 +1100,15 @@ def _make_surface_class_data(rng, make_mini_img):
 
 
 @pytest.fixture()
+def _make_surface_mask(make_mini_mask):
+    def _surface_mask():
+        mask = make_mini_mask()
+        return mask
+
+    return _surface_mask
+
+
+@pytest.fixture()
 def _make_surface_reg_data(rng, make_mini_img):
     """Create a surface image regression for testing."""
 
@@ -1142,6 +1154,37 @@ def test_decoder_screening_percentile_surface(perc, _make_surface_class_data):
         assert model.screening_percentile_ == 100
     else:
         assert model.screening_percentile_ == perc
+
+
+@pytest.mark.parametrize("screening_percentile", [30, 80, 100])
+def test_decoder_screening_percentile_adjustment_surface(
+    _make_surface_mask, _make_surface_class_data, screening_percentile
+):
+    mask = _make_surface_mask()
+    img, y = _make_surface_class_data()
+    mask_n_vertices = get_mask_volume(mask)
+    mesh_n_vertices = img.mesh.n_vertices
+    mask_to_mesh_ratio = (mask_n_vertices / mesh_n_vertices) * 100
+    decoder = Decoder(
+        mask=mask,
+        param_grid={"C": [0.01, 0.1]},
+        cv=3,
+        screening_percentile=screening_percentile,
+    )
+    with pytest.warns(UserWarning, match="Consider raising"):
+        decoder.fit(img, y)
+    adjusted = decoder.screening_percentile_
+    if (
+        screening_percentile == 100
+        or mask_to_mesh_ratio < screening_percentile
+    ):
+        assert adjusted == 100
+    # if mask is larger than given percentile, the percentile is adjusted to
+    # the ratio of mesh to mask
+    elif mask_to_mesh_ratio > screening_percentile:
+        assert adjusted == screening_percentile * (
+            mesh_n_vertices / mask_n_vertices
+        )
 
 
 @pytest.mark.parametrize("mask", [None, SurfaceMasker()])

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -1160,6 +1160,11 @@ def test_decoder_screening_percentile_surface(perc, _make_surface_class_data):
 def test_decoder_screening_percentile_adjustment_surface(
     _make_surface_mask, _make_surface_class_data, screening_percentile
 ):
+    """Test adjustment of screening percentile, such that if mask size is
+    smaller than screening percentile wrt to the mesh size, use whole mask or
+    if mask size is greater than screening percentile wrt to the mesh size,
+    adjust the screening percentile for that mask size.
+    """
     mask = _make_surface_mask()
     img, y = _make_surface_class_data()
     mask_n_vertices = get_mask_volume(mask)

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -1174,10 +1174,7 @@ def test_decoder_screening_percentile_adjustment_surface(
     with pytest.warns(UserWarning, match="Consider raising"):
         decoder.fit(img, y)
     adjusted = decoder.screening_percentile_
-    if (
-        screening_percentile == 100
-        or mask_to_mesh_ratio < screening_percentile
-    ):
+    if mask_to_mesh_ratio <= screening_percentile:
         assert adjusted == 100
     # if mask is larger than given percentile, the percentile is adjusted to
     # the ratio of mesh to mask

--- a/nilearn/experimental/conftest.py
+++ b/nilearn/experimental/conftest.py
@@ -68,10 +68,10 @@ def make_mini_mask(mini_mesh) -> Callable:
         data = {}
         for key, val in mini_mesh.parts.items():
             data_part = np.ones(val.n_vertices, dtype=int)
-            data_part = data_part.astype(bool)
             # make some vertices 0
             data_part[..., 0] = 0
             data_part[..., -1] = 0
+            data_part = data_part.astype(bool)
             data[key] = data_part
         return SurfaceImage(mini_mesh, data)
 

--- a/nilearn/experimental/conftest.py
+++ b/nilearn/experimental/conftest.py
@@ -66,10 +66,10 @@ def make_mini_mask(mini_mesh) -> Callable:
 
     def f():
         data = {}
-        for key, val in enumerate(mini_mesh.parts.items()):
+        for key, val in mini_mesh.parts.items():
             data_part = np.ones(val.n_vertices, dtype=int)
             data_part = data_part.astype(bool)
-            # make outer vertices 0
+            # make some vertices 0
             data_part[..., 0] = 0
             data_part[..., -1] = 0
             data[key] = data_part

--- a/nilearn/experimental/conftest.py
+++ b/nilearn/experimental/conftest.py
@@ -61,6 +61,24 @@ def make_mini_img(mini_mesh) -> Callable:
 
 
 @pytest.fixture
+def make_mini_mask(mini_mesh) -> Callable:
+    """Small surface mask for tests."""
+
+    def f():
+        data = {}
+        for key, val in enumerate(mini_mesh.parts.items()):
+            data_part = np.ones(val.n_vertices, dtype=int)
+            data_part = data_part.astype(bool)
+            # make outer vertices 0
+            data_part[..., 0] = 0
+            data_part[..., -1] = 0
+            data[key] = data_part
+        return SurfaceImage(mini_mesh, data)
+
+    return f
+
+
+@pytest.fixture
 def mini_mask(mini_img) -> SurfaceImage:
     """Raturn small surface mask."""
     data = {k: (v > v.ravel()[0]) for k, v in mini_img.data.parts.items()}


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4626 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- test if screening percentile is adjusted properly during decoding, enforcing following behavior
  - if mask size is smaller than screening percentile wrt to the mesh size, use whole mask
  - if mask size is greater than screening percentile wrt to the mesh size, adjust the screening percentile for that mask size