### PR TITLE
[FIX] GitHub workflow script injection

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -37,6 +37,7 @@ env:
     DISPLAY: :99.0
     NILEARN_DATA: /home/runner/work/nilearn/nilearn/nilearn_data
     MIN_PYTHON_VERSION: '3.9'
+    HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
 
 jobs:
 
@@ -303,5 +304,5 @@ jobs:
                 rm -Rf dev;
                 cp -a ~/doc/_build/html dev;
                 git add -A;
-                git commit -m "Dev docs https://github.com/nilearn/nilearn/commit/${{ github.event.head_commit.id }} : ${{ github.event.head_commit.message }}";
+                git commit -m "Dev docs https://github.com/nilearn/nilearn/commit/${{ github.event.head_commit.id }} : $HEAD_COMMIT_MESSAGE";
                 git push origin main;


### PR DESCRIPTION
Hi! I'm Joyce from Google's Open Source Security Team([GOSST](https://opensource.googleblog.com/2023/04/googles-open-source-security-upstream-team-one-year-later.html)) and I'm here to suggest this small fix to prevent from script injection attacks through the GitHub workflows.

Changes proposed in this pull request:

- parse `github.event.head_commit.message` to an envvar before using it to protect from script injection.

You can see further explanation about this kind of threat in this blogpost [Keeping your GitHub Actions and workflows secure Part 2: Untrusted input](https://securitylab.github.com/resources/github-actions-untrusted-input/).

Let me know if you have any questions! 
