### PR TITLE
[MAINT] run linkcheck only on main

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -2,7 +2,6 @@
 # Workflow to build the documentation.
 #
 # - validate CITATION.CFF file
-# - check for dead links
 # - get datasets from cache or from source
 # - build doc and upload it as artifact
 # - on `main` (or on github release): trigger hosting of dev (or stable) doc on https://github.com/nilearn//nilearn.github.io.git
@@ -168,33 +167,6 @@ jobs:
                     pattern.txt
                 retention-days: 1
                 overwrite: true
-
-    # check the links in the doc
-    # only on full build
-    linkcheck:
-        needs: [build_type]
-        runs-on: ubuntu-latest
-        steps:
-        -   name: Checkout nilearn
-            uses: actions/checkout@v4
-        -   name: Download build type
-            uses: actions/download-artifact@v4
-            with:
-                name: build_type
-        -   name: Verify build type
-            id: build-type
-            run: echo "build=$(cat build.txt)" >> $GITHUB_OUTPUT
-        -   name: Install the latest version of uv
-            uses: astral-sh/setup-uv@v5
-        -   name: Setup python
-            uses: actions/setup-python@v5
-            with:
-                python-version: '3.13'
-        -   name: Install packages
-            run: uv tool install tox --with=tox-uv --with=tox-gh-actions
-        -   name: check links
-            if: ${{ steps.build-type.outputs.build == 'html-strict' }}
-            run: tox run -e linkcheck
 
     get_data:
         # This prevents this workflow from running on a fork.

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -15,6 +15,10 @@ on:
     # Run every Monday at 8am UTC
     -   cron: 0 8 * * 1
 
+    pull_request:
+        branches:
+        -   '*'
+
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:
 

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -15,10 +15,6 @@ on:
     # Run every Monday at 8am UTC
     -   cron: 0 8 * * 1
 
-    pull_request:
-        branches:
-        -   '*'
-
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:
 

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,46 @@
+---
+# Check for dead links in the the documentation.
+#
+# Links to ignore are set in doc/conf.py
+# (see ``linkcheck_.*`` variables).
+#
+###
+name: linkcheck
+
+on:
+    push:
+        branches:
+        -   main
+    schedule:
+    # Run every Monday at 8am UTC
+    -   cron: 0 8 * * 1
+
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+env:
+    # Force to use color
+    FORCE_COLOR: true
+
+jobs:
+
+    # check the links in the doc
+    linkcheck:
+        runs-on: ubuntu-latest
+        steps:
+        -   name: Checkout nilearn
+            uses: actions/checkout@v4
+        -   name: Install the latest version of uv
+            uses: astral-sh/setup-uv@v5
+        -   name: Setup python
+            uses: actions/setup-python@v5
+            with:
+                python-version: '3.13'
+        -   name: Install packages
+            run: uv tool install tox --with=tox-uv --with=tox-gh-actions
+        -   name: check links
+            run: tox run -e linkcheck

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -198,16 +198,7 @@ linkcheck_ignore = [
     # give a 403 Client Error: Forbidden for url:
     r"https://sites.wustl.edu/oasisbrains/.*",
     # similarly below are publishers that do not like doi redirects:
-    r"https://doi.org/10.1523/JNEUROSCI.*",
-    r"https://doi.org/10.1002/.*",
-    r"https://doi.org/10.1073/.*",
-    r"https://doi.org/10.1080/.*",
-    r"https://doi.org/10.1093/.*",
-    r"https://doi.org/10.1111/.*",
-    r"https://doi.org/10.1126/.*",
-    r"https://doi.org/10.1152/.*",
-    r"https://doi.org/10.1162/.*",
-    r"https://doi.org/10.3389/.*",
+    r"https://doi.org/.*",
     # do not check download links for OSF
     r"https://osf.io/.*/download",
 ]


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- extract linkcheck from doc build and run it as a separate workflow on main only 
- skip linkcheck for DOIs as they can be quite flaky
