### PR TITLE
[FIX] Fix bug in `fetch_single_file` with `resume=True` and improve tests

### DIFF
--- a/nilearn/datasets/_utils.py
+++ b/nilearn/datasets/_utils.py
@@ -571,7 +571,6 @@ def fetch_single_file(
     if temp_full_name.exists() and overwrite:
         temp_full_name.unlink()
     t0 = time.time()
-    local_file = None
     initial_size = 0
 
     try:
@@ -610,7 +609,7 @@ def fetch_single_file(
                     ):
                         raise OSError("Server does not support resuming")
                     initial_size = local_file_size
-                    with local_file.open("ab") as fh:
+                    with temp_full_name.open("ab") as fh:
                         _chunk_read_(
                             resp,
                             fh,
@@ -618,7 +617,7 @@ def fetch_single_file(
                             initial_size=initial_size,
                             verbose=verbose,
                         )
-            except Exception:
+            except OSError:
                 logger.log(
                     "Resuming failed, try to download the whole file.", verbose
                 )
@@ -665,7 +664,7 @@ def fetch_single_file(
         raise
     if md5sum is not None and _md5_sum_file(full_name) != md5sum:
         raise ValueError(
-            f"File {local_file} checksum verification has failed."
+            f"File {full_name} checksum verification has failed."
             " Dataset fetching aborted."
         )
     return full_name

--- a/nilearn/datasets/tests/_testing.py
+++ b/nilearn/datasets/tests/_testing.py
@@ -107,6 +107,7 @@ class Response:
         self.url = url
         self.status_code = status_code
         self.headers = {"Content-Length": len(self.content)}
+        self.iter_start = 0
 
     def __enter__(self):
         return self
@@ -115,7 +116,7 @@ class Response:
         pass
 
     def iter_content(self, chunk_size=8):
-        for i in range(0, len(self.content), chunk_size):
+        for i in range(self.iter_start, len(self.content), chunk_size):
             yield self.content[i : i + chunk_size]
 
     @property

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -446,7 +446,7 @@ def test_fetch_file_part(tmp_path, capsys, request_mocker):
     url = "http://foo/temp.txt"
     file_full = tmp_path / "temp.txt"
     file_part = tmp_path / "temp.txt.part"
-    file_part.touch()
+    file_part.write_text("D")  # should not be overwritten
 
     request_mocker.url_mapping[url] = get_response
 
@@ -455,6 +455,7 @@ def test_fetch_file_part(tmp_path, capsys, request_mocker):
     )
 
     assert file_full.exists()
+    assert file_full.read_text() == "Dummy content"  # not overwritten
     assert "Resuming failed" not in capsys.readouterr().out
 
     file_full.unlink()
@@ -462,13 +463,14 @@ def test_fetch_file_part(tmp_path, capsys, request_mocker):
     assert not file_part.exists()
 
     # test for overwrite
-    file_part.touch()
+    file_part.write_text("D")  # should be overwritten
 
     _utils.fetch_single_file(
-        url=url, data_dir=tmp_path, verbose=0, resume=True, overwrite=True
+        url=url, data_dir=tmp_path, resume=True, overwrite=True
     )
 
     assert file_full.exists()
+    assert file_full.read_text() == "dummy content"  # overwritten
 
 
 @pytest.mark.parametrize("should_cast_path_to_string", [False, True])

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -422,24 +422,26 @@ def test_safe_extract(tmp_path):
         _utils.uncompress_file(ztemp, verbose=0)
 
 
-def test_fetch_file_part(tmp_path):
+def test_fetch_file_part(tmp_path, capsys):
     url = "http://foo/temp.txt"
     file_full = tmp_path / "temp.txt"
     file_part = tmp_path / "temp.txt.part"
     file_part.touch()
 
     _utils.fetch_single_file(
-        url=url, data_dir=tmp_path, verbose=0, resume=True
+        url=url, data_dir=tmp_path, verbose=1, resume=True
     )
 
     assert file_full.exists()
+
+    captured = capsys.readouterr()
+    assert "Resuming failed" not in captured.out
 
     file_full.unlink()
     assert not file_full.exists()
     assert not file_part.exists()
 
     # test for overwrite
-    url = "http://foo/temp.txt"
     file_part.touch()
 
     _utils.fetch_single_file(

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -424,7 +424,7 @@ def test_safe_extract(tmp_path):
         _utils.uncompress_file(ztemp, verbose=0)
 
 
-def test_fetch_file_part(tmp_path, capsys, request_mocker):
+def test_fetch_single_file_part(tmp_path, capsys, request_mocker):
     def get_response(match, request):
         """Create mock Response object with correct content range header."""
         req_range = request.headers.get("Range")
@@ -474,7 +474,7 @@ def test_fetch_file_part(tmp_path, capsys, request_mocker):
 
 
 @pytest.mark.parametrize("should_cast_path_to_string", [False, True])
-def test_fetch_file_overwrite(
+def test_fetch_single_file_overwrite(
     should_cast_path_to_string, tmp_path, request_mocker
 ):
     if should_cast_path_to_string:

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -2,7 +2,6 @@
 
 # Author: Alexandre Abraham
 
-import contextlib
 import gzip
 import os
 import re
@@ -120,8 +119,7 @@ def test_get_dataset_dir(tmp_path):
 
     # Verify exception for a path which exists and is a file
     test_file = tmp_path / "some_file"
-    with test_file.open("w") as out:
-        out.write("abcfeg")
+    test_file.write_text("abcfeg")
 
     with pytest.raises(
         OSError,
@@ -366,7 +364,7 @@ def test_uncompress_tar(tmp_path, ext, mode):
     # and check if ftemp exists
     ztemp = tmp_path / f"test.{ext}"
     ftemp = "test"
-    with contextlib.closing(tarfile.open(ztemp, mode)) as testtar:
+    with tarfile.open(ztemp, mode) as testtar:
         temp = tmp_path / ftemp
         temp.write_text(ftemp)
         testtar.add(temp)
@@ -384,7 +382,7 @@ def test_uncompress_zip(tmp_path):
     # and check if ftemp exists
     ztemp = tmp_path / "test.zip"
     ftemp = "test"
-    with contextlib.closing(ZipFile(ztemp, "w")) as testzip:
+    with ZipFile(ztemp, "w") as testzip:
         testzip.writestr(ftemp, " ")
 
     _utils.uncompress_file(ztemp, verbose=0)
@@ -402,8 +400,8 @@ def test_uncompress_gzip(tmp_path, ext):
     ztemp = tmp_path / f"test{ext}"
     ftemp = "test"
 
-    with gzip.open(ztemp, "wb") as testgzip:
-        testgzip.write(ftemp.encode())
+    with gzip.open(ztemp, "wt") as testgzip:
+        testgzip.write(ftemp)
 
     _utils.uncompress_file(ztemp, verbose=0)
     assert (tmp_path / ftemp).exists()
@@ -414,7 +412,7 @@ def test_safe_extract(tmp_path):
     ztemp = tmp_path / "test.tar"
     in_archive_file = tmp_path / "something.txt"
     in_archive_file.write_text("hello")
-    with contextlib.closing(tarfile.open(ztemp, "w")) as tar:
+    with tarfile.open(ztemp, "w") as tar:
         arcname = "../test.tar"
         tar.add(in_archive_file, arcname=arcname)
 
@@ -487,12 +485,10 @@ def test_fetch_single_file_overwrite(
 
     assert request_mocker.url_count == 1
     assert fil.exists()
-    with fil.open() as fp:
-        assert fp.read() == ""
+    assert fil.read_text() == ""
 
     # Modify content
-    with fil.open("w") as fp:
-        fp.write("some content")
+    fil.write_text("some content")
 
     # Don't overwrite existing file.
     fil = _utils.fetch_single_file(
@@ -501,8 +497,7 @@ def test_fetch_single_file_overwrite(
 
     assert request_mocker.url_count == 1
     assert fil.exists()
-    with fil.open() as fp:
-        assert fp.read() == "some content"
+    assert fil.read_text() == "some content"
 
     # Overwrite existing file.
     fil = _utils.fetch_single_file(
@@ -511,8 +506,7 @@ def test_fetch_single_file_overwrite(
 
     assert request_mocker.url_count == 2
     assert fil.exists()
-    with fil.open() as fp:
-        assert fp.read() == ""
+    assert fil.read_text() == ""
 
 
 @pytest.mark.parametrize("should_cast_path_to_string", [False, True])
@@ -557,12 +551,10 @@ def test_fetch_files_overwrite(
 
     assert request_mocker.url_count == 1
     assert fil.exists()
-    with fil.open() as fp:
-        assert fp.read() == ""
+    assert fil.read_text() == ""
 
     # Modify content
-    with fil.open("w") as fp:
-        fp.write("some content")
+    fil.write_text("some content")
 
     # Don't overwrite existing file.
     fil = Path(
@@ -575,8 +567,7 @@ def test_fetch_files_overwrite(
 
     assert request_mocker.url_count == 1
     assert fil.exists()
-    with fil.open() as fp:
-        assert fp.read() == "some content"
+    assert fil.read_text() == "some content"
 
     # Overwrite existing file.
     fil = Path(
@@ -589,8 +580,7 @@ def test_fetch_files_overwrite(
 
     assert request_mocker.url_count == 2
     assert fil.exists()
-    with fil.open() as fp:
-        assert fp.read() == ""
+    assert fil.read_text() == ""
 
 
 def test_naive_ftp_adapter():

--- a/nilearn/datasets/tests/test_utils.py
+++ b/nilearn/datasets/tests/test_utils.py
@@ -471,6 +471,24 @@ def test_fetch_single_file_part(tmp_path, capsys, request_mocker):
     assert file_full.read_text() == "dummy content"  # overwritten
 
 
+def test_fetch_single_file_part_error(tmp_path, capsys, request_mocker):
+    url = "http://foo/temp.txt"
+    file_part = tmp_path / "temp.txt.part"
+    file_part.touch()  # should not be overwritten
+
+    # the default Response from the mocker does not handle Range requests
+    request_mocker.url_mapping[url] = "dummy content"
+
+    _utils.fetch_single_file(
+        url=url, data_dir=tmp_path, verbose=1, resume=True
+    )
+
+    assert (
+        "Resuming failed, try to download the whole file."
+        in capsys.readouterr().out
+    )
+
+
 @pytest.mark.parametrize("should_cast_path_to_string", [False, True])
 def test_fetch_single_file_overwrite(
     should_cast_path_to_string, tmp_path, request_mocker


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4697

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:
- Use `request_mocker` so that the test actually works
- Deleted `local_file` (always `None`) and use actual filename instead
- Make exception catching more specific
- Some improvements in other tests, especially regarding to the use of context managers and `pathlib.Path`'s `read_text` and `write_text` methods
