### PR TITLE
[FIX] release_docs workflow

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -190,18 +190,18 @@ check:
 install: sym_links_datasets glm_reports
 	@echo $(VERSIONTAG)
 	rm -rf _build/doctrees _build/nilearn.github.io
-	mkdir _build
+	mkdir ~/_build
 	# first clone the nilearn.github.io repo because it may ask
 	# for password and we don't want to delay this long build in
 	# the middle of it
 	# --depth 1 is a speed optimization since we don't need the
 	# history prior to the last commit
-	git clone --depth 1 git@github.com:nilearn/nilearn.github.io.git _build/nilearn.github.io
-	touch _build/nilearn.github.io/.nojekyll
-	rm -Rf _build/nilearn.github.io/stable;
-	mkdir _build/nilearn.github.io/stable;
+	git clone --depth 1 git@github.com:nilearn/nilearn.github.io.git ~/_build/nilearn.github.io
+	touch ~/_build/nilearn.github.io/.nojekyll
+	rm -Rf ~/_build/nilearn.github.io/stable;
+	mkdir ~/_build/nilearn.github.io/stable;
 	make html
-	cd _build/ && \
+	cd ~/_build/ && \
 	cp -r html/* nilearn.github.io/stable/ && \
 	cd nilearn.github.io && \
 	git add -A && \

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -190,6 +190,7 @@ check:
 install: sym_links_datasets glm_reports
 	@echo $(VERSIONTAG)
 	rm -rf _build/doctrees _build/nilearn.github.io
+	mkdir _build
 	# first clone the nilearn.github.io repo because it may ask
 	# for password and we don't want to delay this long build in
 	# the middle of it

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -187,9 +187,8 @@ check:
 	rm -rf $(BUILDDIR)/html/_images
 	BUILD_DEV_HTML=1 $(SPHINXBUILD) -W --keep-going -T -n -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 
-install: sym_links_datasets glm_reports
+install: clean sym_links_datasets glm_reports
 	@echo $(VERSIONTAG)
-	rm -rf _build/doctrees _build/nilearn.github.io
 	mkdir ~/_build
 	# first clone the nilearn.github.io repo because it may ask
 	# for password and we don't want to delay this long build in

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -189,7 +189,6 @@ check:
 
 install: clean sym_links_datasets glm_reports
 	@echo $(VERSIONTAG)
-	mkdir ~/_build
 	# first clone the nilearn.github.io repo because it may ask
 	# for password and we don't want to delay this long build in
 	# the middle of it


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but tries to fix the release docs workflow

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:
We get a permission denied error when we try to clone the `nilearn.github.io` repo in `_build/nilearn.github.io`. 
- ~I think it's because `_build` directory does not yet exists, so create a `_build` dir first~
- it seems `git clone` can handle making a new directory if the specified cloning path does not exist. Now I think this happens because we are trying to do things in `.` and we might not have permissions to create directory there. So now we do everything in `~/`
