### PR TITLE
[MAINT] allow possiblity to skip doc build or test in CI via specific commit message

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,14 +1,5 @@
 # GitHub Actions Specification
 
-## Skip CI
-
-You can decide to skip CI at any time by including the tag "[skip ci]" in your commit message.
-For more information, see: https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
-
-```bash
-$ git commit -m "[skip ci] commit message"
-```
-
 ## Automatically assign issue
 
 ### assign.yml

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -6,6 +6,8 @@
 #  Full builds are always run on "main".
 #  This is done every time there is a push on "main" and every week.
 #
+#  Most of this workflow is skipped if "[skip doc]" is in the commit message.
+#
 #  Data is cached after the get_data job to be passed to the build_docs job.
 #  Data can be cached and restore across attempts of a run of this workflow.
 #  Data can be cached and restored across run of this workflow.

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -56,10 +56,27 @@ jobs:
             with:
                 args: --validate
 
+    check_skip_flags:
+        name: Check skip flags
+        runs-on: ubuntu-latest
+        steps:
+        -   name: Get repo
+            uses: actions/checkout@v3
+            with:
+                ref: ${{ github.event.pull_request.head.sha }}
+        -   name: Check head git commit message
+            run: |
+                headCommitMsg=$(git show -s --format=%s)
+                if [[ $headCommitMsg == *"[skip doc]"* ]]; then
+                    echo "skipping tests"
+                    exit 1
+                fi
+
     get_data:
         # This prevents this workflow from running on a fork.
         # To test this workflow on a fork, uncomment the following line.
         if: github.repository == 'nilearn/nilearn'
+        needs: [check_skip_flags]
         runs-on: ubuntu-latest
         defaults:
             run:

--- a/.github/workflows/test_with_tox.yml
+++ b/.github/workflows/test_with_tox.yml
@@ -18,8 +18,24 @@ env:
     FORCE_COLOR: true
 
 jobs:
+
+    check_skip_flags:
+        name: Check skip flags
+        runs-on: ubuntu-latest
+        outputs:
+            head-commit-message: ${{ steps.get_head_commit_message.outputs.headCommitMsg }}
+        steps:
+        -   name: Get repo
+            uses: actions/checkout@v3
+            with:
+                ref: ${{ github.event.pull_request.head.sha }}
+        -   name: Print head git commit message
+            id: get_head_commit_message
+            run: echo "::set-output name=headCommitMsg::$(git show -s --format=%s)"
+
     test_and_coverage:
-        if: github.repository == 'nilearn/nilearn' && ${{ github.event.head_commit.message }}
+        needs: check_skip_flags
+        if: github.repository == 'nilearn/nilearn'
         name: 'Test with ${{ matrix.py }} on ${{ matrix.os }}: ${{ matrix.description }}'
         runs-on: ${{ matrix.os }}
         strategy:
@@ -43,10 +59,6 @@ jobs:
                     os: ubuntu-latest
                     env: test_plot_min
         steps:
-        -   name: Dump job context
-            env:
-                GITHUB_CONTEXT: ${{ toJson(github) }}
-            run: echo "$GITHUB_CONTEXT"
         -   uses: actions/checkout@v4
         -   name: Setup python
             uses: actions/setup-python@v5

--- a/.github/workflows/test_with_tox.yml
+++ b/.github/workflows/test_with_tox.yml
@@ -45,8 +45,8 @@ jobs:
         steps:
         -   name: Dump job context
             env:
-                JOB_CONTEXT: ${{ toJson(job) }}
-            run: echo "$JOB_CONTEXT"
+                GITHUB_CONTEXT: ${{ toJson(github) }}
+            run: echo "$GITHUB_CONTEXT"
         -   uses: actions/checkout@v4
         -   name: Setup python
             uses: actions/setup-python@v5

--- a/.github/workflows/test_with_tox.yml
+++ b/.github/workflows/test_with_tox.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
     test_and_coverage:
-        if: github.repository == 'nilearn/nilearn'
+        if: github.repository == 'nilearn/nilearn' && ${{ github.event.head_commit.message }}
         name: 'Test with ${{ matrix.py }} on ${{ matrix.os }}: ${{ matrix.description }}'
         runs-on: ${{ matrix.os }}
         strategy:
@@ -43,6 +43,10 @@ jobs:
                     os: ubuntu-latest
                     env: test_plot_min
         steps:
+        -   name: Dump job context
+            env:
+                JOB_CONTEXT: ${{ toJson(job) }}
+            run: echo "$JOB_CONTEXT"
         -   uses: actions/checkout@v4
         -   name: Setup python
             uses: actions/setup-python@v5

--- a/.github/workflows/test_with_tox.yml
+++ b/.github/workflows/test_with_tox.yml
@@ -1,4 +1,6 @@
 ---
+#
+#  Most of this workflow is skipped if "[skip test]" is in the commit message.
 name: test
 
 on:

--- a/.github/workflows/test_with_tox.yml
+++ b/.github/workflows/test_with_tox.yml
@@ -22,15 +22,12 @@ jobs:
     check_skip_flags:
         name: Check skip flags
         runs-on: ubuntu-latest
-        outputs:
-            head-commit-message: ${{ steps.get_head_commit_message.outputs.headCommitMsg }}
         steps:
         -   name: Get repo
             uses: actions/checkout@v3
             with:
                 ref: ${{ github.event.pull_request.head.sha }}
-        -   name: Print head git commit message
-            id: get_head_commit_message
+        -   name: Check head git commit message
             run: |
                 headCommitMsg=$(git show -s --format=%s)
                 if [[ $headCommitMsg == *"[skip test]"* ]]; then

--- a/.github/workflows/test_with_tox.yml
+++ b/.github/workflows/test_with_tox.yml
@@ -31,7 +31,12 @@ jobs:
                 ref: ${{ github.event.pull_request.head.sha }}
         -   name: Print head git commit message
             id: get_head_commit_message
-            run: echo "::set-output name=headCommitMsg::$(git show -s --format=%s)"
+            run: |
+                headCommitMsg=$(git show -s --format=%s)
+                if [[ $headCommitMsg == *"[skip test]"* ]]; then
+                    echo "skipping tests"
+                    exit 1
+                fi
 
     test_and_coverage:
         needs: check_skip_flags

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -619,6 +619,24 @@ learn how to use those tools to build documentation.
 
 .. _git_repo:
 
+
+Continuous integration
+----------------------
+
+Please note that if one of the following markers appear in the latest commit message, the following actions are taken.
+
+============================ ===================
+Commit Message Marker        Action Taken by CI
+============================ ===================
+[skip ci]                    Gtihub CI is skipped completely. Several other options are also possible, see `github documentation <https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs>`_).
+[skip test]                  Skip running the tests.
+[skip doc]                   Skip building the doc.
+[test nightly]               Run tests on the nightly build of Nilearn's dependencies.
+[full doc]                   Run a full build of the documentation (meaning that all examples will be run).
+[example] name_of_example.py Run partial documentation build but will run the requested example.
+[force download]             Force a download of all the dataset required for the build of the documentation.
+============================ ===================
+
 Setting up your environment
 ===========================
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes https://github.com/nilearn/nilearn/issues/4669

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- add jobs in doc and test CI workflows to skip doc or test workflows in CI by adding
 `[skip doc]` and respectively `[skip test]`

