### PR TITLE
[MAINT] use tag for commit message of release

### DIFF
--- a/build_tools/github/deploy_doc.sh
+++ b/build_tools/github/deploy_doc.sh
@@ -1,9 +1,16 @@
 #!/bin/bash -exf
 
-#
 # - Clone the doc repo in doc_build.
+#
+# For deploy of doc build on PR (dev)
 # - Deletes dev folder
+# For deploy of doc build on release (stable)
+# - Deletes stable folder
+#
 # - Replaces it with content from doc/_build/html
+# For deploy of doc build on release (stable)
+# - Also copies the doc in a folder X.Y.Z with X.Y.Z corresponding to the doc version
+#
 # - Commits changes and push
 #
 # USAGE
@@ -24,7 +31,6 @@ set -x -e
 
 CLONED_DOC='doc/_build/nilearn.github.io'
 
-
 if [ ! -d ${CLONED_DOC} ]; then
     echo "Cloning nilearn/nilearn.github.io: this may take a while..."
     # --depth 1 is a speed optimization
@@ -40,18 +46,32 @@ git -C ${CLONED_DOC} fetch origin
 git -C ${CLONED_DOC} reset --hard origin/main
 git -C ${CLONED_DOC} clean -xdf
 
-echo "Deploying ${DEPLOY_TYPE} docs."
+echo "Copying ${DEPLOY_TYPE} docs."
+
 rm -fr "${CLONED_DOC:?}/${DEPLOY_TYPE}"
+
 cp -a ./doc/_build/html "${CLONED_DOC}/${DEPLOY_TYPE}"
+
+if [ "${DEPLOY_TYPE}" == "stable" ]; then
+    VERSIONTAG=$(git describe --tags --abbrev=0)
+    cp -a ./doc/_build/html "${CLONED_DOC}/${VERSIONTAG}"
+fi
+
+echo "Deploying ${DEPLOY_TYPE} docs."
+
 git -C ${CLONED_DOC} add -A
 
-HEAD_COMMIT_MESSAGE=$(git log -1 --format=%s)
-git -C ${CLONED_DOC} commit -m "${DEPLOY_TYPE} docs https://github.com/nilearn/nilearn/commit/${COMMIT_SHA} : ${HEAD_COMMIT_MESSAGE}"
+if [ "${DEPLOY_TYPE}" == "stable" ]; then
+    MSG="${VERSIONTAG}"
+else
+    HEAD_COMMIT_MESSAGE=$(git log -1 --format=%s)
+    MSG="https://github.com/nilearn/nilearn/commit/${COMMIT_SHA} : ${HEAD_COMMIT_MESSAGE}"
+fi
+git -C ${CLONED_DOC} commit -m "${DEPLOY_TYPE} docs: ${MSG}"
 
 git -C ${CLONED_DOC} push origin main
 
 if [ "${DEPLOY_TYPE}" == "stable" ]; then
-    VERSIONTAG=$(git describe --tags --abbrev=0)
     git -C ${CLONED_DOC} tag "${VERSIONTAG}" && \
 	git -C ${CLONED_DOC} push --tags
 fi


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Doc build of of the doc on release should have clear identifiable commit message.

Currently they look like those of the dev build: 

`stable docs https://github.com/nilearn/nilearn/commit/ : [MISC] update doc strings types (#5023)`

See https://github.com/nilearn/nilearn.github.io/commit/ceab1acb6c749b5b6e999610b725e90b4743e668

-
