### PR TITLE
[STY] Use `callable` to check if an object is callable

### DIFF
--- a/nilearn/externals/tempita/_looper.py
+++ b/nilearn/externals/tempita/_looper.py
@@ -155,7 +155,7 @@ class loop_pos:
                 return getattr(item, getter)() != getattr(other, getter)()
             else:
                 return getattr(item, getter) != getattr(other, getter)
-        elif hasattr(getter, '__call__'):
+        elif callable(getter):
             return getter(item) != getter(other)
         else:
             return item[getter] != other[getter]


### PR DESCRIPTION
It is unreliable to use `hasattr(object, '__call__')` to check if an object is callable as it can give wrong results if `object` implements custom `__getattr__` or its `__call__` is itself not callable. Use the `callable` built-in instead.