### PR TITLE
[STY] Apply assorted ruff preview rules

### DIFF
--- a/doc/visual_testing/reporter_visual_inspection_suite.py
+++ b/doc/visual_testing/reporter_visual_inspection_suite.py
@@ -632,7 +632,7 @@ def main(args=sys.argv):
     report_multi_nifti_maps_masker(build_type)
 
     t1 = time.time()
-    print(f"\nTook: {t1 - t0 :0.2f} seconds\n")
+    print(f"\nTook: {t1 - t0:0.2f} seconds\n")
 
     print("\nGenerating GLM reports templates\n")
     t0 = time.time()
@@ -643,7 +643,7 @@ def main(args=sys.argv):
     report_slm_oasis(build_type)
 
     t1 = time.time()
-    print(f"\nTook: {t1 - t0 :0.2f} seconds\n")
+    print(f"\nTook: {t1 - t0:0.2f} seconds\n")
 
 
 if __name__ == "__main__":

--- a/examples/07_advanced/plot_beta_series.py
+++ b/examples/07_advanced/plot_beta_series.py
@@ -126,7 +126,7 @@ print("Define and fit LSA")
 # Transform the DataFrame for LSA
 lsa_events_df = events_df.copy()
 conditions = lsa_events_df["trial_type"].unique()
-condition_counter = {c: 0 for c in conditions}
+condition_counter = dict.fromkeys(conditions, 0)
 for i_trial, trial in lsa_events_df.iterrows():
     trial_condition = trial["trial_type"]
     condition_counter[trial_condition] += 1

--- a/maint_tools/check_gha_workflow.py
+++ b/maint_tools/check_gha_workflow.py
@@ -149,7 +149,7 @@ def _update_tsv(
     update: bool,
     output_file: Path,
     workflow_id: str,
-    event_type: None | str = None,
+    event_type: str | None = None,
 ) -> None:
     """Update TSV containing run time of every workflow."""
     update_tsv = update if output_file.exists() else True
@@ -279,7 +279,7 @@ def _set_dependencies(x: str) -> str:
     )
 
 
-def _get_auth(username: str, token_file: Path) -> None | tuple[str, str]:
+def _get_auth(username: str, token_file: Path) -> tuple[str, str] | None:
     """Get authentication with token."""
     token = None
 
@@ -294,10 +294,10 @@ def _get_auth(username: str, token_file: Path) -> None | tuple[str, str]:
 
 def _get_runs(
     workflow_id: str,
-    auth: None | tuple[str, str] = None,
+    auth: tuple[str, str] | None = None,
     page: int = 1,
     include_failed_runs: bool = True,
-    event_type: None | str = None,
+    event_type: str | None = None,
 ) -> list[dict[str, Any]]:
     """Get list of runs for a workflow.
 
@@ -326,7 +326,7 @@ def _get_runs(
     return [run for run in runs if run["conclusion"] in conclusion]
 
 
-def _handle_request(url: str, auth: None | tuple[str, str]):
+def _handle_request(url: str, auth: tuple[str, str] | None):
     """Wrap request."""
     if isinstance(auth, tuple):
         response = requests.get(url, auth=auth)
@@ -345,7 +345,7 @@ def _handle_request(url: str, auth: None | tuple[str, str]):
 def _update_jobs_data(
     jobs_data: dict[str, list[str]],
     runs: list[dict[str, Any]],
-    auth: None | tuple[str, str] = None,
+    auth: tuple[str, str] | None = None,
 ) -> dict[str, list[str]]:
     """Collect info for each job in a run."""
     for run in runs:

--- a/maint_tools/citation_cff_maint.py
+++ b/maint_tools/citation_cff_maint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import operator
 from pathlib import Path
 from typing import Any
 
@@ -171,7 +172,7 @@ def write_core_devs(f):
 def sort_authors(authors: list[dict[str, str]]) -> list[dict[str, str]]:
     """Sort authors by given name."""
     print(" Sorting authors by given name")
-    authors.sort(key=lambda x: x["given-names"])
+    authors.sort(key=operator.itemgetter("given-names"))
     return authors
 
 

--- a/nilearn/_utils/tests/test_exceptions.py
+++ b/nilearn/_utils/tests/test_exceptions.py
@@ -7,4 +7,4 @@ def test_dimension_error_message():
     error = DimensionError(file_dimension=3, required_dimension=5)
     error.increment_stack_counter()
     error.increment_stack_counter()
-    assert re.match("^.*7D.*list of list of 3D images.*5D.*$", error.message)
+    assert re.match(r"^.*7D.*list of list of 3D images.*5D.*$", error.message)

--- a/nilearn/datasets/tests/_testing.py
+++ b/nilearn/datasets/tests/_testing.py
@@ -447,5 +447,5 @@ def list_to_archive(sequence, archive_format="gztar", content=""):
 
     """
     return dict_to_archive(
-        {item: content for item in sequence}, archive_format=archive_format
+        dict.fromkeys(sequence, content), archive_format=archive_format
     )

