### PR TITLE
[MAINT] remove dependency on matplotlib to filter packages to be tested

### DIFF
--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -15,6 +15,8 @@ def _set_mpl_backend():
     If installed, check if the installed version complies with the minimum
     supported matplotlib version. If it does not, raise error; otherwise set
     the matplotlib backend.
+
+    If current backend is not usable, switch to default "Agg" backend.
     """
     # We are doing local imports here to avoid polluting our namespace
     try:

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -7,6 +7,15 @@ OPTIONAL_MATPLOTLIB_MIN_VERSION = "3.3.0"
 
 
 def _set_mpl_backend():
+    """Check if matplotlib is installed.
+
+    If not installed, raise error and display warning to install necessary
+    dependencies.
+
+    If installed, check if the installed version complies with the minimum
+    supported matplotlib version. If it does not, raise error; otherwise set
+    the matplotlib backend.
+    """
     # We are doing local imports here to avoid polluting our namespace
     try:
         import matplotlib

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -3,6 +3,47 @@ import operator
 import os
 import warnings
 
+OPTIONAL_MATPLOTLIB_MIN_VERSION = "3.3.0"
+
+
+def _set_mpl_backend():
+    # We are doing local imports here to avoid polluting our namespace
+    try:
+        import matplotlib
+    except ImportError:
+        warnings.warn(
+            "Some dependencies of nilearn.plotting package seem to be missing."
+            "\nThey can be installed with:\n"
+            " pip install 'nilearn[plotting]'"
+        )
+        raise
+    else:
+        # When matplotlib was successfully imported we need to check
+        # that the version is greater that the minimum required one
+        mpl_version = getattr(matplotlib, "__version__", "0.0.0")
+        if not compare_version(
+            mpl_version, ">=", OPTIONAL_MATPLOTLIB_MIN_VERSION
+        ):
+            raise ImportError(
+                f"A matplotlib version of at least "
+                f"{OPTIONAL_MATPLOTLIB_MIN_VERSION} "
+                f"is required to use nilearn. {mpl_version} was found. "
+                f"Please upgrade matplotlib."
+            )
+        current_backend = matplotlib.get_backend().lower()
+
+        try:
+            # Making sure the current backend is usable by matplotlib
+            matplotlib.use(current_backend)
+        except Exception:
+            # If not, switching to default agg backend
+            matplotlib.use("Agg")
+        new_backend = matplotlib.get_backend().lower()
+
+        if new_backend != current_backend:
+            # Matplotlib backend has been changed, let's warn the user
+            warnings.warn(f"Backend changed to {new_backend}...")
+
 
 def rename_parameters(
     replacement_params,

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -172,7 +172,8 @@ def write_imgs_to_path(*imgs, file_path=None, **kwargs):
 
 def are_tests_running():
     """Return whether we are running the pytest test loader."""
-    return "PYTEST_CURRENT_TEST" in os.environ
+    # https://docs.pytest.org/en/stable/example/simple.html#detect-if-running-from-within-a-pytest-run
+    return os.environ.get("PYTEST_VERSION") is not None
 
 
 def skip_if_running_tests(msg=""):
@@ -185,4 +186,4 @@ def skip_if_running_tests(msg=""):
 
     """
     if are_tests_running():
-        pytest.skip(msg)
+        pytest.skip(msg, allow_module_level=True)

--- a/nilearn/_utils/tests/test_common.py
+++ b/nilearn/_utils/tests/test_common.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from nilearn._utils import all_classes, all_functions, all_modules
+from nilearn._utils.helpers import is_matplotlib_installed
 
 
 @pytest.mark.parametrize("func", [all_modules, all_functions, all_classes])
@@ -17,6 +18,10 @@ def test_all_modules_error(func):
         func(modules_to_ignore=["foo"], modules_to_consider=["bar"])
 
 
+@pytest.mark.skipif(
+    not is_matplotlib_installed(),
+    reason="This test requires matplotlib to be installed.",
+)
 @pytest.mark.parametrize("func", [all_functions, all_classes])
 def test_private_vs_public(func):
     public_only = set(func(return_private=False))
@@ -27,6 +32,10 @@ def test_private_vs_public(func):
     )
 
 
+@pytest.mark.skipif(
+    not is_matplotlib_installed(),
+    reason="This test requires matplotlib to be installed.",
+)
 def test_number_public_functions():
     """Check that number of public functions is stable.
 
@@ -37,6 +46,10 @@ def test_number_public_functions():
     assert len({_[0] for _ in all_functions()}) == 246
 
 
+@pytest.mark.skipif(
+    not is_matplotlib_installed(),
+    reason="This test requires matplotlib to be installed.",
+)
 def test_number_public_classes():
     """Check that number of public classes is stable.
 

