### PR TITLE
[ENH] Add  thresholding examples

### DIFF
--- a/examples/01_plotting/plot_demo_more_plotting.py
+++ b/examples/01_plotting/plot_demo_more_plotting.py
@@ -1,3 +1,4 @@
+# %%
 """
 More plotting tools from nilearn
 ================================
@@ -148,6 +149,61 @@ plotting.plot_stat_map(
     colorbar=False,
     title="display_mode='z', cut_coords=1,\ncolorbar=False",
     figure=plt.figure(figsize=(5, 7)),
+)
+
+# %%
+# Using plotting threshold, vmin, vmax parameters
+# -----------------------------------------------
+#
+# Using ``threshold`` value alongside with ``vmin`` and ``vmax`` parameters
+# enable us to mask certain values in the image.
+#
+# Unthresholded image:
+
+plotting.plot_stat_map(
+    stat_img,
+    display_mode="ortho",
+    cut_coords=[36, -27, 60],
+    title="display_mode='ortho', cut_coords=[36, -27, 60]",
+)
+
+# %%
+# Image thresholded at 1:
+
+plotting.plot_stat_map(
+    stat_img,
+    threshold=1,
+    display_mode="ortho",
+    cut_coords=[36, -27, 60],
+    title="display_mode='ortho', cut_coords=[36, -27, 60]",
+)
+
+# %%
+# Setting ``vmin=0``, it is possible to plot only positive regions.
+#
+# Image thresholded at 1 with ``vmin=0``:
+
+plotting.plot_stat_map(
+    stat_img,
+    threshold=1,
+    display_mode="ortho",
+    cut_coords=[36, -27, 60],
+    title="display_mode='ortho', cut_coords=[36, -27, 60]",
+    vmin=0,
+)
+
+# %%
+# Setting ``vmax=0``, it is possible to plot only negative regions.
+#
+# Image thresholded at 1 with ``vmax=0``:
+
+plotting.plot_stat_map(
+    stat_img,
+    threshold=1,
+    display_mode="ortho",
+    cut_coords=[36, -27, 60],
+    title="display_mode='ortho', cut_coords=[36, -27, 60]",
+    vmax=0,
 )
 
 # %%

--- a/examples/01_plotting/plot_demo_more_plotting.py
+++ b/examples/01_plotting/plot_demo_more_plotting.py
@@ -41,8 +41,13 @@ See :ref:`plotting` for more details.
 """
 
 # %%
-# First, we retrieve data from nilearn provided (general-purpose) datasets
-# ------------------------------------------------------------------------
+# Display objects returned by plotting functions
+# -----------------------------------------------
+#
+# Plotting functions return different display objects depending on the values
+# of the parameters ``display_mode`` and ``cut_coords``.
+#
+# We first retrieve data from nilearn provided (general-purpose) datasets.
 
 from nilearn import datasets
 
@@ -63,8 +68,8 @@ stat_img = datasets.load_sample_motor_activation_image()
 from nilearn import plotting
 
 # %%
-# Visualizing in - 'sagittal', 'coronal' and 'axial' with given coordinates
-# -------------------------------------------------------------------------
+# OrthoSlicer: Three views 'sagittal', 'coronal' and 'axial' with coordinates
+# ```````````````````````````````````````````````````````````````````````````
 #
 # The first argument ``stat_img`` is a path to the filename of a contrast map.
 # The optional argument ``display_mode`` is given as a string 'ortho' to
@@ -83,8 +88,8 @@ plotting.plot_stat_map(
 )
 
 # %%
-# Visualizing in - single view 'axial' with number of cuts=5
-# ----------------------------------------------------------
+# ZSlicer: Single view 'axial' with number of cuts=5
+# ``````````````````````````````````````````````````
 #
 # For axial visualization, we set ``display_mode='z'``. As a
 # consequence :func:`~nilearn.plotting.plot_stat_map` returns a
@@ -102,8 +107,8 @@ plotting.plot_stat_map(
 )
 
 # %%
-# Visualizing in - single view 'sagittal' with only two slices
-# ------------------------------------------------------------
+# XSlicer: Single view 'sagittal' with only two slices
+# ````````````````````````````````````````````````````
 #
 # For sagittal visualization, we set ``display_mode='x'`` which returns a
 # :class:`~nilearn.plotting.displays.XSlicer` object.
@@ -118,8 +123,8 @@ plotting.plot_stat_map(
 )
 
 # %%
