### PR TITLE
[STY] Comparison with callable

### DIFF
--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -2694,14 +2694,17 @@ def fetch_neurovault(
     # Users may get confused if they write their image_filter function
     # and the default filters contained in image_terms still apply, so we
     # issue a warning.
-    if image_filter != _empty_filter and image_terms == basic_image_terms():
+    if (
+        image_filter is not _empty_filter
+        and image_terms == basic_image_terms()
+    ):
         warnings.warn(
             "You specified a value for `image_filter` but the "
             "default filters in `image_terms` still apply. "
             "If you want to disable them, pass `image_terms={}`"
         )
     if (
-        collection_filter != _empty_filter
+        collection_filter is not _empty_filter
         and collection_terms == basic_collection_terms()
     ):
         warnings.warn(

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -1040,7 +1040,7 @@ def test_warning_copy_header_false(request, func, input_img):
     # Use the request fixture to get the actual fixture value
     actual_input_img = request.getfixturevalue(input_img)
     with pytest.warns(FutureWarning, match="From release 0.13.0 onwards*"):
-        if func == threshold_img:
+        if func is threshold_img:
             func(actual_input_img, threshold=0.5, copy_header=False)
         else:
             func(actual_input_img, copy_header=False)

--- a/nilearn/plotting/tests/test_img_plotting/test_img_plotting.py
+++ b/nilearn/plotting/tests/test_img_plotting/test_img_plotting.py
@@ -123,14 +123,14 @@ def test_plot_threshold_for_uint8(affine_eye, plot_func):
     data = 10 * np.ones((10, 10, 10), dtype="uint8")
     # Having a zero minimum value is important to reproduce
     # https://github.com/nilearn/nilearn/issues/762
-    if plot_func == plot_stat_map:
+    if plot_func is plot_stat_map:
         data[0, 0, 0] = 0
     else:
         data[0, 0] = 0
     img = Nifti1Image(data, affine_eye)
     threshold = np.array(5, dtype="uint8")
     kwargs = {"threshold": threshold, "display_mode": "z"}
-    if plot_func == plot_stat_map:
+    if plot_func is plot_stat_map:
         kwargs["bg_img"] = None
         kwargs["cut_coords"] = [0]
     display = plot_func(img, colorbar=True, **kwargs)
@@ -174,7 +174,7 @@ def test_invalid_cut_coords_with_display_mode(
     expected_error_message,
 ):
     """Tests for invalid combinations of cut_coords and display_mode."""
-    if plot_func == plot_glass_brain and display_mode != "ortho":
+    if plot_func is plot_glass_brain and display_mode != "ortho":
         return
     with pytest.raises(ValueError, match=expected_error_message):
         plot_func(
@@ -204,7 +204,7 @@ def test_plotting_functions_with_cmaps(plot_func, cmap):
 def test_plotting_functions_with_nans_in_bg_img(plot_func, img_3d_mni):
     """Smoke test for plotting functions with nans in background image."""
     bg_img = _add_nans_to_img(img_3d_mni)
-    if plot_func == plot_anat:
+    if plot_func is plot_anat:
         plot_func(bg_img)
     else:
         plot_func(img_3d_mni, bg_img=bg_img)
@@ -214,7 +214,7 @@ def test_plotting_functions_with_nans_in_bg_img(plot_func, img_3d_mni):
 @pytest.mark.parametrize("plot_func", [plot_stat_map, plot_anat, plot_img])
 def test_plotting_functions_with_display_mode_tiled(plot_func, img_3d_mni):
     """Smoke test for plotting functions with tiled display mode."""
-    if plot_func == plot_anat:
+    if plot_func is plot_anat:
         plot_func(display_mode="tiled")
     else:
         plot_func(img_3d_mni, display_mode="tiled")


### PR DESCRIPTION
A comparison with a callable may suggest you have forgotten to actually call the function or method. If you intended to check if both of these callables are the same, it's recommended to use the `is` operator for comparison.