### PR TITLE
[REF] refactor test to check 5D input to nifti masker transform

### DIFF
--- a/nilearn/_utils/class_inspect.py
+++ b/nilearn/_utils/class_inspect.py
@@ -195,6 +195,7 @@ def nilearn_check_estimator(estimator):
             yield (clone(estimator), check_nifti_masker_clean_warning)
             yield (clone(estimator), check_nifti_masker_dtype)
             yield (clone(estimator), check_nifti_masker_fit_returns_self)
+            yield (clone(estimator), check_nifti_masker_fit_transform_5d)
 
         if surf_img_input:
             yield (clone(estimator), check_surface_masker_fit_returns_self)
@@ -267,7 +268,7 @@ def check_nifti_masker_fit_transform(estimator):
     - can fit 3D image
     - fitted maskers can transform:
       - 3D image
-      - list of 3D images
+      - list of 3D images with same affine
     - can fit transform 3D image
     """
     from nilearn.conftest import _img_3d_rand, _img_4d_rand_eye
@@ -276,19 +277,71 @@ def check_nifti_masker_fit_transform(estimator):
 
     signal = estimator.transform(_img_3d_rand())
 
+    assert isinstance(signal, np.ndarray)
     assert signal.shape[0] == 1
 
     estimator.transform([_img_3d_rand(), _img_3d_rand()])
 
+    assert isinstance(signal, np.ndarray)
     assert signal.shape[0] == 1
 
     estimator.transform(_img_4d_rand_eye())
 
+    assert isinstance(signal, np.ndarray)
     assert signal.shape[0] == 1
 
     estimator.fit_transform(_img_3d_rand())
 
+    assert isinstance(signal, np.ndarray)
     assert signal.shape[0] == 1
+
+
+def check_nifti_masker_fit_transform_5d(estimator):
+    """Run checks on nifti maskers for transforming 5D images.
+
+    - multi masker should be fine
+      and return a list of numpy arrays
+    - non multimasker should fail
+    """
+    import pytest
+
+    from nilearn.conftest import _img_3d_rand, _img_4d_rand_eye
+
+    n_subject = 3
+
+    estimator.fit(_img_3d_rand())
+
+    input_5d_img = [_img_4d_rand_eye() for _ in range(n_subject)]
+
+    if not is_multimasker(estimator):
+        with pytest.raises(
+            DimensionError,
+            match="Input data has incompatible dimensionality: "
+            "Expected dimension is 4D and you provided "
+            "a list of 4D images \\(5D\\).",
+        ):
+            estimator.transform(input_5d_img)
+
+        with pytest.raises(
+            DimensionError,
+            match="Input data has incompatible dimensionality: "
+            "Expected dimension is 4D and you provided "
+            "a list of 4D images \\(5D\\).",
+        ):
+            estimator.fit_transform(input_5d_img)
+
+    else:
+        signal = estimator.transform(input_5d_img)
+
+        assert isinstance(signal, list)
+        assert all(isinstance(x, np.ndarray) for x in signal)
+        assert len(signal) == n_subject
+
+        signal = estimator.fit_transform(input_5d_img)
+
+        assert isinstance(signal, list)
+        assert all(isinstance(x, np.ndarray) for x in signal)
+        assert len(signal) == n_subject
 
 
 def check_masker_clean_kwargs(estimator):

--- a/nilearn/maskers/tests/test_multi_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_labels_masker.py
@@ -111,7 +111,7 @@ def test_multi_nifti_labels_masker():
     # Should work with 4D + 1D input too (also test fit_transform)
     signals_input = [fmri11_img, fmri11_img]
     signals11_list = masker11.fit_transform(signals_input)
-    assert len(signals11_list) == len(signals_input)
+
     for signals in signals11_list:
         assert signals.shape == (length, n_regions)
 
@@ -420,6 +420,5 @@ def test_multi_nifti_labels_masker_list_of_sample_mask():
         [fmri11_img, fmri11_img], sample_mask=[sample_mask1, sample_mask2]
     )
 
-    assert len(ts_list) == 2
     for ts, n_scrub in zip(ts_list, [n_scrub1, n_scrub2]):
         assert ts.shape == (length - n_scrub, n_regions)

--- a/nilearn/maskers/tests/test_multi_nifti_maps_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_maps_masker.py
@@ -77,7 +77,6 @@ def test_multi_nifti_maps_masker(
 
     signals11_list = masker.fit_transform(signals_input)
 
-    assert len(signals11_list) == len(signals_input)
     for signals in signals11_list:
         assert signals.shape == (length, n_regions)
 
@@ -351,6 +350,5 @@ def test_multi_nifti_maps_masker_list_of_sample_mask(
         [img_fmri, img_fmri], sample_mask=[sample_mask1, sample_mask2]
     )
 
-    assert len(ts_list) == 2
     for ts, n_scrub in zip(ts_list, [n_scrub1, n_scrub2]):
         assert ts.shape == (length - n_scrub, n_regions)

--- a/nilearn/maskers/tests/test_multi_nifti_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_masker.py
@@ -139,10 +139,7 @@ def test_3d_images():
     # Check attributes defined at fit
     assert not hasattr(masker, "n_elements_")
 
-    epis = masker.fit_transform([epi_img1, epi_img2])
-
-    # This is mostly a smoke test
-    assert len(epis) == 2
+    masker.fit_transform([epi_img1, epi_img2])
 
     # Check attributes defined at fit
     assert hasattr(masker, "n_elements_")

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -241,24 +241,6 @@ def test_4d_single_scan(rng, shape_3d_default, affine_eye):
     assert_array_equal(data_trans_4d, data_trans_5d)
 
 
-def test_5d(rng, shape_3d_default, mask_img_1, affine_eye):
-    """Test that list of 4D images with last dim=3 raises a DimensionError."""
-    shape_4d = (*shape_3d_default, 3)
-    data_5d = [rng.random(shape_4d) for _ in range(5)]
-    data_5d = [Nifti1Image(d, affine_eye) for d in data_5d]
-
-    masker = NiftiMasker(mask_img=mask_img_1)
-    masker.fit()
-
-    with pytest.raises(
-        exceptions.DimensionError,
-        match="Input data has incompatible dimensionality: "
-        "Expected dimension is 4D and you provided "
-        "a list of 4D images \\(5D\\).",
-    ):
-        masker.transform(data_5d)
-
-
 def test_sessions(affine_eye):
     """Test the sessions vector."""
     data = np.ones((40, 40, 40, 4))


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but relates to #5095 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- add test to check that nifti maskers cannot transform 5D but that multi niftimasker can