-# Visualizing in - 'coronal' view with single cut
-# -----------------------------------------------
+# YSlicer: Single view 'coronal' with single cut
+# ``````````````````````````````````````````````
 #
 # For coronal view, we set ``display_mode='y'`` which returns a
 # :class:`~nilearn.plotting.displays.YSlicer` object.
@@ -136,79 +141,8 @@ plotting.plot_stat_map(
 )
 
 # %%
-# Visualizing without a colorbar on the right side
-# ------------------------------------------------
-#
-# The argument ``colorbar`` should be set to ``False`` to show plots without
-# a colorbar on the right side.
-
-plotting.plot_stat_map(
-    stat_img,
-    display_mode="z",
-    cut_coords=1,
-    colorbar=False,
-    title="display_mode='z', cut_coords=1,\ncolorbar=False",
-    figure=plt.figure(figsize=(5, 7)),
-)
-
-# %%
-# Using plotting threshold, vmin, vmax parameters
-# -----------------------------------------------
-#
-# Using ``threshold`` value alongside with ``vmin`` and ``vmax`` parameters
-# enable us to mask certain values in the image.
-#
-# Image without plotting threshold:
-
-plotting.plot_stat_map(
-    stat_img,
-    display_mode="ortho",
-    cut_coords=[36, -27, 60],
-    title="display_mode='ortho', cut_coords=[36, -27, 60]",
-)
-
-# %%
-# Plotting threshold set to 1:
-
-plotting.plot_stat_map(
-    stat_img,
-    threshold=1,
-    display_mode="ortho",
-    cut_coords=[36, -27, 60],
-    title="display_mode='ortho', cut_coords=[36, -27, 60]",
-)
-
-# %%
-# Setting ``vmin=0``, it is possible to plot only positive image values.
-#
-# Plotting threshold set to 1 with ``vmin=0``:
-
-plotting.plot_stat_map(
-    stat_img,
-    threshold=1,
-    display_mode="ortho",
-    cut_coords=[36, -27, 60],
-    title="display_mode='ortho', cut_coords=[36, -27, 60]",
-    vmin=0,
-)
-
-# %%
-# Setting ``vmax=0``, it is possible to plot only negative image values.
-#
-# Plotting threshold set to 1 with ``vmax=0``:
-
-plotting.plot_stat_map(
-    stat_img,
-    threshold=1,
-    display_mode="ortho",
-    cut_coords=[36, -27, 60],
-    title="display_mode='ortho', cut_coords=[36, -27, 60]",
-    vmax=0,
-)
-
-# %%
-# Visualize in - two views 'sagittal' and 'axial' with given coordinates
-# ----------------------------------------------------------------------
+# XZSlicer: Two views 'sagittal' and 'axial' with given coordinates
+# `````````````````````````````````````````````````````````````````
 #
 # In order to visualize both sagittal and axial views, we set
 # ``display_mode='xz'``, where 'x' stands for sagittal and 'z' for axial view.
@@ -226,8 +160,8 @@ plotting.plot_stat_map(
 )
 
 # %%
-# Changing the views to 'coronal', 'sagittal' views with coordinates
-# ------------------------------------------------------------------
+# YXSlicer: Two views 'coronal' and 'sagittal' with coordinates
+# `````````````````````````````````````````````````````````````
 #
 # Similarly, we can set ``display_mode='yx'`` for combining a coronal with a
 # sagittal view, which will return a
@@ -242,8 +176,8 @@ plotting.plot_stat_map(
 )
 
 # %%
-# Now, views are changed to 'coronal' and 'axial' views with coordinates
-# ----------------------------------------------------------------------
+# YZSlicer: Two views 'coronal' and 'axial' with coordinates
+# ``````````````````````````````````````````````````````````
 #
 # We can set ``display_mode='yz'`` to combine a coronal with an axial
 # view, which will return a :class:`~nilearn.plotting.displays.YZSlicer`
@@ -257,8 +191,8 @@ plotting.plot_stat_map(
 )
 
 # %%
-# Visualizing three views in 2x2 fashion
-# --------------------------------------
+# TiledSlicer: Three views in 2x2 fashion
+# ```````````````````````````````````````
 #
 # If we want to combine three views in a 2x2 way, we can set
 # ``display_mode='tiled'``, which will combine sagittal, coronal, and axial
@@ -273,14 +207,15 @@ plotting.plot_stat_map(
 )
 
 # %%
