### PR TITLE
[MAINT] Undefined name in `__all__`

### DIFF
--- a/nilearn/datasets/__init__.py
+++ b/nilearn/datasets/__init__.py
@@ -111,7 +111,6 @@ __all__ = [
     "fetch_neurovault_auditory_computation_task",
     "fetch_neurovault_ids",
     "fetch_neurovault_motor_task",
-    "fetch_openneuro_dataset_index",
     "fetch_openneuro_dataset",
     "fetch_spm_auditory",
     "fetch_spm_multimodal_fmri",


### PR DESCRIPTION
Deprecated function `fetch_openneuro_dataset_index` was removed in 6a7a807.

- See #3216 and #4517.