### PR TITLE
[FIX] Warn if smoothing_fwhm parameter passed to FLM for surface data

### DIFF
--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1030,8 +1030,12 @@ class FirstLevelModel(BaseGLM):
             self.mask_img, SurfaceMasker
         ):
             if self.smoothing_fwhm is not None:
-                warn("Parameter smoothing_fwhm is not "
-                     "supported for surface data")
+                warn(
+                    "Parameter smoothing_fwhm is not "
+                    "supported for surface data",
+                    UserWarning,
+                    stacklevel=2,
+                )
             self.masker_ = SurfaceMasker(
                 mask_img=self.mask_img,
                 smoothing_fwhm=self.smoothing_fwhm,

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1030,10 +1030,10 @@ class FirstLevelModel(BaseGLM):
             self.mask_img, SurfaceMasker
         ):
             if self.smoothing_fwhm is not None:
-                warn("parameter smoothing_fwhm is not supported for surface data")
+                warn("Parameter smoothing_fwhm is not supported for surface data")
             self.masker_ = SurfaceMasker(
                 mask_img=self.mask_img,
-                # smoothing_fwhm=self.smoothing_fwhm,
+                smoothing_fwhm=self.smoothing_fwhm,
                 standardize=self.standardize,
                 t_r=self.t_r,
                 memory=self.memory,

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1030,7 +1030,8 @@ class FirstLevelModel(BaseGLM):
             self.mask_img, SurfaceMasker
         ):
             if self.smoothing_fwhm is not None:
-                warn("Parameter smoothing_fwhm is not supported for surface data")
+                warn("Parameter smoothing_fwhm is not "
+                     "supported for surface data")
             self.masker_ = SurfaceMasker(
                 mask_img=self.mask_img,
                 smoothing_fwhm=self.smoothing_fwhm,

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1029,9 +1029,11 @@ class FirstLevelModel(BaseGLM):
         if isinstance(run_img, SurfaceImage) and not isinstance(
             self.mask_img, SurfaceMasker
         ):
+            if self.smoothing_fwhm is not None:
+                warn("parameter smoothing_fwhm is not supported for surface data")
             self.masker_ = SurfaceMasker(
                 mask_img=self.mask_img,
-                smoothing_fwhm=self.smoothing_fwhm,
+                # smoothing_fwhm=self.smoothing_fwhm,
                 standardize=self.standardize,
                 t_r=self.t_r,
                 memory=self.memory,

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1032,9 +1032,9 @@ class FirstLevelModel(BaseGLM):
             if self.smoothing_fwhm is not None:
                 warn(
                     "Parameter smoothing_fwhm is not "
-                    "supported for surface data",
+                    "yet supported for surface data",
                     UserWarning,
-                    stacklevel=2,
+                    stacklevel=3,
                 )
             self.masker_ = SurfaceMasker(
                 mask_img=self.mask_img,

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -2067,8 +2067,8 @@ def test_warn_flm_smooth_surface_image(_make_surface_glm_data):
     mini_img, des = _make_surface_glm_data(5)
     model = FirstLevelModel(mask_img=False, smoothing_fwhm=5)
     with pytest.warns(
-        UserWarning, 
-        match="Parameter smoothing_fwhm is not supported for surface data"
+        UserWarning,
+        match="Parameter smoothing_fwhm is not supported for surface data",
     ):
         model.fit(mini_img, design_matrices=des)
 

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -2067,7 +2067,8 @@ def test_warn_flm_smooth_surface_image(_make_surface_glm_data):
     mini_img, des = _make_surface_glm_data(5)
     model = FirstLevelModel(mask_img=False, smoothing_fwhm=5)
     with pytest.warns(
-        UserWarning, match="Parameter smoothing_fwhm is not supported for surface data"
+        UserWarning, 
+        match="Parameter smoothing_fwhm is not supported for surface data"
     ):
         model.fit(mini_img, design_matrices=des)
 

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -2062,6 +2062,20 @@ def test_flm_fit_surface_image(_make_surface_glm_data):
     assert isinstance(model.masker_, SurfaceMasker)
 
 
+def test_warn_flm_smooth_surface_image(_make_surface_glm_data):
+    """Test FirstLevelModel with surface image and mask_img set to False."""
+    mini_img, des = _make_surface_glm_data(5)
+    model = FirstLevelModel(mask_img=False, smoothing_fwhm=5)
+    with pytest.warns(
+        UserWarning, match="Parameter smoothing_fwhm is not supported for surface data"
+    ):
+        model.fit(mini_img, design_matrices=des)
+
+    assert isinstance(model.masker_.mask_img_, SurfaceImage)
+    assert model.masker_.mask_img_.shape == (9,)
+    assert isinstance(model.masker_, SurfaceMasker)
+
+
 def test_flm_fit_surface_image_one_hemisphere(
     _make_surface_glm_data, drop_img_part
 ):

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -2063,18 +2063,14 @@ def test_flm_fit_surface_image(_make_surface_glm_data):
 
 
 def test_warn_flm_smooth_surface_image(_make_surface_glm_data):
-    """Test FirstLevelModel with surface image and mask_img set to False."""
+    """Test warning raised in FirstLevelModel with surface smoothing."""
     mini_img, des = _make_surface_glm_data(5)
     model = FirstLevelModel(mask_img=False, smoothing_fwhm=5)
     with pytest.warns(
         UserWarning,
-        match="Parameter smoothing_fwhm is not supported for surface data",
+        match="Parameter smoothing_fwhm is not yet supported for surface data",
     ):
         model.fit(mini_img, design_matrices=des)
-
-    assert isinstance(model.masker_.mask_img_, SurfaceImage)
-    assert model.masker_.mask_img_.shape == (9,)
-    assert isinstance(model.masker_, SurfaceMasker)
 
 
 def test_flm_fit_surface_image_one_hemisphere(


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4588

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Warn if `smoothing_FHWM` is not `None` for first-level GLM with surface data
- Adds test to check that warning is correctly raised and flm fitting proceeds correctly 