### PR TITLE
[MAINT] Replace `pytest.warns(DeprecationWarning, match = pattern)` with `pytest.deprecated_call(match = pattern)`

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -71,6 +71,8 @@ Enhancements
 Changes
 -------
 
+- :bdg-secondary:`Maint` Replace :func:`pytest.warns(DeprecationWarning)` with :func:`pytest.deprecated_call()` in tests (:gh:`4637` by `Victoria Shevchenko`_).
+
 - :bdg-dark:`Code` Warn the user when all volumes would be scrubbed when loading fmriprep confounds as this would lead to an empty ``sample_mask`` (:gh:`4558` by `Victoria Shevchenko`_).
 
 - :bdg-dark:`Code` Throw error if ``sample_mask`` is empty when scrubbing an fMRI time series (:gh:`4558` by `Victoria Shevchenko`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -71,7 +71,7 @@ Enhancements
 Changes
 -------
 
-- :bdg-secondary:`Maint` Replace :func:`pytest.warns(DeprecationWarning)` with :func:`pytest.deprecated_call()` in tests (:gh:`4637` by `Victoria Shevchenko`_).
+- :bdg-secondary:`Maint` Replace ``pytest.warns(DeprecationWarning)`` with ``pytest.deprecated_call()`` in tests (:gh:`4637` by `Victoria Shevchenko`_).
 
 - :bdg-dark:`Code` Warn the user when all volumes would be scrubbed when loading fmriprep confounds as this would lead to an empty ``sample_mask`` (:gh:`4558` by `Victoria Shevchenko`_).
 

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -53,7 +53,7 @@ def check_deprecation(func, match=None):
 
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
-        with pytest.warns(DeprecationWarning, match=match):
+        with pytest.deprecated_call(match=match):
             result = func(*args, **kwargs)
         return result
 

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -1,7 +1,6 @@
 """Utilities for testing nilearn."""
 
 # Author: Alexandre Abraham, Philippe Gervais
-import functools
 import gc
 import os
 import sys
@@ -46,18 +45,6 @@ except ImportError:
 def is_64bit() -> bool:
     """Return True if python is run on 64bits."""
     return sys.maxsize > 2**32
-
-
-def check_deprecation(func, match=None):
-    """Check if a function raises a deprecation warning."""
-
-    @functools.wraps(func)
-    def wrapped(*args, **kwargs):
-        with pytest.deprecated_call(match=match):
-            result = func(*args, **kwargs)
-        return result
-
-    return wrapped
 
 
 def assert_memory_less_than(

--- a/nilearn/_utils/tests/test_testing.py
+++ b/nilearn/_utils/tests/test_testing.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import pytest
 from nibabel import Nifti1Image
@@ -44,14 +42,6 @@ def test_int64_niftis(affine_eye, tmp_path):
     for dtype in "int64", "uint64":
         with pytest.raises(AssertionError):
             Nifti1Image(data.astype(dtype), affine_eye)
-
-
-def dummy_deprecation(start_version, end_version):
-    warnings.warn(
-        f"Deprecated in {start_version}."
-        f"and will be removed in version {end_version}.",
-        DeprecationWarning,
-    )
 
 
 @pytest.mark.parametrize("create_files", [True, False])

--- a/nilearn/_utils/tests/test_testing.py
+++ b/nilearn/_utils/tests/test_testing.py
@@ -6,7 +6,6 @@ from nibabel import Nifti1Image
 
 from nilearn._utils.testing import (
     assert_memory_less_than,
-    check_deprecation,
     with_memory_profiler,
     write_imgs_to_path,
 )
@@ -53,10 +52,6 @@ def dummy_deprecation(start_version, end_version):
         f"and will be removed in version {end_version}.",
         DeprecationWarning,
     )
-
-
-def test_check_deprecation():
-    check_deprecation(dummy_deprecation, "Deprecated")("0.0.1", "0.0.2")
 
 
 @pytest.mark.parametrize("create_files", [True, False])

--- a/nilearn/connectome/tests/test_connectivity_matrices.py
+++ b/nilearn/connectome/tests/test_connectivity_matrices.py
@@ -939,7 +939,7 @@ def test_connectivity_measure_standardize(signals):
     """Check warning is raised and then suppressed with setting standardize."""
     match = "default strategy for standardize"
 
-    with pytest.warns(DeprecationWarning, match=match):
+    with pytest.deprecated_call(match=match):
         ConnectivityMeasure(kind="correlation").fit_transform(signals)
 
     with warnings.catch_warnings(record=True) as record:

--- a/nilearn/datasets/tests/test_func.py
+++ b/nilearn/datasets/tests/test_func.py
@@ -857,7 +857,7 @@ def test_fetch_ds000030_urls():
         assert urls == mock_json_content
 
         # fetch_openneuro_dataset_index should do the same, but with a warning
-        with pytest.warns(DeprecationWarning):
+        with pytest.deprecated_call():
             urls_path, urls = func.fetch_openneuro_dataset_index(
                 data_dir=tmpdir,
                 dataset_version=dataset_version,

--- a/nilearn/glm/tests/test_contrasts.py
+++ b/nilearn/glm/tests/test_contrasts.py
@@ -65,7 +65,7 @@ def test_deprecation_contrast_type(rng, set_up_glm):
     labels, results, q = set_up_glm(rng, "ar1")
     con_val = np.eye(q)[0]
 
-    with pytest.warns(DeprecationWarning, match="0.13.0"):
+    with pytest.deprecated_call(match="0.13.0"):
         compute_contrast(
             labels=labels,
             regression_result=results,
@@ -260,10 +260,10 @@ def test_deprecation_contrast_type_attribute():
     effect = np.ones((1, 3))
     variance = effect[0]
 
-    with pytest.warns(DeprecationWarning, match="0.13.0"):
+    with pytest.deprecated_call(match="0.13.0"):
         contrast = Contrast(effect, variance, contrast_type="t")
 
-    with pytest.warns(DeprecationWarning, match="0.13.0"):
+    with pytest.deprecated_call(match="0.13.0"):
         contrast.contrast_type
 
 

--- a/nilearn/glm/tests/test_hemodynamic_models.py
+++ b/nilearn/glm/tests/test_hemodynamic_models.py
@@ -57,7 +57,7 @@ def expected_length(t_r):
 @pytest.mark.parametrize("hrf_model", HRF_MODELS)
 def test_hrf_tr_deprecation(hrf_model):
     """Test that using tr throws a warning."""
-    with pytest.warns(DeprecationWarning, match='"tr" will be removed in'):
+    with pytest.deprecated_call(match='"tr" will be removed in'):
         hrf_model(tr=2)
 
 

--- a/nilearn/maskers/tests/test_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_nifti_labels_masker.py
@@ -217,7 +217,7 @@ def test_nifti_labels_masker_io_shapes(
     masker.fit()
 
     # DeprecationWarning *should* be raised for 3D inputs
-    with pytest.warns(DeprecationWarning, match="Starting in version 0.12"):
+    with pytest.deprecated_call(match="Starting in version 0.12"):
         test_data = masker.transform(img_3d)
         assert test_data.shape == (1, n_regions)
 

--- a/nilearn/maskers/tests/test_nifti_maps_masker.py
+++ b/nilearn/maskers/tests/test_nifti_maps_masker.py
@@ -183,7 +183,7 @@ def test_nifti_maps_masker_io_shapes(rng):
     masker.fit()
 
     # DeprecationWarning *should* be raised for 3D inputs
-    with pytest.warns(DeprecationWarning, match="Starting in version 0.12"):
+    with pytest.deprecated_call(match="Starting in version 0.12"):
         test_data = masker.transform(img_3d)
         assert test_data.shape == (1, n_regions)
 

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -524,7 +524,7 @@ def test_nifti_masker_io_shapes(rng, shape_3d_default, affine_eye):
     masker.fit()
 
     # DeprecationWarning *should* be raised for 3D inputs
-    with pytest.warns(DeprecationWarning, match="Starting in version 0.12"):
+    with pytest.deprecated_call(match="Starting in version 0.12"):
         test_data = masker.transform(img_3d)
         assert test_data.shape == (1, n_regions)
 

--- a/nilearn/maskers/tests/test_nifti_spheres_masker.py
+++ b/nilearn/maskers/tests/test_nifti_spheres_masker.py
@@ -354,7 +354,7 @@ def test_nifti_spheres_masker_io_shapes(rng, shape_3d_default, affine_eye):
     masker.fit()
 
     # DeprecationWarning *should* be raised for 3D inputs
-    with pytest.warns(DeprecationWarning, match="Starting in version 0.12"):
+    with pytest.deprecated_call(match="Starting in version 0.12"):
         test_data = masker.transform(img_3d)
         assert test_data.shape == (1, n_regions)
 

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -752,7 +752,7 @@ def test_tfce_smoke_legacy_warnings():
 
     # output_type is "legacy".
     # raise a deprecation warning, but get the standard output.
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         out = permuted_ols(
             tested_var,
             target_var,
@@ -885,7 +885,7 @@ def test_cluster_level_parameters_warnings(cluster_level_design, masker):
 
     # output_type is "legacy".
     # raise a deprecation warning, but get the standard output.
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         out = permuted_ols(
             tested_var,
             target_var,

--- a/nilearn/plotting/tests/test_html_document.py
+++ b/nilearn/plotting/tests/test_html_document.py
@@ -47,7 +47,7 @@ def test_open_in_browser_timeout(monkeypatch):
 def test_open_in_browser_deprecation_warning(monkeypatch):
     monkeypatch.setattr(webbrowser, "open", Get())
     doc = html_document.HTMLDocument("hello")
-    with pytest.warns(DeprecationWarning, match="temp_file_lifetime"):
+    with pytest.deprecated_call(match="temp_file_lifetime"):
         doc.open_in_browser(temp_file_lifetime=30.0)
 
 

--- a/nilearn/plotting/tests/test_img_plotting/test_plot_carpet.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_plot_carpet.py
@@ -109,7 +109,7 @@ def test_plot_carpet_standardize(img_4d_mni, img_3d_ones_mni):
     """Check warning is raised and then suppressed with setting standardize."""
     match = "default strategy for standardize"
 
-    with pytest.warns(DeprecationWarning, match=match):
+    with pytest.deprecated_call(match=match):
         plot_carpet(img_4d_mni, mask_img=img_3d_ones_mni)
 
     with warnings.catch_warnings(record=True) as record:


### PR DESCRIPTION

Closes #3625
Old PR: #4596

- Removed `check_deprecation` from `nilearn/nilearn/_utils/testing.py`
- Replaced `pytest.warns(DeprecationWarning, match = pattern)` with `pytest.deprecated_call(match = pattern)` in all test scripts where the former was used.
- Updated change log