### PR TITLE
[FIX] change stacklevel warning label masker

### DIFF
--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -578,7 +578,7 @@ class NiftiLabelsMasker(BaseMasker):
                 warnings.warn(
                     "Number of regions in the labels image "
                     "does not match the number of labels provided.",
-                    stacklevel=3,
+                    stacklevel=2,
                 )
             # if number of regions in the labels image is more
             # than the number of labels provided, then we cannot


### PR DESCRIPTION
<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- fixes the stacklevel of a warning

the following code

```python
from nilearn.datasets import fetch_atlas_destrieux_2009, fetch_icbm152_2009
from nilearn.maskers import NiftiLabelsMasker

atlas = fetch_atlas_destrieux_2009()

labels = atlas.labels.name.to_list()

for index, name in [(148, 'R S_temporal_inf'), (149, 'R S_temporal_sup'), (150, 'R S_temporal_transverse')]:
    print(f"{name} in labels {name in labels=}")

masker = NiftiLabelsMasker(labels_img=atlas.maps, labels=labels).fit()
```

would produce

```
/home/remi/miniconda3/bin/python /home/remi/github/nilearn/nilearn/tmp/check_plot.py
[get_dataset_dir] Dataset found in /home/remi/nilearn_data/destrieux_2009
R S_temporal_inf in labels name in labels=True
R S_temporal_sup in labels name in labels=True
R S_temporal_transverse in labels name in labels=True
/home/remi/github/nilearn/nilearn/tmp/check_plot.py:11: UserWarning: Mismatch between the number of provided labels (151) and the number of regions in provided label image (149).
  masker = NiftiLabelsMasker(labels_img=atlas.maps, labels=labels).fit()
sys:1: UserWarning: Number of regions in the labels image does not match the number of labels provided. < ------------- last line should say where there error appeared in my code
```