### PR TITLE
[DOC] fix doc string to remove warning in doc build

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -79,50 +79,46 @@ force:
 view: _build/html/index.html
 	$(BROWSER) _build/html/index.html
 
-html:	sym_links sym_links_datasets glm_reports
+no_jekyll:
+	touch $(BUILDDIR)/html/.nojekyll
+
+html: no_jekyll	sym_links sym_links_datasets glm_reports
 	# These two lines make the build a bit more lengthy, and the
 	# the embedding of images more robust
 	rm -rf $(BUILDDIR)/html/_images
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	touch $(BUILDDIR)/html/.nojekyll
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-html-strict:	sym_links sym_links_datasets glm_reports
+html-strict: no_jekyll sym_links sym_links_datasets glm_reports
 	# Build html documentation using a strict mode: Warnings are
 	# considered as errors.
 	make check
-	touch $(BUILDDIR)/html/.nojekyll
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-html-modified-examples-only: 	sym_links sym_links_datasets glm_reports
+html-modified-examples-only: sym_links sym_links_datasets glm_reports
 	BUILD_DEV_HTML=1 $(SPHINXBUILD) -W --keep-going -D sphinx_gallery_conf.filename_pattern=$(PATTERN) -D sphinx_gallery_conf.run_stale_examples=True -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	touch $(BUILDDIR)/html/.nojekyll
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-html-noplot: sym_links_datasets glm_reports
+html-noplot: no_jekyll sym_links_datasets glm_reports
 	BUILD_DEV_HTML=1 $(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	touch $(BUILDDIR)/html/.nojekyll
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 html-noplot-noreport: sym_links_datasets
 	BUILD_DEV_HTML=1 $(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	touch $(BUILDDIR)/html/.nojekyll
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 ci-html-noplot: sym_links_datasets glm_reports
 	BUILD_DEV_HTML=1 $(SPHINXBUILD) -W --keep-going -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	touch $(BUILDDIR)/html/.nojekyll
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-dirhtml:
+dirhtml: no_jekyll
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
-	touch $(BUILDDIR)/dirhtml .nojekyll
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -2261,8 +2261,10 @@ def fetch_language_localizer_demo_dataset(
     Parameters
     ----------
     %(data_dir)s
+
     %(verbose)s
-    legacy_output: bool, default=True
+
+    legacy_output : :obj:`bool`, default=True
 
         .. versionadded:: 0.10.3
         .. deprecated::0.10.3
@@ -2278,18 +2280,22 @@ def fetch_language_localizer_demo_dataset(
     data : :class:`sklearn.utils.Bunch`
         Dictionary-like object, the interest attributes are :
 
-        - 'data_dir': :obj:`str` Path to downloaded dataset.
-        - 'func': :obj:`list` of :obj:`str`,
-                  Absolute paths of downloaded files on disk
-        - 'description' : :obj:`str`, dataset description
+        - ``'data_dir'``: :obj:`str` Path to downloaded dataset.
 
-    Legacy output
-    -------------
-    data_dir : :obj:`str`
-        Path to downloaded dataset.
+        - ``'func'``: :obj:`list` of :obj:`str`,
+          Absolute paths of downloaded files on disk
 
-    downloaded_files : :obj:`list` of :obj:`str`
-        Absolute paths of downloaded files on disk
+        - ``'description'`` : :obj:`str`, dataset description
+
+    .. warning::
+
+        LEGACY OUTPUT:
+
+        **data_dir** : :obj:`str`
+            Path to downloaded dataset.
+
+        **downloaded_files** : :obj:`list` of :obj:`str`
+            Absolute paths of downloaded files on disk
 
     """
     url = "https://osf.io/3dj2a/download"


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- fixes warning in doc build:

```
 /home/runner/work/nilearn/nilearn/.tox/doc/lib/python3.9/site-packages/numpydoc/docscrape.py:421: UserWarning: Unknown section Legacy Output in the docstring of fetch_language_localizer_demo_dataset in /home/runner/work/nilearn/nilearn/.tox/doc/lib/python3.9/site-packages/nilearn/datasets/func.py.
```

- https://github.com/nilearn/nilearn/actions/runs/11972529499/job/33379897556?pr=4780#step:13:4592

### unrelated

- refactor makefile to create nojekyll file (only needed when deploying to github pages)
