### PR TITLE
[Enh] Remove old surface

### DIFF
--- a/nilearn/surface/__init__.py
+++ b/nilearn/surface/__init__.py
@@ -3,33 +3,23 @@
 from .surface import (
     FileMesh,
     InMemoryMesh,
-    Mesh,
     PolyData,
     PolyMesh,
-    Surface,
     SurfaceImage,
     SurfaceMesh,
-    check_mesh_and_data,
-    check_surface,
     load_surf_data,
     load_surf_mesh,
-    load_surface,
     vol_to_surf,
 )
 
 __all__ = [
     "FileMesh",
     "InMemoryMesh",
-    "Mesh",
     "PolyData",
     "PolyMesh",
-    "Surface",
     "SurfaceImage",
     "SurfaceMesh",
-    "check_mesh_and_data",
-    "check_surface",
     "load_surf_data",
     "load_surf_mesh",
-    "load_surface",
     "vol_to_surf",
 ]

--- a/nilearn/surface/tests/_testing.py
+++ b/nilearn/surface/tests/_testing.py
@@ -4,6 +4,7 @@ import numpy as np
 from scipy.spatial import Delaunay
 
 from nilearn.conftest import _rng
+from nilearn.surface import InMemoryMesh
 
 
 def generate_surf():
@@ -15,7 +16,7 @@ def generate_surf():
     rng = _rng()
     coords = rng.random((20, 3))
     faces = rng.integers(coords.shape[0], size=(30, 3))
-    return [coords, faces]
+    return InMemoryMesh(coordinates=coords, faces=faces)
 
 
 def flat_mesh(x_s, y_s, z=0):
@@ -25,8 +26,7 @@ def flat_mesh(x_s, y_s, z=0):
     z = np.ones(len(x)) * z
     vertices = np.asarray([x, y, z]).T
     triangulation = Delaunay(vertices[:, :2]).simplices
-    mesh = [vertices, triangulation]
-    return mesh
+    return InMemoryMesh(coordinates=vertices, faces=triangulation)
 
 
 def z_const_img(x_s, y_s, z_s):

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -447,7 +447,7 @@ def test_sample_locations():
     inv_affine = np.linalg.inv(affine)
     # transform vertices to world space
     vertices = np.asarray(
-        resampling.coord_transform(*mesh[0].T, affine=affine)
+        resampling.coord_transform(*mesh.coordinates.T, affine=affine)
     ).T
     # compute by hand the true offsets in voxel space
     # (transformed by affine^-1)
@@ -463,9 +463,11 @@ def test_sample_locations():
     # check we get the same locations
     for kind, offsets in [("line", line_offsets), ("ball", ball_offsets)]:
         locations = _sample_locations(
-            [vertices, mesh[1]], affine, 1.0, kind=kind, n_points=10
+            [vertices, mesh.faces], affine, 1.0, kind=kind, n_points=10
         )
-        true_locations = np.asarray([vertex + offsets for vertex in mesh[0]])
+        true_locations = np.asarray(
+            [vertex + offsets for vertex in mesh.coordinates]
+        )
         assert_array_equal(locations.shape, true_locations.shape)
         assert_array_almost_equal(true_locations, locations)
     with pytest.raises(ValueError):

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -312,11 +312,16 @@ def test_load_surf_mesh_file_freesurfer(suffix, tmp_path):
     mesh = generate_surf()
 
     filename_fs_mesh = tmp_path / f"tmp{suffix}"
-    freesurfer.write_geometry(filename_fs_mesh, mesh[0], mesh[1])
+    freesurfer.write_geometry(filename_fs_mesh, mesh.coordinates, mesh.faces)
 
-    assert len(load_surf_mesh(filename_fs_mesh)) == 2
-    assert_array_almost_equal(load_surf_mesh(filename_fs_mesh)[0], mesh[0])
-    assert_array_almost_equal(load_surf_mesh(filename_fs_mesh)[1], mesh[1])
+    assert hasattr(load_surf_mesh(filename_fs_mesh), "coordinates")
+    assert hasattr(load_surf_mesh(filename_fs_mesh), "faces")
+    assert_array_almost_equal(
+        load_surf_mesh(filename_fs_mesh).coordinates, mesh.coordinates
+    )
+    assert_array_almost_equal(
+        load_surf_mesh(filename_fs_mesh).faces, mesh.faces
+    )
 
 
 @pytest.mark.parametrize("suffix", [".vtk", ".obj", ".mnc", ".txt"])

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -536,7 +536,10 @@ def test_vol_to_surf(kind, n_scans, use_mask):
     fsaverage = datasets.fetch_surf_fsaverage()
     mesh = load_surf_mesh(fsaverage["pial_left"])
     inner_mesh = load_surf_mesh(fsaverage["white_left"])
-    center_mesh = np.mean([mesh[0], inner_mesh[0]], axis=0), mesh[1]
+    center_mesh = (
+        np.mean([mesh.coordinates, inner_mesh.coordinates], axis=0),
+        mesh.faces,
+    )
     proj = vol_to_surf(
         img, mesh, kind="depth", inner_mesh=inner_mesh, mask_img=mask_img
     )

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -481,7 +481,7 @@ def test_sample_locations_depth(depth, n_points, affine_eye):
         mesh, affine_eye, radius, n_points=n_points, depth=depth
     )
     offsets = np.asarray([[0.0, 0.0, -z * radius] for z in depth])
-    expected = np.asarray([vertex + offsets for vertex in mesh[0]])
+    expected = np.asarray([vertex + offsets for vertex in mesh.coordinates])
     assert np.allclose(locations, expected)
 
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4789

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- remove old `Mesh` and `Surface` objects and related `check_*` functions
- update `load_surf_mesh` function to output new `InMemoryMesh` object
- remove tests using old `Mesh` and `Surface` objects and related `check_*` functions
- update tests to use `mesh.coordinates` and `mesh.faces` attributes instead of `mesh[0]` and `mesh[1]`
- update old test fixtures to output new `InMemoryMesh` object instead of a list
- [TODO] update plotting related tests that use old surface objects
- [TODO] update docstring