### PR TITLE
[DOC] fix figures stacking in doc

### DIFF
--- a/doc/building_blocks/manual_pipeline.rst
+++ b/doc/building_blocks/manual_pipeline.rst
@@ -129,7 +129,7 @@ Applying a mask
 
 .. figure:: ../auto_examples/00_tutorials/images/sphx_glr_plot_decoding_tutorial_001.png
     :target: ../auto_examples/00_tutorials/plot_decoding_tutorial.html
-    :align: right
+    :align: center
     :scale: 30%
 
 If your dataset provides a mask, the :class:`NiftiMasker` can apply it

--- a/doc/decoding/decoding_intro.rst
+++ b/doc/decoding/decoding_intro.rst
@@ -38,28 +38,28 @@ information on the corresponding category.
 .. figure:: ../auto_examples/02_decoding/images/sphx_glr_plot_haxby_stimuli_007.png
    :target: ../auto_examples/02_decoding/plot_haxby_stimuli.html
    :scale: 30
-   :align: left
+   :align: center
 
    Face stimuli
 
 .. figure:: ../auto_examples/02_decoding/images/sphx_glr_plot_haxby_stimuli_004.png
    :target: ../auto_examples/02_decoding/plot_haxby_stimuli.html
    :scale: 30
-   :align: left
+   :align: center
 
    Cat stimuli
 
 .. figure:: ../auto_examples/01_plotting/images/sphx_glr_plot_haxby_masks_001.png
    :target: ../auto_examples/01_plotting/plot_haxby_masks.html
    :scale: 30
-   :align: left
+   :align: center
 
    Masks
 
 .. figure:: ../auto_examples/02_decoding/images/sphx_glr_plot_haxby_full_analysis_001.png
    :target: ../auto_examples/02_decoding/plot_haxby_full_analysis.html
    :scale: 35
-   :align: left
+   :align: center
 
    Decoding scores per mask
 
@@ -314,7 +314,7 @@ model is better than chance or not.
 .. figure:: ../auto_examples/01_plotting/images/sphx_glr_plot_haxby_masks_001.png
    :target: ../auto_examples/01_plotting/plot_haxby_masks.html
    :scale: 55
-   :align: left
+   :align: center
 
    Masks
 
@@ -322,7 +322,7 @@ model is better than chance or not.
 .. figure:: ../auto_examples/02_decoding/images/sphx_glr_plot_haxby_full_analysis_001.png
    :target: ../auto_examples/02_decoding/plot_haxby_full_analysis.html
    :scale: 70
-   :align: left
+   :align: center
 
 
 Visualizing the decoder's weights
@@ -334,6 +334,7 @@ coefficients of best models for each class in ``decoder.coef_img_``.
 
 .. figure:: ../auto_examples/02_decoding/images/sphx_glr_plot_haxby_anova_svm_001.png
    :target: ../auto_examples/plot_decoding_tutorial.html
+   :align: center
    :scale: 65
 
 .. note::
@@ -383,6 +384,7 @@ To visualize the results, :class:`nilearn.decoding.Decoder` handles two main ste
 
 .. figure:: ../auto_examples/02_decoding/images/sphx_glr_plot_haxby_anova_svm_001.png
    :target: ../auto_examples/02_decoding/plot_haxby_anova_svm.html
+   :align: center
    :scale: 65
 
 .. seealso::

--- a/doc/decoding/estimator_choice.rst
+++ b/doc/decoding/estimator_choice.rst
@@ -86,17 +86,17 @@ understand the classifier's errors in a multiclass problem.
 
 .. figure:: ../auto_examples/02_decoding/images/sphx_glr_plot_haxby_multiclass_001.png
    :target: ../auto_examples/02_decoding/plot_haxby_multiclass.html
-   :align: left
+   :align: center
    :scale: 60
 
 .. figure:: ../auto_examples/02_decoding/images/sphx_glr_plot_haxby_multiclass_002.png
    :target: ../auto_examples/02_decoding/plot_haxby_multiclass.html
-   :align: left
+   :align: center
    :scale: 40
 
 .. figure:: ../auto_examples/02_decoding/images/sphx_glr_plot_haxby_multiclass_003.png
    :target: ../auto_examples/02_decoding/plot_haxby_multiclass.html
-   :align: left
+   :align: center
    :scale: 40
 
 

