### PR TITLE
[DOC] Add missing default values to the docstrings in 'nilearn/glm' - part 1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -763,3 +763,8 @@ authors:
     family-names: Nájera
     website: https://github.com/Titan-C
     affiliation: Checkmk
+  - given-names: Anupriya
+    family-names: Kumari
+    website: https://github.com/anupriyakkumari
+    affiliation: Indian Institute of Technology, Roorkee, India
+    email: anupriyakkumari@gmail.com

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -101,3 +101,5 @@ Changes
 - :bdg-dark:`Code` Reorder condition in internal call of :func:`nilearn.image.resample_img` to skip checking of array values if interpolation is ``nearest`` (:gh:`4571` by `Jason Kai`_).
 
 - :bdg-dark:`Code` Remove redundant sorting of ``np.unique(data)`` in internal call of :func:`nilearn.image.resample_img` when checking array values (:gh:`4571` by `Jason Kai`_).
+
+- :bdg-primary:`Doc` Added missing default values to the docstrings of functions in modules in 'nilearn/glm' and the subpackage 'nilearn/glm/second_level'(:gh:`4656` by `Anupriya Kumari`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -102,4 +102,4 @@ Changes
 
 - :bdg-dark:`Code` Remove redundant sorting of ``np.unique(data)`` in internal call of :func:`nilearn.image.resample_img` when checking array values (:gh:`4571` by `Jason Kai`_).
 
-- :bdg-primary:`Doc` Add missing default values to the docstrings in 'nilearn/glm(:gh:`4656` by `Anupriya Kumari`_).
+- :bdg-primary:`Doc` Add missing default values to the docstrings in 'nilearn/glm'(:gh:`4656` by `Anupriya Kumari`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -102,4 +102,4 @@ Changes
 
 - :bdg-dark:`Code` Remove redundant sorting of ``np.unique(data)`` in internal call of :func:`nilearn.image.resample_img` when checking array values (:gh:`4571` by `Jason Kai`_).
 
-- :bdg-primary:`Doc` Added missing default values to the docstrings of functions in modules in 'nilearn/glm' and the subpackage 'nilearn/glm/second_level'(:gh:`4656` by `Anupriya Kumari`_).
+- :bdg-primary:`Doc` Add missing default values to the docstrings in 'nilearn/glm(:gh:`4656` by `Anupriya Kumari`_).

--- a/nilearn/glm/contrasts.py
+++ b/nilearn/glm/contrasts.py
@@ -67,7 +67,7 @@ def compute_contrast(labels, regression_result, con_val, stat_type=None):
         Where q = number of :term:`contrast` vectors
         and p = number of regressors.
 
-    stat_type : {None, 't', 'F'}, optional, default=None
+    stat_type : {None, 't', 'F'}, default=None
         Type of the :term:`contrast`.
         If None, then defaults to 't' for 1D `con_val`
         and 'F' for 2D `con_val`.
@@ -477,7 +477,7 @@ def compute_fixed_effects(
     variance_imgs : list of Nifti1Images or strings
         The input variance images.
 
-    mask : Nifti1Image or NiftiMasker instance or None, optional, default=None
+    mask : Nifti1Image or NiftiMasker instance or None, default=None
         Mask image. If ``None``, it is recomputed from ``contrast_imgs``.
 
     precision_weighted : Bool, default=False

--- a/nilearn/glm/contrasts.py
+++ b/nilearn/glm/contrasts.py
@@ -67,7 +67,7 @@ def compute_contrast(labels, regression_result, con_val, stat_type=None):
         Where q = number of :term:`contrast` vectors
         and p = number of regressors.
 
-    stat_type : {None, 't', 'F'}, optional
+    stat_type : {None, 't', 'F'}, optional, default=None
         Type of the :term:`contrast`.
         If None, then defaults to 't' for 1D `con_val`
         and 'F' for 2D `con_val`.
@@ -477,7 +477,7 @@ def compute_fixed_effects(
     variance_imgs : list of Nifti1Images or strings
         The input variance images.
 
-    mask : Nifti1Image or NiftiMasker instance or None, optional
+    mask : Nifti1Image or NiftiMasker instance or None, optional, default=None
         Mask image. If ``None``, it is recomputed from ``contrast_imgs``.
 
     precision_weighted : Bool, default=False

--- a/nilearn/glm/contrasts.py
+++ b/nilearn/glm/contrasts.py
@@ -24,10 +24,10 @@ def expression_to_contrast_vector(expression, design_columns):
 
     Parameters
     ----------
-    expression : string
+    expression : :obj:`str`
         The expression to convert to a vector.
 
-    design_columns : list or array of strings
+    design_columns : :obj:`list` or array of strings
         The column names of the design matrix.
 
     """
@@ -59,7 +59,7 @@ def compute_contrast(labels, regression_result, con_val, stat_type=None):
     labels : array of shape (n_voxels,)
         A map of values on voxels used to identify the corresponding model
 
-    regression_result : dict
+    regression_result : :obj:`dict`
         With keys corresponding to the different labels
         values are RegressionResults instances corresponding to the voxels.
 
@@ -200,7 +200,7 @@ class Contrast:
         variance : array of shape (n_voxels)
             The associated variance estimate.
 
-        dim : int or None, optional
+        dim : :obj:`int` or None, optional
             The dimension of the :term:`contrast`.
 
         dof : scalar, default=DEF_DOFMAX
@@ -215,7 +215,7 @@ class Contrast:
 
                 Use ``stat_type`` instead (see above).
 
-        tiny : float, default=DEF_TINY
+        tiny : :obj:`float`, default=DEF_TINY
             Small quantity used to avoid numerical underflows.
 
         dofmax : scalar, default=DEF_DOFMAX
@@ -291,7 +291,7 @@ class Contrast:
 
         Parameters
         ----------
-        baseline : float, default=0.0
+        baseline : :obj:`float`, default=0.0
             Baseline value for the test statistic.
 
         Returns
@@ -326,7 +326,7 @@ class Contrast:
 
         Parameters
         ----------
-        baseline : float, default=0.0
+        baseline : :obj:`float`, default=0.0
             Baseline value for the test statistic.
 
 
@@ -358,7 +358,7 @@ class Contrast:
 
         Parameters
         ----------
-        baseline : float, default=0.0
+        baseline : :obj:`float`, default=0.0
             Baseline value for the test statistic.
 
 
@@ -389,7 +389,7 @@ class Contrast:
 
         Parameters
         ----------
-        baseline : float, optional, default=0.0
+        baseline : :obj:`float`, optional, default=0.0
             Baseline value for the test statistic.
 
 
@@ -471,16 +471,16 @@ def compute_fixed_effects(
 
     Parameters
     ----------
-    contrast_imgs : list of Nifti1Images or strings
+    contrast_imgs : :obj:`list` of Nifti1Images or strings
         The input contrast images.
 
-    variance_imgs : list of Nifti1Images or strings
+    variance_imgs : :obj:`list` of Nifti1Images or strings
         The input variance images.
 
     mask : Nifti1Image or NiftiMasker instance or None, default=None
         Mask image. If ``None``, it is recomputed from ``contrast_imgs``.
 
-    precision_weighted : Bool, default=False
+    precision_weighted : :obj:`bool`, default=False
         Whether fixed effects estimates should be weighted by inverse
         variance or not.
 
@@ -489,7 +489,7 @@ def compute_fixed_effects(
         when ``None``,
         it is assumed that the degrees of freedom are 100 per input.
 
-    return_z_score: Bool, default=False
+    return_z_score: :obj:`bool`, default=False
         Whether ``fixed_fx_z_score_img`` should be output or not.
 
     Returns

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -658,18 +658,18 @@ class SecondLevelModel(BaseGLM):
 
         Parameters
         ----------
-        attribute : str
+        attribute : :obj:`str`
             an attribute of a RegressionResults instance.
             possible values include: 'residuals', 'normalized_residuals',
             'predicted', SSE, r_square, MSE.
 
-        result_as_time_series : bool
+        result_as_time_series : :obj:`bool`
             whether the RegressionResult attribute has a value
             per timepoint of the input nifti image.
 
         Returns
         -------
-        output : list
+        output : :obj:`list`
             A list of Nifti1Image(s).
 
         """

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -744,7 +744,7 @@ def non_parametric_inference(
     ----------
     %(second_level_input)s
 
-    confounds : :obj:`pandas.DataFrame` or None, optional
+    confounds : :obj:`pandas.DataFrame` or None, optional, default=None
         Must contain a subject_label column. All other columns are
         considered as confounds and included in the model. If
         ``design_matrix`` is provided then this argument is ignored.
@@ -753,7 +753,7 @@ def non_parametric_inference(
         At least two columns are expected, ``subject_label`` and at
         least one confound.
 
-    design_matrix : :obj:`pandas.DataFrame` or None, optional
+    design_matrix : :obj:`pandas.DataFrame` or None, optional, default=None
         Design matrix to fit the :term:`GLM`. The number of rows
         in the design matrix must agree with the number of maps derived
         from ``second_level_input``.
@@ -762,7 +762,7 @@ def non_parametric_inference(
 
     %(second_level_contrast)s
 
-    first_level_contrast : :obj:`str`, optional
+    first_level_contrast : :obj:`str`, optional, default=None
         In case a pandas DataFrame was provided as second_level_input this
         is the map name to extract from the pandas dataframe map_name column.
         It has to be a 't' contrast.
@@ -770,7 +770,8 @@ def non_parametric_inference(
         .. versionadded:: 0.9.0
 
     mask : Niimg-like, :obj:`~nilearn.maskers.NiftiMasker` or \
-            :obj:`~nilearn.maskers.MultiNiftiMasker` object, optional
+            :obj:`~nilearn.maskers.MultiNiftiMasker` object
+            optional, default=None
         Mask to be used on data. If an instance of masker is passed,
         then its mask will be used. If no mask is given, it will be computed
         automatically by a :class:`~nilearn.maskers.MultiNiftiMasker` with

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -762,7 +762,7 @@ def non_parametric_inference(
 
     %(second_level_contrast)s
 
-    first_level_contrast : :obj:`str`, default=None
+    first_level_contrast : :obj:`str` or None, default=None
         In case a pandas DataFrame was provided as second_level_input this
         is the map name to extract from the pandas dataframe map_name column.
         It has to be a 't' contrast.
@@ -770,7 +770,8 @@ def non_parametric_inference(
         .. versionadded:: 0.9.0
 
     mask : Niimg-like, :obj:`~nilearn.maskers.NiftiMasker` or \
-            :obj:`~nilearn.maskers.MultiNiftiMasker` object, default=None
+            :obj:`~nilearn.maskers.MultiNiftiMasker` object \
+            or None, default=None
         Mask to be used on data. If an instance of masker is passed,
         then its mask will be used. If no mask is given, it will be computed
         automatically by a :class:`~nilearn.maskers.MultiNiftiMasker` with

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -744,7 +744,7 @@ def non_parametric_inference(
     ----------
     %(second_level_input)s
 
-    confounds : :obj:`pandas.DataFrame` or None, optional, default=None
+    confounds : :obj:`pandas.DataFrame` or None, default=None
         Must contain a subject_label column. All other columns are
         considered as confounds and included in the model. If
         ``design_matrix`` is provided then this argument is ignored.
@@ -753,7 +753,7 @@ def non_parametric_inference(
         At least two columns are expected, ``subject_label`` and at
         least one confound.
 
-    design_matrix : :obj:`pandas.DataFrame` or None, optional, default=None
+    design_matrix : :obj:`pandas.DataFrame` or None, default=None
         Design matrix to fit the :term:`GLM`. The number of rows
         in the design matrix must agree with the number of maps derived
         from ``second_level_input``.
@@ -762,7 +762,7 @@ def non_parametric_inference(
 
     %(second_level_contrast)s
 
-    first_level_contrast : :obj:`str`, optional, default=None
+    first_level_contrast : :obj:`str`, default=None
         In case a pandas DataFrame was provided as second_level_input this
         is the map name to extract from the pandas dataframe map_name column.
         It has to be a 't' contrast.
@@ -770,8 +770,7 @@ def non_parametric_inference(
         .. versionadded:: 0.9.0
 
     mask : Niimg-like, :obj:`~nilearn.maskers.NiftiMasker` or \
-            :obj:`~nilearn.maskers.MultiNiftiMasker` object
-            optional, default=None
+            :obj:`~nilearn.maskers.MultiNiftiMasker` object, default=None
         Mask to be used on data. If an instance of masker is passed,
         then its mask will be used. If no mask is given, it will be computed
         automatically by a :class:`~nilearn.maskers.MultiNiftiMasker` with

--- a/nilearn/glm/thresholding.py
+++ b/nilearn/glm/thresholding.py
@@ -119,10 +119,10 @@ def cluster_level_inference(
 
     Parameters
     ----------
-    stat_img : Niimg-like object or None, optional
+    stat_img : Niimg-like object or None, default=None
        statistical image (presumably in z scale)
 
-    mask_img : Niimg-like object, optional, default=None
+    mask_img : Niimg-like object, default=None
         mask image
 
     threshold : list of floats, default=3.0
@@ -200,12 +200,12 @@ def threshold_stats_img(
 
     Parameters
     ----------
-    stat_img : Niimg-like object or None, optional, default=None
+    stat_img : Niimg-like object or None, default=None
        Statistical image (presumably in z scale) whenever height_control
        is 'fpr' or None, stat_img=None is acceptable.
        If it is 'fdr' or 'bonferroni', an error is raised if stat_img is None.
 
-    mask_img : Niimg-like object, optional, default=None
+    mask_img : Niimg-like object, default=None
         Mask image
 
     alpha : float or list, default=0.001

--- a/nilearn/glm/thresholding.py
+++ b/nilearn/glm/thresholding.py
@@ -119,7 +119,7 @@ def cluster_level_inference(
 
     Parameters
     ----------
-    stat_img : Niimg-like object or None, default=None
+    stat_img : Niimg-like object
        statistical image (presumably in z scale)
 
     mask_img : Niimg-like object, default=None

--- a/nilearn/glm/thresholding.py
+++ b/nilearn/glm/thresholding.py
@@ -59,15 +59,15 @@ def _true_positive_fraction(z_vals, hommel_value, alpha):
     z_vals : array,
         A set of z-variates from which the FDR is computed.
 
-    hommel_value: int
+    hommel_value: :obj:`int`
         The Hommel value, used in the computations.
 
-    alpha : float
+    alpha : :obj:`float`
         The desired FDR control.
 
     Returns
     -------
-    threshold : float
+    threshold : :obj:`float`
         Estimated true positive fraction in the set of values.
 
     """
@@ -89,12 +89,12 @@ def fdr_threshold(z_vals, alpha):
     z_vals : array
         A set of z-variates from which the FDR is computed.
 
-    alpha : float
+    alpha : :obj:`float`
         The desired FDR control.
 
     Returns
     -------
-    threshold : float
+    threshold : :obj:`float`
         FDR-controling threshold from the Benjamini-Hochberg procedure.
 
     """
@@ -125,14 +125,14 @@ def cluster_level_inference(
     mask_img : Niimg-like object, default=None
         mask image
 
-    threshold : list of floats, default=3.0
+    threshold : :obj:`list` of :obj:`float`, default=3.0
        Cluster-forming threshold in z-scale.
 
-    alpha : float or list, default=0.05
+    alpha : :obj:`float` or :obj:`list`, default=0.05
         Level of control on the true positive rate, aka true discovery
         proportion.
 
-    verbose : int or bool, default=0
+    verbose : :obj:`int` or :obj:`bool`, default=0
         Verbosity mode.
 
     Returns
@@ -208,25 +208,25 @@ def threshold_stats_img(
     mask_img : Niimg-like object, default=None
         Mask image
 
-    alpha : float or list, default=0.001
+    alpha : :obj:`float` or :obj:`list`, default=0.001
         Number controlling the thresholding (either a p-value or q-value).
         Its actual meaning depends on the height_control parameter.
         This function translates alpha to a z-scale threshold.
 
-    threshold : float, default=3.0
+    threshold : :obj:`float`, default=3.0
        Desired threshold in z-scale.
        This is used only if height_control is None.
 
-    height_control : string, or None optional, default='fpr'
+    height_control : :obj:`str`, or None optional, default='fpr'
         False positive control meaning of cluster forming
         threshold: None|'fpr'|'fdr'|'bonferroni'
 
-    cluster_threshold : float, default=0
+    cluster_threshold : :obj:`float`, default=0
         cluster size threshold. In the returned thresholded map,
         sets of connected voxels (`clusters`) with size smaller
         than this number will be removed.
 
-    two_sided : Bool, default=True
+    two_sided : :obj:`bool`, default=True
         Whether the thresholding should yield both positive and negative
         part of the maps.
         In that case, alpha is corrected by a factor of 2.
@@ -236,7 +236,7 @@ def threshold_stats_img(
     thresholded_map : Nifti1Image,
         The stat_map thresholded at the prescribed voxel- and cluster-level.
 
-    threshold : float
+    threshold : :obj:`float`
         The voxel-level threshold used actually.
 
     Notes

--- a/nilearn/glm/thresholding.py
+++ b/nilearn/glm/thresholding.py
@@ -122,7 +122,7 @@ def cluster_level_inference(
     stat_img : Niimg-like object or None, optional
        statistical image (presumably in z scale)
 
-    mask_img : Niimg-like object, optional,
+    mask_img : Niimg-like object, optional, default=None
         mask image
 
     threshold : list of floats, default=3.0
@@ -200,12 +200,12 @@ def threshold_stats_img(
 
     Parameters
     ----------
-    stat_img : Niimg-like object or None, optional
+    stat_img : Niimg-like object or None, optional, default=None
        Statistical image (presumably in z scale) whenever height_control
        is 'fpr' or None, stat_img=None is acceptable.
        If it is 'fdr' or 'bonferroni', an error is raised if stat_img is None.
 
-    mask_img : Niimg-like object, optional,
+    mask_img : Niimg-like object, optional, default=None
         Mask image
 
     alpha : float or list, default=0.001


### PR DESCRIPTION
Completes the following tasks from https://github.com/nilearn/nilearn/issues/3865:
 Added missing default values in docstrings of the following files: 

## [nilearn/glm/thresholding.py](https://github.com/nilearn/nilearn/blob/main/nilearn/glm/thresholding.py)
[nilearn/glm/thresholding.py::cluster_level_inference - line: 112](https://github.com/nilearn/nilearn/blob/main/nilearn/glm/thresholding.py#L112)

[nilearn/glm/thresholding.py::threshold_stats_img - line: 190](https://github.com/nilearn/nilearn/blob/main/nilearn/glm/thresholding.py#L190)



## [nilearn/glm/contrasts.py](https://github.com/nilearn/nilearn/blob/main/nilearn/glm/contrasts.py)
[nilearn/glm/contrasts.py::compute_contrast - line: 54](https://github.com/nilearn/nilearn/blob/main/nilearn/glm/contrasts.py#L54)

[nilearn/glm/contrasts.py::compute_fixed_effect_contrast - line: 146](https://github.com/nilearn/nilearn/blob/main/nilearn/glm/contrasts.py#L146)

[nilearn/glm/contrasts.py::compute_fixed_effects - line: 462](https://github.com/nilearn/nilearn/blob/main/nilearn/glm/contrasts.py#L462)



## [nilearn/glm/second_level/second_level.py](https://github.com/nilearn/nilearn/blob/main/nilearn/glm/second_level/second_level.py)
[nilearn/glm/second_level/second_level.py::non_parametric_inference - line: 719](https://github.com/nilearn/nilearn/blob/main/nilearn/glm/second_level/second_level.py#L719)


