### PR TITLE
[MAINT] Replace tempfile in tests with proper pytest fixtures

### DIFF
--- a/nilearn/_utils/tests/test_niimg_conversions.py
+++ b/nilearn/_utils/tests/test_niimg_conversions.py
@@ -9,8 +9,8 @@ ignores modules whose name starts with an underscore.
 
 import os
 import re
-import tempfile
 from pathlib import Path
+from tempfile import mkstemp
 
 import numpy as np
 import pytest
@@ -18,13 +18,18 @@ from nibabel import Nifti1Image, spatialimages
 from numpy.testing import assert_array_equal
 
 import nilearn as ni
-from nilearn import _utils
-from nilearn._utils import niimg_conversions, testing
+from nilearn._utils import (
+    _repr_niimgs,
+    check_niimg,
+    check_niimg_3d,
+    check_niimg_4d,
+)
 from nilearn._utils.exceptions import DimensionError
-from nilearn._utils.niimg_conversions import iter_check_niimg
+from nilearn._utils.niimg_conversions import check_same_fov, iter_check_niimg
 from nilearn._utils.testing import (
     assert_memory_less_than,
     with_memory_profiler,
+    write_imgs_to_path,
 )
 from nilearn.image import get_data
 
@@ -65,14 +70,12 @@ def test_check_same_fov(affine_eye):
     shape_b_affine_a = Nifti1Image(np.empty(shape_b), affine_eye)
     shape_b_affine_b = Nifti1Image(np.empty(shape_b), affine_b)
 
-    niimg_conversions.check_same_fov(
-        a=shape_a_affine_a, b=shape_a_affine_a_2, raise_error=True
-    )
+    check_same_fov(a=shape_a_affine_a, b=shape_a_affine_a_2, raise_error=True)
 
     with pytest.raises(
         ValueError, match="[ac] and [ac] do not have the same affine"
     ):
