### PR TITLE
[DOC] Fix rendering of attributes

### DIFF
--- a/examples/04_glm_first_level/plot_hrf.py
+++ b/examples/04_glm_first_level/plot_hrf.py
@@ -63,16 +63,17 @@ def mion_response_function(t_r, oversampling=16, onset=0.0):
 
     Parameters
     ----------
-    t_r: float
+    t_r : float
         scan repeat time, in seconds
-    oversampling: int, optional
+    oversampling : int, optional
         temporal oversampling factor
-    onset: float, optional
+    onset : float, optional
         hrf onset time, in seconds
 
     Returns
     -------
-    response_function: array of shape(length / t_r * oversampling, dtype=float)
+    response_function :
+        array of shape(length / t_r * oversampling, dtype=float)
         response_function sampling on the oversampled time grid
     """
     dt = t_r / oversampling
@@ -97,14 +98,14 @@ def mion_time_derivative(t_r, oversampling=16.0):
 
     Parameters
     ----------
-    t_r: float
+    t_r : float
         scan repeat time, in seconds
-    oversampling: int, optional
+    oversampling : int, optional
         temporal oversampling factor, optional
 
     Returns
     -------
-    drf: array of shape(time_length / t_r * oversampling, dtype=float)
+    drf : array of shape(time_length / t_r * oversampling, dtype=float)
         derived_response_function sampling on the provided grid
     """
     do = 0.1

