### PR TITLE
[STY] add mising stacklevel in warnings in in nilearn.image

### DIFF
--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -220,7 +220,8 @@ def smooth_array(arr, affine, fwhm=None, ensure_finite=True, copy=True):
     if isinstance(fwhm, (int, float)) and (fwhm == 0.0):
         warnings.warn(
             f"The parameter 'fwhm' for smoothing is specified as {fwhm}. "
-            "Setting it to None (no smoothing will be performed)"
+            "Setting it to None (no smoothing will be performed)",
+            stacklevel=3,
         )
         fwhm = None
     if arr.dtype.kind == "i":

--- a/nilearn/image/resampling.py
+++ b/nilearn/image/resampling.py
@@ -278,7 +278,7 @@ def _resample_one_img(
             "passed to resample. This is a bad thing as they "
             "make resampling ill-defined and much slower.",
             RuntimeWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         if copy:
             # We need to do a copy to avoid modifying the input
@@ -298,7 +298,8 @@ def _resample_one_img(
             "Resampling binary images with continuous or "
             "linear interpolation. This might lead to "
             "unexpected results. You might consider using "
-            "nearest interpolation instead."
+            "nearest interpolation instead.",
+            stacklevel=3,
         )
 
     # Suppresses warnings in https://github.com/nilearn/nilearn/issues/1363
@@ -489,7 +490,8 @@ def resample_img(
             warnings.warn(
                 "The provided image has no sform in its header. "
                 "Please check the provided file. "
-                "Results may not be as expected."
+                "Results may not be as expected.",
+                stacklevel=2,
             )
 
     # noop cases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,16 +218,15 @@ max-complexity = 25
 "**/{examples}/*" = ["B018", "D103", "D400", "E402"]
 "**/{tests}/**/test_*" = ["D100", "D103", "E402"]
 "__init__.py" = ["D104", "E402"]
-"nilearn/signal.py" = ["B028"]
-"nilearn/{_utils}/*" = ["B028"]
-"nilearn/{connectome}/*" = ["B028"]
-"nilearn/{datasets}/*" = ["B028"]
-"nilearn/{decoding}/*" = ["B028"]
-"nilearn/{glm}/*" = ["B028"]
-"nilearn/{image}/*" = ["B028"]
-"nilearn/{maskers}/*" = ["B028"]
-"nilearn/{mass_univariate}/*" = ["B028"]
-"nilearn/{plotting}/*" = ["B028"]
+"nilearn/signal.py" = ["B028"]  # 11 errors to fix
+"nilearn/{_utils}/*" = ["B028"]  # 7 errors to fix
+"nilearn/{connectome}/*" = ["B028"]  # 5 errors to fix
+"nilearn/{datasets}/*" = ["B028"]  # 23 errors to fix
+"nilearn/{decoding}/*" = ["B028"]  # 5 errors to fix
+"nilearn/{glm}/*" = ["B028"]  # 19 errors to fix
+"nilearn/{maskers}/*" = ["B028"]  # 17 errors to fix
+"nilearn/{mass_univariate}/*" = ["B028"]  # 4 errors to fix
+"nilearn/{plotting}/*" = ["B028"]  # 18 errors to fix
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but relates to #4797 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- fix B028 ruff error in nilearn.image
-
