### PR TITLE
[FIX] Pin Kaleido to 0.2.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ deps =
     {[matplotlib]deps}
     kaleido
     plotly
-    kaleido ; platform_system != 'Windows'
+    kaleido==0.2.1 ; platform_system != 'Windows'
     kaleido==0.1.0.post1 ; platform_system == 'Windows'
 
 [global_var]


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #5080

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Apparently Kaleido stopped shipping with chromium as suggested in https://github.com/plotly/Kaleido/issues/223#issuecomment-2483824967
- fix is to pin it to 0.2.1 Kaleido
