### PR TITLE
[MAINT] Special method should return `NotImplemented`

### DIFF
--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -85,7 +85,7 @@ class _SpecialValue:
     """
 
     def __eq__(self, other):
-        raise NotImplementedError("Use a derived class for _SpecialValue")
+        return NotImplemented
 
     def __req__(self, other):
         return self.__eq__(other)


### PR DESCRIPTION
From https://docs.python.org/3/library/constants.html#NotImplemented

> When a binary (or in-place) method returns `NotImplemented` the interpreter will try the reflected operation on the other type (or some other fallback, depending on the operator). If all attempts return `NotImplemented`, the interpreter will raise an appropriate exception.