### PR TITLE
[DOC] add page for older doc versions

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -315,7 +315,7 @@ Featured examples
    maintenance.rst
    changes/whats_new.rst
    authors.rst
-   versions.rst
+   Versions <versions.rst>
    GitHub Repository <https://github.com/nilearn/nilearn>
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -315,6 +315,7 @@ Featured examples
    maintenance.rst
    changes/whats_new.rst
    authors.rst
+   versions.rst
    GitHub Repository <https://github.com/nilearn/nilearn>
 
 

--- a/doc/versions.rst
+++ b/doc/versions.rst
@@ -1,0 +1,12 @@
+Available documentation for Nilearn
+===================================
+
+Web-based documentation is available for versions listed below:
+
+* `Nilearn 0.11.2dev (dev) documentation <http://nilearn.github.io/dev/>`_
+* `Nilearn 0.11.1 (stable) documentation <http://nilearn.github.io/stable/>`_
+* `Nilearn 0.10.2 documentation <http://nilearn.github.io/0.10.2/>`_
+* `Nilearn 0.10.0 documentation <http://nilearn.github.io/0.10.0/>`_
+* `Nilearn 0.9.2 documentation <http://nilearn.github.io/0.9.2/>`_
+* `Nilearn 0.9.1 documentation <http://nilearn.github.io/0.9.1/>`_
+* `Nilearn 0.9.0 documentation <http://nilearn.github.io/0.9.0/>`_


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- add a page to link to older versions of the doc similar to what can be found in sklearn doc: https://scikit-learn.org/dev/versions.html
- I had to to do some git archeology to dig out old versions of the doc and put them in separate folder in the doc repo: https://github.com/nilearn/nilearn.github.io
-
