### PR TITLE
[ENH] Allow SurfaceLabelsMasker to work with a list of Surface images

### DIFF
--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -373,18 +373,13 @@ class SurfaceLabelsMasker(TransformerMixin, CacheMixin, BaseEstimator):
         data = {}
         for part_name, labels_part in self.labels_img.data.parts.items():
             data[part_name] = np.zeros(
-                (1, labels_part.shape[1]),
+                (masked_img.shape[0], labels_part.shape[1]),
                 dtype=masked_img.dtype,
             )
             for label_idx, label in enumerate(self._labels_):
-                if masked_img.ndim == 1:
-                    data[part_name][..., labels_part == label] = masked_img[
-                        ..., label_idx
-                    ]
-                else:
-                    data[part_name][..., labels_part == label] = masked_img[
-                        label_idx
-                    ]
+                data[part_name][..., labels_part[0] == label] = masked_img[
+                    label_idx
+                ]
         return SurfaceImage(mesh=self.labels_img.mesh, data=data)
 
     def generate_report(self):

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -374,9 +374,14 @@ class SurfaceLabelsMasker(TransformerMixin, CacheMixin, BaseEstimator):
                 dtype=masked_img.dtype,
             )
             for label_idx, label in enumerate(self._labels_):
-                data[part_name][..., labels_part == label] = masked_img[
-                    ..., label_idx
-                ]
+                if masked_img.ndim == 1:
+                    data[part_name][..., labels_part == label] = masked_img[
+                        ..., label_idx
+                    ]
+                else:
+                    data[part_name][..., labels_part == label] = masked_img[
+                        label_idx
+                    ]
         return SurfaceImage(mesh=self.labels_img.mesh, data=data)
 
     def generate_report(self):

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -242,7 +242,9 @@ class SurfaceLabelsMasker(TransformerMixin, CacheMixin, BaseEstimator):
 
         Parameters
         ----------
-        img : :obj:`~nilearn.surface.SurfaceImage` object
+        img : :obj:`~nilearn.surface.SurfaceImage` object or \
+              :obj:`list` of :obj:`~nilearn.surface.SurfaceImage` or \
+              :obj:`tuple` of :obj:`~nilearn.surface.SurfaceImage`
             Mesh and data for both hemispheres.
 
         confounds : :class:`numpy.ndarray`, :obj:`str`,\
@@ -334,7 +336,9 @@ class SurfaceLabelsMasker(TransformerMixin, CacheMixin, BaseEstimator):
 
         Parameters
         ----------
-        img : :obj:`~nilearn.surface.SurfaceImage` object
+        img : :obj:`~nilearn.surface.SurfaceImage` object or \
+              :obj:`list` of :obj:`~nilearn.surface.SurfaceImage` or \
+              :obj:`tuple` of :obj:`~nilearn.surface.SurfaceImage`
             Mesh and data for both hemispheres.
 
         y : None

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -378,8 +378,8 @@ class SurfaceLabelsMasker(TransformerMixin, CacheMixin, BaseEstimator):
             )
             for label_idx, label in enumerate(self._labels_):
                 data[part_name][..., labels_part[0] == label] = masked_img[
-                    label_idx
-                ]
+                    :, label_idx
+                ].reshape(-1, 1)
         return SurfaceImage(mesh=self.labels_img.mesh, data=data)
 
     def generate_report(self):

--- a/nilearn/maskers/tests/test_surface_labels_masker.py
+++ b/nilearn/maskers/tests/test_surface_labels_masker.py
@@ -104,8 +104,8 @@ def test_surface_label_masker_transform(surf_label_img, surf_img):
     assert signal.shape == (n_timepoints, n_labels)
 
 
-def test_surface_label_masker_transform_check_output(surf_mesh, surf_img, rng):
-    """Check actual content of the transform.
+def test_surface_label_masker_check_output(surf_mesh, surf_img, rng):
+    """Check actual content of the transform and inverse_transform.
 
     - Use a label mask with more than one label.
     - Use data with known content and expected mean.
@@ -150,8 +150,7 @@ def test_surface_label_masker_transform_check_output(surf_mesh, surf_img, rng):
     surf_img = SurfaceImage(surf_mesh(), data)
     signal = masker.transform(surf_img)
 
