### PR TITLE
[REF] apply use-fstring suggested by sourcery

### DIFF
--- a/examples/02_decoding/plot_miyawaki_encoding.py
+++ b/examples/02_decoding/plot_miyawaki_encoding.py
@@ -86,11 +86,11 @@ plt.figure(figsize=(8, 4))
 plt.subplot(1, 2, 1)
 plt.imshow(stimuli[0][124], interpolation="nearest", cmap="gray")
 plt.axis("off")
-plt.title(f"Run {1}, Stimulus {125}")
+plt.title("Run 1, Stimulus 125")
 plt.subplot(1, 2, 2)
 plt.imshow(stimuli[2][101], interpolation="nearest", cmap="gray")
 plt.axis("off")
-plt.title(f"Run {3}, Stimulus {102}")
+plt.title("Run 3, Stimulus 102")
 plt.subplots_adjust(wspace=0.5)
 
 # %%

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -81,7 +81,7 @@ class _ShelvedFunc:
 
     def __init__(self, func):
         self.func = func
-        self.func_name = func.__name__ + "_shelved"
+        self.func_name = f"{func.__name__}_shelved"
 
     def __call__(self, *args, **kwargs):
         return self.func.call_and_shelve(*args, **kwargs)

--- a/nilearn/_utils/testing.py
+++ b/nilearn/_utils/testing.py
@@ -137,9 +137,8 @@ def write_imgs_to_path(*imgs, file_path=None, **kwargs):
     invalid_keys = input_keys - valid_keys
     if len(invalid_keys) > 0:
         raise TypeError(
-            "{}: unexpected keyword argument(s): {}".format(
-                sys._getframe().f_code.co_name, " ".join(invalid_keys)
-            )
+            f"{sys._getframe().f_code.co_name}: "
+            f"unexpected keyword argument(s): {' '.join(invalid_keys)}"
         )
     create_files = kwargs.get("create_files", True)
     use_wildcards = kwargs.get("use_wildcards", False)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

Apply the following rules from sourcery

https://docs.sourcery.ai/Coding-Assistant/Reference/Rules-and-In-Line-Suggestions/Python/Default-Rules/

- replace-interpolation-with-fstring 
- use-fstring-for-concatenation     
- use-fstring-for-formatting         


sourcery config used

```yaml
---
# 📚 For a complete reference to this file, see the documentation at
# https://docs.sourcery.ai/Configuration/Project-Settings/

version: '1'  # The schema version of this config file

ignore: # A list of paths or files which Sourcery will ignore.
-   .env
-   .git
-   .venv
-   .tox
-   env
-   node_modules
-   vendor
-   venv
-   nilearn/_version.py
-   externals/
-   nilearn/externals/tempita/
-   nilearn/externals/tempita/__init__.py
-   plotting/data/js/*.js

rule_settings:
    enable:
    -   default
    disable: 
    -   assign-if-exp
    -   assignment-operator 
    -   aug-assign
    -   avoid-builtin-shadow
    -   avoid-using-var
    -   avoid-function-declarations-in-blocks                   
    -   boolean-if-exp-identity
    -   binary-operator-identity                            
    -   collection-into-set
    -   comprehension-to-generator          
    -   dont-reassign-parameters              
    -   dont-reassign-caught-exceptions       
    -   dont-self-assign-variables            
    -   do-not-use-bare-except                
    -   de-morgan
    -   default-get
    -   dict-comprehension
    -   dict-assign-update-to-union
    -   flip-comparison 
    -   do-not-use-bare-except
    -   ensure-file-closed                   
    -   for-append-to-extend
    -   flip-comparison                       
    -   for-index-underscore
    -   hoist-statement-from-if
    -   hoist-similar-statement-from-if
    -   inline-variable
    -   identity-comprehension                
    -   invert-ternary                        
    -   introduce-default-else
    -   invert-any-all
    -   last-if-guard
    -   lift-return-into-if
    -   list-comprehension  
    -   low-code-quality
    -   merge-comparisons
    -   merge-dict-assign
    -   merge-duplicate-blocks
    -   merge-else-if 
    -   merge-list-appends-into-extend
    -   move-assign
    -   move-assign-in-block
    -   merge-else-if                         
    -   merge-else-if-into-elif               
    -   merge-nested-ifs                      
    -   no-new-function                       
    -   no-loop-in-tests
    -   no-conditionals-in-tests
    -   raise-from-previous-error
    -   possible-incorrect-bitwise-operator                 
    -   reintroduce-else
    -   raise-specific-error
    -   remove-pass-elif
    -   remove-empty-nested-block
    -   remove-redundant-slice-index
    -   remove-redundant-if
    -   remove-unnecessary-cast
    -   remove-unnecessary-else
    -   simplify-empty-collection-comparison
    -   simplify-generator
    -   simplify-len-comparison
    -   skip-sorted-list-construction
    -   swap-if-else-branches
    -   skip-sorted-list-construction         
    -   simplify-ternary                      
    -   switch
    -   sum-comprehension
    -   use-braces
    -   use-getitem-for-re-match-groups
    -   use-join
    -   use-or-for-fallback
    -   use-named-expression
    -   yield-from
    -   use-assigned-variable     
    rule_types:
    -   refactoring
    # -   suggestion
    # -   comment
    python_version: '3.9'

metrics:
    quality_threshold: 5.0

```