--- a/doc/decoding/frem.rst
+++ b/doc/decoding/frem.rst
@@ -46,6 +46,7 @@ Decoding performance increase on Haxby dataset
 ----------------------------------------------
 
 .. figure:: ../auto_examples/02_decoding/images/sphx_glr_plot_haxby_frem_001.png
+   :align: center
 
 In this example we showcase the use of :term:`FREM` and the performance increase that
 it brings on this problem.
@@ -59,6 +60,7 @@ Spatial regularization of decoding maps on mixed gambles study
 ---------------------------------------------------------------
 
 .. figure:: ../auto_examples/02_decoding/images/sphx_glr_plot_mixed_gambles_frem_001.png
+   :align: center
 
 
 .. topic:: **Code**

--- a/doc/decoding/space_net.rst
+++ b/doc/decoding/space_net.rst
@@ -45,6 +45,7 @@ Related example
 :ref:`Age prediction on OASIS dataset with SpaceNet <sphx_glr_auto_examples_02_decoding_plot_oasis_vbm_space_net.py>`.
 
 .. figure:: ../auto_examples/02_decoding/images/sphx_glr_plot_oasis_vbm_space_net_002.png
+   :align: center
 
 .. note::
 

--- a/doc/glm/glm_intro.rst
+++ b/doc/glm/glm_intro.rst
@@ -78,6 +78,7 @@ or hypothesized internal processes (e.g. memorization of a stimulus), ...
 
 
 .. figure:: ../images/stimulation-time-diagram.png
+   :align: center
 
 
 One expects that a brain region involved in the processing of a certain type of event
@@ -94,6 +95,7 @@ as can be seen in the following figure showing the response to an impulsive even
 (for example, an auditory click played to the participants).
 
 .. figure:: ../images/spm_iHRF.png
+   :align: center
 
 Using our knowledge of the haemodynamic response,
 we can build a predicted time course from the time-diagram of the event
@@ -112,6 +114,7 @@ the voxel is said to exhibit a significant response to the event type.
 
 
 .. figure:: ../images/time-course-and-model-fit-in-a-voxel.png
+   :align: center
 
 Correlations are computed separately at each :term:`voxel` and a correlation map can be produced displaying
 the values of correlations (real numbers between -1 and +1) at each :term:`voxel`.
@@ -127,6 +130,7 @@ The map is thresholded so that only voxels with a p-value less than 1/1000 are c
 
 
 .. figure:: ../images/example-spmZ_map.png
+   :align: center
 
 
 In most :term:`fMRI` experiments, several predictors are needed to fully
@@ -194,6 +198,7 @@ meaning, if there were no effect, the probability of observing an effect as larg
 would be less than :math:`\alpha`.
 
 .. figure:: ../images/student.png
+   :align: center
 
 .. note::
 

--- a/doc/manipulating_images/manipulating_images.rst
+++ b/doc/manipulating_images/manipulating_images.rst
@@ -175,8 +175,9 @@ can be computed from the data:
      :end-before: # Applying the mask to extract the corresponding time series
 
 .. figure:: ../auto_examples/01_plotting/images/sphx_glr_plot_visualization_002.png
-    :target: ../auto_examples/01_plotting/plot_visualization.html
-    :scale: 50%
+   :target: ../auto_examples/01_plotting/plot_visualization.html
+   :scale: 50%
+   :align: center
 
 
 .. _mask_4d_2_3d:

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -156,6 +156,7 @@ or saved as a portable HTML file ``report.save_as_html(output_filepath)``.
 .. figure:: /images/niftimasker_report.png
     :target: ../auto_examples/06_manipulating_images/plot_mask_computation.html
     :scale: 50%
+    :align: center
 
 Different masking strategies
 .............................
@@ -180,6 +181,7 @@ functions documentation, or :doc:`the NiftiMasker example
 .. figure:: /images/niftimasker_report_params.png
     :target: ../auto_examples/06_manipulating_images/plot_mask_computation.html
     :scale: 50%
+    :align: center
 
 .. _masker_preprocessing_steps:
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- center all figures that should prevent some "weird" layout when figures were left aligned

https://nilearn.github.io/stable/decoding/decoding_intro.html#the-haxby-2001-experiment

![image](https://github.com/user-attachments/assets/85240b53-80b1-453c-8c5e-f59ba9928ab1)

