### PR TITLE
[FIX] allow t_r, high_pass, low_pass to be int in signal.clean

### DIFF
--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -1111,7 +1111,9 @@ def _sanitize_confound_dtype(n_signal, confound):
 def _check_filter_parameters(filter, low_pass, high_pass, t_r):
     """Check all filter related parameters are set correctly."""
     if not filter:
-        if any(isinstance(item, float) for item in [low_pass, high_pass]):
+        if any(
+            isinstance(item, (float, int)) for item in [low_pass, high_pass]
+        ):
             warnings.warn(
                 "No filter type selected but cutoff frequency provided."
                 "Will not perform filtering."
@@ -1119,7 +1121,7 @@ def _check_filter_parameters(filter, low_pass, high_pass, t_r):
         return False
     elif filter in availiable_filters:
         if filter == "cosine" and not all(
-            isinstance(item, float) for item in [t_r, high_pass]
+            isinstance(item, (float, int)) for item in [t_r, high_pass]
         ):
             raise ValueError(
                 "Repetition time (t_r) and low cutoff frequency (high_pass) "

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -831,6 +831,37 @@ def test_clean_frequencies_using_power_spectrum_density():
     assert np.sum(Pxx_den_cos[f <= high_pass / 2.0]) <= 1e-4
 
 
+@pytest.mark.parametrize("t_r", [1, 1.0])
+@pytest.mark.parametrize("high_pass", [1, 1.0])
+def test_clean_t_r_highpass_float_int(t_r, high_pass):
+    """Make sure t_r and high_pass can be int.
+
+    Regression test for: https://github.com/nilearn/nilearn/issues/4803
+    """
+    # Create signal
+    sx = np.array(
+        [
+            np.sin(np.linspace(0, 100, 100) * 1.5),
+            np.sin(np.linspace(0, 100, 100) * 3.0),
+            np.sin(np.linspace(0, 100, 100) / 8.0),
+        ]
+    ).T
+
+    # Create confound
+    _, _, confounds = generate_signals(
+        n_features=10, n_confounds=10, length=100
+    )
+    clean(
+        sx,
+        detrend=False,
+        standardize=False,
+        filter="cosine",
+        low_pass=None,
+        high_pass=high_pass,
+        t_r=t_r,
+    )
+
+
 def test_clean_finite_no_inplace_mod():
     """Test for verifying that the passed in signal array is not modified.
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4803

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- allow t_r, high_pass, low_pass to be int in signal.clean

