### PR TITLE
[MAINT] check constructors compatibility with scikitlearn in nilearn.decomposition

### DIFF
--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -543,7 +543,7 @@ def path_scores(
 
 
 @fill_doc
-class BaseSpaceNet(LinearRegression, CacheMixin):
+class BaseSpaceNet(CacheMixin, LinearRegression):
     """Regression and classification learners with sparsity and spatial priors.
 
     `SpaceNet` implements Graph-Net and TV-L1 priors /

--- a/nilearn/decomposition/_base.py
+++ b/nilearn/decomposition/_base.py
@@ -361,8 +361,6 @@ class _BaseDecomposition(CacheMixin, TransformerMixin, BaseEstimator):
         n_jobs=1,
         verbose=0,
     ):
-        if memory is None:
-            memory = Memory(location=None)
         self.n_components = n_components
         self.random_state = random_state
         self.mask = mask
@@ -412,6 +410,8 @@ class _BaseDecomposition(CacheMixin, TransformerMixin, BaseEstimator):
 
         """
         # Base fit for decomposition estimators : compute the embedded masker
+        if self.memory is None:
+            self.memory = Memory(location=None)
 
         if (
             isinstance(imgs, str)

--- a/nilearn/decomposition/_multi_pca.py
+++ b/nilearn/decomposition/_multi_pca.py
@@ -4,7 +4,6 @@ This is a good initialization method for ICA.
 """
 
 import numpy as np
-from joblib import Memory
 from sklearn.utils.extmath import randomized_svd
 
 from nilearn._utils import fill_doc
@@ -158,8 +157,6 @@ class _MultiPCA(_BaseDecomposition):
         n_jobs=1,
         verbose=0,
     ):
-        if memory is None:
-            memory = Memory(location=None)
         self.n_components = n_components
         self.do_cca = do_cca
 

--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -6,7 +6,7 @@ import warnings as _warnings
 from operator import itemgetter
 
 import numpy as np
-from joblib import Memory, Parallel, delayed
+from joblib import Parallel, delayed
 from scipy.stats import scoreatpercentile
 from sklearn.decomposition import fastica
 from sklearn.utils import check_random_state
@@ -177,8 +177,6 @@ class CanICA(_MultiPCA):
         n_jobs=1,
         verbose=0,
     ):
-        if memory is None:
-            memory = Memory(location=None)
         super().__init__(
             n_components=n_components,
             do_cca=do_cca,
@@ -201,13 +199,6 @@ class CanICA(_MultiPCA):
             verbose=verbose,
         )
 
-        if isinstance(threshold, float) and threshold > n_components:
-            raise ValueError(
-                "Threshold must not be higher than number "
-                "of maps. "
-                f"Number of maps is {n_components} and you provided "
-                f"threshold={threshold}"
-            )
         self.threshold = threshold
         self.n_init = n_init
 
@@ -289,6 +280,15 @@ class CanICA(_MultiPCA):
             Unmasked data to process
 
         """
+        if (
+            isinstance(self.threshold, float)
+            and self.threshold > self.n_components
+        ):
+            raise ValueError(
+                "Threshold must not be higher than number of maps. "
+                f"Number of maps is {self.n_components} "
+                f"and you provided threshold={self.threshold}."
+            )
         components = _MultiPCA._raw_fit(self, data)
         self._unmix_components(components)
         return self

--- a/nilearn/decomposition/dict_learning.py
+++ b/nilearn/decomposition/dict_learning.py
@@ -11,7 +11,6 @@ import warnings
 
 import numpy as np
 import sklearn
-from joblib import Memory
 from sklearn.decomposition import dict_learning_online
 from sklearn.linear_model import Ridge
 
@@ -210,8 +209,6 @@ class DictLearning(_BaseDecomposition):
         memory=None,
         memory_level=0,
     ):
-        if memory is None:
-            memory = Memory(location=None)
         _BaseDecomposition.__init__(
             self,
             n_components=n_components,

--- a/nilearn/decomposition/tests/test_base.py
+++ b/nilearn/decomposition/tests/test_base.py
@@ -3,9 +3,7 @@ import pytest
 from nibabel import Nifti1Image
 from numpy.testing import assert_array_almost_equal
 from scipy import linalg
-from sklearn import __version__ as sklearn_version
 
-from nilearn._utils import compare_version
 from nilearn._utils.class_inspect import check_estimator
 from nilearn.conftest import _affine_eye, _img_3d_ones, _rng
 from nilearn.decomposition._base import (
@@ -22,9 +20,8 @@ extra_valid_checks = [
     "check_no_attributes_set_in_init",
     "check_transformers_unfitted",
     "check_transformer_n_iter",
+    "check_parameters_default_constructible",
 ]
-if compare_version(sklearn_version, ">=", "1.6"):
-    extra_valid_checks.append("check_estimator_sparse_array")
 
 
 @pytest.mark.parametrize(

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -146,12 +146,13 @@ def test_check_estimator_invalid(estimator, check, name):  # noqa: ARG001
     check(estimator)
 
 
-def test_threshold_bound_error():
+def test_threshold_bound_error(canica_data):
     """Test that an error is raised when the threshold is higher \
     than the number of components.
     """
     with pytest.raises(ValueError, match="Threshold must not be higher"):
-        CanICA(n_components=4, threshold=5.0)
+        canica = CanICA(n_components=4, threshold=5.0)
+        canica.fit(canica_data)
 
 
 def test_transform_and_fit_errors(canica_data, mask_img):

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -5,6 +5,7 @@ import pytest
 from nibabel import Nifti1Image
 from numpy.testing import assert_array_almost_equal
 
+from nilearn._utils.class_inspect import check_estimator
 from nilearn._utils.testing import write_imgs_to_path
 from nilearn.conftest import _affine_eye, _rng
 from nilearn.decomposition.canica import CanICA
@@ -107,6 +108,42 @@ def mask_img():
 @pytest.fixture(scope="module")
 def canica_data():
     return _make_canica_test_data()[0]
+
+
+extra_valid_checks = [
+    "check_do_not_raise_errors_in_init_or_set_params",
+    "check_estimators_unfitted",
+    "check_get_params_invariance",
+    "check_no_attributes_set_in_init",
+    "check_transformers_unfitted",
+    "check_transformer_n_iter",
+    "check_parameters_default_constructible",
+]
+
+
+@pytest.mark.parametrize(
+    "estimator, check, name",
+    check_estimator(
+        estimator=[CanICA()], extra_valid_checks=extra_valid_checks
+    ),
+)
+def test_check_estimator(estimator, check, name):  # noqa: ARG001
+    """Check compliance with sklearn estimators."""
+    check(estimator)
+
+
+@pytest.mark.xfail(reason="invalid checks should fail")
+@pytest.mark.parametrize(
+    "estimator, check, name",
+    check_estimator(
+        estimator=[CanICA()],
+        valid=False,
+        extra_valid_checks=extra_valid_checks,
+    ),
+)
+def test_check_estimator_invalid(estimator, check, name):  # noqa: ARG001
+    """Check compliance with sklearn estimators."""
+    check(estimator)
 
 
 def test_threshold_bound_error():

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 from nibabel import Nifti1Image
 
+from nilearn._utils.class_inspect import check_estimator
 from nilearn._utils.testing import write_imgs_to_path
 from nilearn.conftest import _affine_eye
 from nilearn.decomposition.dict_learning import DictLearning
@@ -28,6 +29,42 @@ def mask_img():
 def canica_data():
     """Create a canonical ICA data for testing purposes."""
     return _make_canica_test_data()[0]
+
+
+extra_valid_checks = [
+    "check_do_not_raise_errors_in_init_or_set_params",
+    "check_estimators_unfitted",
+    "check_get_params_invariance",
+    "check_no_attributes_set_in_init",
+    "check_transformers_unfitted",
+    "check_transformer_n_iter",
+    "check_parameters_default_constructible",
+]
+
+
+@pytest.mark.parametrize(
+    "estimator, check, name",
+    check_estimator(
+        estimator=[DictLearning()], extra_valid_checks=extra_valid_checks
+    ),
+)
+def test_check_estimator(estimator, check, name):  # noqa: ARG001
+    """Check compliance with sklearn estimators."""
+    check(estimator)
+
+
+@pytest.mark.xfail(reason="invalid checks should fail")
+@pytest.mark.parametrize(
+    "estimator, check, name",
+    check_estimator(
+        estimator=[DictLearning()],
+        valid=False,
+        extra_valid_checks=extra_valid_checks,
+    ),
+)
+def test_check_estimator_invalid(estimator, check, name):  # noqa: ARG001
+    """Check compliance with sklearn estimators."""
+    check(estimator)
 
 
 @pytest.mark.parametrize("n_epochs", [1, 2, 10])

--- a/nilearn/decomposition/tests/test_multi_pca.py
+++ b/nilearn/decomposition/tests/test_multi_pca.py
@@ -5,6 +5,7 @@ import pytest
 from nibabel import Nifti1Image
 from numpy.testing import assert_almost_equal
 
+from nilearn._utils.class_inspect import check_estimator
 from nilearn._utils.testing import write_imgs_to_path
 from nilearn.conftest import _affine_eye, _rng
 from nilearn.decomposition._multi_pca import _MultiPCA
@@ -46,6 +47,42 @@ def mask_img():
 @pytest.fixture(scope="module")
 def multi_pca_data():
     return _make_multi_pca_test_data()[0]
+
+
+extra_valid_checks = [
+    "check_do_not_raise_errors_in_init_or_set_params",
+    "check_estimators_unfitted",
+    "check_get_params_invariance",
+    "check_no_attributes_set_in_init",
+    "check_transformers_unfitted",
+    "check_transformer_n_iter",
+    "check_parameters_default_constructible",
+]
+
+
+@pytest.mark.parametrize(
+    "estimator, check, name",
+    check_estimator(
+        estimator=[_MultiPCA()], extra_valid_checks=extra_valid_checks
+    ),
+)
+def test_check_estimator(estimator, check, name):  # noqa: ARG001
+    """Check compliance with sklearn estimators."""
+    check(estimator)
+
+
+@pytest.mark.xfail(reason="invalid checks should fail")
+@pytest.mark.parametrize(
+    "estimator, check, name",
+    check_estimator(
+        estimator=[_MultiPCA()],
+        valid=False,
+        extra_valid_checks=extra_valid_checks,
+    ),
+)
+def test_check_estimator_invalid(estimator, check, name):  # noqa: ARG001
+    """Check compliance with sklearn estimators."""
+    check(estimator)
 
 
 def test_multi_pca_check_masker_attributes(multi_pca_data, mask_img):


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but relates to https://github.com/nilearn/nilearn/issues/4538#issuecomment-2527259857

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- check compatibility of estimators in nilearn.decomposition with scikitlearn
- update constructors to avoid doing any logic in it: all checks are done at fit time
