### PR TITLE
[FIX] allow support for confounds as numpy arrays in FirstLevelModel

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -18,6 +18,8 @@ Fixes
 
 - :bdg-dark:`Code` Fix all occurrences of the RUF012 error related to mutable default values in Python classes (:gh:`4954` by `Idrissa Traore`_).
 
+- :bdg-dark:`Code` Support for confounds as numpy arrays in :meth:`nilearn.glm.first_level.FirstLevelModel.fit` (:gh:`4967` by `Rémi Gau`_).
+
 Enhancements
 ------------
 

--- a/nilearn/_utils/glm.py
+++ b/nilearn/_utils/glm.py
@@ -13,6 +13,8 @@ def check_and_load_tables(tables_to_check, var_name):
        if they are pandas.DataFrame, \
        or a CSV or TSV file that can be loaded to a pandas.DataFrame.
 
+       Numpy arrays will also be appended as is.
+
     tables_to_check : str or pathlib.Path to a TSV or CSV \
               or pandas.DataFrame or numpy.ndarray or, \
               a list of str or pathlib.Path to a TSV or CSV \
@@ -27,7 +29,7 @@ def check_and_load_tables(tables_to_check, var_name):
 
     Returns
     -------
-    list of pandas.DataFrame
+    list of pandas.DataFrame or numpy.arrays
 
     Raises
     ------
@@ -55,7 +57,7 @@ def check_and_load_tables(tables_to_check, var_name):
         if isinstance(table, str):
             loaded = _read_events_table(table)
             tables.append(loaded)
-        elif isinstance(table, pd.DataFrame):
+        elif isinstance(table, (pd.DataFrame, np.ndarray)):
             tables.append(table)
 
     return tables

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -656,31 +656,76 @@ def test_fmri_inputs_events_type(tmp_path):
 
 
 def test_fmri_inputs_with_confounds(tmp_path):
-    """Test with confounds and, events or design matrix."""
+    """Test with confounds and, events."""
+    n_timepoints = 10
+    shapes = ((3, 4, 5, n_timepoints),)
+    mask, func_img, _ = write_fake_fmri_data_and_design(
+        shapes, file_path=tmp_path
+    )
+
+    conf = pd.DataFrame([0] * n_timepoints, columns=["conf"])
+
+    events = basic_paradigm()
+
+    func_img = func_img[0]
+
+    # Provide t_r, confounds, and events but no design matrix
+    flm = FirstLevelModel(mask_img=mask, t_r=2.0).fit(
+        func_img,
+        confounds=conf,
+        events=events,
+    )
+    assert "conf" in flm.design_matrices_[0]
+
+    # list are OK
+    FirstLevelModel(mask_img=mask, t_r=2.0).fit(
+        func_img,
+        confounds=[conf],
+        events=events,
+    )
+
+    # test with confounds as numpy array
+    flm = FirstLevelModel(mask_img=mask, t_r=2.0).fit(
+        func_img,
+        confounds=conf.to_numpy(),
+        events=events,
+    )
+    assert "confound_0" in flm.design_matrices_[0]
+
+    flm = FirstLevelModel(mask_img=mask, t_r=2.0).fit(
+        func_img,
+        confounds=[conf.to_numpy()],
+        events=events,
+    )
+    assert "confound_0" in flm.design_matrices_[0]
+
+
+def test_fmri_inputs_confounds_ingored_with_design_matrix(tmp_path):
+    """Test with confounds with design matrix.
+
+    Confounds ignored if design matrix is passed
+    """
     n_timepoints = 10
     shapes = ((3, 4, 5, n_timepoints),)
     mask, func_img, des = write_fake_fmri_data_and_design(
         shapes, file_path=tmp_path
     )
 
-    conf = pd.DataFrame([0, 0])
-
-    events = basic_paradigm()
+    conf = pd.DataFrame([0] * n_timepoints, columns=["conf"])
 
     func_img = func_img[0]
-    des = des[0]
 
-    # Provide t_r, confounds, and events but no design matrix
-    FirstLevelModel(mask_img=mask, t_r=2.0).fit(
-        func_img,
-        confounds=pd.DataFrame([0] * n_timepoints, columns=["conf"]),
-        events=events,
+    des = pd.read_csv(
+        des[0],
+        sep="\t",
+    )
+    n_col_in_des = len(des.columns)
+
+    flm = FirstLevelModel(mask_img=mask).fit(
+        func_img, confounds=conf, design_matrices=des
     )
 
-    # test with confounds as numpy array
-    FirstLevelModel(mask_img=mask).fit(
-        [func_img], confounds=conf.values, design_matrices=[des]
-    )
+    assert len(flm.design_matrices_[0].columns) == n_col_in_des
 
 
 def test_fmri_inputs_errors(tmp_path, shape_4d_default):

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -700,7 +700,7 @@ def test_fmri_inputs_with_confounds(tmp_path):
     assert "confound_0" in flm.design_matrices_[0]
 
 
-def test_fmri_inputs_confounds_ingored_with_design_matrix(tmp_path):
+def test_fmri_inputs_confounds_ignored_with_design_matrix(tmp_path):
     """Test with confounds with design matrix.
 
     Confounds ignored if design matrix is passed

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -715,10 +715,7 @@ def test_fmri_inputs_confounds_ignored_with_design_matrix(tmp_path):
 
     func_img = func_img[0]
 
-    des = pd.read_csv(
-        des[0],
-        sep="\t",
-    )
+    des = pd.read_csv(des[0], sep="\t")
     n_col_in_des = len(des.columns)
 
     flm = FirstLevelModel(mask_img=mask).fit(


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4893

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- add test to check that numpy array confounds are used in model
- adapt code to make test pass