--- a/nilearn/_utils/helpers.py
+++ b/nilearn/_utils/helpers.py
@@ -233,8 +233,10 @@ VERSION_OPERATORS = {
 def compare_version(version_a, operator, version_b):
     """Compare two version strings via a user-specified operator.
 
-    Note: This function is inspired from MNE-Python.
-    See https://github.com/mne-tools/mne-python/blob/main/mne/fixes.py
+    .. note::
+
+        This function is inspired from MNE-Python.
+        See https://github.com/mne-tools/mne-python/blob/main/mne/fixes.py
 
     Parameters
     ----------

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -33,19 +33,19 @@ def safe_get_data(img, ensure_finite=False, copy_data=False):
 
     Parameters
     ----------
-    img: Nifti image/object
+    img : Nifti image/object
         Image to get data.
 
-    ensure_finite: bool
+    ensure_finite : bool
         If True, non-finite values such as (NaNs and infs) found in the
         image will be replaced by zeros.
 
-    copy_data: bool, default=False
+    copy_data : bool, default=False
         If true, the returned data is a copy of the img data.
 
     Returns
     -------
-    data: numpy array
+    data : numpy array
         nilearn.image.get_data return from Nifti image.
     """
     if copy_data:
@@ -74,10 +74,10 @@ def _get_target_dtype(dtype, target_dtype):
 
     Parameters
     ----------
-    dtype: dtype
+    dtype : dtype
         Data type of the original data
 
-    target_dtype: {None, dtype, "auto"}
+    target_dtype : {None, dtype, "auto"}
         If None, no conversion is required. If a type is provided, the
         function will check if a conversion is needed. The "auto" mode will
         automatically convert to int32 if dtype is discrete and float32 if it
@@ -85,7 +85,7 @@ def _get_target_dtype(dtype, target_dtype):
 
     Returns
     -------
-    dtype: dtype
+    dtype : dtype
         The data type toward which the original data should be converted.
     """
     if target_dtype is None:
@@ -102,18 +102,18 @@ def load_niimg(niimg, dtype=None):
 
     Parameters
     ----------
-    niimg: Niimg-like object
+    niimg : Niimg-like object
         See :ref:`extracting_data`.
         Image to load.
 
-    dtype: {dtype, "auto"}
+    dtype : {dtype, "auto"}
         Data type toward which the data should be converted. If "auto", the
         data will be converted to int32 if dtype is discrete and float32 if it
         is continuous.
 
     Returns
     -------
-    img: image
+    img : image
         A loaded image object.
     """
     from ..image import new_img_like  # avoid circular imports
@@ -154,13 +154,13 @@ def is_binary_niimg(niimg):
 
     Parameters
     ----------
-    niimg: Niimg-like object
+    niimg : Niimg-like object
         See :ref:`extracting_data`.
         Image to test.
 
     Returns
     -------
-    is_binary: Boolean
+    is_binary : Boolean
         True if binary, False otherwise.
 
     """
@@ -177,17 +177,17 @@ def _repr_niimgs(niimgs, shorten=True):
 
     Parameters
     ----------
-    niimgs: image or collection of images
+    niimgs : image or collection of images
         nibabel SpatialImage to repr.
 
-    shorten: boolean, default=True
+    shorten : boolean, default=True
         If True, filenames with more than 20 characters will be
         truncated, and lists of more than 3 file names will be
         printed with only first and last element.
 
     Returns
     -------
-    repr: str
+    repr : str
         String representation of the image.
     """
     # Maximum number of elements to be displayed

--- a/nilearn/_utils/numpy_conversions.py
+++ b/nilearn/_utils/numpy_conversions.py
@@ -25,8 +25,31 @@ def as_ndarray(arr, copy=False, dtype=None, order="K"):
     Caveat: this function does not copy during bool to/from 1-byte dtype
     conversions. This can lead to some surprising results in some rare cases.
 
-    Example:
+    Parameters
+    ----------
+    arr : array-like
+        input array. Any value accepted by numpy.asarray is valid.
 
+    copy : bool
+        if True, force a copy of the array. Always True when arr is a memmap.
+
+    dtype : any numpy dtype
+        dtype of the returned array. Performing copy and type conversion at the
+        same time can in some cases avoid an additional copy.
+
+    order : :obj:`str`, default='K'
+        gives the order of the returned array.
+        Valid values are: "C", "F", "A", "K", None.
+        See ndarray.copy() for more information.
+
+    Returns
+    -------
+    ret : numpy.ndarray
+        Numpy array containing the same data as arr, always of class
+        numpy.ndarray, and with no link to any underlying file.
+
+    Examples
+    --------
     >>> import numpy
     >>> a = numpy.asarray([0, 1, 2], dtype=numpy.int8)
     >>> b = as_ndarray(a, dtype=bool)
@@ -39,29 +62,6 @@ def as_ndarray(arr, copy=False, dtype=None, order="K"):
     The usually expected result for the last line would be array([0, 1, 1])
     because True evaluates to 1. Since there is no copy made here, the original
     array is recovered.
-
-    Parameters
-    ----------
-    arr: array-like
-        input array. Any value accepted by numpy.asarray is valid.
-
-    copy: bool
-        if True, force a copy of the array. Always True when arr is a memmap.
-
-    dtype: any numpy dtype
-        dtype of the returned array. Performing copy and type conversion at the
-        same time can in some cases avoid an additional copy.
-
-    order: :obj:`str`, default='K'
-        gives the order of the returned array.
-        Valid values are: "C", "F", "A", "K", None.
-        See ndarray.copy() for more information.
-
-    Returns
-    -------
-    ret: numpy.ndarray
-        Numpy array containing the same data as arr, always of class
-        numpy.ndarray, and with no link to any underlying file.
     """
     if order not in ("C", "F", "A", "K", None):
         raise ValueError(f"Invalid value for 'order': {order!s}")
@@ -99,20 +99,20 @@ def csv_to_array(csv_path, delimiters=" \t,;", **kwargs):
 
     Parameters
     ----------
-    csv_path: string or pathlib.Path
+    csv_path : string or pathlib.Path
         Path of the CSV file to load.
 
-    delimiters: string
+    delimiters : string
         Each character of the delimiters string is a potential delimiters for
         the CSV file.
 
-    kwargs: keyword arguments
+    kwargs : keyword arguments
         The additional keyword arguments are passed to numpy.genfromtxt when
         loading the CSV.
 
     Returns
     -------
-    array: numpy.ndarray
+    array : numpy.ndarray
         An array containing the data loaded from the CSV file.
     """
     try:

--- a/nilearn/_utils/param_validation.py
+++ b/nilearn/_utils/param_validation.py
@@ -151,7 +151,7 @@ def adjust_screening_percentile(
 
     Returns
     -------
-    screening_percentile: float in the interval [0, 100]
+    screening_percentile : float in the interval [0, 100]
         Percentile value for ANOVA univariate feature selection.
 
     """

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -175,12 +175,16 @@ def fetch_atlas_craddock_2012(
     Parameters
     ----------
     %(data_dir)s
+
     %(url)s
+
     %(resume)s
+
     %(verbose)s
-    homogeneity: :obj:`str`, optional
+
+    homogeneity : :obj:`str`, optional
         The choice of the homogeneity ('spatial' or 'temporal' or 'random')
-    grp_mean: :obj:`bool`, default=True
+    grp_mean : :obj:`bool`, default=True
         The choice of the :term:`parcellation` (with group_mean or without)
         Default=True.
 
@@ -190,20 +194,20 @@ def fetch_atlas_craddock_2012(
     data : :class:`sklearn.utils.Bunch`
         Dictionary-like object, keys are:
 
-            - 'scorr_mean': obj:`str`, path to nifti file containing the
-              group-mean :term:`parcellation`
-              when emphasizing spatial homogeneity.
-            - 'tcorr_mean': obj:`str`, path to nifti file containing the
-              group-mean parcellation when emphasizing temporal homogeneity.
-            - 'scorr_2level': obj:`str`, path to nifti file containing the
-              :term:`parcellation` obtained
-              when emphasizing spatial homogeneity.
-            - 'tcorr_2level': obj:`str`, path to nifti file containing the
-              :term:`parcellation` obtained
-              when emphasizing temporal homogeneity.
-            - 'random': obj:`str`, path to nifti file containing the
-              :term:`parcellation` obtained with random clustering.
-            - 'description': :obj:`str`, general description of the dataset.
+        - ``'scorr_mean'``: obj:`str`, path to nifti file containing
+            the group-mean :term:`parcellation`
+            when emphasizing spatial homogeneity.
+        - ``'tcorr_mean'``: obj:`str`, path to nifti file containing
+            the group-mean parcellation when emphasizing temporal homogeneity.
+        - ``'scorr_2level'``: obj:`str`, path to nifti file containing
+            the :term:`parcellation` obtained
+            when emphasizing spatial homogeneity.
+        - ``'tcorr_2level'``: obj:`str`, path to nifti file containing
+            the :term:`parcellation` obtained
+            when emphasizing temporal homogeneity.
+        - ``'random'``: obj:`str`, path to nifti file containing
+            the :term:`parcellation` obtained with random clustering.
+        - ``'description'``: :obj:`str`, general description of the dataset.
 
     Warns
     -----
@@ -963,16 +967,22 @@ def fetch_atlas_smith_2009(
     Parameters
     ----------
     %(data_dir)s
+
     %(url)s
+
     %(resume)s
+
     %(verbose)s
+
     mirror : :obj:`str`, default='origin'
         By default, the dataset is downloaded from the original website of the
         atlas. Specifying "nitrc" will force download from a mirror, with
         potentially higher bandwidth.
-    dimension: :obj:`int`, optional
+
+    dimension : :obj:`int`, optional
         Number of dimensions in the dictionary. Valid resolutions
         available are {10, 20, 70}.
+
     resting : :obj:`bool`, default=True
         Either to fetch the resting-:term:`fMRI` or BrainMap components
 
@@ -981,27 +991,27 @@ def fetch_atlas_smith_2009(
     data : :class:`sklearn.utils.Bunch`
         Dictionary-like object, contains:
 
-            - 'rsn20': :obj:`str`, path to nifti file containing the
-              20-dimensional :term:`ICA`, resting-:term:`fMRI` components.
-              The shape of the image is ``(91, 109, 91, 20)``.
-            - 'rsn10': :obj:`str`, path to nifti file containing the
-              10 well-matched maps from the 20 maps obtained as for 'rsn20',
-              as shown in :footcite:t:`Smith2009b`. The shape of the
-              image is ``(91, 109, 91, 10)``.
-            - 'bm20': :obj:`str`, path to nifti file containing the
-              20-dimensional :term:`ICA`, BrainMap components.
-              The shape of the image is ``(91, 109, 91, 20)``.
-            - 'bm10': :obj:`str`, path to nifti file containing the
-              10 well-matched maps from the 20 maps obtained as for 'bm20',
-              as shown in :footcite:t:`Smith2009b`. The shape of the
-              image is ``(91, 109, 91, 10)``.
-            - 'rsn70': :obj:`str`, path to nifti file containing the
-              70-dimensional :term:`ICA`, resting-:term:`fMRI` components.
-              The shape of the image is ``(91, 109, 91, 70)``.
-            - 'bm70': :obj:`str`, path to nifti file containing the
-              70-dimensional :term:`ICA`, BrainMap components.
-              The shape of the image is ``(91, 109, 91, 70)``.
-            - 'description': :obj:`str`, description of the atlas.
+        - ``'rsn20'``: :obj:`str`, path to nifti file containing
+            the 20-dimensional :term:`ICA`, resting-:term:`fMRI` components.
+            The shape of the image is ``(91, 109, 91, 20)``.
+        - ``'rsn10'``: :obj:`str`, path to nifti file containing
+            the 10 well-matched maps from the 20 maps obtained as for 'rsn20',
+            as shown in :footcite:t:`Smith2009b`.
+            The shape of the image is ``(91, 109, 91, 10)``.
+        - ``'bm20'``: :obj:`str`, path to nifti file containing
+            the 20-dimensional :term:`ICA`, BrainMap components.
+            The shape of the image is ``(91, 109, 91, 20)``.
+        - ``'bm10'``: :obj:`str`, path to nifti file containing
+            the 10 well-matched maps from the 20 maps obtained as for 'bm20',
+            as shown in :footcite:t:`Smith2009b`.
+            The shape of the image is ``(91, 109, 91, 10)``.
+        - ``'rsn70'``: :obj:`str`, path to nifti file containing
+            the 70-dimensional :term:`ICA`, resting-:term:`fMRI` components.
+            The shape of the image is ``(91, 109, 91, 70)``.
+        - ``'bm70'``: :obj:`str`, path to nifti file containing
+            the 70-dimensional :term:`ICA`, BrainMap components.
+            The shape of the image is ``(91, 109, 91, 70)``.
+        - ``'description'``: :obj:`str`, description of the atlas.
 
     Warns
     -----
@@ -1143,7 +1153,7 @@ def fetch_atlas_yeo_2011(data_dir=None, url=None, resume=True, verbose=1):
 
     Notes
     -----
-    Licence: unknown.
+    Licence : unknown.
 
     """
     if url is None:
@@ -1269,7 +1279,7 @@ def fetch_atlas_aal(
 
     Notes
     -----
-    Licence: unknown.
+    Licence : unknown.
 
     """
     versions = ["SPM5", "SPM8", "SPM12", "3v2"]
@@ -1378,15 +1388,22 @@ def fetch_atlas_basc_multiscale_2015(
     Parameters
     ----------
     %(data_dir)s
+
     %(url)s
+
     %(resume)s
+
     %(verbose)s
-    resolution: :ob:`int`, optional
-        Number of networks in the dictionary. Valid resolutions
-        available are {7, 12, 20, 36, 64, 122, 197, 325, 444}
+
+    resolution : :ob:`int`, optional
+        Number of networks in the dictionary.
+        Valid resolutions  available are
+        {7, 12, 20, 36, 64, 122, 197, 325, 444}
+
     version : {'sym', 'asym'}, default='sym'
-        Available versions are 'sym' or 'asym'. By default all scales of
-        brain parcellations of version 'sym' will be returned.
+        Available versions are 'sym' or 'asym'.
+        By default all scales of brain parcellations of version 'sym'
+        will be returned.
 
     Returns
     -------
@@ -1692,7 +1709,7 @@ def fetch_atlas_allen_2011(data_dir=None, url=None, resume=True, verbose=1):
 
     Notes
     -----
-    Licence: unknown
+    Licence : unknown
 
     See http://mialab.mrn.org/data/index.html for more information
     on this dataset.
@@ -2121,7 +2138,7 @@ def fetch_atlas_schaefer_2018(
     label names. For more details, see
     https://github.com/ThomasYeoLab/CBIG/blob/master/stable_projects/brain_parcellation/Schaefer2018_LocalGlobal/Parcellations/Updates/Update_20190916_README.md
 
-    Licence: MIT.
+    Licence : MIT.
 
     """  # noqa: E501
     valid_n_rois = list(range(100, 1100, 100))

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -2698,9 +2698,12 @@ def fetch_localizer_first_level(data_dir=None, verbose=1):
     -------
     data : :obj:`sklearn.utils.Bunch`
         Dictionary-like object, with the keys:
-        epi_img: the input 4D image
-        events: a csv file describing the paradigm
-        description: data description
+
+        - epi_img: the input 4D image
+
+        - events: a csv file describing the paradigm
+
+        - description: data description
 
     """
     url = "https://osf.io/2bqxn/download"

--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -1360,7 +1360,7 @@ def _json_from_file(file_name):
 
     Parameters
     ----------
-    file_name: str or pathlib.Path
+    file_name : str or pathlib.Path
     """
     with Path(file_name).open("rb") as dumped:
         loaded = json.loads(dumped.read().decode("utf-8"))
@@ -1372,8 +1372,9 @@ def _json_add_collection_dir(file_name, force=True):
 
     Parameters
     ----------
-    file_name: str or pathlib.Path
-    force: bool
+    file_name : str or pathlib.Path
+
+    force : bool
     """
     file_name = Path(file_name)
     loaded = _json_from_file(file_name)

--- a/nilearn/datasets/struct.py
+++ b/nilearn/datasets/struct.py
@@ -186,7 +186,7 @@ def load_mni152_template(resolution=None):
 
     Parameters
     ----------
-    resolution: int, default=1
+    resolution : :obj:`int`, default=1
         If resolution is different from 1, the template is re-sampled with the
         specified resolution.
 
@@ -250,7 +250,7 @@ def load_mni152_gm_template(resolution=None):
 
     Parameters
     ----------
-    resolution: int, default=1
+    resolution : :obj:`int`, default=1
         If resolution is different from 1, the template is re-sampled with the
         specified resolution.
 
@@ -306,7 +306,7 @@ def load_mni152_wm_template(resolution=None):
 
     Parameters
     ----------
-    resolution: int, default=1
+    resolution : :obj:`int`, default=1
         If resolution is different from 1, the template is re-sampled with the
         specified resolution.
 
@@ -360,7 +360,7 @@ def load_mni152_brain_mask(resolution=None, threshold=0.2):
 
     Parameters
     ----------
-    resolution: int, default=1
+    resolution : :obj:`int`, default=1
         If resolution is different from 1, the template loaded is first
         re-sampled with the specified resolution.
 
@@ -404,7 +404,7 @@ def load_mni152_gm_mask(resolution=None, threshold=0.2, n_iter=2):
 
     Parameters
     ----------
-    resolution: int, default=1
+    resolution : :obj:`int`, default=1
         If resolution is different from 1, the template loaded is first
         re-sampled with the specified resolution.
 
@@ -412,7 +412,7 @@ def load_mni152_gm_mask(resolution=None, threshold=0.2, n_iter=2):
         Values of the grey-matter MNI152 template above this threshold will be
         included.
 
-    n_iter: int, default=2
+    n_iter : :obj:`int`, default=2
         Number of repetitions of :term:`dilation<Dilation>`
         and :term:`erosion<Erosion>` steps performed in
         scipy.ndimage.binary_closing function.
@@ -457,7 +457,7 @@ def load_mni152_wm_mask(resolution=None, threshold=0.2, n_iter=2):
 
     Parameters
     ----------
-    resolution: int, default=1
+    resolution : :obj:`int`, default=1
         If resolution is different from 1, the template loaded is first
         re-sampled with the specified resolution.
 
@@ -465,7 +465,7 @@ def load_mni152_wm_mask(resolution=None, threshold=0.2, n_iter=2):
         Values of the white-matter MNI152 template above this threshold will be
         included.
 
-    n_iter: int, default=2
+    n_iter : :obj:`int`, default=2
         Number of repetitions of :term:`dilation<Dilation>`
         and :term:`erosion<Erosion>` steps performed in
         scipy.ndimage.binary_closing function.
@@ -513,12 +513,14 @@ def fetch_icbm152_brain_gm_mask(
     Parameters
     ----------
     %(data_dir)s
+
     threshold : float, default=0.2
         Values of the ICBM152 grey-matter template above this threshold will be
         included.
 
     %(resume)s
-    n_iter: int, default=2
+
+    n_iter : :obj:`int`, default=2
         Number of repetitions of :term:`dilation<Dilation>`
         and :term:`erosion<Erosion>` steps performed in
         scipy.ndimage.binary_closing function.
@@ -1126,7 +1128,7 @@ def load_fsaverage_data(
 
     Returns
     -------
-    img: SurfaceImage
+    img : :obj:`~nilearn.surface.SurfaceImage`
         SurfaceImage with the freesurfer mesh and data.
     """
     if mesh_type not in ALLOWED_MESH_TYPES:

--- a/nilearn/datasets/tests/test_neurovault.py
+++ b/nilearn/datasets/tests/test_neurovault.py
@@ -114,10 +114,10 @@ def _parse_query(query):
 def _neurovault_collections(parts, query):
     """Mock the Neurovault API behind the `/api/collections/` path.
 
-    parts: the parts of the URL path after "collections"
+    parts : the parts of the URL path after "collections"
      ie [], ["<somecollectionid>"], or ["<somecollectionid>", "images"]
 
-    query: the parsed query string, e.g. {"offset": "15", "limit": "5"}
+    query : the parsed query string, e.g. {"offset": "15", "limit": "5"}
 
     returns a dictionary of API results
 
@@ -136,7 +136,7 @@ def _neurovault_one_collection(parts):
     """Mock Neurovault API \
        behind the `/api/collections/<somecollectionid>` path.
 
-    parts: parts of the URL path after "collections",
+    parts : parts of the URL path after "collections",
       ie ["<somecollectionid>"] or ["<somecollectionid>", "images"]
 
     returns a dictionary of API results
@@ -162,10 +162,10 @@ def _neurovault_one_collection(parts):
 def _neurovault_images(parts, query):
     """Mock the Neurovault API behind the `/api/images/` path.
 
-    parts: parts of the URL path after "images",
+    parts : parts of the URL path after "images",
       ie [] or ["<someimageid>"]
 
-    query: the parsed query string, e.g. {"offset": "15", "limit": "5"}
+    query : the parsed query string, e.g. {"offset": "15", "limit": "5"}
 
     returns a dictionary of API results
 

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -86,22 +86,22 @@ def _check_param_grid(estimator, X, y, param_grid=None):
 
     Parameters
     ----------
-    estimator: str
+    estimator : str
         The estimator to choose among:
         %(classifier_options)s
         %(regressor_options)s
 
-    X: list of Niimg-like objects
+    X : list of Niimg-like objects
         See :ref:`extracting_data`.
         Data on which model is to be fitted. If this is a list,
         the affine is considered the same for all.
 
-    y: array or list of shape (n_samples)
+    y : array or list of shape (n_samples)
         The dependent variable (age, sex, IQ, yes/no, etc.).
         Target variable to predict. Must have exactly as many elements as
         3D images in niimg.
 
-    param_grid: dict of str to sequence, or sequence of such. Default None
+    param_grid : dict of str to sequence, or sequence of such. Default None
         The parameter grid to explore, as a dictionary mapping estimator
         parameters to sequences of allowed values.
 
@@ -116,7 +116,7 @@ def _check_param_grid(estimator, X, y, param_grid=None):
 
     Returns
     -------
-    param_grid: dict of str to sequence, or sequence of such. Sensible default
+    param_grid : dict of str to sequence, or sequence of such. Sensible default
     dict has size 1 for linear models.
 
     """
@@ -139,24 +139,24 @@ def _default_param_grid(estimator, X, y):
 
     Parameters
     ----------
-    estimator: str
+    estimator : str
         The estimator to choose among:
         %(classifier_options)s
         %(regressor_options)s
 
-    X: list of Niimg-like objects
+    X : list of Niimg-like objects
         See :ref:`extracting_data`.
         Data on which model is to be fitted. If this is a list,
         the affine is considered the same for all.
 
-    y: array or list of shape (n_samples)
+    y : array or list of shape (n_samples)
         The dependent variable (age, sex, IQ, yes/no, etc.).
         Target variable to predict. Must have exactly as many elements as
         3D images in niimg.
 
     Returns
     -------
-    param_grid: dict of str to sequence, or sequence of such. Sensible default
+    param_grid : dict of str to sequence, or sequence of such. Sensible default
     dict has size 1 for linear models.
     """
     param_grid = {}
@@ -468,13 +468,13 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
 
     Parameters
     ----------
-    estimator: str, default='svc'
+    estimator : str, default='svc'
         The estimator to use. For classification, choose among:
         %(classifier_options)s
         For regression, choose among:
         %(regressor_options)s
 
-    mask: filename, Nifti1Image, NiftiMasker, MultiNiftiMasker, or\
+    mask : filename, Nifti1Image, NiftiMasker, MultiNiftiMasker, or\
           SurfaceMasker, default=None
         Mask to be used on data. If an instance of masker is passed,
         then its mask and parameters will be used. If no mask is given, mask
@@ -483,11 +483,11 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
         or SurfaceMasker to check for default parameters. For use with
         SurfaceImage data, a SurfaceMasker instance must be passed.
 
-    cv: cross-validation generator or int, default=10
+    cv : cross-validation generator or int, default=10
         A cross-validation generator.
         See: https://scikit-learn.org/stable/modules/cross_validation.html
 
-    param_grid: dict of str to sequence, or sequence of such, default=None
+    param_grid : dict of str to sequence, or sequence of such, default=None
         The parameter grid to explore, as a dictionary mapping estimator
         parameters to sequences of allowed values.
 
@@ -500,7 +500,7 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
 
         For Dummy estimators, parameter grid defaults to empty dictionary.
 
-    clustering_percentile: int, float, in the [0, 100], default=100
+    clustering_percentile : int, float, in the [0, 100], default=100
         Percentile of features to keep after clustering. If it is lower
         than 100, a ReNA clustering is performed as a first step of fit
         to agglomerate similar features together. ReNA is typically efficient
@@ -508,7 +508,7 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
         :class:`nilearn.decoding.FREMClassifier` and
         :class:`nilearn.decoding.FREMRegressor`.
 
-    screening_percentile: int, float, \
+    screening_percentile : int, float, \
                           in the closed interval [0, 100], \
                           default=20
         The percentage of brain volume that will be kept with respect to a full
@@ -517,7 +517,7 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
         performed. A float according to a percentile of the highest
         scores. If None is passed, the percentile is set to 100.
 
-    scoring: str, callable or None,
+    scoring : str, callable or None,
              default=None
         The scoring strategy to use. See the scikit-learn documentation at
         https://scikit-learn.org/stable/modules/model_evaluation.html#the-scoring-parameter-defining-model-evaluation-rules
@@ -531,13 +531,21 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
 
         For classification, valid entries are: 'accuracy', 'f1', 'precision',
         'recall' or 'roc_auc'. Defaults to 'roc_auc'.
+
     %(smoothing_fwhm)s
+
     %(standardize)s
+
     %(target_affine)s
+
     %(target_shape)s
+
     %(low_pass)s
+
     %(high_pass)s
+
     %(t_r)s
+
     %(mask_strategy)s
 
         .. note::
@@ -550,9 +558,13 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
             :func:`nilearn.masking.compute_brain_mask`.
 
         Default is 'background'.
+
     %(memory)s
+
     %(memory_level)s
+
     %(n_jobs)s
+
     %(verbose0)s
 
     See Also
@@ -704,7 +716,7 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
         n_outputs_ : int
             Number of outputs (column-wise)
 
-        dummy_output_: ndarray, shape=(n_classes, 2) \
+        dummy_output_ : ndarray, shape=(n_classes, 2) \
                        or shape=(1, 1) for regression
             Contains dummy estimator attributes after class predictions
             using strategies of :class:`sklearn.dummy.DummyClassifier`
@@ -896,7 +908,7 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
 
         Returns
         -------
-        y_pred: :class:`numpy.ndarray`, shape (n_samples,)
+        y_pred : :class:`numpy.ndarray`, shape (n_samples,)
             Predicted class label per sample.
         """
         # for backwards compatibility - apply masker transform if X is

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -79,10 +79,10 @@ def _univariate_feature_screening(
     y : ndarray, shape (n_samples,)
         Response Vector.
 
-    mask: ndarray or booleans, shape (nx, ny, nz)
+    mask : ndarray or booleans, shape (nx, ny, nz)
         Mask defining brain Rois.
 
-    is_classif: bool
+    is_classif : bool
         Flag telling whether the learning task is classification or regression.
 
     screening_percentile : float in the closed interval [0., 100.]
@@ -93,7 +93,7 @@ def _univariate_feature_screening(
 
     Returns
     -------
-    X_: ndarray, shape (n_samples, n_features_)
+    X_ : ndarray, shape (n_samples, n_features_)
         Reduced design matrix with only columns corresponding to the voxels
         retained after screening.
 

--- a/nilearn/decoding/space_net_solvers.py
+++ b/nilearn/decoding/space_net_solvers.py
@@ -49,7 +49,7 @@ def _squared_loss_and_spatial_grad(X, y, w, mask, grad_weight):
     w : ndarray shape (n_features,)
         Unmasked, ravelized weights map.
 
-    grad_weight: float
+    grad_weight : float
         l1_ratio * alpha.
 
     Returns
@@ -82,7 +82,7 @@ def _squared_loss_and_spatial_grad_derivative(X, y, w, mask, grad_weight):
     w : ndarray shape (n_features,)
         Unmasked, ravelized weights map.
 
-    grad_weight: float
+    grad_weight : float
         l1_ratio * alpha
 
     Returns
@@ -116,7 +116,7 @@ def _graph_net_data_function(X, w, mask, grad_weight):
     w : ndarray shape (n_features,)
         Unmasked, ravelized weights map.
 
-    grad_weight: float
+    grad_weight : float
         l1_ratio * alpha.
 
     Returns
@@ -156,7 +156,7 @@ def _graph_net_adjoint_data_function(X, w, adjoint_mask, grad_weight):
     w : ndarray shape (n_features,)
         Unmasked, ravelized weights map.
 
-    grad_weight: float
+    grad_weight : float
         l1_ratio * alpha.
 
     Returns
@@ -436,7 +436,7 @@ def _tvl1_objective_from_gradient(gradient):
 
     Parameters
     ----------
-    gradient: ndarray, shape (4, nx, ny, nz)
+    gradient : ndarray, shape (4, nx, ny, nz)
        precomputed "gradient + id" array
 
     Returns
@@ -549,7 +549,7 @@ def tvl1_solver(
     objective : array of floats
         Objective function (fval) computed on every iteration.
 
-    solver_info: float
+    solver_info : float
         Solver information, for warm start.
 
     """

--- a/nilearn/glm/contrasts.py
+++ b/nilearn/glm/contrasts.py
@@ -500,7 +500,7 @@ def compute_fixed_effects(
         when ``None``,
         it is assumed that the degrees of freedom are 100 per input.
 
-    return_z_score: :obj:`bool`, default=False
+    return_z_score : :obj:`bool`, default=False
         Whether ``fixed_fx_z_score_img`` should be output or not.
 
     Returns

--- a/nilearn/glm/thresholding.py
+++ b/nilearn/glm/thresholding.py
@@ -59,7 +59,7 @@ def _true_positive_fraction(z_vals, hommel_value, alpha):
     z_vals : array,
         A set of z-variates from which the FDR is computed.
 
-    hommel_value: :obj:`int`
+    hommel_value : :obj:`int`
         The Hommel value, used in the computations.
 
     alpha : :obj:`float`

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1657,12 +1657,12 @@ def copy_img(img):
 
     Parameters
     ----------
-    img: image
+    img : image
         nibabel SpatialImage object to copy.
 
     Returns
     -------
-    img_copy: image
+    img_copy : image
         copy of input (data, affine and header)
     """
     if not isinstance(img, spatialimages.SpatialImage):

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -73,7 +73,7 @@ def from_matrix_vector(matrix, vector):
 
     Returns
     -------
-    xform: numpy.ndarray
+    xform : numpy.ndarray
         An (N+1, N+1) transform matrix.
 
     See Also
@@ -117,8 +117,10 @@ def coord_transform(x, y, z, affine):
     z : number or ndarray (same shape as input)
         The z coordinates in the output space.
 
-    Warning: The x, y and z have their output space (e.g. MNI) coordinate
-    ordering, not 3D numpy image ordering.
+    .. warning::
+
+        The x, y and z have their output space (e.g. MNI) coordinate ordering,
+        not 3D numpy image ordering.
 
     Examples
     --------
@@ -783,7 +785,7 @@ def resample_to_img(
 
     Returns
     -------
-    resampled: nibabel.Nifti1Image
+    resampled : nibabel.Nifti1Image
         input image, resampled to have respectively target image shape and
         affine as shape and affine.
 

--- a/nilearn/interfaces/fmriprep/load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_utils.py
@@ -488,7 +488,8 @@ class MissingConfoundError(Exception):
     Parameters
     ----------
     params : list of missing params, default=[]
-    keywords: list of missing keywords, default=[]
+
+    keywords : list of missing keywords, default=[]
     """
 
     def __init__(self, params=None, keywords=None):

--- a/nilearn/maskers/_utils.py
+++ b/nilearn/maskers/_utils.py
@@ -57,7 +57,7 @@ def compute_mean_surface_image(img):
 
     Parameters
     ----------
-    img: SurfaceImage
+    img : SurfaceImage
 
     Returns
     -------
@@ -78,13 +78,13 @@ def get_min_max_surface_image(img):
 
     Parameters
     ----------
-    img: SurfaceImage
+    img : SurfaceImage
 
     Returns
     -------
-    vmin: float
+    vmin : float
 
-    vmax: float
+    vmax : float
     """
     vmin = min(min(x.ravel()) for x in img.data.parts.values())
     vmax = max(max(x.ravel()) for x in img.data.parts.values())

--- a/nilearn/maskers/multi_nifti_labels_masker.py
+++ b/nilearn/maskers/multi_nifti_labels_masker.py
@@ -37,8 +37,10 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
 
     background_label : :obj:`int` or :obj:`float`, default=0
         Label used in labels_img to represent background.
-        Warning: This value must be consistent with label values and
-        image provided.
+
+        .. warning::
+
+            This value must be consistent with label values and image provided.
 
     mask_img : Niimg-like object, optional
         See :ref:`extracting_data`.

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -76,8 +76,10 @@ class NiftiLabelsMasker(BaseMasker):
 
     background_label : :obj:`int` or :obj:`float`, default=0
         Label used in labels_img to represent background.
-        Warning: This value must be consistent with label values and
-        image provided.
+
+        .. warning:::
+
+            This value must be consistent with label values and image provided.
 
     mask_img : Niimg-like object, optional
         See :ref:`extracting_data`.
@@ -307,11 +309,11 @@ class NiftiLabelsMasker(BaseMasker):
         ----------
         region_ids : :obj:`list` or numpy.array
 
-        tolerant: :obj:`bool`, default=True
+        tolerant : :obj:`bool`, default=True
                   If set to `True` this function will throw a warning,
                   and will throw an error otherwise.
 
-        resampling_done: :obj:`bool`, default=False
+        resampling_done : :obj:`bool`, default=False
                          Used to mention if this check is done
                          before or after the resampling has been done,
                          to adapt the message accordingly.

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -173,10 +173,10 @@ def _iter_signals_from_spheres(
         If a 3D niimg is provided, a singleton dimension will be added to
         the output to represent the single scan in the niimg.
 
-    radius: float
+    radius : float
         Indicates, in millimeters, the radius for the sphere around the seed.
 
-    allow_overlap: boolean
+    allow_overlap : boolean
         If False, an error is raised if the maps overlaps (ie at least two
         maps have a non-zero value for the same voxel).
 

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -57,7 +57,7 @@ def load_mask_img(mask_img, allow_empty=False):
     mask : :class:`numpy.ndarray`
         Boolean version of the mask.
 
-    mask_affine: None or (4,4) array-like
+    mask_affine : None or (4,4) array-like
         Affine of the mask.
     """
     mask_img = _utils.check_niimg_3d(mask_img)

--- a/nilearn/mass_univariate/tests/_testing.py
+++ b/nilearn/mass_univariate/tests/_testing.py
@@ -11,15 +11,15 @@ def get_tvalue_with_alternative_library(tested_vars, target_vars, covars=None):
 
     Parameters
     ----------
-    tested_vars: array-like, shape=(n_samples, n_regressors)
+    tested_vars : array-like, shape=(n_samples, n_regressors)
       Tested variates, the associated coefficient of which are to be tested
       independently with a t-test, resulting in as many t-values.
 
-    target_vars: array-like, shape=(n_samples, n_descriptors)
+    target_vars : array-like, shape=(n_samples, n_descriptors)
       Target variates, to be approximated with a linear combination of
       the tested variates and the confounding variates.
 
-    covars: array-like, shape=(n_samples, n_confounds)
+    covars : array-like, shape=(n_samples, n_confounds)
       Confounding variates, to be fitted but not to be tested
 
     Returns

--- a/nilearn/plotting/_utils.py
+++ b/nilearn/plotting/_utils.py
@@ -67,9 +67,9 @@ def check_surface_plotting_inputs(
 def _check_bg_map(bg_map, hemi):
     """Get the requested hemisphere if bg_map is a SurfaceImage.
 
-    bg_map: Any
+    bg_map : Any
 
-    hemi: str
+    hemi : str
 
     Returns
     -------

--- a/nilearn/plotting/displays/_slicers.py
+++ b/nilearn/plotting/displays/_slicers.py
@@ -278,7 +278,7 @@ class BaseSlicer:
                   values below the threshold (in absolute value) are
                   plotted as transparent.
 
-        cbar_tick_format: str, default="%%.2g" (scientific notation)
+        cbar_tick_format : str, default="%%.2g" (scientific notation)
             Controls how to format the tick labels of the colorbar.
             Ex: use "%%i" to display as integers.
 

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -100,7 +100,7 @@ def _prepare_colors_for_markers(marker_color, number_of_nodes):
 
     Returns
     -------
-    markers_colors: :obj:`list`
+    markers_colors : :obj:`list`
         List of `number_of_nodes` colors as hexadecimal values
     """
     if isinstance(marker_color, str) and marker_color == "auto":

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -168,7 +168,9 @@ def _bytes_io_to_base64(handle_io):
 
     Also closes the file.
 
-    Returns: data
+    Returns
+    -------
+    data
     """
     handle_io.seek(0)
     data = b64encode(handle_io.read()).decode("utf-8")
@@ -191,7 +193,15 @@ class StatMapView(HTMLDocument):  # noqa: D101
 def _mask_stat_map(stat_map_img, threshold=None):
     """Load a stat map and apply a threshold.
 
-    Returns: mask_img, stat_map_img, data, threshold
+    Returns
+    -------
+    mask_img
+
+    stat_map_img
+
+    data
+
+    threshold
     """
     # Load stat map
     stat_map_img = check_niimg_3d(stat_map_img, dtype="auto")
@@ -212,8 +222,15 @@ def _load_bg_img(stat_map_img, bg_img="MNI152", black_bg="auto", dim="auto"):
     """Load and resample bg_img in an isotropic resolution, \
     with a positive diagonal affine matrix.
 
-    Returns: bg_img, bg_min, bg_max, black_bg
+    Returns
+    -------
+    bg_img
 
+    bg_min
+
+    bg_max
+
+    black_bg
     """
     if bg_img is None or bg_img is False:
         if black_bg == "auto":
@@ -243,8 +260,11 @@ def _resample_stat_map(
 ):
     """Resample the stat map and mask to the background.
 
-    Returns: stat_map_img, mask_img
+    Returns
+    -------
+    stat_map_img
 
+    mask_img
     """
     stat_map_img = resample_to_img(
         stat_map_img,
@@ -281,8 +301,9 @@ def _json_view_params(
 ):
     """Create a dictionary with all the brainsprite parameters.
 
-    Returns: params
-
+    Returns
+    -------
+    params
     """
     # Set color parameters
     if black_bg:
@@ -329,8 +350,11 @@ def _json_view_params(
 def _json_view_size(params, width_view=600):
     """Define the size of the viewer.
 
-    Returns: width_view, height_view
+    Returns
+    -------
+    width_view
 
+    height_view
     """
     # slices_width = sagittal_width (y) + coronal_width (x) + axial_width (x)
     slices_width = params["nbSlice"]["Y"] + 2 * params["nbSlice"]["X"]
@@ -372,8 +396,9 @@ def _json_view_data(
 ):
     """Create a json-like viewer object, and populate with base64 data.
 
-    Returns: json_view
-
+    Returns
+    -------
+    json_view
     """
     # Initialise brainsprite data structure
     json_view = dict.fromkeys(
@@ -423,8 +448,9 @@ def _json_view_data(
 def _json_view_to_html(json_view, width_view=600):
     """Fill a brainsprite html template with relevant parameters and data.
 
-    Returns: html_view
-
+    Returns
+    -------
+    html_view
     """
     # Fix the size of the viewer
     width, height = _json_view_size(json_view["params"], width_view)

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -188,7 +188,7 @@ def _plot_img_with_bg(
     display_factory : function, default=get_slicer
         Takes a display_mode argument and return a display class.
 
-    kwargs:  extra keyword arguments, optional
+    kwargs :  extra keyword arguments, optional
         Extra keyword arguments passed
         to the display.add_overlay method (see below).
         Ultimately passed to `matplotlib.pyplot.imshow` via
@@ -357,33 +357,51 @@ def plot_img(
     Parameters
     ----------
     %(img)s
+
     %(cut_coords)s
+
     %(output_file)s
+
     %(display_mode)s
+
     %(figure)s
+
     %(axes)s
+
     %(title)s
+
     %(threshold)s
+
     %(annotate)s
+
     decimals : :obj:`int` or :obj:`bool`, default=False
         Number of decimal places on slice position annotation.
         If False (default),
         the slice position is integer without decimal point.
+
     %(draw_cross)s
+
     %(black_bg)s
         Default=False.
+
     %(colorbar)s
         Default=False.
-    cbar_tick_format: :obj:`str`, default="%%.2g" (scientific notation)
+
+    cbar_tick_format : :obj:`str`, default="%%.2g" (scientific notation)
         Controls how to format the tick labels of the colorbar.
         Ex: use "%%i" to display as integers.
+
     %(resampling_interpolation)s
         Default='continuous'.
+
     %(bg_img)s
         If nothing is specified, no background image is plotted.
         Default=None.
+
     %(vmin)s
+
     %(vmax)s
+
     %(radiological)s
 
     kwargs : extra keyword arguments, optional
@@ -604,31 +622,48 @@ def plot_anat(
         See :ref:`extracting_data`.
         The anatomical image to be used as a background. If None is
         given, nilearn tries to find a T1 template.
+
     %(cut_coords)s
+
     %(output_file)s
+
     %(display_mode)s
+
     %(figure)s
+
     %(axes)s
+
     %(title)s
+
     %(annotate)s
+
     %(threshold)s
+
     %(draw_cross)s
+
     %(black_bg)s
         Default='auto'.
+
     %(dim)s
         Default='auto'.
+
     %(cmap)s
         Default=`plt.cm.gray`.
+
     colorbar : :obj:`bool`, default=False
         If True, display a colorbar on the right of the plots.
-    cbar_tick_format: :obj:`str`, default="%%.2g" (scientific notation)
+
+    cbar_tick_format : :obj:`str`, default="%%.2g" (scientific notation)
         Controls how to format the tick labels of the colorbar.
         Ex: use "%%i" to display as integers.
+
     %(radiological)s
+
     %(vmin)s
+
     %(vmax)s
 
-    kwargs: extra keyword arguments, optional
+    kwargs : extra keyword arguments, optional
         Extra keyword arguments
         ultimately passed to `matplotlib.pyplot.imshow` via
         :meth:`~nilearn.plotting.displays.BaseSlicer.add_overlay`.
@@ -707,28 +742,43 @@ def plot_epi(
     ----------
     epi_img : a Niimg-like object or None, default=None
         The :term:`EPI` (T2*) image.
+
     %(cut_coords)s
+
     %(output_file)s
+
     %(display_mode)s
+
     %(figure)s
+
     %(axes)s
+
     %(title)s
+
     %(annotate)s
+
     %(draw_cross)s
+
     %(black_bg)s
         Default=True.
+
     colorbar : :obj:`bool`, default=False
         If True, display a colorbar on the right of the plots.
-    cbar_tick_format: :obj:`str`, default="%%.2g" (scientific notation)
+
+    cbar_tick_format : :obj:`str`, default="%%.2g" (scientific notation)
         Controls how to format the tick labels of the colorbar.
         Ex: use "%%i" to display as integers.
+
     %(cmap)s
         Default=`plt.cm.nipy_spectral`.
+
     %(vmin)s
+
     %(vmax)s
+
     %(radiological)s
 
-    kwargs: extra keyword arguments, optional
+    kwargs : extra keyword arguments, optional
         Extra keyword arguments
         ultimately passed to `matplotlib.pyplot.imshow` via
         :meth:`~nilearn.plotting.displays.BaseSlicer.add_overlay`.
@@ -742,7 +792,6 @@ def plot_epi(
     Notes
     -----
     Arrays should be passed in numpy convention: (x, y, z) ordered.
-
     """
     display = plot_img(
         epi_img,
@@ -856,49 +905,71 @@ def plot_roi(
         See :ref:`extracting_data`.
         The ROI/mask image, it could be binary mask or an atlas or ROIs
         with integer values.
+
     %(bg_img)s
         If nothing is specified, the MNI152 template will be used.
         To turn off background image, just pass "bg_img=None".
         Default=MNI152TEMPLATE.
+
     %(cut_coords)s
+
     %(output_file)s
+
     %(display_mode)s
+
     %(figure)s
+
     %(axes)s
+
     %(title)s
+
     %(annotate)s
+
     %(draw_cross)s
+
     %(black_bg)s
         Default='auto'.
+
     %(threshold)s
         Default=0.5.
+
     alpha : :obj:`float` between 0 and 1, default=0.7
         Alpha sets the transparency of the color inside the filled
         contours.
+
     %(cmap)s
         Default=`plt.cm.gist_ncar`.
+
     %(dim)s
         Default='auto'.
+
     colorbar : :obj:`bool`, default=False
         If True, display a colorbar on the right of the plots.
-    cbar_tick_format: :obj:`str`, default="%%i"
+
+    cbar_tick_format : :obj:`str`, default="%%i"
         Controls how to format the tick labels of the colorbar.
         Ex: use "%%.2g" to use scientific notation.
+
     %(vmin)s
+
     %(vmax)s
+
     %(resampling_interpolation)s
         Default='nearest'.
+
     view_type : {'continuous', 'contours'}, default='continuous'
         By default view_type == 'continuous',
         rois are shown as continuous colors.
         If view_type == 'contours', maps are shown as contours.
         For this type, label
         denoted as 0 is considered as background and not shown.
+
     %(linewidths)s
         Default=2.5.
+
     %(radiological)s
 
-    kwargs: extra keyword arguments, optional
+    kwargs : extra keyword arguments, optional
         Extra keyword arguments
         ultimately passed to `matplotlib.pyplot.imshow` via
         :meth:`~nilearn.plotting.displays.BaseSlicer.add_overlay`.
@@ -921,7 +992,6 @@ def plot_roi(
     --------
     nilearn.plotting.plot_prob_atlas : To simply plot probabilistic atlases
         (4D images)
-
     """
     valid_view_types = ["continuous", "contours"]
     if view_type not in valid_view_types:
@@ -1003,6 +1073,7 @@ def plot_prob_atlas(
     ----------
     maps_img : Niimg-like object or the filename
         4D image of the :term:`Probabilistic atlas` maps.
+
     %(bg_img)s
         If nothing is specified, the MNI152 template will be used.
         To turn off background image, just pass "bg_img=False".
@@ -1041,31 +1112,47 @@ def plot_prob_atlas(
         directly to threshold the maps without any percentile calculation.
         If None, a very small threshold is applied to remove numerical
         noise from the maps background.
+
     %(linewidths)s
         Default=2.5.
+
     %(cut_coords)s
+
     %(output_file)s
+
     %(display_mode)s
+
     %(figure)s
+
     %(axes)s
+
     %(title)s
+
     %(annotate)s
+
     %(draw_cross)s
+
     %(black_bg)s
         Default='auto'.
+
     %(dim)s
         Default='auto'.
+
     %(cmap)s
         Default=`plt.cm.gist_rainbow`.
+
     %(colorbar)s
         Default=False.
+
     %(vmin)s
+
     %(vmax)s
+
     alpha : :obj:`float` between 0 and 1, default=0.7
         Alpha sets the transparency of the color inside the filled contours.
     %(radiological)s
 
-    kwargs: extra keyword arguments, optional
+    kwargs : extra keyword arguments, optional
         Extra keyword arguments
         ultimately passed to `matplotlib.pyplot.imshow` via
         :meth:`~nilearn.plotting.displays.BaseSlicer.add_overlay`.
@@ -1079,7 +1166,6 @@ def plot_prob_atlas(
     See Also
     --------
     nilearn.plotting.plot_roi : To simply plot max-prob atlases (3D images)
-
     """
     display = plot_anat(
         bg_img,
@@ -1239,43 +1325,63 @@ def plot_stat_map(
     stat_map_img : Niimg-like object
         See :ref:`extracting_data`.
         The statistical map image
+
     %(bg_img)s
         If nothing is specified, the MNI152 template will be used.
         To turn off background image, just pass "bg_img=None".
         Default=MNI152TEMPLATE.
+
     %(cut_coords)s
+
     %(output_file)s
+
     %(display_mode)s
+
     %(colorbar)s
         Default=True.
-    cbar_tick_format: :obj:`str`, default="%%.2g" (scientific notation)
+
+    cbar_tick_format : :obj:`str`, default="%%.2g" (scientific notation)
         Controls how to format the tick labels of the colorbar.
         Ex: use "%%i" to display as integers.
+
     %(figure)s
+
     %(axes)s
+
     %(title)s
+
     %(threshold)s
         Default=1e-6.
+
     %(annotate)s
+
     %(draw_cross)s
+
     %(black_bg)s
         Default='auto'.
+
     %(cmap)s
 
         .. note::
             The colormap *must* be symmetrical.
 
         Default=`plt.cm.cold_hot`.
+
     %(symmetric_cbar)s
+
     %(dim)s
         Default='auto'.
+
     %(vmin)s
+
     %(vmax)s
+
     %(resampling_interpolation)s
         Default='continuous'.
+
     %(radiological)s
 
-    kwargs: extra keyword arguments, optional
+    kwargs : extra keyword arguments, optional
         Extra keyword arguments
         ultimately passed to `matplotlib.pyplot.imshow` via
         :meth:`~nilearn.plotting.displays.BaseSlicer.add_overlay`.
@@ -1298,7 +1404,6 @@ def plot_stat_map(
     nilearn.plotting.plot_anat : To simply plot anatomical images
     nilearn.plotting.plot_epi : To simply plot raw EPI images
     nilearn.plotting.plot_glass_brain : To plot maps in a glass brain
-
     """
     # dim the background
     bg_img, black_bg, bg_vmin, bg_vmax = load_anat(
@@ -1383,7 +1488,9 @@ def plot_glass_brain(
         The statistical map image.
         It needs to be in :term:`MNI` space
         in order to align with the brain schematics.
+
     %(output_file)s
+
     display_mode : :obj:`str`, default='ortho'
         Choose the direction of the cuts: 'x' - sagittal, 'y' - coronal,
         'z' - axial, 'l' - sagittal left hemisphere only,
@@ -1391,25 +1498,38 @@ def plot_glass_brain(
         performed in orthogonal directions. Possible values are: 'ortho',
         'x', 'y', 'z', 'xz', 'yx', 'yz', 'l', 'r', 'lr', 'lzr', 'lyr',
         'lzry', 'lyrz'.
+
     %(colorbar)s
         Default=False.
-    cbar_tick_format: :obj:`str`, default="%%.2g" (scientific notation)
+
+    cbar_tick_format : :obj:`str`, default="%%.2g" (scientific notation)
         Controls how to format the tick labels of the colorbar.
         Ex: use "%%i" to display as integers.
+
     %(figure)s
+
     %(axes)s
+
     %(title)s
+
     %(threshold)s
         Default='auto'.
+
     %(annotate)s
+
     %(black_bg)s
         Default=False.
+
     %(cmap)s
         Default=None.
+
     alpha : :obj:`float` between 0 and 1, default=0.7
         Alpha transparency for the brain schematics.
+
     %(vmin)s
+
     %(vmax)s
+
     plot_abs : :obj:`bool`, default=True
         If set to True maximum intensity projection of the
         absolute value will be used (rendering positive and negative
@@ -1418,16 +1538,18 @@ def plot_glass_brain(
         See
         :ref:`sphx_glr_auto_examples_01_plotting_plot_demo_glass_brain_extensive.py`
         for examples.
+
     %(symmetric_cbar)s
+
     %(resampling_interpolation)s
         Default='continuous'.
+
     %(radiological)s
 
-    kwargs: extra keyword arguments, optional
+    kwargs : extra keyword arguments, optional
         Extra keyword arguments
         ultimately passed to `matplotlib.pyplot.imshow` via
         :meth:`~nilearn.plotting.displays.BaseSlicer.add_overlay`.
-
 
     Returns
     -------
@@ -1438,7 +1560,6 @@ def plot_glass_brain(
     Notes
     -----
     Arrays should be passed in numpy convention: (x, y, z) ordered.
-
     """
     if cmap is None:
         cmap = cm.cold_hot if black_bg else cm.cold_white_hot

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -1165,7 +1165,7 @@ def plot_surf_contours(
 
     %(output_file)s
 
-    kwargs: extra keyword arguments, optional
+    kwargs : extra keyword arguments, optional
         Extra keyword arguments passed to
         :func:`~nilearn.plotting.plot_surf`.
 
@@ -1568,12 +1568,12 @@ def _check_view_is_valid(view) -> bool:
 
     Parameters
     ----------
-    view: :obj:`str` in {"anterior", "posterior", "medial", "lateral",
+    view : :obj:`str` in {"anterior", "posterior", "medial", "lateral",
         "dorsal", "ventral" or pair of floats (elev, azim).
 
     Returns
     -------
-    valid: True if view is valid, False otherwise.
+    valid : True if view is valid, False otherwise.
     """
     if isinstance(view, str) and (view in VALID_VIEWS):
         return True
@@ -1595,7 +1595,7 @@ def _check_views(views) -> list:
 
     Returns
     -------
-    views: :obj:`list`
+    views : :obj:`list`
         Views given as inputs.
     """
     invalid_views = [not _check_view_is_valid(view) for view in views]

--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -25,7 +25,11 @@ def _check_html(html_view, title=None):
 def _simulate_img(affine=None):
     """Simulate data with one "spot".
 
-    Returns: img, data
+    Returns
+    -------
+    img
+
+    data
     """
     if affine is None:
         affine = np.eye(4)

--- a/nilearn/regions/hierarchical_kmeans_clustering.py
+++ b/nilearn/regions/hierarchical_kmeans_clustering.py
@@ -63,10 +63,10 @@ def hierarchical_k_means(
 
     Parameters
     ----------
-    X: ndarray (n_samples, n_features)
+    X : ndarray (n_samples, n_features)
         Data to cluster
 
-    n_clusters: int,
+    n_clusters : int,
         The number of clusters to find.
 
     init : {'k-means++', 'random' or an ndarray}, default='k-means++'
@@ -148,7 +148,7 @@ class HierarchicalKMeans(ClusterMixin, TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    n_clusters: int
+    n_clusters : int
         The number of clusters to find.
 
     init : {'k-means++', 'random' or an ndarray}, default='k-means++'
@@ -182,13 +182,13 @@ class HierarchicalKMeans(ClusterMixin, TransformerMixin, BaseEstimator):
         Determines random number generation for centroid initialization and
         random reassignment. Use an int to make the randomness deterministic.
 
-    scaling: bool, optional (default False)
+    scaling : bool, optional (default False)
         If scaling is True, each cluster is scaled by the square root of its
         size during transform(), preserving the l2-norm of the image.
         inverse_transform() will apply inversed scaling to yield an image with
         same l2-norm as input.
 
-    verbose: int, optional (default 0)
+    verbose : int, optional (default 0)
         Verbosity level.
 
     Attributes
@@ -230,9 +230,9 @@ class HierarchicalKMeans(ClusterMixin, TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        X: ndarray, shape = [n_features, n_samples]
+        X : ndarray, shape = [n_features, n_samples]
             Training data.
-        y: Ignored
+        y : Ignored
 
         Returns
         -------
@@ -280,12 +280,12 @@ class HierarchicalKMeans(ClusterMixin, TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        X: ndarray, shape = [n_features, n_samples]
+        X : ndarray, shape = [n_features, n_samples]
             Data to transform with the fitted clustering.
 
         Returns
         -------
-        X_red: ndarray, shape = [n_clusters, n_samples]
+        X_red : ndarray, shape = [n_clusters, n_samples]
             Data reduced with agglomerated signal for each cluster
         """
         check_is_fitted(self, "labels_")
@@ -310,12 +310,12 @@ class HierarchicalKMeans(ClusterMixin, TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        X_red: ndarray , shape = [n_clusters, n_samples]
+        X_red : ndarray , shape = [n_clusters, n_samples]
             Data reduced with agglomerated signal for each cluster
 
         Returns
         -------
-        X_inv: ndarray, shape = [n_features, n_samples]
+        X_inv : ndarray, shape = [n_features, n_samples]
             Data reduced expanded to the original feature space
         """
         check_is_fitted(self, "labels_")

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -28,7 +28,7 @@ def _estimator_fit(data, estimator, method=None):
     estimator : instance of estimator from sklearn
         MiniBatchKMeans or AgglomerativeClustering.
 
-    method: str,
+    method : str,
     {'kmeans', 'ward', 'complete', 'average', 'rena', 'hierarchical_kmeans'},
     optional
 

--- a/nilearn/reporting/glm_reporter.py
+++ b/nilearn/reporting/glm_reporter.py
@@ -318,7 +318,7 @@ def _coerce_to_dict(input_arg):
 
     Returns
     -------
-    input_args: Dict[str, np.array or str]
+    input_args : Dict[str, np.array or str]
 
     """
     if not isinstance(input_arg, dict):

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -1553,9 +1553,9 @@ class PolyMesh:
 def _check_data_and_mesh_compat(mesh, data):
     """Check that mesh and data have the same keys and that shapes match.
 
-    mesh: :obj:`nilearn.surface.PolyMesh`
+    mesh : :obj:`nilearn.surface.PolyMesh`
 
-    data: :obj:`nilearn.surface.PolyData`
+    data : :obj:`nilearn.surface.PolyData`
     """
     data_keys, mesh_keys = set(data.parts.keys()), set(mesh.parts.keys())
     if data_keys != mesh_keys:
@@ -1584,7 +1584,7 @@ def _mesh_to_gifti(coordinates, faces, gifti_file):
     faces : :obj:`numpy.ndarray`
         a Numpy array containing the indices (into coords) of the mesh faces.
 
-    gifti_file: :obj:`str` or :obj:`pathlib.Path`
+    gifti_file : :obj:`str` or :obj:`pathlib.Path`
         name for the output gifti file.
     """
     gifti_file = Path(gifti_file)
@@ -1613,7 +1613,7 @@ def _data_to_gifti(data, gifti_file):
         - NIFTI_TYPE_FLOAT32
         See https://github.com/nipy/nibabel/blob/master/nibabel/gifti/gifti.py
 
-    gifti_file: :obj:`str` or :obj:`pathlib.Path`
+    gifti_file : :obj:`str` or :obj:`pathlib.Path`
         name for the output gifti file.
     """
     if data.dtype in [np.uint16, np.uint32, np.uint64]:


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- change doc string of certain attributes from `    foo:` to `    foo :` (extra space after `:`) to fix HTML rendering that could lead to things like this

![image](https://github.com/user-attachments/assets/8a861993-36ef-4036-8f08-8870c3390b76)


## unrelated

- add some vertical spacing between attributes in some functions to help readability
- add some semantic line breaks in a few places