-    n_labels = len(expected_mean_value)
-    assert signal.shape == (1, n_labels)
+    assert signal.shape == (surf_img.shape[0], masker.n_elements_)
 
     expected_signal = np.asarray(
         [
@@ -165,6 +164,64 @@ def test_surface_label_masker_transform_check_output(surf_mesh, surf_img, rng):
     )
 
     assert_array_equal(signal, expected_signal)
+
+    # also check the output of inverse_transform
+    img = masker.inverse_transform(signal)
+    assert img.shape == surf_img.shape
+    # expected inverse data is the same as the input data
+    # but with the random value replaced by zeros
+    expected_inverse_data = {
+        "left": np.asarray(
+            [
+                [
+                    expected_mean_value["2"],
+                    0.0,
+                    expected_mean_value["10"],
+                    expected_mean_value["1"],
+                ]
+            ]
+        ),
+        "right": np.asarray(
+            [
+                [
+                    expected_mean_value["10"],
+                    expected_mean_value["1"],
+                    expected_mean_value["20"],
+                    expected_mean_value["20"],
+                    0.0,
+                ]
+            ]
+        ),
+    }
+
+    assert_array_equal(img.data.parts["left"], expected_inverse_data["left"])
+    assert_array_equal(img.data.parts["right"], expected_inverse_data["right"])
+
+
+def test_surface_label_masker_check_output_with_timepoints(surf_mesh, rng):
+    """Check actual content of the transform and inverse_transform when
+    we have multiple timepoints.
+
+    - Use a label mask with more than one label.
+    - Use data with known content and expected mean.
+      and background label data has random value.
+    - Check that output data is properly averaged,
+      even when labels are spread across hemispheres.
+    """
+    labels = {
+        "left": np.asarray([2, 0, 10, 1]),
+        "right": np.asarray([10, 1, 20, 20, 0]),
+    }
+    surf_label_img = SurfaceImage(surf_mesh(), labels)
+    masker = SurfaceLabelsMasker(labels_img=surf_label_img)
+    masker = masker.fit()
+
+    expected_mean_value = {
+        "1": 5,
+        "2": 6,
+        "10": 50,
+        "20": 60,
+    }
 
     # Now with 2 'time points'
     data = {
@@ -204,20 +261,72 @@ def test_surface_label_masker_transform_check_output(surf_mesh, surf_img, rng):
         ),
     }
 
-    assert signal.shape == (1, n_labels)
+    surf_img = SurfaceImage(surf_mesh(), data)
+    signal = masker.transform(surf_img)
+
+    assert signal.shape == (surf_img.shape[0], masker.n_elements_)
 
     expected_signal = np.asarray(
         [
             [
-                expected_mean_value["1"],
-                expected_mean_value["2"],
-                expected_mean_value["10"],
-                expected_mean_value["20"],
-            ]
+                expected_mean_value["1"] - 1,
+                expected_mean_value["2"] - 1,
+                expected_mean_value["10"] - 1,
+                expected_mean_value["20"] - 1,
+            ],
+            [
+                expected_mean_value["1"] + 1,
+                expected_mean_value["2"] + 1,
+                expected_mean_value["10"] + 1,
+                expected_mean_value["20"] + 1,
+            ],
         ]
     )
-
     assert_array_equal(signal, expected_signal)
+
+    # also check the output of inverse_transform
+    img = masker.inverse_transform(signal)
+    assert img.shape == surf_img.shape
+    # expected inverse data is the same as the input data
+    # but with the random values replaced by zeros
+    expected_inverse_data = {
+        "left": np.asarray(
+            [
+                [
+                    expected_mean_value["2"] - 1,
+                    0.0,
+                    expected_mean_value["10"] - 1,
+                    expected_mean_value["1"] - 1,
+                ],
+                [
+                    expected_mean_value["2"] + 1,
+                    0.0,
+                    expected_mean_value["10"] + 1,
+                    expected_mean_value["1"] + 1,
+                ],
+            ]
+        ),
+        "right": np.asarray(
+            [
+                [
+                    expected_mean_value["10"] - 1,
+                    expected_mean_value["1"] - 1,
+                    expected_mean_value["20"] - 1,
+                    expected_mean_value["20"] - 1,
+                    0.0,
+                ],
+                [
+                    expected_mean_value["10"] + 1,
+                    expected_mean_value["1"] + 1,
+                    expected_mean_value["20"] + 1,
+                    expected_mean_value["20"] + 1,
+                    0.0,
+                ],
+            ]
+        ),
+    }
+    assert_array_equal(img.data.parts["left"], expected_inverse_data["left"])
+    assert_array_equal(img.data.parts["right"], expected_inverse_data["right"])
 
 
 def test_warning_smoothing(surf_img, surf_label_img):
@@ -262,7 +371,9 @@ def test_surface_label_masker_inverse_transform(surf_label_img, surf_img):
     assert img.shape == surf_img().shape
 
 
-def test_transform_list_surf_images(surf_label_img, surf_img):
+def test_surface_label_masker_transform_list_surf_images(
+    surf_label_img, surf_img
+):
     """Test transform on list of surface images."""
     masker = SurfaceLabelsMasker(surf_label_img).fit()
     signals = masker.transform([surf_img(), surf_img(), surf_img()])
