### PR TITLE
[ENH] Plot PNG instead of SVG in surface masker reports

### DIFF
--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -510,7 +510,7 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
         """
         import matplotlib.pyplot as plt
 
-        from nilearn.reporting.utils import figure_to_svg_base64
+        from nilearn.reporting.utils import figure_to_png_base64
 
         # Handle the edge case where this function is
         # called with a masker having report capabilities disabled
@@ -521,7 +521,7 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
 
         plt.close()
 
-        init_display = figure_to_svg_base64(fig)
+        init_display = figure_to_png_base64(fig)
 
         return [init_display]
 

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -427,7 +427,7 @@ class SurfaceMasker(_BaseSurfaceMasker):
         # avoid circular import
         import matplotlib.pyplot as plt
 
-        from nilearn.reporting.utils import figure_to_svg_base64
+        from nilearn.reporting.utils import figure_to_png_base64
 
         # Handle the edge case where this function is
         # called with a masker having report capabilities disabled
@@ -441,7 +441,7 @@ class SurfaceMasker(_BaseSurfaceMasker):
 
         plt.close()
 
-        init_display = figure_to_svg_base64(fig)
+        init_display = figure_to_png_base64(fig)
 
         return [init_display]
 

--- a/nilearn/reporting/data/html/report_body_template_surfacemasker.html
+++ b/nilearn/reporting/data/html/report_body_template_surfacemasker.html
@@ -9,7 +9,7 @@
       <img
         class="pure-img"
         width="100%"
-        src="data:image/svg+xml;base64,{{content}}"
+        src="data:image/png;base64,{{content}}"
         alt="image"
       />
       {{if overlay}}
@@ -17,7 +17,7 @@
         <img
           class="pure-img"
           width="100%"
-          src="data:image/svg+xml;base64,{{overlay}}"
+          src="data:image/png;base64,{{overlay}}"
           alt="overlay"
         />
       </div>

--- a/nilearn/reporting/tests/test_html_report.py
+++ b/nilearn/reporting/tests/test_html_report.py
@@ -30,7 +30,10 @@ from nilearn.maskers import (
 def _check_html(html_view):
     """Check the presence of some expected code in the html viewer."""
     assert "<th>Parameter</th>" in str(html_view)
-    assert "data:image/svg+xml;base64," in str(html_view)
+    if "Surface" in str(html_view):
+        assert "data:image/png;base64," in str(html_view)
+    else:
+        assert "data:image/svg+xml;base64," in str(html_view)
     assert html_view._repr_html_() == html_view.body
 
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes None but related to point 3 in https://github.com/nilearn/nilearn/pull/4968#issuecomment-2594970907 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- use `figure_to_png_base64` instead of `figure_to_svg_base64`
- update report template accordingly
