### PR TITLE
[FIX] Convert Schaeffer atlas labels to list of strings

### DIFF
--- a/doc/visual_testing/reporter_visual_inspection_suite.py
+++ b/doc/visual_testing/reporter_visual_inspection_suite.py
@@ -364,7 +364,7 @@ def report_nifti_labels_masker(build_type):
 
     atlas = fetch_atlas_schaefer_2018()
 
-    atlas.labels = np.insert(atlas.labels, 0, "Background")
+    atlas.labels.insert(0, "Background")
 
     masker = NiftiLabelsMasker(
         atlas.maps,

--- a/nilearn/datasets/atlas.py
+++ b/nilearn/datasets/atlas.py
@@ -2099,7 +2099,7 @@ def fetch_atlas_schaefer_2018(
               The values are consecutive integers
               between 0 and ``n_rois`` which can be interpreted as indices
               in the list of labels.
-            - 'labels': :class:`numpy.ndarray` of :obj:`str`, array
+            - 'labels': :obj:`list` of :obj:`str`, list
               containing the ROI labels including Yeo-network annotation.
 
                 .. warning::
@@ -2187,9 +2187,12 @@ def fetch_atlas_schaefer_2018(
         data_dir, files, resume=resume, verbose=verbose
     )
 
-    labels = np.genfromtxt(
-        labels_file, usecols=1, dtype="S", delimiter="\t", encoding=None
+    lut = pd.read_csv(
+        labels_file,
+        delimiter="\t",
+        names=["index", "name", "r", "g", "b", "fs"],
     )
+    labels = list(lut["name"])
     fdescr = get_dataset_descr(dataset_name)
 
     return Bunch(maps=atlas_file, labels=labels, description=fdescr)

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -863,9 +863,9 @@ def test_fetch_atlas_schaefer_2018(tmp_path, request_mocker):
 
         assert data.description != ""
         assert isinstance(data.maps, str)
-        assert isinstance(data.labels, np.ndarray)
+        assert isinstance(data.labels, list)
         assert len(data.labels) == n_rois
-        assert data.labels[0].astype(str).startswith(f"{yeo_networks}Networks")
+        assert data.labels[0].startswith(f"{yeo_networks}Networks")
 
         img = load(data.maps)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but should fix doc build

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- make Schaeffer atlas labels are a list of strings
- update script to generate masker report to avoid errors
