### PR TITLE
[FIX] Fix several errors (PTH101, PTH102, PTH107, PTH110, PTH111, PTH113, PTH201) in `nilearn.datasets` package

### DIFF
--- a/nilearn/datasets/_utils.py
+++ b/nilearn/datasets/_utils.py
@@ -347,31 +347,31 @@ def uncompress_file(file_, delete_archive=True, verbose=1):
             z.extractall(path=data_dir)
             z.close()
             if delete_archive:
-                os.remove(file_)
-            file_ = filename
+                file_.unlink()
+            file_ = Path(filename)
             processed = True
         elif file_.suffix == ".gz" or header.startswith(b"\x1f\x8b"):
             import gzip
 
             if file_.suffix == ".tgz":
-                filename = Path(f"{filename}.tar")
+                filename = f"{filename}.tar"
             elif file_.suffix == "":
                 # We rely on the assumption that gzip files have an extension
                 shutil.move(file_, f"{file_}.gz")
-                file_ = f"{file_}.gz"
+                file_ = Path(f"{file_}.gz")
             with gzip.open(file_) as gz:
                 with open(filename, "wb") as out:
                     shutil.copyfileobj(gz, out, 8192)
             # If file is .tar.gz, this will be handled in the next case
             if delete_archive:
-                os.remove(file_)
-            file_ = filename
+                file_.unlink()
+            file_ = Path(filename)
             processed = True
         if file_.is_file() and tarfile.is_tarfile(file_):
             with contextlib.closing(tarfile.open(file_, "r")) as tar:
                 _safe_extract(tar, path=data_dir)
             if delete_archive:
-                os.remove(file_)
+                file_.unlink()
             processed = True
         if not processed:
             raise OSError(f"[Uncompress] unknown archive file format: {file_}")

--- a/nilearn/datasets/_utils.py
+++ b/nilearn/datasets/_utils.py
@@ -348,7 +348,6 @@ def uncompress_file(file_, delete_archive=True, verbose=1):
             z.close()
             if delete_archive:
                 file_.unlink()
-            file_ = Path(filename)
             processed = True
         elif file_.suffix == ".gz" or header.startswith(b"\x1f\x8b"):
             import gzip

--- a/nilearn/datasets/_utils.py
+++ b/nilearn/datasets/_utils.py
@@ -358,7 +358,7 @@ def uncompress_file(file_, delete_archive=True, verbose=1):
                 # We rely on the assumption that gzip files have an extension
                 shutil.move(file_, f"{file_}.gz")
                 file_ = file_.with_suffix(".gz")
-            with file_.open() as gz, filename.open("wb") as out:
+            with gzip.open(file_) as gz, filename.open("wb") as out:
                 shutil.copyfileobj(gz, out, 8192)
             # If file is .tar.gz, this will be handled in the next case
             if delete_archive:

--- a/nilearn/datasets/_utils.py
+++ b/nilearn/datasets/_utils.py
@@ -353,18 +353,18 @@ def uncompress_file(file_, delete_archive=True, verbose=1):
             import gzip
 
             if file_.suffix == ".tgz":
-                filename = f"{filename}.tar"
+                filename = filename.with_suffix(".tar")
             elif file_.suffix == "":
                 # We rely on the assumption that gzip files have an extension
                 shutil.move(file_, f"{file_}.gz")
-                file_ = Path(f"{file_}.gz")
+                file_ = file_.with_suffix(".gz")
             with gzip.open(file_) as gz:
                 with open(filename, "wb") as out:
                     shutil.copyfileobj(gz, out, 8192)
             # If file is .tar.gz, this will be handled in the next case
             if delete_archive:
                 file_.unlink()
