### PR TITLE
[ENH] allow to ignore certain BIDS entities when using query_bids

### DIFF
--- a/examples/07_advanced/plot_beta_series.py
+++ b/examples/07_advanced/plot_beta_series.py
@@ -61,21 +61,20 @@ to build the LSS beta series.
 # sphinx_gallery_thumbnail_number = -2
 
 # %%
-from nilearn import image, plotting
-
-# %%
 # Prepare data and analysis parameters
 # ------------------------------------
 # Download data in :term:`BIDS` format and event information for one subject,
 # and create a standard :class:`~nilearn.glm.first_level.FirstLevelModel`.
 from nilearn.datasets import fetch_language_localizer_demo_dataset
 from nilearn.glm.first_level import FirstLevelModel, first_level_from_bids
+from nilearn.plotting import plot_design_matrix, plot_stat_map, show
 
 data = fetch_language_localizer_demo_dataset(legacy_output=False)
 
 models, models_run_imgs, events_dfs, models_confounds = first_level_from_bids(
     dataset_path=data.data_dir,
     task_label="languagelocalizer",
+    space_label="",
     sub_labels=["01"],
     img_filters=[("desc", "preproc")],
     n_jobs=2,
@@ -110,8 +109,8 @@ standard_glm.fit(fmri_file, events_df)
 # The standard design matrix has one column for each condition, along with
 # columns for the confound regressors and drifts
 fig, ax = plt.subplots(figsize=(5, 10))
-plotting.plot_design_matrix(standard_glm.design_matrices_[0], axes=ax)
-fig.show()
+plot_design_matrix(standard_glm.design_matrices_[0], axes=ax)
+show()
 
 # %%
 # Define the LSA model
@@ -140,13 +139,14 @@ lsa_glm = FirstLevelModel(**glm_parameters)
 lsa_glm.fit(fmri_file, lsa_events_df)
 
 fig, ax = plt.subplots(figsize=(10, 10))
-plotting.plot_design_matrix(lsa_glm.design_matrices_[0], axes=ax)
-fig.show()
+plot_design_matrix(lsa_glm.design_matrices_[0], axes=ax)
+show()
 
 # %%
 # Aggregate beta maps from the LSA model based on condition
 # `````````````````````````````````````````````````````````
 # Collect the :term:`Parameter Estimate` maps
+from nilearn.image import concat_imgs
 
 lsa_beta_maps = {cond: [] for cond in events_df["trial_type"].unique()}
 trialwise_conditions = lsa_events_df["trial_type"].unique()
@@ -159,7 +159,7 @@ for condition in trialwise_conditions:
 # We can concatenate the lists of 3D maps into a single 4D beta series for
 # each condition, if we want
 lsa_beta_maps = {
-    name: image.concat_imgs(maps) for name, maps in lsa_beta_maps.items()
+    name: concat_imgs(maps) for name, maps in lsa_beta_maps.items()
 }
 
 # %%
@@ -241,7 +241,7 @@ for i_trial in range(events_df.shape[0]):
 # We can concatenate the lists of 3D maps into a single 4D beta series for
 # each condition, if we want
 lss_beta_maps = {
-    name: image.concat_imgs(maps) for name, maps in lss_beta_maps.items()
+    name: concat_imgs(maps) for name, maps in lss_beta_maps.items()
 }
 
 # %%
@@ -249,13 +249,13 @@ lss_beta_maps = {
 # `````````````````````````````````````````````````
 fig, axes = plt.subplots(ncols=3, figsize=(20, 10))
 for i_trial in range(3):
-    plotting.plot_design_matrix(
+    plot_design_matrix(
         lss_design_matrices[i_trial],
         axes=axes[i_trial],
     )
     axes[i_trial].set_title(f"Trial {i_trial + 1}")
 
-fig.show()
+show()
 
 # %%
 # Compare the three modeling approaches
@@ -276,10 +276,10 @@ fig, axes = plt.subplots(
 )
 
 for i_ax, _ in enumerate(axes):
-    plotting.plot_design_matrix(DESIGN_MATRICES[i_ax], axes=axes[i_ax])
+    plot_design_matrix(DESIGN_MATRICES[i_ax], axes=axes[i_ax])
     axes[i_ax].set_title(DM_TITLES[i_ax])
 
-fig.show()
+show()
 
 # %%
 # Applications of beta series
@@ -365,7 +365,7 @@ string_connectivity_img = brain_masker.inverse_transform(string_corrs.T)
 # Show both correlation maps
 fig, axes = plt.subplots(figsize=(10, 8), nrows=2)
 
-display = plotting.plot_stat_map(
+display = plot_stat_map(
     language_connectivity_img,
     threshold=0.5,
     vmax=1,
@@ -373,6 +373,7 @@ display = plotting.plot_stat_map(
     title="Language",
     figure=fig,
     axes=axes[0],
+    cmap="bwr",
 )
 display.add_markers(
     marker_coords=coords,
@@ -380,7 +381,7 @@ display.add_markers(
     marker_size=300,
 )
 
-display = plotting.plot_stat_map(
+display = plot_stat_map(
     string_connectivity_img,
     threshold=0.5,
     vmax=1,
@@ -388,6 +389,7 @@ display = plotting.plot_stat_map(
     title="String",
     figure=fig,
     axes=axes[1],
+    cmap="bwr",
 )
 display.add_markers(
     marker_coords=coords,
@@ -396,7 +398,7 @@ display.add_markers(
 )
 fig.suptitle("LSS Beta Series Functional Connectivity")
 
-fig.show()
+show()
 
 # %%
 # References

--- a/examples/07_advanced/plot_bids_analysis.py
+++ b/examples/07_advanced/plot_bids_analysis.py
@@ -17,6 +17,11 @@ More specifically:
 3. Fit a second level model on the fitted first level models.
    Notice that in this case the preprocessed :term:`bold<BOLD>`
    images were already normalized to the same :term:`MNI` space.
+
+.. note::
+
+      We are only using a subset of participants from the dataset
+      to lower the run time of the example.
 """
 
 from nilearn import plotting
@@ -59,7 +64,12 @@ task_label = "languagelocalizer"
     models_events,
     models_confounds,
 ) = first_level_from_bids(
-    data.data_dir, task_label, img_filters=[("desc", "preproc")], n_jobs=2
+    data.data_dir,
+    task_label,
+    img_filters=[("desc", "preproc")],
+    n_jobs=2,
+    space_label="",
+    sub_labels=["01", "02", "03", "04"],  # comment to run all subjects
 )
 
 # %%
@@ -103,9 +113,16 @@ p001_unc = norm.isf(0.001)
 
 # %%
 # Prepare figure for concurrent plot of individual maps.
-import matplotlib.pyplot as plt
+from math import ceil
 
-fig, axes = plt.subplots(nrows=2, ncols=5, figsize=(8, 4.5))
+import matplotlib.pyplot as plt
+import numpy as np
+
+ncols = 3
+nrows = ceil(len(models) / ncols)
+
+fig, axes = plt.subplots(nrows=nrows, ncols=ncols, figsize=(8, 4.5))
+axes = np.atleast_2d(axes)
 model_and_args = zip(models, models_run_imgs, models_events, models_confounds)
 for midx, (model, imgs, events, confounds) in enumerate(model_and_args):
     # fit the GLM
@@ -117,9 +134,10 @@ for midx, (model, imgs, events, confounds) in enumerate(model_and_args):
         colorbar=False,
         threshold=p001_unc,
         title=f"sub-{model.subject_label}",
-        axes=axes[int(midx / 5), int(midx % 5)],
+        axes=axes[int(midx / ncols), int(midx % ncols)],
         plot_abs=False,
         display_mode="x",
+        cmap="bwr",
     )
 fig.suptitle("subjects z_map language network (unc p<0.001)")
 plotting.show()
@@ -160,5 +178,6 @@ plotting.plot_glass_brain(
     plot_abs=False,
     display_mode="x",
     figure=plt.figure(figsize=(5, 4)),
+    cmap="bwr",
 )
 plotting.show()

--- a/examples/07_advanced/plot_surface_bids_analysis.py
+++ b/examples/07_advanced/plot_surface_bids_analysis.py
@@ -59,6 +59,7 @@ task_label = "languagelocalizer"
 models, run_imgs, events, confounds = first_level_from_bids(
     data.data_dir,
     task_label,
+    space_label="",
     img_filters=[("desc", "preproc")],
     hrf_model="glover + derivative",
     n_jobs=2,

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1792,7 +1792,9 @@ def _get_processed_imgs(
         verbose=verbose,
     )
 
-    if space_label is not None and space_label not in ("fsaverage5"):
+    if space_label is not None and (
+        space_label == "" or space_label not in ("fsaverage5")
+    ):
         imgs = get_bids_files(
             main_path=derivatives_path,
             modality_folder="func",

--- a/nilearn/interfaces/bids/query.py
+++ b/nilearn/interfaces/bids/query.py
@@ -252,7 +252,8 @@ def get_bids_files(
             files = [
                 file_
                 for file_ in files
-                if (key in file_ and file_[key] == value)
+                if (key not in file_ and value == "")
+                or (key in file_ and file_[key] == value)
             ]
         return [ref_file["file_path"] for ref_file in files]
 

--- a/nilearn/interfaces/tests/test_bids.py
+++ b/nilearn/interfaces/tests/test_bids.py
@@ -294,6 +294,54 @@ def test_get_bids_files(tmp_path):
     assert len(selection) == 12 * n_sub
 
 
+def test_get_bids_files_no_space_entity(tmp_path):
+    """Pass empty string for a label ignores files containing that label.
+
+    - remove space entity only from subject 01
+    - check that only files from the appropriate subject are returned
+      when passing ("space", "T1w") or ("space", "")
+    """
+    n_sub = 2
+
+    bids_path = create_fake_bids_dataset(
+        base_dir=tmp_path,
+        n_sub=n_sub,
+        n_ses=2,
+        tasks=["main"],
+        n_runs=[2],
+    )
+
+    for file in (bids_path / "derivatives" / "sub-01").glob(
+        "**/*_space-*.nii.gz"
+    ):
+        stem = [
+            entity
+            for entity in file.stem.split("_")
+            if not entity.startswith("space")
+        ]
+        file.replace(file.with_stem("_".join(stem)))
+
+    selection = get_bids_files(
+        bids_path / "derivatives",
+        file_tag="bold",
+        file_type="nii.gz",
+        filters=[("space", "T1w")],
+    )
+
+    assert selection
+    assert not any("sub-01" in file for file in selection)
+
+    selection = get_bids_files(
+        bids_path / "derivatives",
+        file_tag="bold",
+        file_type="nii.gz",
+        filters=[("space", "")],
+    )
+
+    assert selection
+    assert not any("sub-02" in file for file in selection)
+
+
 def test_parse_bids_filename():
     fields = ["sub", "ses", "task", "lolo"]
     labels = ["01", "01", "langloc", "lala"]


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- relates to #4801 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- allow query_bids to not return filename containing `entity` when passed filter contain `entityname = ""`
- add test
- adapt first level from bids
- adapt example
