### PR TITLE
[STY] remove code block wrapping

### DIFF
--- a/doc/themes/custom.css
+++ b/doc/themes/custom.css
@@ -148,9 +148,3 @@ table.plotting-table img {
 .announcement-content {
   white-space: normal;
 }
-
-/* Wrap code blocks */
-pre {
-  white-space: pre-wrap !important;
-  word-break: break-all;
-}


### PR DESCRIPTION
Remove code block wrapping in doc

- the solution to long line is not to wrap them but to break them in smaller chunks 
- code block wrapping kicks in on most narrow device making the code much harder to read.

<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4972 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
