### PR TITLE
[ENH] improve nilearn check is fitted

### DIFF
--- a/nilearn/_utils/class_inspect.py
+++ b/nilearn/_utils/class_inspect.py
@@ -275,13 +275,12 @@ def check_masker_fitted(estimator):
     """
     import pytest
 
-    from nilearn._utils.data_gen import generate_random_img
+    from nilearn.conftest import _img_3d_rand, _make_surface_img
 
     # Failure should happen before the input type is determined
     # so we can pass nifti image to surface maskers.
-    img_3d_rand_eye = generate_random_img(shape=(7, 8, 9), affine=np.eye(4))
     with pytest.raises(ValueError, match=_not_fitted_error_message(estimator)):
-        estimator.transform(img_3d_rand_eye)
+        estimator.transform(_img_3d_rand())
 
     # Failure should happen before the size of the input type is determined
     # so we can pass any array here.
@@ -289,7 +288,11 @@ def check_masker_fitted(estimator):
     with pytest.raises(ValueError, match=_not_fitted_error_message(estimator)):
         estimator.inverse_transform(signals)
 
-    estimator.fit()
+    # NiftiMasker and SurfaceMasker cannot accept None on fit
+    if accept_niimg_input(estimator):
+        estimator.fit(_img_3d_rand())
+    else:
+        estimator.fit(_make_surface_img(10))
 
     assert estimator.__sklearn_is_fitted__()
 
@@ -311,7 +314,7 @@ def check_surface_masker_fit_returns_self(estimator):
     """
     from nilearn.conftest import _make_surface_img
 
-    assert estimator.fit(_make_surface_img(100)) is estimator
+    assert estimator.fit(_make_surface_img(10)) is estimator
 
 
 def check_nifti_masker_fit_transform(estimator):

--- a/nilearn/_utils/class_inspect.py
+++ b/nilearn/_utils/class_inspect.py
@@ -204,7 +204,7 @@ def nilearn_check_estimator(estimator):
         is_masker = getattr(tags.input_tags, "masker", False)
         surf_img_input = getattr(tags.input_tags, "surf_img", False)
 
-    yield (clone(estimator), check_estimator_fitted)
+    yield (clone(estimator), check_estimator_has_sklearn_is_fitted)
 
     if is_masker:
         yield (clone(estimator), check_masker_fitted)
@@ -261,12 +261,12 @@ def _not_fitted_error_message(estimator):
     )
 
 
-def check_estimator_fitted(estimator):
+def check_estimator_has_sklearn_is_fitted(estimator):
     """Check appropriate response to check_fitted from sklearn before fitting.
 
     check that before fitting
-    - masker has a __sklearn_is_fitted__ method
-    - running sklearn check_fitted on masker throws an error
+    - estimator has a __sklearn_is_fitted__ method
+    - running sklearn check_is_fitted on estimator throws an error
     """
     import pytest
 

--- a/nilearn/_utils/class_inspect.py
+++ b/nilearn/_utils/class_inspect.py
@@ -266,10 +266,12 @@ def check_masker_fitted(estimator):
     for sklearn's check_fit_check_is_fitted
 
     check that before fitting
-    - masker has a __sklearn_is_fitted__ method
-    - running sklearn check_fitted on masker throws an error
     - transform() and inverse_transform() \
       throw same error
+
+    check that after fitting
+    - __sklearn_is_fitted__ returns true
+    - running sklearn check_fitted throws no error
     """
     import pytest
 
@@ -286,6 +288,12 @@ def check_masker_fitted(estimator):
     signals = np.ones((10, 11))
     with pytest.raises(ValueError, match=_not_fitted_error_message(estimator)):
         estimator.inverse_transform(signals)
+
+    estimator.fit()
+
+    assert estimator.__sklearn_is_fitted__()
+
+    check_is_fitted(estimator)
 
 
 def check_nifti_masker_fit_returns_self(estimator):

--- a/nilearn/_utils/class_inspect.py
+++ b/nilearn/_utils/class_inspect.py
@@ -70,7 +70,12 @@ except ImportError:
     ...
 
 
-def check_estimator(estimator=None, valid=True, extra_valid_checks=None):
+def check_estimator(
+    estimator=None,
+    valid=True,
+    extra_valid_checks=None,
+    expected_failed_checks=None,
+):
     """Yield a valid or invalid scikit-learn estimators check.
 
     As some of Nilearn estimators do not comply
@@ -104,6 +109,16 @@ def check_estimator(estimator=None, valid=True, extra_valid_checks=None):
 
     extra_valid_checks : list of strings
         Names of checks to be tested as valid for this estimator.
+
+    expected_failed_checks: dict, default=None
+        A dictionary of the form::
+
+            {
+                "check_name": "this check is expected to fail because ...",
+            }
+
+        Where `"check_name"` is the name of the check, and `"my reason"` is why
+        the check fails.
     """
     valid_checks = VALID_CHECKS
     if extra_valid_checks is not None:
@@ -115,6 +130,15 @@ def check_estimator(estimator=None, valid=True, extra_valid_checks=None):
         for e, check in sklearn_check_estimator(
             estimator=est, generate_only=True
         ):
+            # TODO when dropping sklearn 1.5,
+            # pass expected_failed_checks directly to
+            # sklearn_check_estimator above
+            if (
+                isinstance(expected_failed_checks, dict)
+                and check.func.__name__ in expected_failed_checks
+            ):
+                continue
+
             tags = est._more_tags()
 
             niimg_input = False

--- a/nilearn/_utils/class_inspect.py
+++ b/nilearn/_utils/class_inspect.py
@@ -238,7 +238,7 @@ def is_multimasker(estimator):
     # TODO remove first if when dropping sklearn 1.5
     #  for sklearn >= 1.6 tags are always a dataclass
     if isinstance(tags, dict) and "X_types" in tags:
-        return "niimg_like" in tags["X_types"]
+        return "multi_masker" in tags["X_types"]
     else:
         return getattr(tags.input_tags, "multi_masker", False)
 
@@ -249,7 +249,7 @@ def accept_niimg_input(estimator):
     # TODO remove first if when dropping sklearn 1.5
     #  for sklearn >= 1.6 tags are always a dataclass
     if isinstance(tags, dict) and "X_types" in tags:
-        return "multi_masker" in tags["X_types"]
+        return "niimg_like" in tags["X_types"]
     else:
         return getattr(tags.input_tags, "niimg_like", False)
 

--- a/nilearn/_utils/tests/test_class_inspect.py
+++ b/nilearn/_utils/tests/test_class_inspect.py
@@ -6,6 +6,7 @@ which we historically used,
 ignores modules whose name starts with an underscore.
 """
 
+import pytest
 from sklearn.base import BaseEstimator
 
 from nilearn._utils import class_inspect
@@ -35,3 +36,31 @@ def test_get_params():
     assert params_a_in_b == {"a": 1}
     params_a_in_b = class_inspect.get_params(A, b, ignore=["a"])
     assert params_a_in_b == {}
