### PR TITLE
[MAINT] Fail fast for test matrix

### DIFF
--- a/.github/workflows/test_with_tox.yml
+++ b/.github/workflows/test_with_tox.yml
@@ -43,7 +43,7 @@ jobs:
         name: 'Test with ${{ matrix.py }} on ${{ matrix.os }}: ${{ matrix.description }}'
         runs-on: ${{ matrix.os }}
         strategy:
-            fail-fast: false
+            fail-fast: true
             matrix:
                 description: [latest dependencies]
                 py: ['3.13', '3.12', '3.11', '3.10', '3.9']


### PR DESCRIPTION
- fail early on tests runs
  - if one of the OS / python version fails then all the other ones are cancelled (whether queued or in progress)

- pros: speed things up by vacating resources for other CI jobs (which we currently need)
- cons: things may fail for only a specific OS or python version and this may hide it