-            file_ = Path(filename)
+            file_ = filename
             processed = True
         if file_.is_file() and tarfile.is_tarfile(file_):
             with contextlib.closing(tarfile.open(file_, "r")) as tar:

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -151,7 +151,7 @@ def fetch_atlas_difumo(
     readme_files = [
         ("README.md", "https://osf.io/4k9bf/download", {"move": "README.md"})
     ]
-    if not os.path.exists(os.path.join(data_dir, "README.md")):
+    if not Path(data_dir, "README.md").exists():
         fetch_files(data_dir, readme_files, verbose=verbose, resume=resume)
 
     fdescr = get_dataset_descr(dataset_name)

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -2292,7 +2292,7 @@ def fetch_bids_langloc_dataset(data_dir=None, verbose=1):
     )
     # The files_spec needed for fetch_files
     files_spec = [(f"{main_folder}.zip", url, {"move": f"{main_folder}.zip"})]
-    if not os.path.exists(os.path.join(data_dir, main_folder)):
+    if not Path(data_dir, main_folder).exists():
         downloaded_files = fetch_files(
             data_dir, files_spec, resume=True, verbose=verbose
         )
@@ -2519,7 +2519,7 @@ def patch_openneuro_dataset(file_list):
         for name in file_list:
             if old_pattern in name:
                 new_name = name.replace(old_pattern, new_pattern)
-                if not os.path.exists(new_name):
+                if not Path(new_name).exists():
                     os.symlink(name, new_name)
 
 

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -2150,7 +2150,7 @@ def _reduce_confounds(regressors, keep_confounds):
     reduced_regressors = []
     for in_file in regressors:
         out_file = in_file.replace("desc-confounds", "desc-reducedConfounds")
-        if not os.path.isfile(out_file):
+        if not Path(out_file).is_file():
             confounds = pd.read_csv(in_file, delimiter="\t").to_records()
             selected_confounds = confounds[keep_confounds]
             header = "\t".join(selected_confounds.dtype.names)
@@ -2811,7 +2811,7 @@ def _get_session_trials_spm_multimodal(subject_dir, session, _subject_data):
     sess_trials = os.path.join(
         subject_dir, f"fMRI/trials_ses{int(session)}.mat"
     )
-    if not os.path.isfile(sess_trials):
+    if not Path(sess_trials).is_file():
         logger.log(f"Missing session file: {sess_trials}", stack_level=2)
         return None
 
@@ -2821,7 +2821,7 @@ def _get_session_trials_spm_multimodal(subject_dir, session, _subject_data):
 
 def _get_anatomical_data_spm_multimodal(subject_dir, _subject_data):
     anat = os.path.join(subject_dir, "sMRI/smri.img")
-    if not os.path.isfile(anat):
+    if not Path(anat).is_file():
         logger.log("Missing structural image.", stack_level=2)
         return None
 
@@ -3018,7 +3018,7 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
         for run in [1, 2]:
             # glob func data for session
             session_func = os.path.join(subject_dir, f"run{int(run)}.nii.gz")
-            if not os.path.isfile(session_func):
+            if not Path(session_func).is_file():
                 logger.log(f"Missing functional scan for session {int(run)}.")
                 return None
 
@@ -3026,7 +3026,7 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
 
             # glob design matrix .npz file
             sess_dmtx = os.path.join(subject_dir, f"run{int(run)}_design.npz")
-            if not os.path.isfile(sess_dmtx):
+            if not Path(sess_dmtx).is_file():
                 logger.log(f"Missing run file: {sess_dmtx}")
                 return None
 
@@ -3034,7 +3034,7 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
 
         # glob for mask data
         mask = os.path.join(subject_dir, "mask.nii.gz")
-        if not os.path.isfile(mask):
+        if not Path(mask).is_file():
             logger.log("Missing mask image.")
             return None
 

--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -1529,7 +1529,7 @@ def _download_image_nii_file(image_info, collection, download_params):
 
         tmp_file = f"tmp_{struuid}.nii.gz"
 