-        niimg_conversions.check_same_fov(
+        check_same_fov(
             a=shape_a_affine_a,
             b=shape_a_affine_a_2,
             c=shape_a_affine_b,
@@ -81,20 +84,20 @@ def test_check_same_fov(affine_eye):
     with pytest.raises(
         ValueError, match="[ab] and [ab] do not have the same shape"
     ):
-        niimg_conversions.check_same_fov(
+        check_same_fov(
             a=shape_a_affine_a, b=shape_b_affine_a, raise_error=True
         )
     with pytest.raises(
         ValueError, match="[ab] and [ab] do not have the same affine"
     ):
-        niimg_conversions.check_same_fov(
+        check_same_fov(
             a=shape_b_affine_b, b=shape_a_affine_a, raise_error=True
         )
 
     with pytest.raises(
         ValueError, match="[ab] and [ab] do not have the same shape"
     ):
-        niimg_conversions.check_same_fov(
+        check_same_fov(
             a=shape_b_affine_b, b=shape_a_affine_a, raise_error=True
         )
 
@@ -102,11 +105,11 @@ def test_check_same_fov(affine_eye):
 def test_check_niimg_3d(affine_eye, img_3d_zeros_eye, tmp_path):
     # check error for non-forced but necessary resampling
     with pytest.raises(TypeError, match="nibabel format"):
-        _utils.check_niimg(0)
+        check_niimg(0)
 
     # check error for non-forced but necessary resampling
     with pytest.raises(TypeError, match="empty object"):
-        _utils.check_niimg([])
+        check_niimg([])
 
     # Test dimensionality error
     with pytest.raises(
@@ -115,20 +118,20 @@ def test_check_niimg_3d(affine_eye, img_3d_zeros_eye, tmp_path):
         "Expected dimension is 3D and you provided a list "
         "of 3D images \\(4D\\).",
     ):
-        _utils.check_niimg_3d([img_3d_zeros_eye, img_3d_zeros_eye])
+        check_niimg_3d([img_3d_zeros_eye, img_3d_zeros_eye])
 
     # Check that a filename does not raise an error
     data = np.zeros((40, 40, 40, 1))
     data[20, 20, 20] = 1
     data_img = Nifti1Image(data, affine_eye)
 
-    filename = testing.write_imgs_to_path(
+    filename = write_imgs_to_path(
         data_img, file_path=tmp_path, create_files=True
     )
-    _utils.check_niimg_3d(filename)
+    check_niimg_3d(filename)
 
     # check data dtype equal with dtype='auto'
-    img_check = _utils.check_niimg_3d(img_3d_zeros_eye, dtype="auto")
+    img_check = check_niimg_3d(img_3d_zeros_eye, dtype="auto")
     assert (
         get_data(img_3d_zeros_eye).dtype.kind == get_data(img_check).dtype.kind
     )
@@ -136,10 +139,10 @@ def test_check_niimg_3d(affine_eye, img_3d_zeros_eye, tmp_path):
 
 def test_check_niimg_4d_errors(affine_eye, img_3d_zeros_eye, shape_3d_default):
     with pytest.raises(TypeError, match="nibabel format"):
-        _utils.check_niimg_4d(0)
+        check_niimg_4d(0)
 
     with pytest.raises(TypeError, match="empty object"):
-        _utils.check_niimg_4d([])
+        check_niimg_4d([])
 
     # This should raise an error: a 3D img is given and we want a 4D
     with pytest.raises(
@@ -147,18 +150,18 @@ def test_check_niimg_4d_errors(affine_eye, img_3d_zeros_eye, shape_3d_default):
         match="Input data has incompatible dimensionality: "
         "Expected dimension is 4D and you provided a 3D image.",
     ):
-        _utils.check_niimg_4d(img_3d_zeros_eye)
+        check_niimg_4d(img_3d_zeros_eye)
 
     a = img_3d_zeros_eye
     b = np.zeros(shape_3d_default)
-    c = _utils.check_niimg_4d([a, b], return_iterator=True)
+    c = check_niimg_4d([a, b], return_iterator=True)
     with pytest.raises(
         TypeError, match="Error encountered while loading image #1"
     ):
         list(c)
 
     b = Nifti1Image(np.zeros((10, 20, 10)), affine_eye)
-    c = _utils.check_niimg_4d([a, b], return_iterator=True)
+    c = check_niimg_4d([a, b], return_iterator=True)
     with pytest.raises(
         ValueError,
         match="Field of view of image #1 is different from reference FOV",
@@ -168,36 +171,34 @@ def test_check_niimg_4d_errors(affine_eye, img_3d_zeros_eye, shape_3d_default):
 
 def test_check_niimg_4d(affine_eye, img_3d_zeros_eye, shape_3d_default):
     # Tests with return_iterator=False
-    img_4d_1 = _utils.check_niimg_4d([img_3d_zeros_eye, img_3d_zeros_eye])
+    img_4d_1 = check_niimg_4d([img_3d_zeros_eye, img_3d_zeros_eye])
     assert get_data(img_4d_1).shape == (10, 10, 10, 2)
     assert_array_equal(img_4d_1.affine, affine_eye)
 
-    img_4d_2 = _utils.check_niimg_4d(img_4d_1)
+    img_4d_2 = check_niimg_4d(img_4d_1)
     assert_array_equal(get_data(img_4d_2), get_data(img_4d_2))
     assert_array_equal(img_4d_2.affine, img_4d_2.affine)
 
     # Tests with return_iterator=True
-    img_3d_iterator = _utils.check_niimg_4d(
+    img_3d_iterator = check_niimg_4d(
         [img_3d_zeros_eye, img_3d_zeros_eye], return_iterator=True
     )
     img_3d_iterator_length = sum(1 for _ in img_3d_iterator)
     assert img_3d_iterator_length == 2
 
-    img_3d_iterator_1 = _utils.check_niimg_4d(
+    img_3d_iterator_1 = check_niimg_4d(
         [img_3d_zeros_eye, img_3d_zeros_eye], return_iterator=True
     )
-    img_3d_iterator_2 = _utils.check_niimg_4d(
-        img_3d_iterator_1, return_iterator=True
-    )
+    img_3d_iterator_2 = check_niimg_4d(img_3d_iterator_1, return_iterator=True)
     for img_1, img_2 in zip(img_3d_iterator_1, img_3d_iterator_2):
         assert get_data(img_1).shape == shape_3d_default
         assert_array_equal(get_data(img_1), get_data(img_2))
         assert_array_equal(img_1.affine, img_2.affine)
 
-    img_3d_iterator_1 = _utils.check_niimg_4d(
+    img_3d_iterator_1 = check_niimg_4d(
         [img_3d_zeros_eye, img_3d_zeros_eye], return_iterator=True
     )
-    img_3d_iterator_2 = _utils.check_niimg_4d(img_4d_1, return_iterator=True)
+    img_3d_iterator_2 = check_niimg_4d(img_4d_1, return_iterator=True)
     for img_1, img_2 in zip(img_3d_iterator_1, img_3d_iterator_2):
         assert get_data(img_1).shape == shape_3d_default
         assert_array_equal(get_data(img_1), get_data(img_2))
@@ -205,7 +206,7 @@ def test_check_niimg_4d(affine_eye, img_3d_zeros_eye, shape_3d_default):
 
     # Test a Niimg-like object that does not hold a shape attribute
     phony_img = PhonyNiimage()
-    _utils.check_niimg_4d(phony_img)
+    check_niimg_4d(phony_img)
 
 
 def test_check_niimg(img_3d_zeros_eye, img_4d_zeros_eye):
@@ -218,7 +219,7 @@ def test_check_niimg(img_3d_zeros_eye, img_4d_zeros_eye):
         "Expected dimension is 2D and you provided "
         "a list of list of list of 3D images \\(6D\\)",
     ):
-        _utils.check_niimg(img_3_3d, ensure_ndim=2)
+        check_niimg(img_3_3d, ensure_ndim=2)
 
     with pytest.raises(
         DimensionError,
@@ -226,16 +227,16 @@ def test_check_niimg(img_3d_zeros_eye, img_4d_zeros_eye):
         "Expected dimension is 4D and you provided "
         "a list of list of 4D images \\(6D\\)",
     ):
-        _utils.check_niimg(img_2_4d, ensure_ndim=4)
+        check_niimg(img_2_4d, ensure_ndim=4)
 
     # check data dtype equal with dtype='auto'
-    img_3d_check = _utils.check_niimg(img_3d_zeros_eye, dtype="auto")
+    img_3d_check = check_niimg(img_3d_zeros_eye, dtype="auto")
     assert (
         get_data(img_3d_zeros_eye).dtype.kind
         == get_data(img_3d_check).dtype.kind
     )
 
-    img_4d_check = _utils.check_niimg(img_4d_zeros_eye, dtype="auto")
+    img_4d_check = check_niimg(img_4d_zeros_eye, dtype="auto")
     assert (
         get_data(img_4d_zeros_eye).dtype.kind
         == get_data(img_4d_check).dtype.kind
@@ -243,11 +244,11 @@ def test_check_niimg(img_3d_zeros_eye, img_4d_zeros_eye):
 
 
 def test_check_niimg_pathlike(img_3d_zeros_eye, tmp_path):
-    filename = testing.write_imgs_to_path(
+    filename = write_imgs_to_path(
         img_3d_zeros_eye, file_path=tmp_path, create_files=True
     )
     filename = Path(filename)
-    _utils.check_niimg_3d(filename)
+    check_niimg_3d(filename)
 
 
 def test_check_niimg_wildcards_errors():
@@ -266,12 +267,12 @@ def test_check_niimg_wildcards_errors():
     # Check bad filename
     # Non existing file (with no magic) raise a ValueError exception
     with pytest.raises(ValueError, match=file_not_found_msg % nofile_path):
-        _utils.check_niimg(nofile_path)
+        check_niimg(nofile_path)
     # Non matching wildcard raises a ValueError exception
     with pytest.raises(
         ValueError, match=wildcards_msg % re.escape(nofile_path_wildcards)
     ):
-        _utils.check_niimg(nofile_path_wildcards)
+        check_niimg(nofile_path_wildcards)
 
 
 @pytest.mark.parametrize("shape", [(10, 10, 10), (10, 10, 10, 3)])
@@ -282,11 +283,9 @@ def test_check_niimg_wildcards(affine_eye, shape, wildcards, tmp_path):
     # First create some testing data
     img = Nifti1Image(np.zeros(shape), affine_eye)
 
-    filename = testing.write_imgs_to_path(
-        img, file_path=tmp_path, create_files=True
-    )
+    filename = write_imgs_to_path(img, file_path=tmp_path, create_files=True)
     assert_array_equal(
-        get_data(_utils.check_niimg(filename, wildcards=wildcards)),
+        get_data(check_niimg(filename, wildcards=wildcards)),
         get_data(img),
     )
 
@@ -297,32 +296,32 @@ def test_check_niimg_wildcards_one_file_name(img_3d_zeros_eye, tmp_path):
     # Testing with a glob matching exactly one filename
     # Using a glob matching one file containing a 3d image returns a 4d image
     # with 1 as last dimension.
-    globs = testing.write_imgs_to_path(
+    globs = write_imgs_to_path(
         img_3d_zeros_eye,
         file_path=tmp_path,
         create_files=True,
         use_wildcards=True,
     )
     assert_array_equal(
-        get_data(_utils.check_niimg(globs))[..., 0],
+        get_data(check_niimg(globs))[..., 0],
         get_data(img_3d_zeros_eye),
     )
     # Disabled globbing behavior should raise an ValueError exception
     with pytest.raises(
         ValueError, match=file_not_found_msg % re.escape(globs)
     ):
-        _utils.check_niimg(globs, wildcards=False)
+        check_niimg(globs, wildcards=False)
 
     # Testing with a glob matching multiple filenames
-    img_4d = _utils.check_niimg_4d((img_3d_zeros_eye, img_3d_zeros_eye))
-    globs = testing.write_imgs_to_path(
+    img_4d = check_niimg_4d((img_3d_zeros_eye, img_3d_zeros_eye))
+    globs = write_imgs_to_path(
         img_3d_zeros_eye,
         img_3d_zeros_eye,
         file_path=tmp_path,
         create_files=True,
         use_wildcards=True,
     )
-    assert_array_equal(get_data(_utils.check_niimg(globs)), get_data(img_4d))
+    assert_array_equal(get_data(check_niimg(globs)), get_data(img_4d))
 
 
 def test_check_niimg_wildcards_no_expand_wildcards(
@@ -340,26 +339,26 @@ def test_check_niimg_wildcards_no_expand_wildcards(
     # globbing but global wildcards variable overrides this feature => raises
     # a ValueError
     with pytest.raises(ValueError, match=file_not_found_msg % nofile_path):
-        _utils.check_niimg(nofile_path)
+        check_niimg(nofile_path)
 
     # Verify wildcards function parameter has no effect
     with pytest.raises(ValueError, match=file_not_found_msg % nofile_path):
-        _utils.check_niimg(nofile_path, wildcards=False)
+        check_niimg(nofile_path, wildcards=False)
 
     # Testing with an exact filename matching (3d case)
-    filename = testing.write_imgs_to_path(
+    filename = write_imgs_to_path(
         img_3d_zeros_eye, file_path=tmp_path, create_files=True
     )
     assert_array_equal(
-        get_data(_utils.check_niimg(filename)), get_data(img_3d_zeros_eye)
+        get_data(check_niimg(filename)), get_data(img_3d_zeros_eye)
     )
 
     # Testing with an exact filename matching (4d case)
-    filename = testing.write_imgs_to_path(
+    filename = write_imgs_to_path(
         img_4d_zeros_eye, file_path=tmp_path, create_files=True
     )
     assert_array_equal(
-        get_data(_utils.check_niimg(filename)), get_data(img_4d_zeros_eye)
+        get_data(check_niimg(filename)), get_data(img_4d_zeros_eye)
     )
 
     # Reverting to default behavior
@@ -382,23 +381,17 @@ def test_iter_check_niimgs(tmp_path, img_4d_zeros_eye):
     img_2_4d = [[img_4d_zeros_eye, img_4d_zeros_eye]]
 
     # Create a test file
-    fd, filename = tempfile.mkstemp(
-        prefix="nilearn_test", suffix=".nii", dir=str(tmp_path)
-    )
-    os.close(fd)
+    filename = tmp_path / "nilearn_test.nii"
     img_4d_zeros_eye.to_filename(filename)
     niimgs = list(iter_check_niimg([filename]))
     assert_array_equal(
-        get_data(niimgs[0]), get_data(_utils.check_niimg(img_4d_zeros_eye))
+        get_data(niimgs[0]), get_data(check_niimg(img_4d_zeros_eye))
     )
     del niimgs
-    Path(filename).unlink()
 
     # Regular case
     niimgs = list(iter_check_niimg(img_2_4d))
-    assert_array_equal(
-        get_data(niimgs[0]), get_data(_utils.check_niimg(img_2_4d))
-    )
+    assert_array_equal(get_data(niimgs[0]), get_data(check_niimg(img_2_4d)))
 
 
 def _check_memory(list_img_3d):
@@ -423,15 +416,15 @@ def test_iter_check_niimgs_memory(affine_eye):
 
 def test_repr_niimgs():
     # Tests with file path
-    assert _utils._repr_niimgs("test") == "test"
-    assert _utils._repr_niimgs("test", shorten=False) == "test"
+    assert _repr_niimgs("test") == "test"
+    assert _repr_niimgs("test", shorten=False) == "test"
 
     # Shortening long names by default
     long_name = "this-is-a-very-long-name-for-a-nifti-file.nii"
     short_name = "this-is-a-very-lon..."
-    assert _utils._repr_niimgs(long_name) == short_name
+    assert _repr_niimgs(long_name) == short_name
     # Explicit shortening of long names
-    assert _utils._repr_niimgs(long_name, shorten=True) == short_name
+    assert _repr_niimgs(long_name, shorten=True) == short_name
 
     # Lists of long names up to length 3
     list_of_size_3 = [
@@ -447,7 +440,7 @@ def test_repr_niimgs():
     )
 
     assert (
-        _utils._repr_niimgs(list_of_size_3, shorten=True)
+        _repr_niimgs(list_of_size_3, shorten=True)
         == shortened_rep_list_of_size_3
     )
 
@@ -457,7 +450,7 @@ def test_repr_niimgs():
     shortened_rep_long_list_small_names = "[test,\n         ...\n rereretest]"
 
     assert (
-        _utils._repr_niimgs(long_list_small_names, shorten=True)
+        _repr_niimgs(long_list_small_names, shorten=True)
         == shortened_rep_long_list_small_names
     )
 
@@ -470,7 +463,7 @@ def test_repr_niimgs():
     )
 
     assert (
-        _utils._repr_niimgs(list_of_size_4, shorten=True)
+        _repr_niimgs(list_of_size_4, shorten=True)
         == shortened_rep_long_list_long_names
     )
 
@@ -478,14 +471,11 @@ def test_repr_niimgs():
 def test_repr_niimgs_force_long_names():
     long_name = "this-is-a-very-long-name-for-a-nifti-file.nii"
     # Force long display of long names
-    assert _utils._repr_niimgs(long_name, shorten=False) == long_name
+    assert _repr_niimgs(long_name, shorten=False) == long_name
 
     # Tests with list of file paths
-    assert _utils._repr_niimgs(["test", "retest"]) == "[test, retest]"
-    assert (
-        _utils._repr_niimgs(["test", "retest"], shorten=False)
-        == "[test, retest]"
-    )
+    assert _repr_niimgs(["test", "retest"]) == "[test, retest]"
+    assert _repr_niimgs(["test", "retest"], shorten=False) == "[test, retest]"
 
     # Force display, all 3 names are displayed
     list_of_size_3 = [
@@ -499,8 +489,7 @@ def test_repr_niimgs_force_long_names():
         " this-is-again-another-very-long-name-for-a-nifti-file.nii]"
     )
     assert (
-        _utils._repr_niimgs(list_of_size_3, shorten=False)
-        == long_rep_list_of_size_3
+        _repr_niimgs(list_of_size_3, shorten=False) == long_rep_list_of_size_3
     )
 
     long_list_small_names = ["test", "retest", "reretest", "rereretest"]
@@ -509,7 +498,7 @@ def test_repr_niimgs_force_long_names():
     )
 
     assert (
-        _utils._repr_niimgs(long_list_small_names, shorten=False)
+        _repr_niimgs(long_list_small_names, shorten=False)
         == long_rep_long_list_small_names
     )
 
@@ -524,7 +513,7 @@ def test_repr_niimgs_force_long_names():
     )
 
     assert (
-        _utils._repr_niimgs(list_of_size_4, shorten=False)
+        _repr_niimgs(list_of_size_4, shorten=False)
         == long_rep_long_list_long_names
     )
 
@@ -534,16 +523,16 @@ def test_repr_niimgs_with_niimg_pathlib():
     # Case with very long path and small filename
     long_path = Path("/this/is/a/fake/long/path/to/file.nii")
     short_path = Path(".../path/to/file.nii")
-    assert _utils._repr_niimgs(long_path, shorten=True) == str(short_path)
-    assert _utils._repr_niimgs(long_path, shorten=False) == str(long_path)
+    assert _repr_niimgs(long_path, shorten=True) == str(short_path)
+    assert _repr_niimgs(long_path, shorten=False) == str(long_path)
 
     # Case with very long path but very long filename
     long_path_long_name = Path(
         "/this/is/a/fake/long/path/to/my_file_with_a_very_long_name.nii"
     )
     short_name = "my_file_with_a_ver..."
-    assert _utils._repr_niimgs(long_path_long_name, shorten=True) == short_name
-    assert _utils._repr_niimgs(long_path_long_name, shorten=False) == str(
+    assert _repr_niimgs(long_path_long_name, shorten=True) == short_name
+    assert _repr_niimgs(long_path_long_name, shorten=False) == str(
         long_path_long_name
     )
 
@@ -561,15 +550,10 @@ def test_repr_niimgs_with_niimg_pathlib():
         f" a-very-long-file-n...]"
     )
 
-    assert (
-        _utils._repr_niimgs(list_of_paths, shorten=True)
-        == shortened_list_of_paths
-    )
+    assert _repr_niimgs(list_of_paths, shorten=True) == shortened_list_of_paths
     long_list_of_paths = ",\n ".join([str(_) for _ in list_of_paths])
     long_list_of_paths = f"[{long_list_of_paths}]"
-    assert (
-        _utils._repr_niimgs(list_of_paths, shorten=False) == long_list_of_paths
-    )
+    assert _repr_niimgs(list_of_paths, shorten=False) == long_list_of_paths
 
 
 @pytest.mark.parametrize("shorten", [True, False])
@@ -577,23 +561,23 @@ def test_repr_niimgs_with_niimg(
     shorten, tmp_path, affine_eye, img_3d_ones_eye, shape_3d_default
 ):
     # Shorten has no effect in this case
-    assert _utils._repr_niimgs(img_3d_ones_eye, shorten=shorten).replace(
+    assert _repr_niimgs(img_3d_ones_eye, shorten=shorten).replace(
         "10L", "10"
     ) == (
         f"{img_3d_ones_eye.__class__.__name__}(\nshape={shape_3d_default!r},\naffine={affine_eye!r}\n)"
     )
 
     # Add filename long enough to qualify for shortening
-    fd, tmpimg1 = tempfile.mkstemp(suffix="_very_long.nii", dir=str(tmp_path))
+    fd, tmpimg1 = mkstemp(suffix="_very_long.nii", dir=str(tmp_path))
     os.close(fd)
     img_3d_ones_eye.to_filename(tmpimg1)
     class_name = img_3d_ones_eye.__class__.__name__
     filename = Path(img_3d_ones_eye.get_filename())
     assert (
-        _utils._repr_niimgs(img_3d_ones_eye, shorten=False)
+        _repr_niimgs(img_3d_ones_eye, shorten=False)
         == f"{class_name}('{filename}')"
     )
     assert (
-        _utils._repr_niimgs(img_3d_ones_eye, shorten=True)
+        _repr_niimgs(img_3d_ones_eye, shorten=True)
         == f"{class_name}('{Path(filename).name[:18]}...')"
     )

--- a/nilearn/_utils/tests/test_numpy_conversions.py
+++ b/nilearn/_utils/tests/test_numpy_conversions.py
@@ -5,8 +5,6 @@ which we historically used,
 ignores modules whose name starts with an underscore.
 """
 
-import os
-import tempfile
 from pathlib import Path
 
 import numpy as np
@@ -239,15 +237,11 @@ def test_as_ndarray_more():
 
 def test_csv_to_array(tmp_path):
     # Create a phony CSV file
-    fd, filename = tempfile.mkstemp(suffix=".csv", dir=tmp_path)
-    os.close(fd)
-    try:
-        with open(filename, mode="w") as fp:
-            fp.write("1.,2.,3.,4.,5.\n")
-        assert np.allclose(
-            csv_to_array(filename), np.asarray([1.0, 2.0, 3.0, 4.0, 5.0])
-        )
-        with pytest.raises(TypeError):
-            csv_to_array(filename, delimiters="?!")
-    finally:
-        Path(filename).unlink()
+    filename = tmp_path / "tmp.csv"
+    with open(filename, mode="w") as fp:
+        fp.write("1.,2.,3.,4.,5.\n")
+    assert np.allclose(
+        csv_to_array(filename), np.asarray([1.0, 2.0, 3.0, 4.0, 5.0])
+    )
+    with pytest.raises(TypeError):
+        csv_to_array(filename, delimiters="?!")

--- a/nilearn/plotting/tests/test_js_plotting_utils.py
+++ b/nilearn/plotting/tests/test_js_plotting_utils.py
@@ -189,6 +189,7 @@ def check_html(
 ):
     """Perform several checks on raw HTML code."""
     fd, tmpfile = tempfile.mkstemp()
+    tmpfile = Path(tmpfile)
     try:
         os.close(fd)
         html.save_as_html(tmpfile)
@@ -199,7 +200,7 @@ def check_html(
         standalone = html.get_standalone().replace("\r\n", "\n")
         assert saved == standalone
     finally:
-        Path(tmpfile).unlink()
+        tmpfile.unlink()
     assert "INSERT" not in html.html
     assert html.get_standalone() == html.html
     assert html._repr_html_() == html.get_iframe()


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4615 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Replace tempfile in tests with pytest tmp_path fixture where possible and easy

### unrelated

- simplify imports in nilearn/_utils/tests/test_niimg_conversions.py to avoid importing entire modules

