### PR TITLE
[FIX] set git username / mail for dev doc deploy

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -359,4 +359,7 @@ jobs:
                 SSH_AUTH_SOCK: /tmp/ssh_agent.sock
                 COMMIT_SHA: ${{ github.event.head_commit.id }}
                 DEPLOY_TYPE: ${{ steps.deploy-type.outputs.DEPLOY_TYPE }}
-            run: ./build_tools/github/deploy_doc.sh
+            run: |
+                git config --global user.email "actions@github.com"
+                git config --global user.name "GitHub actions"
+                ./build_tools/github/deploy_doc.sh


### PR DESCRIPTION
Closes none but should fix deploy of dev doc on main:

see failure: https://github.com/nilearn/nilearn/actions/runs/12545676635/job/34984186478#step:6:150

```
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
```