-        tmp_path = os.path.join(collection["absolute_path"], tmp_file)
+        tmp_path = Path(collection["absolute_path"], tmp_file)
 
         _simple_download(
             image_url,
@@ -1552,7 +1552,7 @@ def _download_image_nii_file(image_info, collection, download_params):
         im_resampled.to_filename(resampled_image_absolute_path)
 
         # Remove temporary file
-        os.remove(tmp_path)
+        tmp_path.unlink()
     else:
         _simple_download(
             image_url,
@@ -1564,7 +1564,8 @@ def _download_image_nii_file(image_info, collection, download_params):
 
 
 def _check_has_words(file_name):
-    if not os.path.isfile(file_name):
+    file_name = Path(file_name)
+    if not file_name.is_file():
         return False
     info = _remove_none_strings(_json_from_file(file_name))
     try:
@@ -1572,7 +1573,7 @@ def _check_has_words(file_name):
         return True
     except (AttributeError, TypeError, AssertionError):
         pass
-    os.remove(file_name)
+    file_name.unlink()
     return False
 
 

--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -1614,7 +1614,7 @@ def _download_image_terms(image_info, collection, download_params):
         collection["absolute_path"], ns_words_file_name
     )
 
-    if os.path.isfile(image_info["ns_words_absolute_path"]):
+    if Path(image_info["ns_words_absolute_path"]).is_file():
         return image_info, collection
 
     query = urljoin(
@@ -1783,7 +1783,7 @@ def _scroll_local(download_params):
         for image in good_images:
             image, collection = _update(image, collection, download_params)
             if download_params["resample"]:
-                if not os.path.isfile(image["resampled_absolute_path"]):
+                if not Path(image["resampled_absolute_path"]).is_file():
                     # TODO switch to force_resample=True
                     # when bumping to version > 0.13
                     im_resampled = resample_img(
@@ -1797,7 +1797,7 @@ def _scroll_local(download_params):
                 download_params["visited_images"].add(image["id"])
                 download_params["visited_collections"].add(collection["id"])
                 yield image, collection
-            elif os.path.isfile(image["absolute_path"]):
+            elif Path(image["absolute_path"]).is_file():
                 download_params["visited_images"].add(image["id"])
                 download_params["visited_collections"].add(collection["id"])
                 yield image, collection

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -669,12 +669,12 @@ def test_fetch_atlas_allen_2011(tmp_path, request_mocker):
 
 
 def test_fetch_atlas_surf_destrieux(tmp_path):
-    data_dir = str(tmp_path / "destrieux_surface")
-    os.mkdir(data_dir)
+    data_dir = tmp_path / "destrieux_surface"
+    data_dir.mkdir()
     # Create mock annots
     for hemi in ("left", "right"):
         freesurfer.write_annot(
-            os.path.join(data_dir, f"{hemi}.aparc.a2009s.annot"),
+            data_dir / f"{hemi}.aparc.a2009s.annot",
             np.arange(4),
             np.zeros((4, 5)),
             5 * ["a"],

--- a/nilearn/datasets/tests/test_func.py
+++ b/nilearn/datasets/tests/test_func.py
@@ -1136,5 +1136,5 @@ def test_fiac(tmp_path):
 def test_load_sample_motor_activation_image():
     path_img = func.load_sample_motor_activation_image()
 
-    assert os.path.exists(path_img)
+    assert Path(path_img).exists()
     assert load_img(path_img)

--- a/nilearn/datasets/tests/test_func.py
+++ b/nilearn/datasets/tests/test_func.py
@@ -770,10 +770,9 @@ datadir = PACKAGE_DIRECTORY / "data"
 
 
 def test_fetch_bids_langloc_dataset(tmp_path):
-    data_dir = str(tmp_path / "bids_langloc_example")
-    os.mkdir(data_dir)
-    main_folder = os.path.join(data_dir, "bids_langloc_dataset")
-    os.mkdir(main_folder)
+    data_dir = tmp_path / "bids_langloc_example"
+    main_folder = data_dir / "bids_langloc_dataset"
+    main_folder.mkdir(parents=True)
 
     datadir, dl_files = func.fetch_bids_langloc_dataset(tmp_path)
 
@@ -847,10 +846,10 @@ def test_fetch_ds000030_urls():
         tmp_list = []
         for subdir in subdir_names:
             tmp_list.append(subdir)
-            subdirpath = os.path.join(tmpdir, *tmp_list)
-            os.mkdir(subdirpath)
+            subdirpath = Path(tmpdir, *tmp_list)
+            subdirpath.mkdir()
 
-        filepath = os.path.join(subdirpath, "urls.json")
+        filepath = subdirpath / "urls.json"
         mock_json_content = ["junk1", "junk2"]
         with open(filepath, "w") as f:
             json.dump(mock_json_content, f)
@@ -862,7 +861,7 @@ def test_fetch_ds000030_urls():
         )
         urls_path = urls_path.replace("/", os.sep)
 
-        assert urls_path == filepath
+        assert urls_path == str(filepath)
         assert urls == mock_json_content
 
         # fetch_openneuro_dataset_index should do the same, but with a warning
@@ -875,7 +874,7 @@ def test_fetch_ds000030_urls():
 
         urls_path = urls_path.replace("/", os.sep)
 
-        assert urls_path == filepath
+        assert urls_path == str(filepath)
         assert urls == mock_json_content
 
         # fetch_openneuro_dataset_index should even grab ds000030 when you
@@ -892,7 +891,7 @@ def test_fetch_ds000030_urls():
 
         urls_path = urls_path.replace("/", os.sep)
 
-        assert urls_path == filepath
+        assert urls_path == str(filepath)
         assert urls == mock_json_content
 
 

--- a/nilearn/datasets/tests/test_mocking_autoused.py
+++ b/nilearn/datasets/tests/test_mocking_autoused.py
@@ -38,7 +38,7 @@ def test_request_mocking_autoused_urllib():
 
 
 def test_temp_nilearn_home_autoused():
-    home_dir = Path(os.path.expanduser("~"))
+    home_dir = Path("~").expanduser()
 
     assert home_dir.name.startswith("temp_nilearn_home")
 

--- a/nilearn/datasets/tests/test_neurovault.py
+++ b/nilearn/datasets/tests/test_neurovault.py
@@ -534,7 +534,7 @@ def test_simple_download(tmp_path):
         tmp_path / "image_35.nii.gz",
         tmp_path,
     )
-    assert os.path.isfile(downloaded_file)
+    assert downloaded_file.is_file()
 
 
 def test_simple_download_error(tmp_path, request_mocker):
@@ -994,7 +994,7 @@ def test_download_resamp_images_along_original_images_if_previously_downloaded(
 def _check_resampled_version_is_here(data):
     assert np.all(
         [
-            os.path.isfile(im_meta["resampled_absolute_path"])
+            Path(im_meta["resampled_absolute_path"]).is_file()
             for im_meta in data["images_meta"]
         ]
     )
@@ -1003,7 +1003,7 @@ def _check_resampled_version_is_here(data):
 def _check_resampled_version_is_not_here(data):
     assert not np.any(
         [
-            os.path.isfile(im_meta["resampled_absolute_path"])
+            Path(im_meta["resampled_absolute_path"]).is_file()
             for im_meta in data["images_meta"]
         ]
     )
@@ -1012,7 +1012,7 @@ def _check_resampled_version_is_not_here(data):
 def _check_original_version_is_here(data):
     assert np.all(
         [
-            os.path.isfile(im_meta["absolute_path"])
+            Path(im_meta["absolute_path"]).is_file()
             for im_meta in data["images_meta"]
         ]
     )
@@ -1021,7 +1021,7 @@ def _check_original_version_is_here(data):
 def _check_original_version_is_not_here(data):
     assert not np.any(
         [
-            os.path.isfile(im_meta["absolute_path"])
+            Path(im_meta["absolute_path"]).is_file()
             for im_meta in data["images_meta"]
         ]
     )

--- a/nilearn/datasets/tests/test_neurovault.py
+++ b/nilearn/datasets/tests/test_neurovault.py
@@ -772,8 +772,8 @@ def test_fetch_neurovault(tmp_path):
 
     # using a data directory we can't write into should raise a
     # warning unless mode is 'offline'
-    os.chmod(tmp_path, stat.S_IREAD | stat.S_IEXEC)
-    os.chmod(os.path.join(tmp_path, "neurovault"), stat.S_IREAD | stat.S_IEXEC)
+    tmp_path.chmod(stat.S_IREAD | stat.S_IEXEC)
+    (tmp_path / "neurovault").chmod(stat.S_IREAD | stat.S_IEXEC)
     if os.access(os.path.join(tmp_path, "neurovault"), os.W_OK):
         return
 

--- a/nilearn/datasets/tests/test_testing.py
+++ b/nilearn/datasets/tests/test_testing.py
@@ -61,7 +61,7 @@ def test_loading_from_archive_contents(tmp_path):
 
         with tarfile.open(str(file_path)) as tarf:
             assert sorted(map(Path, tarf.getnames())) == [
-                Path("."),
+                Path(),
                 *expected_contents,
             ]
             tarf.extractall(str(tar_extract_dir))
@@ -228,7 +228,7 @@ def test_dict_to_archive(tmp_path):
         assert sorted(map(Path, tarf.getnames())) == sorted(
             [
                 *list(map(Path, archive_spec.keys())),
-                Path("."),
+                Path(),
                 Path("a"),
                 Path("a", "b"),
                 Path("data"),

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -94,7 +94,7 @@ def test_get_dataset_dir(tmp_path):
     data_dir = _utils.get_dataset_dir("test", verbose=0)
 
     assert data_dir == str(expected_base_dir / "test")
-    assert os.path.exists(data_dir)
+    assert Path(data_dir).exists()
 
     shutil.rmtree(data_dir)
 
@@ -103,7 +103,7 @@ def test_get_dataset_dir(tmp_path):
     data_dir = _utils.get_dataset_dir("test", verbose=0)
 
     assert data_dir == str(expected_base_dir / "test")
-    assert os.path.exists(data_dir)
+    assert Path(data_dir).exists()
 
     shutil.rmtree(data_dir)
 
@@ -112,7 +112,7 @@ def test_get_dataset_dir(tmp_path):
     data_dir = _utils.get_dataset_dir("test", verbose=0)
 
     assert data_dir == str(expected_base_dir / "test")
-    assert os.path.exists(data_dir)
+    assert Path(data_dir).exists()
 
     shutil.rmtree(data_dir)
 
@@ -146,7 +146,7 @@ def test_get_dataset_dir_path_as_str(should_cast_path_to_string, tmp_path):
     )
 
     assert data_dir == str(expected_dataset_dir)
-    assert os.path.exists(data_dir)
+    assert Path(data_dir).exists()
 
     shutil.rmtree(data_dir)
 
@@ -166,7 +166,7 @@ def test_get_dataset_dir_write_access(tmp_path):
 
     # Non writeable dir is returned because dataset may be in there.
     assert data_dir == str(no_write)
-    assert os.path.exists(data_dir)
+    assert Path(data_dir).exists()
 
     no_write.chmod(0o600)
     shutil.rmtree(data_dir)
@@ -187,7 +187,7 @@ def test_get_dataset_dir_symlink(tmp_path):
     )
 
     assert data_dir == str(expected_linked_dir)
-    assert os.path.exists(data_dir)
+    assert Path(data_dir).exists()
 
 
 def test_md5_sum_file(tmp_path):
@@ -534,7 +534,7 @@ def test_fetch_files_overwrite(
     )
 
     assert request_mocker.url_count == 1
-    assert os.path.exists(fil[0])
+    assert Path(fil[0]).exists()
     with open(fil[0]) as fp:
         assert fp.read() == ""
 
@@ -550,7 +550,7 @@ def test_fetch_files_overwrite(
     )
 
     assert request_mocker.url_count == 1
-    assert os.path.exists(fil[0])
+    assert Path(fil[0]).exists()
     with open(fil[0]) as fp:
         assert fp.read() == "some content"
 
@@ -562,7 +562,7 @@ def test_fetch_files_overwrite(
     )
 
     assert request_mocker.url_count == 2
-    assert os.path.exists(fil[0])
+    assert Path(fil[0]).exists()
     with open(fil[0]) as fp:
         assert fp.read() == ""
 

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -9,7 +9,6 @@ import shutil
 import tarfile
 import urllib
 from pathlib import Path
-from tempfile import mkstemp
 from unittest.mock import MagicMock
 from zipfile import ZipFile
 
@@ -191,26 +190,23 @@ def test_get_dataset_dir_symlink(tmp_path):
     assert os.path.exists(data_dir)
 
 
-def test_md5_sum_file():
+def test_md5_sum_file(tmp_path):
     # Create dummy temporary file
-    out, f = mkstemp()
-    os.write(out, b"abcfeg")
-    os.close(out)
+    f = tmp_path / "test"
+    f.write_bytes(b"abcfeg")
 
     assert _utils._md5_sum_file(f) == "18f32295c556b2a1a3a8e68fe1ad40f7"
 
-    os.remove(f)
+    f.unlink()
 
 
-def test_read_md5_sum_file():
+def test_read_md5_sum_file(tmp_path):
     # Create dummy temporary file
-    out, f = mkstemp()
-    os.write(
-        out,
+    f = tmp_path / "test"
+    f.write_bytes(
         b"20861c8c3fe177da19a7e9539a5dbac  /tmp/test\n"
         b"70886dcabe7bf5c5a1c24ca24e4cbd94  test/some_image.nii",
     )
-    os.close(out)
     h = _utils.read_md5_sum_file(f)
 
     assert "/tmp/test" in h
@@ -218,7 +214,7 @@ def test_read_md5_sum_file():
     assert h["test/some_image.nii"] == "70886dcabe7bf5c5a1c24ca24e4cbd94"
     assert h["/tmp/test"] == "20861c8c3fe177da19a7e9539a5dbac"
 
-    os.remove(f)
+    f.unlink()
 
 
 def test_tree(tmp_path):

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -198,7 +198,6 @@ def test_md5_sum_file(tmp_path):
     assert _utils._md5_sum_file(f) == "18f32295c556b2a1a3a8e68fe1ad40f7"
 
 
-
 def test_read_md5_sum_file(tmp_path):
     # Create dummy temporary file
     f = tmp_path / "test"
@@ -212,7 +211,6 @@ def test_read_md5_sum_file(tmp_path):
     assert "/etc/test" not in h
     assert h["test/some_image.nii"] == "70886dcabe7bf5c5a1c24ca24e4cbd94"
     assert h["/tmp/test"] == "20861c8c3fe177da19a7e9539a5dbac"
-
 
 
 def test_tree(tmp_path):

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -157,7 +157,7 @@ def test_get_dataset_dir_write_access(tmp_path):
 
     no_write = tmp_path / "no_write"
     no_write.mkdir(parents=True)
-    os.chmod(no_write, 0o400)
+    no_write.chmod(0o400)
 
     expected_base_dir = tmp_path / "nilearn_shared_data"
     os.environ["NILEARN_SHARED_DATA"] = str(expected_base_dir)
@@ -169,7 +169,7 @@ def test_get_dataset_dir_write_access(tmp_path):
     assert data_dir == str(no_write)
     assert os.path.exists(data_dir)
 
-    os.chmod(no_write, 0o600)
+    no_write.chmod(0o600)
     shutil.rmtree(data_dir)
 
 

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -197,7 +197,6 @@ def test_md5_sum_file(tmp_path):
 
     assert _utils._md5_sum_file(f) == "18f32295c556b2a1a3a8e68fe1ad40f7"
 
-    f.unlink()
 
 
 def test_read_md5_sum_file(tmp_path):
@@ -214,7 +213,6 @@ def test_read_md5_sum_file(tmp_path):
     assert h["test/some_image.nii"] == "70886dcabe7bf5c5a1c24ca24e4cbd94"
     assert h["/tmp/test"] == "20861c8c3fe177da19a7e9539a5dbac"
 
-    f.unlink()
 
 
 def test_tree(tmp_path):

--- a/nilearn/datasets/utils.py
+++ b/nilearn/datasets/utils.py
@@ -1,6 +1,7 @@
 """Downloading NeuroImaging datasets: utility functions."""
 
 import os
+from pathlib import Path
 from warnings import warn
 
 from .._utils import fill_doc
@@ -60,7 +61,7 @@ def get_data_dirs(data_dir=None):
         if local_data is not None:
             paths.extend(local_data.split(os.pathsep))
 
-        paths.append(os.path.expanduser("~/nilearn_data"))
+        paths.append(str(Path("~/nilearn_data").expanduser()))
     return paths
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ max-complexity = 41
 "**/{examples}/*" = ["D103", "D400", "E402"]
 "**/{tests}/*" = ["D100", "D101", "D102", "D103", "E402"]
 "__init__.py" = ["D104", "E402"]
-"nilearn/datasets/**/*" = ["PTH101", "PTH102", "PTH107", "PTH110", "PTH111", "PTH113"]
+"nilearn/datasets/**/*" = ["PTH102", "PTH107", "PTH110", "PTH111", "PTH113"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ max-complexity = 41
 "**/{examples}/*" = ["D103", "D400", "E402"]
 "**/{tests}/*" = ["D100", "D101", "D102", "D103", "E402"]
 "__init__.py" = ["D104", "E402"]
-"nilearn/datasets/**/*" = ["PTH102", "PTH107", "PTH110", "PTH111", "PTH113"]
+"nilearn/datasets/**/*" = ["PTH107", "PTH110", "PTH111", "PTH113"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ max-complexity = 41
 "**/{examples}/*" = ["D103", "D400", "E402"]
 "**/{tests}/*" = ["D100", "D101", "D102", "D103", "E402"]
 "__init__.py" = ["D104", "E402"]
-"nilearn/datasets/**/*" = ["PTH107", "PTH110", "PTH111", "PTH113"]
+"nilearn/datasets/**/*" = ["PTH110", "PTH111", "PTH113"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,6 @@ max-complexity = 41
 "**/{examples}/*" = ["D103", "D400", "E402"]
 "**/{tests}/*" = ["D100", "D101", "D102", "D103", "E402"]
 "__init__.py" = ["D104", "E402"]
-"nilearn/datasets/**/*" = ["PTH113"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ max-complexity = 41
 "**/{examples}/*" = ["D103", "D400", "E402"]
 "**/{tests}/*" = ["D100", "D101", "D102", "D103", "E402"]
 "__init__.py" = ["D104", "E402"]
-"nilearn/datasets/**/*" = ["PTH111", "PTH113"]
+"nilearn/datasets/**/*" = ["PTH113"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ max-complexity = 41
 "**/{examples}/*" = ["D103", "D400", "E402"]
 "**/{tests}/*" = ["D100", "D101", "D102", "D103", "E402"]
 "__init__.py" = ["D104", "E402"]
-"nilearn/datasets/**/*" = ["PTH110", "PTH111", "PTH113"]
+"nilearn/datasets/**/*" = ["PTH111", "PTH113"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ max-complexity = 41
 "**/{examples}/*" = ["D103", "D400", "E402"]
 "**/{tests}/*" = ["D100", "D101", "D102", "D103", "E402"]
 "__init__.py" = ["D104", "E402"]
-"nilearn/datasets/**/*" = ["PTH201", "PTH101", "PTH102", "PTH107", "PTH110", "PTH111", "PTH113"]
+"nilearn/datasets/**/*" = ["PTH101", "PTH102", "PTH107", "PTH110", "PTH111", "PTH113"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
- Closes  none but relates to #4327 

Changes proposed in this pull request:

fixes errors remaining in `nilearn/datasets` package:

- PTH 101: https://docs.astral.sh/ruff/rules/os-chmod/
- PTH 102: https://docs.astral.sh/ruff/rules/os-mkdir/
- PTH 107: https://docs.astral.sh/ruff/rules/os-remove/
- PTH 110: https://docs.astral.sh/ruff/rules/os-path-exists/
- PTH 111: https://docs.astral.sh/ruff/rules/os-path-expanduser/
- PTH 113: https://docs.astral.sh/ruff/rules/os-path-isfile/
- PTH 201: https://docs.astral.sh/ruff/rules/path-constructor-current-directory/