### PR TITLE
[DOC] update colormaps and doc strings

### DIFF
--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -231,7 +231,7 @@ class NiftiMasker(BaseMasker):
         If set to True, data is saved in order to produce a report.
 
     %(cmap)s
-        default="CMRmap_r"
+        default="gray"
         Only relevant for the report figures.
 
     %(masker_kwargs)s

--- a/nilearn/plotting/displays/_axes.py
+++ b/nilearn/plotting/displays/_axes.py
@@ -530,7 +530,7 @@ class GlassBrainAxes(BaseAxes):
         line_values : array_like
             Values of the lines.
 
-        cmap : :class:`~matplotlib.colors.Colormap`
+        %(cmap)s
             Colormap used to map ``line_values`` to a color.
 
         vmin, vmax : :obj:`float`, optional

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -134,8 +134,8 @@ def _prepare_lines_metadata(
         e.g. "25.3%", and only connections of amplitude above the
         given percentile will be shown.
 
-    cmap : :obj:`str` or matplotlib colormap, default=cm.bwr
-        Colormap to use.
+    %(cmap)s
+        default=cm.bwr
 
     symmetric_cmap : :obj:`bool`, default=True
         Make colormap symmetric (ranging from -vmax to vmax).

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -131,8 +131,9 @@ def _save_sprite(
     mask : :class:`numpy.ndarray`, optional
         Mask to use.
 
-    cmap : :obj:`str` or colormap, default='Greys'
-        Colormap to use.
+    %(cmap)s
+        default='Greys'
+
 
     format : :obj:`str`, default='png'
         Format to use for output image.
@@ -561,7 +562,7 @@ def view_img(
         If set to auto, an educated guess is made to find if the background
         is white or black.
     %(cmap)s
-        Default=`plt.cm.cold_hot`.
+        default="RdBu_r"
     symmetric_cmap : :obj:`bool`, default=True
         True: make colormap symmetric (ranging from -vmax to vmax).
         False: the colormap will go from the minimum of the volume to vmax.

--- a/nilearn/plotting/html_surface.py
+++ b/nilearn/plotting/html_surface.py
@@ -338,7 +338,7 @@ def view_img_on_surf(
     stat_map_img,
     surf_mesh="fsaverage5",
     threshold=None,
-    cmap=cm.cold_hot,
+    cmap="RdBu_r",
     black_bg=False,
     vmax=None,
     vmin=None,
@@ -376,8 +376,8 @@ def view_img_on_surf(
         e.g. "25.3%%", and only values of amplitude above the
         given percentile will be shown.
 
-    cmap : :obj:`str` or matplotlib colormap, default=cm.cold_hot
-        Colormap to use.
+    %(cmap)s
+        default="RdBu_r"
 
     black_bg : :obj:`bool`, default=False
         If True, image is plotted on a black background. Otherwise on a
@@ -472,7 +472,7 @@ def view_surf(
     bg_map=None,
     hemi=None,
     threshold=None,
-    cmap=cm.cold_hot,
+    cmap="RdBu_r",
     black_bg=False,
     vmax=None,
     vmin=None,
@@ -550,9 +550,8 @@ def view_surf(
         e.g. "25.3%%", and only values of amplitude above the
         given percentile will be shown.
 
-    cmap : :obj:`str` or matplotlib colormap, default=cm.cold_hot
-        You might want to change it to 'gnist_ncar' if plotting a
-        surface atlas.
+    %(cmap)s
+        default="RdBu_r"
 
     black_bg : :obj:`bool`, default=False
         If True, image is plotted on a black background. Otherwise on a

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -772,7 +772,7 @@ def plot_epi(
         Ex: use "%%i" to display as integers.
 
     %(cmap)s
-        Default=`plt.cm.nipy_spectral`.
+        Default=`plt.cm.gray`.
 
     %(vmin)s
 
@@ -831,8 +831,7 @@ def _plot_roi_contours(display, roi_img, cmap, alpha, linewidths):
         The ROI/mask image, it could be binary mask or an atlas or ROIs
         with integer values.
 
-    cmap : matplotlib colormap
-        The colormap for the atlas maps.
+    %(cmap)s
 
     alpha : :obj:`float` between 0 and 1
         Alpha sets the transparency of the color inside the filled
@@ -1309,7 +1308,7 @@ def plot_stat_map(
     annotate=True,
     draw_cross=True,
     black_bg="auto",
-    cmap=plt.cm.RdBu_r,
+    cmap="RdBu_r",
     symmetric_cbar="auto",
     dim="auto",
     vmin=None,
@@ -1367,7 +1366,7 @@ def plot_stat_map(
         .. note::
             The colormap *must* be symmetrical.
 
-        Default=`plt.cm.cold_hot`.
+        Default=default="RdBu_r".
 
     %(symmetric_cbar)s
 
@@ -1994,7 +1993,6 @@ def plot_carpet(
     %(vmax)s
     %(title)s
     %(cmap)s
-
         Default=`gray`.
 
     cmap_labels : :class:`matplotlib.colors.Colormap`, or :obj:`str`, \

--- a/nilearn/plotting/matrix_plotting.py
+++ b/nilearn/plotting/matrix_plotting.py
@@ -218,7 +218,7 @@ def plot_matrix(
     figure=None,
     axes=None,
     colorbar=True,
-    cmap=plt.cm.RdBu_r,
+    cmap="RdBu_r",
     tri="full",
     auto_fit=True,
     grid=False,
@@ -257,8 +257,10 @@ def plot_matrix(
 
     %(colorbar)s
         Default=True.
+
     %(cmap)s
-        Default=`plt.cm.RdBu_r`.
+        default="RdBu_r"
+
     tri : {'full', 'lower', 'diag'}, default='full'
         Which triangular part of the matrix to plot:
 
@@ -641,7 +643,7 @@ def plot_event(model_event, cmap=None, output_file=None, **fig_kwargs):
 def plot_design_matrix_correlation(
     design_matrix,
     tri="full",
-    cmap=plt.cm.RdBu_r,
+    cmap="RdBu_r",
     output_file=None,
     **kwargs,
 ):
@@ -664,7 +666,7 @@ def plot_design_matrix_correlation(
         - ``"full"``: Plot the full matrix
 
     %(cmap)s
-        Default="bwr".
+        default="RdBu_r"
 
         This must be a diverging colormap as the correlation matrix
         will be centered on 0.

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -1438,6 +1438,7 @@ def plot_surf_stat_map(
         as transparent.
 
     %(cmap)s
+        default="RdBu_r"
 
     %(cbar_tick_format)s
         Default="auto" which will select:
@@ -1789,7 +1790,7 @@ def plot_img_on_surf(
     %(threshold)s
     %(symmetric_cbar)s
     %(cmap)s
-        Default='cold_hot'.
+        Default="RdBu_r".
     %(cbar_tick_format)s
     kwargs : :obj:`dict`, optional
         keyword arguments passed to plot_surf_stat_map.


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- update some colormaps forgotten in #4959
- update doc strings that still used the old default
