### PR TITLE
[ENH] allow numpy equivalent to int and float for several common parameters

### DIFF
--- a/examples/01_plotting/plot_demo_plotting.py
+++ b/examples/01_plotting/plot_demo_plotting.py
@@ -45,12 +45,14 @@ stat_img = datasets.load_sample_motor_activation_image()
 
 from nilearn import plotting
 
+# %%
 # Visualizing t-map image on EPI template with manual
 # positioning of coordinates using cut_coords given as a list
 plotting.plot_stat_map(
     stat_img, threshold=3, title="plot_stat_map", cut_coords=[36, -27, 66]
 )
 
+# %%
 # It's also possible to visualize volumes in a LR-flipped "radiological" view
 # Just set radiological=True
 plotting.plot_stat_map(
@@ -126,8 +128,6 @@ plotting.plot_epi(mean_haxby_img, title="plot_epi")
 # in script mode (ie outside IPython)
 plotting.show()
 
-# sphinx_gallery_dummy_images=5
-
 # %%
 # Thresholding plots
 # ------------------
@@ -160,13 +160,11 @@ plotting.plot_stat_map(
     title="plotting threshold=1",
 )
 
-
 # %%
 # Plotting threshold set to 1 with ``vmin=0``
 # ```````````````````````````````````````````
 #
 # Setting ``vmin=0``, it is possible to plot only positive image values.
-
 
 plotting.plot_stat_map(
     stat_img,
@@ -183,7 +181,6 @@ plotting.plot_stat_map(
 # ```````````````````````````````````````````
 #
 # Setting ``vmax=0``, it is possible to plot only negative image values.
-
 
 plotting.plot_stat_map(
     stat_img,
@@ -209,3 +206,5 @@ plotting.plot_stat_map(
     colorbar=False,
     title="no colorbar",
 )
+
+# sphinx_gallery_dummy_images=5

--- a/nilearn/typing.py
+++ b/nilearn/typing.py
@@ -27,29 +27,26 @@ from joblib.memory import Memory
 from numpy import ndarray
 from numpy.typing import DTypeLike
 
-BorderSize = int
-Connected = int
+Connected = bool
 Detrend = bool
-LowerCutoff = float
-MemoryLevel = int
-NJobs = int
-NPerm = int
 Resume = bool
 Standardize = bool
 Tfce = bool
 TwoSidedTest = bool
-UpperCutoff = float
-Verbose = int
-
 
 # TODO update when dropping python 3.9
 if sys.version_info[1] < 10:
+    BorderSize = (int, np.integer)
     DataDir = (str, pathlib.Path)
     DType = DTypeLike
     HighPass = (float, int, np.floating, np.integer)
     HrfModel = (str, Callable, list)
     LowPass = (float, int, np.floating, np.integer)
+    LowerCutoff = (float, np.floating)
+    MemoryLevel = (int, np.integer)
     MemoryLike = (Memory, str, pathlib.Path)
+    NJobs = (int, np.integer)
+    NPerm = (int, np.integer)
     Opening = (bool, int, np.integer)
     RandomState = (int, np.integer, np.random.RandomState)
     Resolution = (int, np.integer)
@@ -60,6 +57,8 @@ if sys.version_info[1] < 10:
     Title = str
     Tr = (float, int)
     Url = str
+    UpperCutoff = (float, np.floating)
+    Verbose = (int, np.integer)
     Vmin = (float, int, np.floating, np.integer)
     Vmax = (float, int, np.floating, np.integer)
 
@@ -67,6 +66,7 @@ if sys.version_info[1] < 10:
 else:
     from typing import TypeAlias
 
+    BorderSize: TypeAlias = int | np.integer
     DataDir: TypeAlias = str | pathlib.Path | None
     DType: TypeAlias = DTypeLike | None
 
@@ -77,8 +77,12 @@ else:
     HrfModel: TypeAlias = str | Callable | list | None
 
     HighPass: TypeAlias = float | int | np.floating | np.integer | None
+    LowerCutoff: TypeAlias = float | np.floating
     LowPass: TypeAlias = float | int | np.floating | np.integer | None
     MemoryLike: TypeAlias = Memory | str | pathlib.Path | None
+    MemoryLevel: TypeAlias = int | np.integer
+    NJobs: TypeAlias = int | np.integer
+    NPerm: TypeAlias = int | np.integer
     RandomState = int | np.floating | np.integer | np.random.RandomState | None
     Opening: TypeAlias = bool | int | np.integer
     Resolution: TypeAlias = int | np.integer | None
@@ -96,5 +100,7 @@ else:
     Title: TypeAlias = str | None
     Tr: TypeAlias = float | int | np.floating | np.integer | None
     Url: TypeAlias = str | None
+    UpperCutoff: TypeAlias = float | np.floating
+    Verbose: TypeAlias = int | np.integer
     Vmin = float | int | np.floating | np.integer | None
     Vmax = float | int | np.floating | np.integer | None

--- a/nilearn/typing.py
+++ b/nilearn/typing.py
@@ -46,22 +46,22 @@ Verbose = int
 if sys.version_info[1] < 10:
     DataDir = (str, pathlib.Path)
     DType = DTypeLike
-    HighPass = (float, int)
+    HighPass = (float, int, np.floating, np.integer)
     HrfModel = (str, Callable, list)
-    LowPass = (float, int)
+    LowPass = (float, int, np.floating, np.integer)
     MemoryLike = (Memory, str, pathlib.Path)
-    Opening = (bool, int)
-    RandomState = (int, np.random.RandomState)
-    Resolution = int
-    SmoothingFwhm = (float, int)
+    Opening = (bool, int, np.integer)
+    RandomState = (int, np.integer, np.random.RandomState)
+    Resolution = (int, np.integer)
+    SmoothingFwhm = (float, int, np.floating, np.integer)
     TargetAffine = ndarray
     TargetShape = (tuple, list)
-    Threshold = (int, float, str)
+    Threshold = (float, int, str, np.floating, np.integer)
     Title = str
     Tr = (float, int)
     Url = str
-    Vmin = (float, int)
-    Vmax = (float, int)
+    Vmin = (float, int, np.floating, np.integer)
+    Vmax = (float, int, np.floating, np.integer)
 
 
 else:
@@ -76,13 +76,13 @@ else:
     # if we wanted to use proper type annotation
     HrfModel: TypeAlias = str | Callable | list | None
 
-    HighPass: TypeAlias = float | int | None
-    LowPass: TypeAlias = float | int | None
+    HighPass: TypeAlias = float | int | np.floating | np.integer | None
+    LowPass: TypeAlias = float | int | np.floating | np.integer | None
     MemoryLike: TypeAlias = Memory | str | pathlib.Path | None
-    RandomState = int | np.random.RandomState | None
-    Opening: TypeAlias = bool | int
-    Resolution: TypeAlias = int | None
-    SmoothingFwhm: TypeAlias = float | int | None
+    RandomState = int | np.floating | np.integer | np.random.RandomState | None
+    Opening: TypeAlias = bool | int | np.integer
+    Resolution: TypeAlias = int | np.integer | None
+    SmoothingFwhm: TypeAlias = float | int | np.floating | np.integer | None
     TargetAffine: TypeAlias = ndarray | None
 
     # Note that this is usable as for static type checking,
@@ -91,10 +91,10 @@ else:
     TargetShape: TypeAlias = tuple | list | None
 
     # str is too generic: should be Literal["auto"]
-    Threshold: TypeAlias = int | float | str | None
+    Threshold: TypeAlias = float | int | np.floating | np.integer | str | None
 
     Title: TypeAlias = str | None
-    Tr: TypeAlias = float | int | None
+    Tr: TypeAlias = float | int | np.floating | np.integer | None
     Url: TypeAlias = str | None
-    Vmin = float | int | None
-    Vmax = float | int | None
+    Vmin = float | int | np.floating | np.integer | None
+    Vmax = float | int | np.floating | np.integer | None


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but fixes doc build crash on main

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- expand accepted numeric types for common parameters to accept numpy.floating and numpy.integer where appropriate

Should avoid error due to 

```python
>>> import numpy as np
>>> a = np.int32(1)
>>> isinstance(a, int)
False
```