+
+
+def test_check_estimator_has_sklearn_is_fitted():
+    """Check errors are thrown for unfitted estimator.
+
+    Check that before fitting
+    - estimlator has a __sklearn_is_fitted__ method that returns false
+    - running sklearn check_is_fitted on masker throws an error
+    """
+
+    class DummyEstimator:
+        def __init__(self):
+            pass
+
+    with pytest.raises(
+        TypeError, match="must have __sklearn_is_fitted__ method"
+    ):
+        class_inspect.check_estimator_has_sklearn_is_fitted(DummyEstimator())
+
+    class DummyEstimator:
+        def __init__(self):
+            pass
+
+        def __sklearn_is_fitted__(self):
+            return True
+
+    with pytest.raises(ValueError, match="must return False before fit"):
+        class_inspect.check_estimator_has_sklearn_is_fitted(DummyEstimator())

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -677,14 +677,6 @@ class ConnectivityMeasure(TransformerMixin, BaseEstimator):
     def __sklearn_is_fitted__(self):
         return not hasattr(self, "cov_estimator_")
 
-    def _check_fitted(self):
-        if self.__sklearn_is_fitted__():
-            raise ValueError(
-                f"It seems that {self.__class__.__name__} "
-                "has not been fitted. "
-                "You must call fit() before calling transform()."
-            )
-
     def inverse_transform(self, connectivities, diagonal=None):
         """Return connectivity matrices from connectivities, \
         vectorized or not.

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy import linalg
 from sklearn.base import BaseEstimator, TransformerMixin, clone
 from sklearn.covariance import LedoitWolf
+from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn._utils.docs import fill_doc
 
@@ -670,7 +671,7 @@ class ConnectivityMeasure(TransformerMixin, BaseEstimator):
             Vectors are cleaned when vectorize=True and confounds are provided.
 
         """
-        self._check_fitted()
+        check_is_fitted(self)
         return self._fit_transform(X, do_transform=True, confounds=confounds)
 
     def __sklearn_is_fitted__(self):
@@ -709,7 +710,7 @@ class ConnectivityMeasure(TransformerMixin, BaseEstimator):
             If kind is 'tangent', the covariance matrices are reconstructed.
 
         """
-        self._check_fitted()
+        check_is_fitted(self)
 
         connectivities = np.array(connectivities)
         if self.vectorize:

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -675,7 +675,7 @@ class ConnectivityMeasure(TransformerMixin, BaseEstimator):
         return self._fit_transform(X, do_transform=True, confounds=confounds)
 
     def __sklearn_is_fitted__(self):
-        return not hasattr(self, "cov_estimator_")
+        return hasattr(self, "cov_estimator_")
 
     def inverse_transform(self, connectivities, diagonal=None):
         """Return connectivity matrices from connectivities, \

--- a/nilearn/connectome/group_sparse_cov.py
+++ b/nilearn/connectome/group_sparse_cov.py
@@ -638,6 +638,9 @@ class GroupSparseCovariance(CacheMixin, BaseEstimator):
         self.precisions_ = ret
         return self
 
+    def __sklearn_is_fitted__(self):
+        return hasattr(self, "precisions_") and hasattr(self, "covariances_")
+
 
 def empirical_covariances(subjects, assume_centered=False, standardize=False):
     """Compute empirical covariances for several signals.
@@ -1251,3 +1254,6 @@ class GroupSparseCovarianceCV(CacheMixin, BaseEstimator):
             debug=self.debug,
         )
         return self
+
+    def __sklearn_is_fitted__(self):
+        return hasattr(self, "precisions_") and hasattr(self, "covariances_")

--- a/nilearn/connectome/tests/test_connectivity_matrices.py
+++ b/nilearn/connectome/tests/test_connectivity_matrices.py
@@ -66,6 +66,9 @@ extra_valid_checks = [
                 ConnectivityMeasure(cov_estimator=EmpiricalCovariance())
             ],
             extra_valid_checks=extra_valid_checks,
+            expected_failed_checks={
+                "check_fit_check_is_fitted": "handled by nilearn checks"
+            },
         )
     ),
 )
@@ -85,6 +88,9 @@ def test_check_estimator_group_sparse_covariance(
         estimator=[ConnectivityMeasure(cov_estimator=EmpiricalCovariance())],
         valid=False,
         extra_valid_checks=extra_valid_checks,
+        expected_failed_checks={
+            "check_fit_check_is_fitted": "handled by nilearn checks"
+        },
     ),
 )
 def test_check_estimator_invalid_group_sparse_covariance(

--- a/nilearn/connectome/tests/test_connectivity_matrices.py
+++ b/nilearn/connectome/tests/test_connectivity_matrices.py
@@ -835,10 +835,6 @@ def test_connectivity_measure_check_vectorization_option(kind, signals):
         vectorized_connectivities, sym_matrix_to_vec(connectivities)
     )
 
-    # Check not fitted error
-    with pytest.raises(ValueError, match="has not been fitted. "):
-        ConnectivityMeasure().inverse_transform(vectorized_connectivities)
-
 
 @pytest.mark.parametrize(
     "kind",

--- a/nilearn/connectome/tests/test_group_sparse_cov.py
+++ b/nilearn/connectome/tests/test_group_sparse_cov.py
@@ -25,6 +25,9 @@ extra_valid_checks = [
         check_estimator(
             estimator=[GroupSparseCovarianceCV(), GroupSparseCovariance()],
             extra_valid_checks=extra_valid_checks,
+            expected_failed_checks={
+                "check_fit_check_is_fitted": "handled by nilearn checks"
+            },
         )
     ),
 )
@@ -40,6 +43,9 @@ def test_check_estimator_group_sparse_covariance(estimator, check, name):  # noq
         estimator=[GroupSparseCovarianceCV(), GroupSparseCovariance()],
         valid=False,
         extra_valid_checks=extra_valid_checks,
+        expected_failed_checks={
+            "check_fit_check_is_fitted": "handled by nilearn checks"
+        },
     ),
 )
 def test_check_estimator_invalid_group_sparse_covariance(

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -784,6 +784,9 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
             if self.is_classification and (self.n_classes_ == 2):
                 self.dummy_output_ = self.dummy_output_[0, :][np.newaxis, :]
 
+    def __sklearn_is_fitted__(self):
+        return hasattr(self, "coef_") and hasattr(self, "masker_")
+
     def score(self, X, y, *args):
         """Compute the prediction score using the scoring \
         metric defined by the scoring attribute.
@@ -807,8 +810,7 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
             Prediction score.
 
         """
-        check_is_fitted(self, "coef_")
-        check_is_fitted(self, "masker_")
+        check_is_fitted(self)
         return self.scorer_(self, X, y, *args)
 
     def decision_function(self, X):
@@ -862,8 +864,7 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
             case, confidence score for self.classes_[1] where >0 means this
             class would be predicted.
         """
-        check_is_fitted(self, "coef_")
-        check_is_fitted(self, "masker_")
+        check_is_fitted(self)
 
         n_samples = np.shape(X)[-1]
 

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -438,10 +438,6 @@ class SearchLight(TransformerMixin, BaseEstimator):
             and self.process_mask_ is not None
         )
 
-    def _check_fitted(self):
-        if not self.__sklearn_is_fitted__():
-            raise ValueError("The model has not been fitted yet.")
-
     @property
     def scores_img_(self):
         """Convert the 3D scores array into a NIfTI image."""

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -18,6 +18,7 @@ from sklearn import svm
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.model_selection import KFold, cross_val_score
+from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn._utils import check_niimg_3d, check_niimg_4d, fill_doc, logger
 from nilearn._utils.tags import SKLEARN_LT_1_6
