### PR TITLE
[MAINT] Fix `check_docstrings` not checking any files and not catching unneeded `fill_doc`

### DIFF
--- a/maint_tools/check_docstrings.py
+++ b/maint_tools/check_docstrings.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import ast
 import re
+from pathlib import Path
 
 from numpydoc.docscrape import NumpyDocString
 from rich import print
@@ -63,13 +64,13 @@ def main() -> None:
 
 
 def check_fill_doc_decorator(
-    ast_node: ast.ClassDef | ast.FunctionDef, filename: str
+    ast_node: ast.ClassDef | ast.FunctionDef, filename: str | Path
 ) -> None:
     """Check that fill_doc decorator is present when needed.
 
     Checks if '%(' is present in the doc string
     and warns if the function or class
-    does not have the @fill_doc dcorator.
+    does not have the @fill_doc decorator.
 
     Also warns if the decorator is used for no reason.
     """
@@ -94,7 +95,12 @@ def check_fill_doc_decorator(
                 "- [red]missing @fill_doc decorator."
             )
     elif any(
-        getattr(x, "name", "") == "fill_doc" for x in ast_node.decorator_list
+        (
+            getattr(x, "name", "") == "fill_doc"
+            or getattr(x, "id", "") == "fill_doc"
+            or getattr(x, "attr", "") == "fill_doc"
+        )
+        for x in ast_node.decorator_list
     ):
         print(
             f"{filename}:{ast_node.lineno} "

--- a/maint_tools/utils.py
+++ b/maint_tools/utils.py
@@ -38,7 +38,10 @@ def list_modules(
     modules = []
     nilearn_dir = root_dir() / "nilearn"
     for mod in nilearn_dir.glob("**/*.py"):
-        if any(x.stem in folders_to_skip for x in mod.relative_to(nilearn_dir).parents):
+        if any(
+            x.stem in folders_to_skip
+            for x in mod.relative_to(nilearn_dir).parents
+        ):
             continue
         if any(mod.name.startswith(s) for s in files_to_skip):
             continue

--- a/maint_tools/utils.py
+++ b/maint_tools/utils.py
@@ -36,8 +36,9 @@ def list_modules(
         files_to_skip += "_"
 
     modules = []
-    for mod in (root_dir() / "nilearn").glob("**/*.py"):
-        if any(x.stem in folders_to_skip for x in mod.parents):
+    nilearn_dir = root_dir() / "nilearn"
+    for mod in nilearn_dir.glob("**/*.py"):
+        if any(x.stem in folders_to_skip for x in mod.relative_to(nilearn_dir).parents):
             continue
         if any(mod.name.startswith(s) for s in files_to_skip):
             continue

--- a/nilearn/interfaces/fmriprep/load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_utils.py
@@ -9,7 +9,6 @@ import numpy as np
 import pandas as pd
 from sklearn.preprocessing import scale
 
-from nilearn._utils import fill_doc
 from nilearn._utils.fmriprep_confounds import flag_single_gifti, is_camel_case
 from nilearn.interfaces.bids import parse_bids_filename
 
@@ -482,7 +481,6 @@ def _demean_confounds(confounds, sample_mask):
     return pd.DataFrame(confounds, columns=confound_cols)
 
 
-@fill_doc
 class MissingConfoundError(Exception):
     """
     Exception raised when failing to find params in the confounds.

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -40,7 +40,6 @@ class _MaskWarning(UserWarning):
 warnings.simplefilter("always", _MaskWarning)
 
 
-@fill_doc
 def load_mask_img(mask_img, allow_empty=False):
     """Check that a mask is valid.
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- `maint_tools/utils.list_modules` ignores all modules if a parent directory above the repository root matches a folder to skip. For example if my Nilearn repo is at `/data/nilearn`, then the `check_docstrings.py` script doesn't work. Updated to only check parent directories within the `nilearn` root repo
- I noticed that [`nilearn.masking.load_mask_img`](https://github.com/nilearn/nilearn/blob/d52c31f79a74219aa38477fde267f4fd25600ce8/nilearn/masking.py#L43-L65) is decorated with `fill_doc` but does not have any `%(` substring inside it. Somehow that wasn't caught by `check_fill_doc_decorator`, so I updated it to catch that too
- Removed 2 instances of unneeded `fill_doc`