--- a/nilearn/interfaces/tests/test_bids.py
+++ b/nilearn/interfaces/tests/test_bids.py
@@ -12,6 +12,7 @@ from nilearn._utils.data_gen import (
     create_fake_bids_dataset,
     generate_fake_fmri_data_and_design,
 )
+from nilearn._utils.helpers import is_matplotlib_installed
 from nilearn.glm.first_level import FirstLevelModel
 from nilearn.glm.second_level import SecondLevelModel
 from nilearn.interfaces.bids import (
@@ -307,6 +308,10 @@ def test_parse_bids_filename():
     assert file_dict["file_fields"] == fields
 
 
+@pytest.mark.skipif(
+    not is_matplotlib_installed(),
+    reason="This test requires matplotlib to be installed.",
+)
 @pytest.mark.parametrize(
     "prefix", ["sub-01_ses-01_task-nback", "sub-01_task-nback", "task-nback"]
 )
@@ -370,6 +375,10 @@ def test_save_glm_to_bids(tmp_path_factory, prefix):
         assert (tmpdir / sub_prefix / f"{prefix}_{fname}").exists()
 
 
+@pytest.mark.skipif(
+    not is_matplotlib_installed(),
+    reason="This test requires matplotlib to be installed.",
+)
 def test_save_glm_to_bids_serialize_affine(tmp_path):
     """Test that affines are turned into a serializable type.
 
@@ -441,6 +450,10 @@ def two_runs_model(n_cols_design_matrix):
     )
 
 
+@pytest.mark.skipif(
+    not is_matplotlib_installed(),
+    reason="This test requires matplotlib to be installed.",
+)
 def test_save_glm_to_bids_errors(
     tmp_path_factory, two_runs_model, n_cols_design_matrix
 ):
@@ -485,6 +498,10 @@ def test_save_glm_to_bids_errors(
         )
 
 
+@pytest.mark.skipif(
+    not is_matplotlib_installed(),
+    reason="This test requires matplotlib to be installed.",
+)
 @pytest.mark.parametrize(
     "prefix", ["sub-01_ses-01_task-nback", "sub-01_task-nback_", 1]
 )
@@ -548,6 +565,10 @@ def test_save_glm_to_bids_contrast_definitions(
         assert (tmpdir / sub_prefix / f"{prefix}{fname}").exists()
 
 
+@pytest.mark.skipif(
+    not is_matplotlib_installed(),
+    reason="This test requires matplotlib to be installed.",
+)
 @pytest.mark.parametrize("prefix", ["task-nback"])
 def test_save_glm_to_bids_second_level(tmp_path_factory, prefix):
     """Test save_glm_to_bids on a SecondLevelModel.

--- a/nilearn/plotting/__init__.py
+++ b/nilearn/plotting/__init__.py
@@ -16,8 +16,8 @@ def _set_mpl_backend():
         import matplotlib
     except ImportError:
         warnings.warn(
-            "Some plotting dependencies of Nilearn seem to be missing.\n"
-            "They can be installed with:\n"
+            "Some dependencies of nilearn.plotting package seem to be missing."
+            "\nThey can be installed with:\n"
             " pip install 'nilearn[plotting]'"
         )
         raise

--- a/nilearn/plotting/__init__.py
+++ b/nilearn/plotting/__init__.py
@@ -1,7 +1,6 @@
 """Plotting code for nilearn."""
 
 # Original Authors: Chris Filo Gorgolewski, Gael Varoquaux
-import importlib
 import warnings
 
 OPTIONAL_MATPLOTLIB_MIN_VERSION = "3.3.0"
@@ -16,11 +15,6 @@ def _set_mpl_backend():
     try:
         import matplotlib
     except ImportError:
-        if importlib.util.find_spec("pytest") is not None:
-            from .._utils.testing import skip_if_running_tests
-
-            # No need to fail when running tests
-            skip_if_running_tests("matplotlib not installed")
         warnings.warn(
             "Some plotting dependencies of Nilearn seem to be missing.\n"
             "They can be installed with:\n"

--- a/nilearn/plotting/__init__.py
+++ b/nilearn/plotting/__init__.py
@@ -1,55 +1,7 @@
 """Plotting code for nilearn."""
 
 # Original Authors: Chris Filo Gorgolewski, Gael Varoquaux
-import warnings
-
-OPTIONAL_MATPLOTLIB_MIN_VERSION = "3.3.0"
-
-###############################################################################
-# Make sure that we don't get DISPLAY problems when running without X on
-# unices
-
-
-def _set_mpl_backend():
-    # We are doing local imports here to avoid polluting our namespace
-    try:
-        import matplotlib
-    except ImportError:
-        warnings.warn(
-            "Some dependencies of nilearn.plotting package seem to be missing."
-            "\nThey can be installed with:\n"
-            " pip install 'nilearn[plotting]'"
-        )
-        raise
-    else:
-        from .._utils import compare_version
-
-        # When matplotlib was successfully imported we need to check
-        # that the version is greater that the minimum required one
-        mpl_version = getattr(matplotlib, "__version__", "0.0.0")
-        if not compare_version(
-            mpl_version, ">=", OPTIONAL_MATPLOTLIB_MIN_VERSION
-        ):
-            raise ImportError(
-                f"A matplotlib version of at least "
-                f"{OPTIONAL_MATPLOTLIB_MIN_VERSION} "
-                f"is required to use nilearn. {mpl_version} was found. "
-                f"Please upgrade matplotlib."
-            )
-        current_backend = matplotlib.get_backend().lower()
-
-        try:
-            # Making sure the current backend is usable by matplotlib
-            matplotlib.use(current_backend)
-        except Exception:
-            # If not, switching to default agg backend
-            matplotlib.use("Agg")
-        new_backend = matplotlib.get_backend().lower()
-
-        if new_backend != current_backend:
-            # Matplotlib backend has been changed, let's warn the user
-            warnings.warn(f"Backend changed to {new_backend}...")
-
+from nilearn._utils.helpers import _set_mpl_backend
 
 _set_mpl_backend()
 

--- a/nilearn/plotting/tests/test_matplotlib_backend.py
+++ b/nilearn/plotting/tests/test_matplotlib_backend.py
@@ -3,13 +3,9 @@ from unittest.mock import patch
 
 import pytest
 
-from nilearn._utils.helpers import is_matplotlib_installed
 from nilearn.plotting import _set_mpl_backend
 
-SKIP_REASON = "Matplotlib not installed; required for this test"
 
-
-@pytest.mark.skipif(not is_matplotlib_installed(), reason=SKIP_REASON)
 @patch("matplotlib.use")
 @patch("matplotlib.get_backend", side_effect=["backend_1", "backend_2"])
 def test_should_raise_warning_if_backend_changes(*_):
@@ -19,7 +15,6 @@ def test_should_raise_warning_if_backend_changes(*_):
         _set_mpl_backend()
 
 
-@pytest.mark.skipif(not is_matplotlib_installed(), reason=SKIP_REASON)
 @patch("matplotlib.use")
 @patch("matplotlib.get_backend", side_effect=["backend_1", "backend_1"])
 def test_should_not_raise_warning_if_backend_is_not_changed(*_):
@@ -30,7 +25,6 @@ def test_should_not_raise_warning_if_backend_is_not_changed(*_):
         _set_mpl_backend()
 
 
-@pytest.mark.skipif(not is_matplotlib_installed(), reason=SKIP_REASON)
 @patch(
     "matplotlib.use", side_effect=[Exception("Failed to switch backend"), True]
 )
@@ -44,7 +38,6 @@ def test_should_switch_to_agg_backend_if_current_backend_fails(use_mock):
     use_mock.assert_called_with("Agg")
 
 
-@pytest.mark.skipif(not is_matplotlib_installed(), reason=SKIP_REASON)
 @patch("matplotlib.__version__", "0.0.0")
 def test_should_raise_import_error_for_version_check():
     with pytest.raises(ImportError, match="A matplotlib version of at least"):

--- a/nilearn/reporting/__init__.py
+++ b/nilearn/reporting/__init__.py
@@ -5,6 +5,11 @@ This module implements plotting functions useful to report analysis results.
 
 # Author: Martin Perez-Guevara, Elvis Dohmatob, 2017
 
+from nilearn._utils.helpers import _set_mpl_backend
+
+_set_mpl_backend()
+
+###############################################################################
 from nilearn.reporting.get_clusters_table import get_clusters_table
 from nilearn.reporting.glm_reporter import make_glm_report
 from nilearn.reporting.html_report import HTMLReport

--- a/nilearn/reporting/tests/test_glm_reporter.py
+++ b/nilearn/reporting/tests/test_glm_reporter.py
@@ -7,7 +7,6 @@ from nilearn._utils.data_gen import (
     basic_paradigm,
     write_fake_fmri_data_and_design,
 )
-from nilearn._utils.helpers import is_matplotlib_installed
 from nilearn.glm.first_level import FirstLevelModel
 from nilearn.glm.first_level.design_matrix import (
     make_first_level_design_matrix,
@@ -30,10 +29,6 @@ def flm(tmp_path):
     )
 
 
-@pytest.mark.skipif(
-    not is_matplotlib_installed(),
-    reason="Matplotlib not installed; required for this test",
-)
 @pytest.mark.parametrize("height_control", ["fpr", "fdr", "bonferroni", None])
 def test_flm_reporting(flm, height_control):
     """Smoke test for first level model reporting."""
@@ -55,10 +50,6 @@ def test_flm_reporting(flm, height_control):
     report_flm.get_iframe()
 
 
-@pytest.mark.skipif(
-    not is_matplotlib_installed(),
-    reason="Matplotlib not installed; required for this test",
-)
 def test_flm_reporting_method(flm):
     """Smoke test for the first level generate method."""
     contrast = np.eye(3)[1]
@@ -86,10 +77,6 @@ def slm(tmp_path):
     return model.fit(Y, design_matrix=X)
 
 
-@pytest.mark.skipif(
-    not is_matplotlib_installed(),
-    reason="Matplotlib not installed; required for this test",
-)
 @pytest.mark.parametrize("height_control", ["fpr", "fdr", "bonferroni", None])
 def test_slm_reporting_method(slm, height_control):
     """Smoke test for the second level reporting."""
@@ -101,10 +88,6 @@ def test_slm_reporting_method(slm, height_control):
     report_slm.get_iframe()
 
 
-@pytest.mark.skipif(
-    not is_matplotlib_installed(),
-    reason="Matplotlib not installed; required for this test",
-)
 def test_slm_reporting(slm):
     """Smoke test for the second level model generate method."""
     c1 = np.eye(len(slm.design_matrix_.columns))[0]
@@ -291,10 +274,6 @@ def test_plot_contrasts():
     )
 
 
-@pytest.mark.skipif(
-    not is_matplotlib_installed(),
-    reason="Matplotlib not installed; required for this test",
-)
 def test_masking_first_level_model(tmp_path):
     """Check that using NiftiMasker when instantiating FirstLevelModel \
        doesn't raise Error when calling generate_report().

--- a/nilearn/reporting/tests/test_reporting.py
+++ b/nilearn/reporting/tests/test_reporting.py
@@ -6,10 +6,10 @@ from nilearn._utils.helpers import is_matplotlib_installed
 from nilearn.image import get_data
 
 # Set backend to avoid DISPLAY problems
-from nilearn.reporting import get_clusters_table
 from nilearn.reporting.get_clusters_table import (
     _cluster_nearest_neighbor,
     _local_max,
+    get_clusters_table,
 )
 
 

--- a/nilearn/reporting/tests/test_reporting.py
+++ b/nilearn/reporting/tests/test_reporting.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 from nibabel import Nifti1Image
 
-from nilearn._utils.helpers import is_matplotlib_installed
 from nilearn.image import get_data
 
 # Set backend to avoid DISPLAY problems
@@ -18,10 +17,6 @@ def shape():
     return (9, 10, 11)
 
 
-@pytest.mark.skipif(
-    not is_matplotlib_installed(),
-    reason="Matplotlib not installed; required for this test",
-)
 def test_local_max_two_maxima(shape, affine_eye):
     """Basic test of nilearn.reporting._get_clusters_table._local_max()."""
     # Two maxima (one global, one local), 10 voxels apart.
@@ -39,10 +34,6 @@ def test_local_max_two_maxima(shape, affine_eye):
     assert np.array_equal(vals, np.array([6]))
 
 
-@pytest.mark.skipif(
-    not is_matplotlib_installed(),
-    reason="Matplotlib not installed; required for this test",
-)
 def test_local_max_two_global_maxima(shape, affine_eye):
     """Basic test of nilearn.reporting._get_clusters_table._local_max()."""
     # Two global (equal) maxima, 10 voxels apart.
@@ -60,10 +51,6 @@ def test_local_max_two_global_maxima(shape, affine_eye):
     assert np.array_equal(vals, np.array([5]))
 
 
-@pytest.mark.skipif(
-    not is_matplotlib_installed(),
-    reason="Matplotlib not installed; required for this test",
-)
 def test_local_max_donut(shape, affine_eye):
     """Basic test of nilearn.reporting._get_clusters_table._local_max()."""
     # A donut.

--- a/nilearn/reporting/tests/test_reporting.py
+++ b/nilearn/reporting/tests/test_reporting.py
@@ -6,7 +6,6 @@ from nilearn._utils.helpers import is_matplotlib_installed
 from nilearn.image import get_data
 
 # Set backend to avoid DISPLAY problems
-from nilearn.plotting import _set_mpl_backend  # noqa
 from nilearn.reporting import get_clusters_table
 from nilearn.reporting.get_clusters_table import (
     _cluster_nearest_neighbor,

--- a/nilearn/tests/test_package_import.py
+++ b/nilearn/tests/test_package_import.py
@@ -17,3 +17,13 @@ def test_should_raise_warning_if_matplotlib_not_installed():
         ),
     ):
         from nilearn.plotting import cm  # noqa
+
+    with (
+        pytest.raises(
+            ModuleNotFoundError, match="No module named 'matplotlib'"
+        ),
+        pytest.warns(
+            UserWarning, match="Some dependencies of nilearn.plotting"
+        ),
+    ):
+        from nilearn.reporting import make_glm_report  # noqa

--- a/nilearn/tests/test_package_import.py
+++ b/nilearn/tests/test_package_import.py
@@ -12,6 +12,8 @@ def test_should_raise_warning_if_matplotlib_not_installed():
         pytest.raises(
             ModuleNotFoundError, match="No module named 'matplotlib'"
         ),
-        pytest.warns(UserWarning, match="Some plotting dependencies"),
+        pytest.warns(
+            UserWarning, match="Some dependencies of nilearn.plotting"
+        ),
     ):
         from nilearn.plotting import cm  # noqa

--- a/nilearn/tests/test_package_import.py
+++ b/nilearn/tests/test_package_import.py
@@ -7,7 +7,7 @@ from nilearn._utils.helpers import is_matplotlib_installed
     is_matplotlib_installed(),
     reason="This test should run only if matplotlib is not installed.",
 )
-def test_should_raise_warning_if_matplotlib_not_installed():
+def test_import_plotting_should_raise_warning_if_matplotlib_not_installed():
     with (
         pytest.raises(
             ModuleNotFoundError, match="No module named 'matplotlib'"
@@ -18,6 +18,12 @@ def test_should_raise_warning_if_matplotlib_not_installed():
     ):
         from nilearn.plotting import cm  # noqa
 
+
+@pytest.mark.skipif(
+    is_matplotlib_installed(),
+    reason="This test should run only if matplotlib is not installed.",
+)
+def test_import_reporting_should_raise_warning_if_matplotlib_not_installed():
     with (
         pytest.raises(
             ModuleNotFoundError, match="No module named 'matplotlib'"

--- a/nilearn/tests/test_package_import.py
+++ b/nilearn/tests/test_package_import.py
@@ -1,0 +1,13 @@
+import pytest
+
+from nilearn._utils.helpers import is_matplotlib_installed
+from nilearn.plotting import _set_mpl_backend
+
+
+@pytest.mark.skipif(
+    is_matplotlib_installed(),
+    reason="This test should run only if matplotlib is not installed.",
+)
+def test_should_raise_warning_if_matplotlib_not_installed():
+    with pytest.warns(UserWarning, match="Some plotting dependencies"):
+        _set_mpl_backend()

--- a/nilearn/tests/test_package_import.py
+++ b/nilearn/tests/test_package_import.py
@@ -1,7 +1,6 @@
 import pytest
 
 from nilearn._utils.helpers import is_matplotlib_installed
-from nilearn.plotting import _set_mpl_backend
 
 
 @pytest.mark.skipif(
@@ -9,5 +8,10 @@ from nilearn.plotting import _set_mpl_backend
     reason="This test should run only if matplotlib is not installed.",
 )
 def test_should_raise_warning_if_matplotlib_not_installed():
-    with pytest.warns(UserWarning, match="Some plotting dependencies"):
-        _set_mpl_backend()
+    with (
+        pytest.raises(
+            ModuleNotFoundError, match="No module named 'matplotlib'"
+        ),
+        pytest.warns(UserWarning, match="Some plotting dependencies"),
+    ):
+        from nilearn.plotting import cm  # noqa


### PR DESCRIPTION
- Closes #4702.

- tests in `nilearn.plotting` and `nilearn.reporting` are still ignored by `conftest.py` 
- removed all `@pytest.mark.skipif(not is_matplotlib_installed(), ...` lines  from `nilearn.plotting` and `nilearn.reporting` tests, as these tests are already ignored by `conftest.py` (considering [your answer](https://github.com/nilearn/nilearn/issues/4702#issuecomment-2456859036) on reporting @Remi-Gau  to be able to work without matplotlib in the future, I am not sure about this part, and I can revert it. However for the moment I see these marks misleading)
- moved `_set_mpl_backend` to `nilearn._utils.helpers` so that it can be imported from any package
- added tests to see if the exception and warning are raised when matplotlib is not installed while importing from `nilearn.plotting` and `nilearn.reporting`