--- a/nilearn/datasets/tests/test_neurovault.py
+++ b/nilearn/datasets/tests/test_neurovault.py
@@ -783,7 +783,7 @@ def test_fetch_neurovault_errors(capsys, request_mocker):
     data = neurovault.fetch_neurovault()
 
     captured = capsys.readouterr()
-    match = re.search("500 Error", captured.err)
+    match = re.search(r"500 Error", captured.err)
     assert match is not None
 
     assert len(data.images) == 0

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -4,6 +4,7 @@ first level contrasts or directly on fitted first level models.
 Author: Martin Perez-Guevara, 2016
 """
 
+import operator
 import time
 from pathlib import Path
 from warnings import warn
@@ -402,7 +403,7 @@ def _sort_input_dataframe(second_level_input):
     columns = second_level_input.columns.tolist()
     column_index = columns.index("subject_label")
     sorted_matrix = sorted(
-        second_level_input.values, key=lambda x: x[column_index]
+        second_level_input.values, key=operator.itemgetter(column_index)
     )
     return pd.DataFrame(sorted_matrix, columns=columns)
 

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -682,7 +682,7 @@ class SecondLevelModel(BaseGLM):
         # Report progress
         logger.log(
             "\nComputation of second level model done in "
-            f"{time.time() - t0 :0.2f} seconds.\n",
+            f"{time.time() - t0:0.2f} seconds.\n",
             verbose=self.verbose,
         )
 

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -1,5 +1,6 @@
 import itertools
 import shutil
+import string
 import unittest.mock
 import warnings
 from itertools import product
@@ -1190,7 +1191,7 @@ def test_first_level_with_scaling(affine_eye):
     design_matrices = [
         pd.DataFrame(
             np.ones((shapes[0][-1], rk)),
-            columns=list("abcdefghijklmnopqrstuvwxyz")[:rk],
+            columns=list(string.ascii_lowercase)[:rk],
         )
     ]
     fmri_glm = FirstLevelModel(
@@ -1221,7 +1222,7 @@ def test_first_level_with_no_signal_scaling(affine_eye):
     design_matrices = [
         pd.DataFrame(
             np.ones((shapes[0][-1], rk)),
-            columns=list("abcdefghijklmnopqrstuvwxyz")[:rk],
+            columns=list(string.ascii_lowercase)[:rk],
         )
     ]
     fmri_data = [Nifti1Image(np.zeros((1, 1, 1, 2)) + 6, affine_eye)]

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
@@ -632,7 +632,7 @@ def test_ica_aroma(tmp_path, fmriprep_version):
     )
     for col_name in conf.columns:
         # only aroma and non-steady state columns will be present
-        assert re.match("(?:aroma_motion_+|non_steady_state+)", col_name)
+        assert re.match(r"(?:aroma_motion_+|non_steady_state+)", col_name)
 
     # Non-aggressive strategy
     conf, _ = load_confounds(

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -293,7 +293,7 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
                     / self.labels_img.mesh.parts[part].n_vertices
                     * 100
                 )
-                relative_size.append(f"{tmp :.2}")
+                relative_size.append(f"{tmp:.2}")
 
             regions_summary["size<br>(number of vertices)"] = size
             regions_summary["relative size<br>(% vertices in hemisphere)"] = (


### PR DESCRIPTION
Changes proposed in this pull request:

- [E203](https://docs.astral.sh/ruff/rules/whitespace-before-punctuation/)
- [C420](https://docs.astral.sh/ruff/rules/unnecessary-dict-comprehension-for-iterable/)
- [FURB118](https://docs.astral.sh/ruff/rules/reimplemented-operator/)
- [FURB156](https://docs.astral.sh/ruff/rules/hardcoded-string-charset/)
- [RUF036](https://docs.astral.sh/ruff/rules/none-not-at-end-of-union/)
- [RUF039](https://docs.astral.sh/ruff/rules/unraw-re-pattern/)