@@ -444,12 +445,12 @@ class SearchLight(TransformerMixin, BaseEstimator):
     @property
     def scores_img_(self):
         """Convert the 3D scores array into a NIfTI image."""
-        self._check_fitted()
+        check_is_fitted(self)
         return new_img_like(self.mask_img, self.scores_)
 
     def transform(self, imgs):
         """Apply the fitted searchlight on new images."""
-        self._check_fitted()
+        check_is_fitted(self)
 
         imgs = check_niimg_4d(imgs)
 

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -27,6 +27,7 @@ from sklearn.metrics import accuracy_score
 from sklearn.model_selection import check_cv
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.utils import check_array, check_X_y
+from sklearn.utils.estimator_checks import check_is_fitted
 from sklearn.utils.extmath import safe_sparse_dot
 
 from nilearn._utils.masker_validation import check_embedded_masker
@@ -1021,6 +1022,9 @@ class BaseSpaceNet(CacheMixin, LinearRegression):
 
         return self
 
+    def __sklearn_is_fitted__(self):
+        return hasattr(self, "masker_")
+
     def decision_function(self, X):
         """Predict confidence scores for samples.
 
@@ -1073,10 +1077,8 @@ class BaseSpaceNet(CacheMixin, LinearRegression):
             Predicted class label per sample.
         """
         # cast X into usual 2D array
-        if not hasattr(self, "masker_"):
-            raise RuntimeError(
-                f"This {self.__class__.__name__} instance is not fitted yet!"
-            )
+        check_is_fitted(self)
+
         X = self.masker_.transform(X)
 
         # handle regression (least-squared loss)

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -26,7 +26,7 @@ from numpy.testing import assert_array_almost_equal
 from sklearn.datasets import load_iris, make_classification, make_regression
 from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.ensemble import RandomForestClassifier