@@ -271,12 +382,18 @@ def test_transform_list_surf_images(surf_label_img, surf_img):
     assert signals.shape == (9, masker.n_elements_)
 
 
-def test_inverse_transform_list_surf_images(surf_label_img, surf_img):
+def test_surface_label_masker_inverse_transform_list_surf_images(
+    surf_label_img, surf_img
+):
     """Test inverse_transform on list of surface images."""
     masker = SurfaceLabelsMasker(surf_label_img).fit()
     signals = masker.transform([surf_img((3,)), surf_img((4,))])
     img = masker.inverse_transform(signals)
     assert img.shape == (7, surf_label_img.mesh.n_vertices)
+
+
+def test_surface_label_masker_list_inverse_transform_output(surf_mesh):
+    """Test inverse_transform output is as expected."""
 
 
 @pytest.mark.skipif(

--- a/nilearn/maskers/tests/test_surface_labels_masker.py
+++ b/nilearn/maskers/tests/test_surface_labels_masker.py
@@ -258,7 +258,6 @@ def test_surface_label_masker_inverse_transform(surf_label_img, surf_img):
 
 def test_transform_list_surf_images(surf_label_img, surf_img):
     """Test transform on list of surface images."""
-    print()
     masker = SurfaceLabelsMasker(surf_label_img).fit()
     signals = masker.transform([surf_img(), surf_img(), surf_img()])
     assert signals.shape == (3, masker.n_elements_)

--- a/nilearn/maskers/tests/test_surface_labels_masker.py
+++ b/nilearn/maskers/tests/test_surface_labels_masker.py
@@ -256,6 +256,24 @@ def test_surface_label_masker_inverse_transform(surf_label_img, surf_img):
     masker.inverse_transform(signal)
 
 
+def test_transform_list_surf_images(surf_label_img, surf_img):
+    """Test transform on list of surface images."""
+    print()
+    masker = SurfaceLabelsMasker(surf_label_img).fit()
+    signals = masker.transform([surf_img(), surf_img(), surf_img()])
+    assert signals.shape == (3, masker.n_elements_)
+    signals = masker.transform([surf_img((5,)), surf_img((4,))])
+    assert signals.shape == (9, masker.n_elements_)
+
+
+def test_inverse_transform_list_surf_images(surf_label_img, surf_img):
+    """Test inverse_transform on list of surface images."""
+    masker = SurfaceLabelsMasker(surf_label_img).fit()
+    signals = masker.transform([surf_img((3,)), surf_img((4,))])
+    img = masker.inverse_transform(signals)
+    assert img.shape == (7, surf_label_img.mesh.n_vertices)
+
+
 @pytest.mark.skipif(
     is_matplotlib_installed(),
     reason="Test requires matplotlib not to be installed.",

--- a/nilearn/maskers/tests/test_surface_labels_masker.py
+++ b/nilearn/maskers/tests/test_surface_labels_masker.py
@@ -104,7 +104,7 @@ def test_surface_label_masker_transform(surf_label_img, surf_img):
     assert signal.shape == (n_timepoints, n_labels)
 
 
-def test_surface_label_masker_check_output(surf_mesh, surf_img, rng):
+def test_surface_label_masker_check_output(surf_mesh, rng):
     """Check actual content of the transform and inverse_transform.
 
     - Use a label mask with more than one label.

--- a/nilearn/maskers/tests/test_surface_labels_masker.py
+++ b/nilearn/maskers/tests/test_surface_labels_masker.py
@@ -238,7 +238,8 @@ def test_surface_label_masker_transform_clean(surf_label_img, surf_img):
 def test_surface_label_masker_fit_transform(surf_label_img, surf_img):
     """Smoke test for fit_transform."""
     masker = SurfaceLabelsMasker(labels_img=surf_label_img)
-    masker.fit_transform(surf_img())
+    signal = masker.fit_transform(surf_img())
+    assert signal.shape == (1, masker.n_elements_)
 
 
 def test_error_transform_before_fit(surf_label_img, surf_img):
@@ -253,7 +254,8 @@ def test_surface_label_masker_inverse_transform(surf_label_img, surf_img):
     masker = SurfaceLabelsMasker(labels_img=surf_label_img)
     masker = masker.fit()
     signal = masker.transform(surf_img())
-    masker.inverse_transform(signal)
+    img = masker.inverse_transform(signal)
+    assert img.shape == surf_img().shape
 
 
 def test_transform_list_surf_images(surf_label_img, surf_img):


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4762

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- use concatenation of a list of surface images and then do the masking
- allow inverse_transform method to work with 2D extracted region signals