-# Visualizing three views along multiple rows and columns
-# -------------------------------------------------------
+# MosaicSlicer: Three views along multiple rows and columns
+# `````````````````````````````````````````````````````````
 #
 # If we set ``display_mode='mosaic'``, we can easily combine sagittal,
 # coronal, and axial views with different rows and columns. In this
 # situation, :func:`~nilearn.plotting.plot_stat_map` returns a
 # :class:`~nilearn.plotting.displays.MosaicSlicer` object.
-# In addition, we show here the default option ``cut_coords=None``.
+#
+# Below we show the default option ``cut_coords=None``.
 
 plotting.plot_stat_map(
     stat_img,
@@ -289,12 +224,8 @@ plotting.plot_stat_map(
 )
 
 # %%
-# Now, changing the number of slices along columns
-# ------------------------------------------------
-#
-# Here, we still set ``display_mode='mosaic'``, but we set the number of
-# slices to be the same across views. In this case, we can specify it as
-# an integer, i.e. ``cut_coords=3``.
+# We can also set the number of slices to be the same across views.
+# In this case, we can specify it as an integer, i.e. ``cut_coords=3``.
 
 plotting.plot_stat_map(
     stat_img,
@@ -304,9 +235,6 @@ plotting.plot_stat_map(
 )
 
 # %%
-# Now, another way of limiting the number of slices along rows and columns
-# ------------------------------------------------------------------------
-#
 # It can be the case that we want to display a different number of cuts in
 # each view. In this situation, we still set ``display_mode='mosaic'``, but
 # we specify the number of slices as a tuple of length 3.
@@ -319,8 +247,8 @@ plotting.plot_stat_map(
 )
 
 # %%
-# Demonstrating various display features
-# --------------------------------------
+# Display object's features
+# -------------------------
 #
 # In this second part, we demonstrate how to interact with the obtained
 # figures. More precisely, we will show how to use specific methods of the
@@ -335,8 +263,8 @@ from nilearn import image
 mean_haxby_img = image.mean_img(haxby_func_filename, copy_header=True)
 
 # %%
-# Showing how to use `add_edges`
-# ------------------------------
+# Overlay anatomical image as edges: `add_edges`
+# ``````````````````````````````````````````````
 #
 # Now let us see how to use the method
 # :meth:`~nilearn.plotting.displays.OrthoSlicer.add_edges` for checking
@@ -356,8 +284,8 @@ display = plotting.plot_anat(mean_haxby_img, title="add_edges")
 display.add_edges(haxby_anat_filename, color="r")
 
 # %%
-# How to use `add_contours`
-# -------------------------
+# Plot the outline of a mask: `add_contours`
+# ``````````````````````````````````````````
 #
 # Here, we show how to plot the outline of a mask (in red) on top of the
 # mean :term:`EPI` image with the method
@@ -406,8 +334,8 @@ display.add_contours(
 )
 
 # %%
-# Plotting seeds using `add_markers`
-# ----------------------------------
+# Plotting seeds: `add_markers`
+# `````````````````````````````
 #
 # Plotting seed regions of interest as spheres using method
 # :meth:`~nilearn.plotting.displays.OrthoSlicer.add_markers`
@@ -425,8 +353,8 @@ coords = [(-34, -39, -9)]
 display.add_markers(coords, marker_color="y", marker_size=100)
 
 # %%
-# Annotating plots
-# ----------------
+# Annotate plots: `annotate`
+# ``````````````````````````
 #
 # It is possible to alter the default annotations of plots, using the
 # method :meth:`~nilearn.plotting.displays.OrthoSlicer.annotate` of the
@@ -450,8 +378,8 @@ display = plotting.plot_anat(
 display.annotate(scalebar=True, scale_size=25, scale_units="mm")
 
 # %%
-# Saving plots to file
-# --------------------
+# Save plots to a file: `savefig`
+# ```````````````````````````````
 #
 # Finally, we can save a plot to file in two different ways:
 #

--- a/examples/01_plotting/plot_demo_more_plotting.py
+++ b/examples/01_plotting/plot_demo_more_plotting.py
@@ -158,7 +158,7 @@ plotting.plot_stat_map(
 # Using ``threshold`` value alongside with ``vmin`` and ``vmax`` parameters
 # enable us to mask certain values in the image.
 #
-# Unthresholded image:
+# Image without plotting threshold:
 
 plotting.plot_stat_map(
     stat_img,
@@ -168,7 +168,7 @@ plotting.plot_stat_map(
 )
 
 # %%
-# Image thresholded at 1:
+# Plotting threshold set to 1:
 
 plotting.plot_stat_map(
     stat_img,
@@ -179,9 +179,9 @@ plotting.plot_stat_map(
 )
 
 # %%
-# Setting ``vmin=0``, it is possible to plot only positive regions.
+# Setting ``vmin=0``, it is possible to plot only positive image values.
 #
-# Image thresholded at 1 with ``vmin=0``:
+# Plotting threshold set to 1 with ``vmin=0``:
 
 plotting.plot_stat_map(
     stat_img,
@@ -193,9 +193,9 @@ plotting.plot_stat_map(
 )
 
 # %%
-# Setting ``vmax=0``, it is possible to plot only negative regions.
+# Setting ``vmax=0``, it is possible to plot only negative image values.
 #
-# Image thresholded at 1 with ``vmax=0``:
+# Plotting threshold set to 1 with ``vmax=0``:
 
 plotting.plot_stat_map(
     stat_img,

--- a/examples/01_plotting/plot_demo_plotting.py
+++ b/examples/01_plotting/plot_demo_plotting.py
@@ -207,5 +207,5 @@ plotting.plot_stat_map(
     display_mode="ortho",
     cut_coords=[36, -27, 60],
     colorbar=False,
-    title="no colormap",
+    title="no colorbar",
 )

--- a/examples/01_plotting/plot_demo_plotting.py
+++ b/examples/01_plotting/plot_demo_plotting.py
@@ -171,6 +171,7 @@ plotting.plot_stat_map(
 plotting.plot_stat_map(
     stat_img,
     threshold=1,
+    cmap="inferno",
     display_mode="ortho",
     cut_coords=[36, -27, 60],
     title="plotting threshold=1, vmin=0",
@@ -187,6 +188,7 @@ plotting.plot_stat_map(
 plotting.plot_stat_map(
     stat_img,
     threshold=1,
+    cmap="inferno",
     display_mode="ortho",
     cut_coords=[36, -27, 60],
     title="plotting threshold=1, vmax=0",

--- a/examples/01_plotting/plot_demo_plotting.py
+++ b/examples/01_plotting/plot_demo_plotting.py
@@ -135,8 +135,8 @@ plotting.show()
 # Using ``threshold`` value alongside with ``vmin`` and ``vmax`` parameters
 # enable us to mask certain values in the image.
 #
-# Plotting without threshold:
-# ```````````````````````````
+# Plotting without threshold
+# ``````````````````````````
 
 plotting.plot_stat_map(
     stat_img,
@@ -146,8 +146,8 @@ plotting.plot_stat_map(
 )
 
 # %%
-# Plotting threshold set to 1:
-# ````````````````````````````
+# Plotting threshold set to 1
+# ```````````````````````````
 #
 # When plotting threshold is set to 1, the values between -1 and 1
 # are masked in the plot.

--- a/examples/01_plotting/plot_demo_plotting.py
+++ b/examples/01_plotting/plot_demo_plotting.py
@@ -192,3 +192,18 @@ plotting.plot_stat_map(
     title="plotting threshold=1, vmax=0",
     vmax=0,
 )
+
+# %%
+# Visualizing without a colorbar on the right side
+# ------------------------------------------------
+#
+# The argument ``colorbar`` should be set to ``False`` to show plots without
+# a colorbar on the right side.
+
+plotting.plot_stat_map(
+    stat_img,
+    display_mode="ortho",
+    cut_coords=[36, -27, 60],
+    colorbar=False,
+    title="no colormap",
+)

--- a/examples/01_plotting/plot_demo_plotting.py
+++ b/examples/01_plotting/plot_demo_plotting.py
@@ -111,7 +111,7 @@ plotting.plot_roi(
 # Plotting :term:`EPI` image: `plot_epi`
 # ``````````````````````````````````````
 
-# Import image processing tool0c6ffeed5899307f736c3dc3ef364afc86a76707
+# Import image processing tool
 from nilearn import image
 
 # Compute the voxel_wise mean of functional images across time.

--- a/examples/01_plotting/plot_demo_plotting.py
+++ b/examples/01_plotting/plot_demo_plotting.py
@@ -1,3 +1,4 @@
+# %%
 """
 Plotting tools in nilearn
 =========================
@@ -11,8 +12,8 @@ See :ref:`plotting` for more details.
 """
 
 # %%
-# Retrieve data from nilearn provided (general-purpose) datasets
-# --------------------------------------------------------------
+# We will first retrieve data from nilearn provided (general-purpose)
+# datasets.
 
 from nilearn import datasets
 
@@ -36,8 +37,11 @@ stat_img = datasets.load_sample_motor_activation_image()
 
 
 # %%
-# Plotting statistical maps with function `plot_stat_map`
-# -------------------------------------------------------
+# Nilearn plotting functions
+# --------------------------
+#
+# Plotting statistical maps: `plot_stat_map`
+# ``````````````````````````````````````````
 
 from nilearn import plotting
 
@@ -59,8 +63,8 @@ plotting.plot_stat_map(
 
 
 # %%
-# Making interactive visualizations with function `view_img`
-# ----------------------------------------------------------
+# Making interactive visualizations: `view_img`
+# `````````````````````````````````````````````
 # An alternative to :func:`~nilearn.plotting.plot_stat_map` is to use
 # :func:`~nilearn.plotting.view_img` that gives more interactive
 # visualizations in a web browser. See :ref:`interactive-stat-map-plotting`
@@ -78,23 +82,23 @@ view
 
 
 # %%
-# Plotting statistical maps in a glass brain with function `plot_glass_brain`
-# ---------------------------------------------------------------------------
+# Plotting statistical maps in a glass brain: `plot_glass_brain`
+# ``````````````````````````````````````````````````````````````
 #
 # Now, the t-map image is mapped on glass brain representation where glass
 # brain is always a fixed background template
 plotting.plot_glass_brain(stat_img, title="plot_glass_brain", threshold=3)
 
 # %%
-# Plotting anatomical images with function `plot_anat`
-# ----------------------------------------------------
+# Plotting anatomical images: `plot_anat`
+# ```````````````````````````````````````
 #
 # Visualizing anatomical image of haxby dataset
 plotting.plot_anat(haxby_anat_filename, title="plot_anat")
 
 # %%
-# Plotting ROIs (here the mask) with function `plot_roi`
-# ------------------------------------------------------
+# Plotting ROIs (here the mask): `plot_roi`
+# `````````````````````````````````````````
 #
 # Visualizing ventral temporal region image from haxby dataset overlaid on
 # subject specific anatomical image
@@ -104,10 +108,10 @@ plotting.plot_roi(
 )
 
 # %%
-# Plotting :term:`EPI` image with function `plot_epi`
-# ---------------------------------------------------
+# Plotting :term:`EPI` image: `plot_epi`
+# ``````````````````````````````````````
 
-# Import image processing tool
+# Import image processing tool0c6ffeed5899307f736c3dc3ef364afc86a76707
 from nilearn import image
 
 # Compute the voxel_wise mean of functional images across time.
@@ -123,3 +127,68 @@ plotting.plot_epi(mean_haxby_img, title="plot_epi")
 plotting.show()
 
 # sphinx_gallery_dummy_images=5
+
+# %%
+# Thresholding plots
+# ------------------
+#
+# Using ``threshold`` value alongside with ``vmin`` and ``vmax`` parameters
+# enable us to mask certain values in the image.
+#
+# Plotting without threshold:
+# ```````````````````````````
+
+plotting.plot_stat_map(
+    stat_img,
+    display_mode="ortho",
+    cut_coords=[36, -27, 60],
+    title="No plotting threshold",
+)
+
+# %%
+# Plotting threshold set to 1:
+# ````````````````````````````
+#
+# When plotting threshold is set to 1, the values between -1 and 1
+# are masked in the plot.
+
+plotting.plot_stat_map(
+    stat_img,
+    threshold=1,
+    display_mode="ortho",
+    cut_coords=[36, -27, 60],
+    title="plotting threshold=1",
+)
+
+
+# %%
+# Plotting threshold set to 1 with ``vmin=0``
+# ```````````````````````````````````````````
+#
+# Setting ``vmin=0``, it is possible to plot only positive image values.
+
+
+plotting.plot_stat_map(
+    stat_img,
+    threshold=1,
+    display_mode="ortho",
+    cut_coords=[36, -27, 60],
+    title="plotting threshold=1, vmin=0",
+    vmin=0,
+)
+
+# %%
+# Plotting threshold set to 1 with ``vmax=0``
+# ```````````````````````````````````````````
+#
+# Setting ``vmax=0``, it is possible to plot only negative image values.
+
+
+plotting.plot_stat_map(
+    stat_img,
+    threshold=1,
+    display_mode="ortho",
+    cut_coords=[36, -27, 60],
+    title="plotting threshold=1, vmax=0",
+    vmax=0,
+)

--- a/examples/06_manipulating_images/plot_threshold_image.py
+++ b/examples/06_manipulating_images/plot_threshold_image.py
@@ -91,6 +91,8 @@ plotting.plot_stat_map(
 # This will set all image values below 2 to 0.
 
 import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib import colors
 
 from nilearn.image import threshold_img
 
@@ -109,6 +111,12 @@ fig, axes = plt.subplots(
     figsize=(8, 8),
 )
 
+
+pos_cmap = colors.LinearSegmentedColormap.from_list(
+    "new_cmap", plt.get_cmap(cmap)(np.linspace(0.5, 1, 10))
+)
+
+
 plotting.plot_stat_map(
     image,
     colorbar=True,
@@ -121,7 +129,7 @@ plotting.plot_stat_map(
 plotting.plot_stat_map(
     thresholded_img,
     colorbar=True,
-    cmap=cmap,
+    cmap=pos_cmap,
     title="image thresholded at 2 with two_sided=False",
     cut_coords=cut_coords,
     axes=axes[1],
@@ -137,8 +145,8 @@ plotting.plot_stat_map(
 # This will set all image values above -2 to 0.
 
 import matplotlib.pyplot as plt
-
-from nilearn.image import threshold_img
+import numpy as np
+from matplotlib import colors
 
 thresholded_img = threshold_img(
     image,
@@ -155,6 +163,10 @@ fig, axes = plt.subplots(
     figsize=(8, 8),
 )
 
+neg_cmap = colors.LinearSegmentedColormap.from_list(
+    "new_cmap", plt.get_cmap(cmap)(np.linspace(0, 0.5, 10))
+)
+
 plotting.plot_stat_map(
     image,
     colorbar=True,
@@ -167,7 +179,7 @@ plotting.plot_stat_map(
 plotting.plot_stat_map(
     thresholded_img,
     colorbar=True,
-    cmap=cmap,
+    cmap=neg_cmap,
     title="image thresholded at -2 with two_sided=False",
     cut_coords=cut_coords,
     axes=axes[1],

--- a/examples/06_manipulating_images/plot_threshold_image.py
+++ b/examples/06_manipulating_images/plot_threshold_image.py
@@ -1,3 +1,4 @@
+# %%
 """
 Image thresholding
 ==================
@@ -82,7 +83,7 @@ plotting.plot_stat_map(
 
 # %%
 # Image thresholded at 2 when two_sided=False
-# ------------------------------------------
+# -------------------------------------------
 #
 # Now we will use ``threshold=2`` together with ``two_sided=False`` to
 # see the effect.
@@ -128,7 +129,7 @@ plotting.plot_stat_map(
 
 # %%
 # Image thresholded at -2 when two_sided=False
-# ------------------------------------------
+# --------------------------------------------
 #
 # Now we will use ``threshold=-2`` together with ``two_sided=False`` to
 # see the effect.

--- a/examples/06_manipulating_images/plot_threshold_image.py
+++ b/examples/06_manipulating_images/plot_threshold_image.py
@@ -1,0 +1,174 @@
+"""
+Image thresholding
+==================
+
+The goal of this example is to illustrate the use of the function
+:func:`~nilearn.image.threshold_img` together with ``threshold`` and
+``two_sided`` parameters to view certain values in image data.
+
+The ``threshold`` parameter can take both positive and negative values.
+``two_sided`` parameter is complementary to ``threshold`` effecting its
+behavior.
+
+"""
+
+# +
+# Image without threshold
+# -----------------------
+#
+# We will first load the dataset and display the image without manipulation.
+
+from nilearn import datasets, plotting
+
+cmap = "RdBu_r"
+cut_coords = [-26, -33, 59]
+
+image = datasets.load_sample_motor_activation_image()
+
+plotting.plot_stat_map(
+    image,
+    colorbar=True,
+    cmap=cmap,
+    title="image without threshold",
+    cut_coords=cut_coords,
+)
+
+# +
+# Image thresholded at 2 when two_sided=True
+# ------------------------------------------
+#
+# Now we will use ``threshold=2`` together with ``two_sided=True`` to
+# threshold the image. When ``two_sided=True``, we can only use positive
+# values for ``threshold``.
+#
+# This will set all image values between -2 and 2 to 0.
+
+import matplotlib.pyplot as plt
+
+from nilearn.image import threshold_img
+
+thresholded_img = threshold_img(
+    image,
+    threshold=2,
+    cluster_threshold=0,
+    two_sided=True,
+    copy=True,
+)
+
+
+fig, axes = plt.subplots(
+    1,
+    2,
+    figsize=(17, 5),
+)
+
+plotting.plot_stat_map(
+    image,
+    colorbar=True,
+    cmap=cmap,
+    title="image without threshold",
+    axes=axes[0],
+    cut_coords=cut_coords,
+)
+
+plotting.plot_stat_map(
+    thresholded_img,
+    colorbar=True,
+    cmap=cmap,
+    title="image thresholded at 2 with two_sided=True",
+    cut_coords=cut_coords,
+    axes=axes[1],
+)
+
+# +
+# Image thresholded at 2 when two_sided=False
+# ------------------------------------------
+#
+# Now we will use ``threshold=2`` together with ``two_sided=False`` to
+# see the effect.
+#
+# This will set all image values below 2 to 0.
+
+import matplotlib.pyplot as plt
+
+from nilearn.image import threshold_img
+
+thresholded_img = threshold_img(
+    image,
+    threshold=2,
+    cluster_threshold=0,
+    two_sided=False,
+    copy=True,
+)
+
+
+fig, axes = plt.subplots(
+    1,
+    2,
+    figsize=(17, 5),
+)
+
+plotting.plot_stat_map(
+    image,
+    colorbar=True,
+    cmap=cmap,
+    title="image without threshold",
+    axes=axes[0],
+    cut_coords=cut_coords,
+)
+
+plotting.plot_stat_map(
+    thresholded_img,
+    colorbar=True,
+    cmap=cmap,
+    title="image thresholded at 2 with two_sided=False",
+    cut_coords=cut_coords,
+    axes=axes[1],
+)
+
+# +
+# Image thresholded at -2 when two_sided=False
+# ------------------------------------------
+#
+# Now we will use ``threshold=-2`` together with ``two_sided=False`` to
+# see the effect.
+#
+# This will set all image values above -2 to 0.
+
+import matplotlib.pyplot as plt
+
+from nilearn.image import threshold_img
+
+thresholded_img = threshold_img(
+    image,
+    threshold=-2,
+    cluster_threshold=0,
+    two_sided=False,
+    copy=True,
+)
+
+
+fig, axes = plt.subplots(
+    1,
+    2,
+    figsize=(17, 5),
+)
+
+plotting.plot_stat_map(
+    image,
+    colorbar=True,
+    cmap=cmap,
+    title="image without threshold",
+    axes=axes[0],
+    cut_coords=cut_coords,
+)
+
+plotting.plot_stat_map(
+    thresholded_img,
+    colorbar=True,
+    cmap=cmap,
+    title="image thresholded at -2 with two_sided=False",
+    cut_coords=cut_coords,
+    axes=axes[1],
+)
+# -

--- a/examples/06_manipulating_images/plot_threshold_image.py
+++ b/examples/06_manipulating_images/plot_threshold_image.py
@@ -58,9 +58,9 @@ thresholded_img = threshold_img(
 
 
 fig, axes = plt.subplots(
-    1,
     2,
-    figsize=(17, 5),
+    1,
+    figsize=(8, 8),
 )
 
 plotting.plot_stat_map(
@@ -104,9 +104,9 @@ thresholded_img = threshold_img(
 
 
 fig, axes = plt.subplots(
-    1,
     2,
-    figsize=(17, 5),
+    1,
+    figsize=(8, 8),
 )
 
 plotting.plot_stat_map(
@@ -150,9 +150,9 @@ thresholded_img = threshold_img(
 
 
 fig, axes = plt.subplots(
-    1,
     2,
-    figsize=(17, 5),
+    1,
+    figsize=(8, 8),
 )
 
 plotting.plot_stat_map(

--- a/examples/06_manipulating_images/plot_threshold_image.py
+++ b/examples/06_manipulating_images/plot_threshold_image.py
@@ -12,7 +12,7 @@ behavior.
 
 """
 
-# +
+# %%
 # Image without threshold
 # -----------------------
 #
@@ -33,7 +33,7 @@ plotting.plot_stat_map(
     cut_coords=cut_coords,
 )
 
-# +
+# %%
 # Image thresholded at 2 when two_sided=True
 # ------------------------------------------
 #
@@ -80,7 +80,7 @@ plotting.plot_stat_map(
     axes=axes[1],
 )
 
-# +
+# %%
 # Image thresholded at 2 when two_sided=False
 # ------------------------------------------
 #
@@ -126,7 +126,7 @@ plotting.plot_stat_map(
     axes=axes[1],
 )
 
-# +
+# %%
 # Image thresholded at -2 when two_sided=False
 # ------------------------------------------
 #

--- a/examples/06_manipulating_images/plot_threshold_image.py
+++ b/examples/06_manipulating_images/plot_threshold_image.py
@@ -21,7 +21,6 @@ behavior.
 
 from nilearn import datasets, plotting
 
-cmap = "RdBu_r"
 cut_coords = [-26, -33, 59]
 
 image = datasets.load_sample_motor_activation_image()
@@ -29,7 +28,6 @@ image = datasets.load_sample_motor_activation_image()
 plotting.plot_stat_map(
     image,
     colorbar=True,
-    cmap=cmap,
     title="image without threshold",
     cut_coords=cut_coords,
 )
@@ -66,7 +64,6 @@ fig, axes = plt.subplots(
 plotting.plot_stat_map(
     image,
     colorbar=True,
-    cmap=cmap,
     title="image without threshold",
     axes=axes[0],
     cut_coords=cut_coords,
@@ -75,7 +72,6 @@ plotting.plot_stat_map(
 plotting.plot_stat_map(
     thresholded_img,
     colorbar=True,
-    cmap=cmap,
     title="image thresholded at 2 with two_sided=True",
     cut_coords=cut_coords,
     axes=axes[1],
@@ -91,8 +87,6 @@ plotting.plot_stat_map(
 # This will set all image values below 2 to 0.
 
 import matplotlib.pyplot as plt
-import numpy as np
-from matplotlib import colors
 
 from nilearn.image import threshold_img
 
@@ -112,15 +106,9 @@ fig, axes = plt.subplots(
 )
 
 
-pos_cmap = colors.LinearSegmentedColormap.from_list(
-    "new_cmap", plt.get_cmap(cmap)(np.linspace(0.5, 1, 10))
-)
-
-
 plotting.plot_stat_map(
     image,
     colorbar=True,
-    cmap=cmap,
     title="image without threshold",
     axes=axes[0],
     cut_coords=cut_coords,
@@ -129,7 +117,7 @@ plotting.plot_stat_map(
 plotting.plot_stat_map(
     thresholded_img,
     colorbar=True,
-    cmap=pos_cmap,
+    cmap="Reds",
     title="image thresholded at 2 with two_sided=False",
     cut_coords=cut_coords,
     axes=axes[1],
@@ -145,8 +133,6 @@ plotting.plot_stat_map(
 # This will set all image values above -2 to 0.
 
 import matplotlib.pyplot as plt
-import numpy as np
-from matplotlib import colors
 
 thresholded_img = threshold_img(
     image,
@@ -163,14 +149,9 @@ fig, axes = plt.subplots(
     figsize=(8, 8),
 )
 
-neg_cmap = colors.LinearSegmentedColormap.from_list(
-    "new_cmap", plt.get_cmap(cmap)(np.linspace(0, 0.5, 10))
-)
-
 plotting.plot_stat_map(
     image,
     colorbar=True,
-    cmap=cmap,
     title="image without threshold",
     axes=axes[0],
     cut_coords=cut_coords,
@@ -179,9 +160,11 @@ plotting.plot_stat_map(
 plotting.plot_stat_map(
     thresholded_img,
     colorbar=True,
-    cmap=neg_cmap,
+    cmap="Blues_r",
     title="image thresholded at -2 with two_sided=False",
     cut_coords=cut_coords,
     axes=axes[1],
 )
 # -
+
+# %%

--- a/nilearn/plotting/img_plotting.py
+++ b/nilearn/plotting/img_plotting.py
@@ -1456,9 +1456,6 @@ def plot_stat_map(
 
     %(cmap)s
 
-        .. note::
-            The colormap *must* be symmetrical.
-
         Default=default="RdBu_r".
 
     %(symmetric_cbar)s


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #5106 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Modify notebook [examples/01_plotting/plot_demo_plotting.py](https://github.com/nilearn/nilearn/blob/main/examples/01_plotting/plot_demo_plotting.py) to add examples on usage of `threshold`, `vmin` and `vmax` for image plotting.
- Modify notebook [examples/01_plotting/plot_demo_more_plotting.py](https://github.com/nilearn/nilearn/blob/main/examples/01_plotting/plot_demo_more_plotting.py) reorganize headings and heading levels.
- Move colorbar example from [examples/01_plotting/plot_demo_more_plotting.py](https://github.com/nilearn/nilearn/blob/main/examples/01_plotting/plot_demo_more_plotting.py) to  [examples/01_plotting/plot_demo_more_plotting.py](https://github.com/nilearn/nilearn/blob/main/examples/01_plotting/plot_demo_more_plotting.py) .
- Add [notebook](https://github.com/nilearn/nilearn/blob/main/examples/06_manipulating_images/plot_threshold_image.py) for image thresholding example.