-from sklearn.exceptions import ConvergenceWarning, NotFittedError
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import (
     LassoCV,
     LogisticRegressionCV,
@@ -753,17 +753,6 @@ def test_decoder_dummy_classifier_with_callable(binary_classification_data):
 
     assert model.scoring == accuracy_scorer
     assert model.score(X, y) == accuracy_score(y, y_pred)
-
-
-def test_decoder_error_model_not_fitted(tiny_binary_classification_data):
-    X, y, mask = tiny_binary_classification_data
-
-    model = Decoder(estimator="dummy_classifier", mask=mask)
-
-    with pytest.raises(
-        NotFittedError, match="This Decoder instance is not fitted yet."
-    ):
-        model.score(X, y)
 
 
 def test_decoder_dummy_classifier_strategy_prior():

--- a/nilearn/decoding/tests/test_searchlight.py
+++ b/nilearn/decoding/tests/test_searchlight.py
@@ -224,37 +224,6 @@ def test_searchlight_group_cross_validation_with_extra_group_variable(
     sl.fit(imgs, y)
 
 
-def test_searchlight_attributes_exist_after_fit():
-    """Test if attributes `process_mask_` and `masked_scores_`
-    exist after fitting using mock data.
-    """
-    # Use the existing helper function to generate data
-    frames = 20
-    data_img, cond, mask_img = _make_searchlight_test_data(frames)
-
-    # Instantiate and fit the SearchLight with mock data
-    sl = searchlight.SearchLight(mask_img, radius=1.0)
-    sl.fit(data_img, y=cond)
-
-    # Check if attributes exist after fitting
-    assert hasattr(sl, "process_mask_")
-    assert hasattr(sl, "masked_scores_")
-
-
-def test_searchlight_scores_img_error_before_fit():
-    """Test if accessing `scores_img_` raises an error before fitting."""
-    # Create mock mask
-    frames = 20
-    data_img, cond, mask_img = _make_searchlight_test_data(frames)
-
-    # Instantiate SearchLight without fitting
-    sl = searchlight.SearchLight(mask_img, radius=5.0)
-
-    # Check if accessing `scores_img_` raises a ValueError
-    with pytest.raises(ValueError, match="The model has not been fitted yet."):
-        sl.scores_img_()
-
-
 def test_mask_img_dimension_mismatch():
     """Test if SearchLight handles mismatched mask and
     image dimensions gracefully.
@@ -275,16 +244,6 @@ def test_mask_img_dimension_mismatch():
     # Ensure scores_ exists and is the correct shape
     assert sl.scores_ is not None
     assert sl.scores_.shape == invalid_mask_img.shape
-
-
-def test_transform_without_fit():
-    """Test if calling `transform()` raises ValueError before fitting."""
-    frames = 20
-    data_img, cond, mask_img = _make_searchlight_test_data(frames)
-    sl = searchlight.SearchLight(mask_img, radius=1.0)
-
-    with pytest.raises(ValueError, match="The model has not been fitted yet."):
-        sl.transform(data_img)
 
 
 def test_transform_applies_mask_correctly():

--- a/nilearn/decoding/tests/test_space_net.py
+++ b/nilearn/decoding/tests/test_space_net.py
@@ -450,22 +450,6 @@ def test_crop_mask_empty_mask(mask_empty):
 
 
 @pytest.mark.parametrize("model", [SpaceNetRegressor, SpaceNetClassifier])
-def test_space_net_no_crash_not_fitted(model):
-    """Regression test."""
-    iris = load_iris()
-    X, y = iris.data, iris.target
-    X, mask = to_niimgs(X, [2, 2, 2])
-
-    with pytest.raises(
-        RuntimeError,
-        match=f"This {model.__name__} instance is not fitted yet",
-    ):
-        model().predict(X)
-
-    model(mask=mask, alphas=1.0).fit(X, y).predict(X)
-
-
-@pytest.mark.parametrize("model", [SpaceNetRegressor, SpaceNetClassifier])
 def test_space_net_one_alpha_no_crash(model):
     """Regression test."""
     iris = load_iris()

--- a/nilearn/decomposition/_base.py
+++ b/nilearn/decomposition/_base.py
@@ -15,6 +15,7 @@ from scipy import linalg
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.linear_model import LinearRegression
 from sklearn.utils import check_random_state
+from sklearn.utils.estimator_checks import check_is_fitted
 from sklearn.utils.extmath import randomized_svd, svd_flip
 
 import nilearn
@@ -538,13 +539,8 @@ class _BaseDecomposition(CacheMixin, TransformerMixin, BaseEstimator):
         )
         return self.maps_masker_
 
-    def _check_components_(self):
-        if not hasattr(self, "components_"):
-            raise ValueError(
-                "Object has no components_ attribute. "
-                "This is probably because fit has not "
-                "been called."
-            )
+    def __sklearn_is_fitted__(self):
+        return hasattr(self, "components_")
 
     def transform(self, imgs, confounds=None):
         """Project the data into a reduced representation.
@@ -569,7 +565,8 @@ class _BaseDecomposition(CacheMixin, TransformerMixin, BaseEstimator):
             shape: number of subjects * (number of scans, number of regions)
 
         """
-        self._check_components_()
+        check_is_fitted(self)
+
         # XXX: dealing properly with 4D/ list of 4D data?
         if confounds is None:
             confounds = [None] * len(imgs)
@@ -595,14 +592,8 @@ class _BaseDecomposition(CacheMixin, TransformerMixin, BaseEstimator):
         For each loading, reconstructed Nifti1Image or SurfaceImage.
 
         """
-        if not hasattr(self, "components_"):
-            raise ValueError(
-                "Object has no components_ attribute. This is "
-                "either because fit has not been called "
-                "or because _DecompositionEstimator has "
-                "directly been used"
-            )
-        self._check_components_()
+        check_is_fitted(self)
+
         # XXX: dealing properly with 2D/ list of 2D data?
         return [
             self.maps_masker_.inverse_transform(loading)
@@ -652,7 +643,8 @@ class _BaseDecomposition(CacheMixin, TransformerMixin, BaseEstimator):
             is squeezed if the number of subjects is one
 
         """
-        self._check_components_()
+        check_is_fitted(self)
+
         data = _mask_and_reduce(
             self.masker_,
             imgs,

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -151,15 +151,8 @@ def test_threshold_bound_error(canica_data):
         canica.fit(canica_data)
 
 
-def test_transform_and_fit_errors(canica_data, mask_img):
+def test_transform_and_fit_errors(mask_img):
     canica = CanICA(mask=mask_img, n_components=3)
-
-    with pytest.raises(
-        ValueError,
-        match="Object has no components_ attribute. "
-        "This is probably because fit has not been called.",
-    ):
-        canica.transform(canica_data)
 
     # error when empty list of provided.
     with pytest.raises(

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -176,18 +176,6 @@ def test_masker_attributes_with_fit(canica_data, mask_img):
     assert dict_learning.mask_img_ == dict_learning.masker_.mask_img_
 
 
-def test_transform_before_fit_error(canica_data, mask_img):
-    dict_learning = DictLearning(mask=mask_img, n_components=3)
-
-    with pytest.raises(
-        ValueError,
-        match="Object has no components_ attribute. "
-        "This is probably because "
-        "fit has not been called",
-    ):
-        dict_learning.transform(canica_data)
-
-
 def test_empty_data_to_fit_error(mask_img):
     """Test if raises an error when empty list of provided."""
     dict_learning = DictLearning(mask=mask_img, n_components=3)
@@ -272,16 +260,3 @@ def test_dictlearning_score(canica_data, mask_img):
     assert scores.shape, (n_components,)
     assert np.all(scores <= 1)
     assert np.all(scores >= 0)
-
-
-def test_dictlearning_score_before_object_fit_error(canica_data, mask_img):
-    dict_learning = DictLearning(
-        n_components=10, mask=mask_img, random_state=0
-    )
-
-    with pytest.raises(
-        ValueError,
-        match="Object has no components_ attribute. "
-        "This is probably because fit has not been called",
-    ):
-        dict_learning.score(canica_data, per_component=False)

--- a/nilearn/decomposition/tests/test_multi_pca.py
+++ b/nilearn/decomposition/tests/test_multi_pca.py
@@ -111,17 +111,6 @@ def test_multi_pca_with_confounds_smoke(multi_pca_data, mask_img):
     multi_pca.fit(multi_pca_data, confounds=confounds)
 
 
-def test_multi_pca_componenent_errors(mask_img):
-    """Test that a ValueError is raised \
-    if the number of components is too low.
-    """
-    multi_pca = _MultiPCA(mask=mask_img)
-    with pytest.raises(
-        ValueError, match="Object has no components_ attribute."
-    ):
-        multi_pca._check_components_()
-
-
 def test_multi_pca_errors(multi_pca_data, mask_img):
     """Fit and transform fail without the proper arguments."""
     multi_pca = _MultiPCA(mask=mask_img)

--- a/nilearn/decomposition/tests/test_multi_pca.py
+++ b/nilearn/decomposition/tests/test_multi_pca.py
@@ -119,14 +119,6 @@ def test_multi_pca_errors(multi_pca_data, mask_img):
     with pytest.raises(TypeError, match="missing 1 required positional"):
         multi_pca.fit()
 
-    # transform before fit raises an error
-    with pytest.raises(
-        ValueError,
-        match="Object has no components_ attribute. This is "
-        "probably because fit has not been called",
-    ):
-        multi_pca.transform(multi_pca_data)
-
     # Test if raises an error when empty list of provided.
     with pytest.raises(
         ValueError,

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -1025,6 +1025,8 @@ class FirstLevelModel(BaseGLM):
 
         """
         # check if valid attribute is being accessed.
+        check_is_fitted(self)
+
         all_attributes = dict(vars(RegressionResults)).keys()
         possible_attributes = [
             prop for prop in all_attributes if "__" not in prop
@@ -1042,8 +1044,6 @@ class FirstLevelModel(BaseGLM):
                 "To do so, set `minimize_memory` to `False` "
                 "when initializing the `FirstLevelModel`-object."
             )
-
-        check_is_fitted(self)
 
         output = []
 

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -691,10 +691,6 @@ class FirstLevelModel(BaseGLM):
             and self.results_ is not None
         )
 
-    def _check_fitted(self):
-        if not self.__sklearn_is_fitted__():
-            raise ValueError("The model has not been fit yet.")
-
     def _more_tags(self):
         """Return estimator tags.
 
@@ -1138,7 +1134,7 @@ class FirstLevelModel(BaseGLM):
 
         else:
             # Make sure masker has been fitted otherwise no attribute mask_img_
-            self.mask_img._check_fitted()
+            check_is_fitted(self.mask_img)
             if self.mask_img.mask_img_ is None and self.masker_ is None:
                 self.masker_ = clone(self.mask_img)
                 for param_name in [

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -18,6 +18,7 @@ from joblib import Memory, Parallel, delayed
 from nibabel import Nifti1Image
 from sklearn.base import clone
 from sklearn.cluster import KMeans
+from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn._utils import fill_doc, logger, stringify_path
 from nilearn._utils.glm import check_and_load_tables
@@ -936,7 +937,7 @@ class FirstLevelModel(BaseGLM):
             keyed by the type of image.
 
         """
-        self._check_fitted()
+        check_is_fitted(self)
 
         if isinstance(contrast_def, (np.ndarray, str)):
             con_vals = [contrast_def]
@@ -1046,7 +1047,7 @@ class FirstLevelModel(BaseGLM):
                 "when initializing the `FirstLevelModel`-object."
             )
 
-        self._check_fitted()
+        check_is_fitted(self)
 
         output = []
 

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -15,6 +15,7 @@ from joblib import Memory
 from nibabel import Nifti1Image
 from nibabel.funcs import four_to_three
 from sklearn.base import clone
+from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn._utils import fill_doc, logger, stringify_path
 from nilearn._utils.glm import check_and_load_tables
@@ -743,11 +744,7 @@ class SecondLevelModel(BaseGLM):
             keyed by the type of image.
 
         """
-        if (
-            not hasattr(self, "second_level_input_")
-            or self.second_level_input_ is None
-        ):
-            raise ValueError("The model has not been fit yet.")
+        check_is_fitted(self)
 
         # check first_level_contrast
         _check_first_level_contrast(
@@ -848,6 +845,7 @@ class SecondLevelModel(BaseGLM):
             A list of Nifti1Image(s).
 
         """
+        check_is_fitted(self)
         # check if valid attribute is being accessed.
         all_attributes = dict(vars(RegressionResults)).keys()
         possible_attributes = [
@@ -874,10 +872,7 @@ class SecondLevelModel(BaseGLM):
             or self.results_ is None
         ):
             raise ValueError(
-                "The model has no results. This could be "
-                "because the model has not been fitted yet "
-                "or because no contrast has been computed "
-                "already."
+                "The model has no results. No contrast has been computed yet."
             )
 
         if result_as_time_series:

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -1135,7 +1135,7 @@ def test_first_level_contrast_computation_errors(tmp_path, shape_4d_default):
     c1, cnull = np.eye(7)[0], np.zeros(7)
 
     # asking for contrast before model fit gives error
-    with pytest.raises(ValueError, match="The model has not been fit yet"):
+    with pytest.raises(ValueError, match="not fitted yet"):
         model.compute_contrast(c1)
 
     # fit model
@@ -1291,9 +1291,6 @@ def test_first_level_residuals_errors(shape_4d_default):
     model = FirstLevelModel(
         mask_img=mask, minimize_memory=False, noise_model="ols"
     )
-
-    with pytest.raises(ValueError, match="The model has not been fit yet"):
-        model.residuals[0]
 
     model.fit(fmri_data, design_matrices=design_matrices)
 

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -97,7 +97,7 @@ def test_high_level_glm_one_run(shape_4d_default):
     # Give an unfitted NiftiMasker as mask_img and check that we get an error
     masker = NiftiMasker(mask)
     with pytest.raises(
-        ValueError, match="It seems that NiftiMasker has not been fitted."
+        ValueError, match="NiftiMasker instance is not fitted yet."
     ):
         FirstLevelModel(mask_img=masker).fit(
             fmri_data[0], design_matrices=design_matrices[0]

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -549,12 +549,6 @@ def test_slm_4d_image(img_4d_mni):
 def test_high_level_glm_with_paths_errors(tmp_path):
     func_img, mask = fake_fmri_data(file_path=tmp_path)
 
-    model = SecondLevelModel(mask_img=mask)
-
-    # asking for contrast before model fit gives error
-    with pytest.raises(ValueError, match="The model has not been fit yet"):
-        model.compute_contrast([])
-
     # fit model
     Y = [func_img] * 4
     X = pd.DataFrame([[1]] * 4, columns=["intercept"])
@@ -946,9 +940,6 @@ def test_second_level_voxelwise_attribute_errors(attribute):
     mask, fmri_data, _ = generate_fake_fmri_data_and_design((SHAPE,))
     model = SecondLevelModel(mask_img=mask, minimize_memory=False)
 
-    with pytest.raises(ValueError, match="The model has no results."):
-        getattr(model, attribute)
-
     Y = fmri_data * 4
     X = pd.DataFrame([[1]] * 4, columns=["intercept"])
     model.fit(Y, design_matrix=X)
@@ -1204,7 +1195,7 @@ def test_second_level_contrast_computation_errors(tmp_path, rng):
     model = SecondLevelModel(mask_img=mask)
 
     # asking for contrast before model fit gives error
-    with pytest.raises(ValueError, match="The model has not been fit yet"):
+    with pytest.raises(ValueError, match="not fitted yet"):
         model.compute_contrast(second_level_contrast="intercept")
 
     # fit model

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -9,6 +9,7 @@ import warnings
 import numpy as np
 from joblib import Memory
 from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn._utils.tags import SKLEARN_LT_1_6
 from nilearn.image import high_variance_confounds
@@ -234,6 +235,9 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
         tags.input_tags = InputTags(masker=True)
         return tags
 
+    def __sklearn_is_fitted__(self):
+        return hasattr(self, "mask_img_")
+
     def fit(self, imgs=None, y=None):
         """Present only to comply with sklearn estimators checks."""
         ...
@@ -278,7 +282,7 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
             inputs.
 
         """
-        self._check_fitted()
+        check_is_fitted(self)
 
         if confounds is None and not self.high_variance_confounds:
             return self.transform_single_imgs(
@@ -382,7 +386,7 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
         img : Transformed image in brain space.
 
         """
-        self._check_fitted()
+        check_is_fitted(self)
 
         img = self._cache(masking.unmask)(X, self.mask_img_)
         # Be robust again memmapping that will create read-only arrays in
@@ -390,14 +394,6 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
         with contextlib.suppress(Exception):
             img._header._structarr = np.array(img._header._structarr).copy()
         return img
-
-    def _check_fitted(self):
-        if not hasattr(self, "mask_img_"):
-            raise ValueError(
-                f"It seems that {self.__class__.__name__} "
-                "has not been fitted. "
-                "You must call fit() before calling transform()."
-            )
 
 
 class _BaseSurfaceMasker(TransformerMixin, CacheMixin, BaseEstimator):

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -235,9 +235,6 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
         tags.input_tags = InputTags(masker=True)
         return tags
 
-    def __sklearn_is_fitted__(self):
-        return hasattr(self, "mask_img_")
-
     def fit(self, imgs=None, y=None):
         """Present only to comply with sklearn estimators checks."""
         ...

--- a/nilearn/maskers/multi_nifti_labels_masker.py
+++ b/nilearn/maskers/multi_nifti_labels_masker.py
@@ -3,6 +3,7 @@
 import itertools
 
 from joblib import Parallel, delayed
+from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn._utils import fill_doc
 from nilearn._utils.niimg_conversions import iter_check_niimg
@@ -205,7 +206,7 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
         # We handle the resampling of labels separately because the affine of
         # the labels image should not impact the extraction of the signal.
 
-        self._check_fitted()
+        check_is_fitted(self)
         niimg_iter = iter_check_niimg(
             imgs_list,
             ensure_ndim=None,
@@ -246,7 +247,7 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
             shape: list of (number of scans, number of labels)
 
         """
-        self._check_fitted()
+        check_is_fitted(self)
         if not hasattr(imgs, "__iter__") or isinstance(imgs, str):
             return self.transform_single_imgs(imgs)
         return self.transform_imgs(

--- a/nilearn/maskers/multi_nifti_maps_masker.py
+++ b/nilearn/maskers/multi_nifti_maps_masker.py
@@ -3,6 +3,7 @@
 import itertools
 
 from joblib import Parallel, delayed
+from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn._utils import fill_doc
 from nilearn._utils.niimg_conversions import iter_check_niimg
@@ -213,7 +214,7 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
         # affine of the maps and mask images should not impact the extraction
         # of the signal.
 
-        self._check_fitted()
+        check_is_fitted(self)
 
         niimg_iter = iter_check_niimg(
             imgs_list,
@@ -255,7 +256,7 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
             shape: list of (number of scans, number of maps)
 
         """
-        self._check_fitted()
+        check_is_fitted(self)
         if not hasattr(imgs, "__iter__") or isinstance(imgs, str):
             return self.transform_single_imgs(imgs)
         return self.transform_imgs(

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -10,6 +10,7 @@ import warnings
 from functools import partial
 
 from joblib import Parallel, delayed
+from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn._utils import (
     check_niimg_3d,
@@ -526,7 +527,7 @@ class MultiNiftiMasker(NiftiMasker):
             inputs.
 
         """
-        self._check_fitted()
+        check_is_fitted(self)
         if not hasattr(imgs, "__iter__") or isinstance(imgs, str):
             return self.transform_single_imgs(imgs)
 

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -5,6 +5,7 @@ import warnings
 import numpy as np
 from joblib import Memory
 from nibabel import Nifti1Image
+from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn import _utils
 from nilearn._utils import logger
@@ -953,7 +954,7 @@ class NiftiLabelsMasker(BaseMasker):
         """
         from ..regions import signal_extraction
 
-        self._check_fitted()
+        check_is_fitted(self)
 
         logger.log("computing image from signals", verbose=self.verbose)
         return signal_extraction.signals_to_img_labels(

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -740,7 +740,7 @@ class NiftiLabelsMasker(BaseMasker):
         )
 
     def __sklearn_is_fitted__(self):
-        return hasattr(self, "labels_img_")
+        return hasattr(self, "labels_img_") and hasattr(self, "n_elements_")
 
     def transform_single_imgs(self, imgs, confounds=None, sample_mask=None):
         """Extract signals from a single 4D niimg.

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -739,13 +739,8 @@ class NiftiLabelsMasker(BaseMasker):
             imgs, confounds=confounds, sample_mask=sample_mask
         )
 
-    def _check_fitted(self):
-        if not hasattr(self, "labels_img_"):
-            raise ValueError(
-                f"It seems that {self.__class__.__name__} has not been "
-                "fitted. "
-                "You must call fit() before calling transform()."
-            )
+    def __sklearn_is_fitted__(self):
+        return hasattr(self, "labels_img_")
 
     def transform_single_imgs(self, imgs, confounds=None, sample_mask=None):
         """Extract signals from a single 4D niimg.

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -4,6 +4,7 @@ import warnings
 
 import numpy as np
 from joblib import Memory
+from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn import _utils
 from nilearn._utils import logger
@@ -704,7 +705,7 @@ class NiftiMapsMasker(BaseMasker):
         """
         from ..regions import signal_extraction
 
-        self._check_fitted()
+        check_is_fitted(self)
 
         logger.log("computing image from signals", verbose=self.verbose)
         return signal_extraction.signals_to_img_maps(

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -505,7 +505,7 @@ class NiftiMapsMasker(BaseMasker):
         return self
 
     def __sklearn_is_fitted__(self):
-        return hasattr(self, "maps_img_")
+        return hasattr(self, "maps_img_") and hasattr(self, "n_elements_")
 
     def fit_transform(self, imgs, confounds=None, sample_mask=None):
         """Prepare and perform signal extraction."""

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -504,13 +504,8 @@ class NiftiMapsMasker(BaseMasker):
 
         return self
 
-    def _check_fitted(self):
-        if not hasattr(self, "maps_img_"):
-            raise ValueError(
-                f"It seems that {self.__class__.__name__} has not been "
-                "fitted. "
-                "You must call fit() before calling transform()."
-            )
+    def __sklearn_is_fitted__(self):
+        return hasattr(self, "maps_img_")
 
     def fit_transform(self, imgs, confounds=None, sample_mask=None):
         """Prepare and perform signal extraction."""

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -415,13 +415,8 @@ class NiftiMasker(BaseMasker):
 
         return [init_display, final_display]
 
-    def _check_fitted(self):
-        if not hasattr(self, "mask_img_"):
-            raise ValueError(
-                f"It seems that {self.__class__.__name__} has not been "
-                "fitted. "
-                "You must call fit() before calling transform()."
-            )
+    def __sklearn_is_fitted__(self):
+        return hasattr(self, "mask_img_")
 
     def fit(
         self,

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -655,7 +655,7 @@ class NiftiSpheresMasker(BaseMasker):
         )
 
     def __sklearn_is_fitted__(self):
-        return hasattr(self, "seeds_")
+        return hasattr(self, "seeds_") and hasattr(self, "n_elements_")
 
     def transform_single_imgs(self, imgs, confounds=None, sample_mask=None):
         """Extract signals from a single 4D niimg.

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -654,13 +654,8 @@ class NiftiSpheresMasker(BaseMasker):
             imgs, confounds=confounds, sample_mask=sample_mask
         )
 
-    def _check_fitted(self):
-        if not hasattr(self, "seeds_"):
-            raise ValueError(
-                f"It seems that {self.__class__.__name__} "
-                "has not been fitted. "
-                "You must call fit() before calling transform()."
-            )
+    def __sklearn_is_fitted__(self):
+        return hasattr(self, "seeds_")
 
     def transform_single_imgs(self, imgs, confounds=None, sample_mask=None):
         """Extract signals from a single 4D niimg.

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -10,6 +10,7 @@ import numpy as np
 from joblib import Memory
 from scipy import sparse
 from sklearn import neighbors
+from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn._utils import fill_doc, logger
 from nilearn._utils.class_inspect import get_params
@@ -702,7 +703,7 @@ class NiftiSpheresMasker(BaseMasker):
             inputs.
 
         """
-        self._check_fitted()
+        check_is_fitted(self)
 
         params = get_params(NiftiSpheresMasker, self)
         params["clean_kwargs"] = self.clean_args
@@ -757,7 +758,7 @@ class NiftiSpheresMasker(BaseMasker):
             shape: (mask_img, number of scans).
 
         """
-        self._check_fitted()
+        check_is_fitted(self)
 
         logger.log("computing image from signals", verbose=self.verbose)
 

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -4,6 +4,7 @@ import warnings
 
 import numpy as np
 from joblib import Memory
+from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn import signal
 from nilearn._utils import constrained_layout_kwargs, fill_doc
@@ -304,12 +305,6 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
     def __sklearn_is_fitted__(self):
         return hasattr(self, "n_elements_")
 
-    def _check_fitted(self):
-        if not self.__sklearn_is_fitted__():
-            raise ValueError(
-                f"It seems that {self.__class__.__name__} has not been fitted."
-            )
-
     def transform(self, img, confounds=None, sample_mask=None):
         """Extract signals from surface object.
 
@@ -339,7 +334,7 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
             Signal for each element.
             shape: (img data shape, total number of vertices)
         """
-        self._check_fitted()
+        check_is_fitted(self)
 
         # if img is a single image, convert it to a list
         # to be able to concatenate it
@@ -469,7 +464,7 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
         :obj:`~nilearn.surface.SurfaceImage` object
             Mesh and data for both hemispheres.
         """
-        self._check_fitted()
+        check_is_fitted(self)
 
         return signals_to_surf_img_labels(
             signals,

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -7,6 +7,7 @@ import warnings
 import numpy as np
 from joblib import Memory
 from scipy import linalg
+from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn import signal
 from nilearn._utils import constrained_layout_kwargs, fill_doc, logger
@@ -223,12 +224,6 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
     def __sklearn_is_fitted__(self):
         return hasattr(self, "n_elements_")
 
-    def _check_fitted(self):
-        if not self.__sklearn_is_fitted__():
-            raise ValueError(
-                f"It seems that {self.__class__.__name__} has not been fitted."
-            )
-
     def transform(self, img, confounds=None, sample_mask=None):
         """Extract signals from surface object.
 
@@ -260,7 +255,7 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
             Signal for each region as provided in the maps (via `maps_img`).
             shape: (n_timepoints, n_regions)
         """
-        self._check_fitted()
+        check_is_fitted(self)
 
         # if img is a single image, convert it to a list
         # to be able to concatenate it
@@ -405,7 +400,7 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
             The data for each hemisphere is of shape
             (n_vertices_per_hemisphere, n_timepoints).
         """
-        self._check_fitted()
+        check_is_fitted(self)
 
         # get concatenated hemispheres/parts data from maps_img and mask_img
         maps_data = get_data(self.maps_img)

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -6,6 +6,7 @@ import warnings
 
 import numpy as np
 from joblib import Memory
+from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn import signal
 from nilearn._utils import constrained_layout_kwargs, fill_doc
@@ -132,13 +133,6 @@ class SurfaceMasker(_BaseSurfaceMasker):
             and self.output_dimension_ is not None
         )
 
-    def _check_fitted(self):
-        if not self.__sklearn_is_fitted__():
-            raise ValueError(
-                "This masker has not been fitted.\n"
-                "Call fit before calling transform."
-            )
-
     def _fit_mask_img(self, img):
         """Get mask passed during init or compute one from input image.
 
@@ -252,6 +246,8 @@ class SurfaceMasker(_BaseSurfaceMasker):
             Signal for each element.
             shape: (n samples, total number of vertices)
         """
+        check_is_fitted(self)
+
         if self.smoothing_fwhm is not None:
             warnings.warn(
                 "Parameter smoothing_fwhm "
@@ -271,8 +267,6 @@ class SurfaceMasker(_BaseSurfaceMasker):
         if self.clean_args is None:
             self.clean_args = {}
         parameters["clean_args"] = self.clean_args
-
-        self._check_fitted()
 
         if not isinstance(img, list):
             img = [img]
@@ -369,7 +363,7 @@ class SurfaceMasker(_BaseSurfaceMasker):
         :obj:`~nilearn.surface.SurfaceImage`
             Mesh and data for both hemispheres.
         """
-        self._check_fitted()
+        check_is_fitted(self)
 
         if signals.ndim == 1:
             signals = np.array([signals])

--- a/nilearn/maskers/tests/test_multi_nifti_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_masker.py
@@ -136,16 +136,10 @@ def test_3d_images():
     epi_img2 = Nifti1Image(np.ones((2, 2, 2)), affine=np.diag((2, 2, 2, 1)))
     masker = MultiNiftiMasker(mask_img=mask_img)
 
-    # Check attributes defined at fit
-    assert not hasattr(masker, "n_elements_")
-
     epis = masker.fit_transform([epi_img1, epi_img2])
 
     # This is mostly a smoke test
     assert len(epis) == 2
-
-    # Check attributes defined at fit
-    assert hasattr(masker, "n_elements_")
 
 
 def test_joblib_cache(mask_img_1, tmp_path):

--- a/nilearn/maskers/tests/test_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_nifti_labels_masker.py
@@ -86,15 +86,9 @@ def test_nifti_labels_masker(affine_eye, shape_3d_default, n_regions, length):
     # No exception should be raised either
     masker = NiftiLabelsMasker(labels_img, resampling_target=None)
 
-    # Check attributes defined at fit
-    assert not hasattr(masker, "labels_img_")
-    assert not hasattr(masker, "n_elements_")
-
     masker.fit()
 
     # Check attributes defined at fit
-    assert hasattr(masker, "labels_img_")
-    assert hasattr(masker, "n_elements_")
     assert masker.n_elements_ == n_regions
 
     masker.inverse_transform(signals)

--- a/nilearn/maskers/tests/test_nifti_maps_masker.py
+++ b/nilearn/maskers/tests/test_nifti_maps_masker.py
@@ -130,15 +130,10 @@ def test_nifti_maps_masker_data_atlas_different_shape(
 def test_nifti_maps_masker_fit(n_regions, img_maps):
     """Check fitted attributes."""
     masker = NiftiMapsMasker(img_maps, resampling_target=None)
-    # Check attributes defined at fit
-    assert not hasattr(masker, "maps_img_")
-    assert not hasattr(masker, "n_elements_")
 
     masker.fit()
 
     # Check attributes defined at fit
-    assert hasattr(masker, "maps_img_")
-    assert hasattr(masker, "n_elements_")
     assert masker.n_elements_ == n_regions
 
 

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -226,13 +226,9 @@ def test_4d_single_scan(rng, shape_3d_default, affine_eye):
 
     masker = NiftiMasker(mask_img=mask_img)
 
-    # Check attributes defined at fit
-    assert not hasattr(masker, "n_elements_")
-
     masker.fit()
 
     # Check attributes defined at fit
-    assert hasattr(masker, "n_elements_")
     assert masker.n_elements_ == np.sum(mask)
 
     data_trans_5d = masker.transform(data_5d)

--- a/nilearn/maskers/tests/test_nifti_spheres_masker.py
+++ b/nilearn/maskers/tests/test_nifti_spheres_masker.py
@@ -82,19 +82,10 @@ def test_sphere_extraction(rng, affine_eye):
 
     masker = NiftiSpheresMasker([seed], radius=1)
 
-    # Check attributes defined at fit
-    assert not hasattr(masker, "seeds_")
-    assert not hasattr(masker, "n_elements_")
-
     masker.fit()
 
     # Check attributes defined at fit
-    assert hasattr(masker, "seeds_")
-    assert hasattr(masker, "n_elements_")
     assert masker.n_elements_ == 1
-
-    # Test the fit
-    masker.fit()
 
     # Test the transform
     s = masker.transform(img)

--- a/nilearn/maskers/tests/test_surface_labels_masker.py
+++ b/nilearn/maskers/tests/test_surface_labels_masker.py
@@ -32,7 +32,6 @@ extra_valid_checks = [
     "check_dont_overwrite_parameters",
     "check_estimators_fit_returns_self",
     "check_estimators_overwrite_params",
-    "check_fit_check_is_fitted",
     "check_positive_only_tag_during_fit",
     "check_readonly_memmap_input",
 ]

--- a/nilearn/maskers/tests/test_surface_labels_masker.py
+++ b/nilearn/maskers/tests/test_surface_labels_masker.py
@@ -392,13 +392,6 @@ def test_surface_label_masker_fit_transform(surf_label_img, surf_img_1d):
     assert signal.shape == (1, masker.n_elements_)
 
 
-def test_error_transform_before_fit(surf_label_img, surf_img_1d):
-    """Transform requires masker to be fitted."""
-    masker = SurfaceLabelsMasker(labels_img=surf_label_img)
-    with pytest.raises(ValueError, match="has not been fitted"):
-        masker.transform(surf_img_1d)
-
-
 def test_surface_label_masker_inverse_transform(surf_label_img, surf_img_1d):
     """Test transform extract signals."""
     masker = SurfaceLabelsMasker(labels_img=surf_label_img)
@@ -444,13 +437,6 @@ def test_surface_label_masker_inverse_transform_with_mask(
         # the data for label 2 should be zeros
         assert np.all(img_inverted.data.parts["left"][-1, :] == 0)
         assert np.all(img_inverted.data.parts["right"][2:, :] == 0)
-
-
-def test_surface_label_masker_inverse_transform_before_fit(surf_label_img):
-    """Test inverse_transform requires masker to be fitted."""
-    masker = SurfaceLabelsMasker(labels_img=surf_label_img)
-    with pytest.raises(ValueError, match="has not been fitted"):
-        masker.inverse_transform(np.zeros((1, 1)))
 
 
 def test_surface_label_masker_transform_list_surf_images(

--- a/nilearn/maskers/tests/test_surface_maps_masker.py
+++ b/nilearn/maskers/tests/test_surface_maps_masker.py
@@ -60,7 +60,6 @@ extra_valid_checks = [
     "check_dont_overwrite_parameters",
     "check_estimators_fit_returns_self",
     "check_estimators_overwrite_params",
-    "check_fit_check_is_fitted",
     "check_no_attributes_set_in_init",
     "check_positive_only_tag_during_fit",
     "check_readonly_memmap_input",

--- a/nilearn/maskers/tests/test_surface_maps_masker.py
+++ b/nilearn/maskers/tests/test_surface_maps_masker.py
@@ -225,23 +225,6 @@ def test_surface_maps_masker_1d_img(surf_maps_img, surf_img_1d):
         masker.transform(surf_img_1d)
 
 
-def test_surface_maps_masker_not_fitted_error(surf_maps_img):
-    """Test that an error is raised when transform or inverse_transform is
-    called before fit.
-    """
-    masker = SurfaceMapsMasker(surf_maps_img)
-    with pytest.raises(
-        ValueError,
-        match="SurfaceMapsMasker has not been fitted",
-    ):
-        masker.transform(None)
-    with pytest.raises(
-        ValueError,
-        match="SurfaceMapsMasker has not been fitted",
-    ):
-        masker.inverse_transform(None)
-
-
 def test_surface_maps_masker_smoothing_not_supported_error(
     surf_maps_img, surf_img_2d
 ):

--- a/nilearn/plotting/tests/_utils.py
+++ b/nilearn/plotting/tests/_utils.py
@@ -1,0 +1,14 @@
+"""Testing utilities."""
+
+import matplotlib.colorbar as cbar
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+
+def assert_colorbar_present(fig):
+    """Check if a colorbar exists in the figure."""
+    if (
+        isinstance(fig, Figure)
+        and not any(isinstance(ax, cbar.Colorbar) for ax in fig.get_children())
+    ) or (isinstance(fig, Axes) and not isinstance(fig, cbar.Colorbar)):
+        raise RuntimeError("Figures should have a colorbar by default.")

--- a/nilearn/regions/hierarchical_kmeans_clustering.py
+++ b/nilearn/regions/hierarchical_kmeans_clustering.py
@@ -312,6 +312,9 @@ class HierarchicalKMeans(ClusterMixin, TransformerMixin, BaseEstimator):
         self.n_clusters = len(sizes)
         return self
 
+    def __sklearn_is_fitted__(self):
+        return hasattr(self, "labels_")
+
     def transform(
         self,
         X,
@@ -329,7 +332,7 @@ class HierarchicalKMeans(ClusterMixin, TransformerMixin, BaseEstimator):
         X_red : ndarray, shape = [n_samples, n_clusters]
             Data reduced with agglomerated signal for each cluster
         """
-        check_is_fitted(self, "labels_")
+        check_is_fitted(self)
 
         # Transpose the data so that we can cluster features (voxels)
         # and input them as samples to the sklearn's clustering algorithm
@@ -366,7 +369,8 @@ class HierarchicalKMeans(ClusterMixin, TransformerMixin, BaseEstimator):
         X_inv : ndarray, shape = [n_samples, n_features]
             Data reduced expanded to the original feature space
         """
-        check_is_fitted(self, "labels_")
+        check_is_fitted(self)
+
         X_red = X_red.T
         inverse = self.labels_
         if self.scaling:

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -526,13 +526,8 @@ class Parcellations(_MultiPCA):
 
         return self
 
-    def _check_fitted(self):
-        """Check whether fit is called or not."""
-        if not hasattr(self, "labels_img_"):
-            raise ValueError(
-                "Object has no labels_img_ attribute. "
-                "Ensure that fit() is called before transform."
-            )
+    def __sklearn_is_fitted__(self):
+        return hasattr(self, "labels_img_")
 
     @fill_doc
     def transform(self, imgs, confounds=None):

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -8,6 +8,7 @@ from joblib import Memory, Parallel, delayed
 from scipy.sparse import coo_matrix
 from sklearn.base import clone
 from sklearn.feature_extraction import image
+from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn.maskers import NiftiLabelsMasker, SurfaceLabelsMasker
 from nilearn.maskers.surface_labels_masker import signals_to_surf_img_labels
@@ -561,7 +562,7 @@ class Parcellations(_MultiPCA):
             (number of scans, number of labels)
 
         """
-        self._check_fitted()
+        check_is_fitted(self)
         imgs, confounds, single_subject = _check_parameters_transform(
             imgs, confounds
         )
@@ -663,7 +664,7 @@ class Parcellations(_MultiPCA):
         """
         from .signal_extraction import signals_to_img_labels
 
-        self._check_fitted()
+        check_is_fitted(self)
 
         if not isinstance(signals, (list, tuple)) or isinstance(
             signals, np.ndarray

--- a/nilearn/regions/rena_clustering.py
+++ b/nilearn/regions/rena_clustering.py
@@ -768,6 +768,9 @@ class ReNA(ClusterMixin, TransformerMixin, BaseEstimator):
 
         return self
 
+    def __sklearn_is_fitted__(self):
+        return hasattr(self, "labels_")
+
     def transform(
         self,
         X,
@@ -786,7 +789,7 @@ class ReNA(ClusterMixin, TransformerMixin, BaseEstimator):
             Data reduced with agglomerated signal for each cluster.
 
         """
-        check_is_fitted(self, "labels_")
+        check_is_fitted(self)
 
         unique_labels = np.unique(self.labels_)
 
@@ -816,7 +819,7 @@ class ReNA(ClusterMixin, TransformerMixin, BaseEstimator):
             Data reduced expanded to the original feature space.
 
         """
-        check_is_fitted(self, "labels_")
+        check_is_fitted(self)
 
         _, inverse = np.unique(self.labels_, return_inverse=True)
 

--- a/nilearn/regions/tests/test_region_extractor.py
+++ b/nilearn/regions/tests/test_region_extractor.py
@@ -76,7 +76,6 @@ extra_valid_checks = [
     "check_do_not_raise_errors_in_init_or_set_params",
     "check_estimators_fit_returns_self",
     "check_estimators_unfitted",
-    "check_fit_check_is_fitted",
     "check_positive_only_tag_during_fit",
     "check_readonly_memmap_input",
 ]


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but relates to https://github.com/nilearn/nilearn/issues/4538

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- ensure all nilearn estimators pass the `check_fit_check_is_fitted` check from sklearn
- for estimators that take image input at fit time (maskers, glm...) skip that check
- create an equivalent check for maskers (other estimators that take image as input will be done in another PR)
- remove tests made redundant by this new checks

---

- ensure all estimators have a `__sklearn_is_fitted__` method and remove `_check_fitted` method
- had an extra argument `expected_failed_checks` to  `check_estimator` to be able to pass checks to skip for a some estimators (similar to the `check_estimator` from sklearn)
