### PR TITLE
[FIX] return design matrices of FIAC as dataframes

### DIFF
--- a/doc/visual_testing/reporter_visual_inspection_suite.py
+++ b/doc/visual_testing/reporter_visual_inspection_suite.py
@@ -238,8 +238,7 @@ def report_flm_fiac(build_type):
 
     mean_img_ = mean_img(fmri_img[0], copy_header=True)
 
-    design_files = [data["design_matrix1"], data["design_matrix2"]]
-    design_matrices = [pd.DataFrame(np.load(df)["X"]) for df in design_files]
+    design_matrices = [data["design_matrix1"], data["design_matrix2"]]
 
     fmri_glm = FirstLevelModel(mask_img=data["mask"], minimize_memory=True)
     fmri_glm = fmri_glm.fit(fmri_img, design_matrices=design_matrices)

--- a/nilearn/datasets/description/fiac.rst
+++ b/nilearn/datasets/description/fiac.rst
@@ -14,29 +14,31 @@ Analysis from the Functional Imaging Analysis Contest (FIAC).
 This is a block design experiment with a 2 X 2 experimental design
 with the following factors:
 
-- ``Sentence`` with 2 levels: Same (SSt) vs Different (DSt)
-- ``Speaker``  with 2 levels: Same (SSp) vs Different (DSp)
+- ``Sentence`` with 2 levels: Same (``SSt``) vs Different (``DSt``)
+- ``Speaker``  with 2 levels: Same (``SSp``) vs Different (``DSp``)
 
 giving the 4 following conditions:
 
-- Same Sentence-Same Speaker (SStSSp)
-- Same Sentence-Different Speakers (SStDSp)
-- Different Sentences-Same Speaker (DStSSp)
-- Different Sentences-Different Speakers (DStDSp)
+- Same Sentence-Same Speaker (``SStSSp``)
+- Same Sentence-Different Speakers (``SStDSp``)
+- Different Sentences-Same Speaker (``DStSSp``)
+- Different Sentences-Different Speakers (``DStDSp``)
 
 The design also included a 5th condition
 containing the first sentence pooled across all conditions.
+
+Direct download link: https://nipy.org/data-packages/nipy-data-0.2.tar.gz.
 
 For more details on the data, please see experiment 2 :footcite:t:`Dehaene2006`.
 
 Content
 -------
-    :'design_matrix1': Path to design matrix .npz file of run 1
-    :'func1': Path to Nifti file of run 1
-    :'design_matrix2': Path to design matrix .npz file of run 2
-    :'func2': Path to Nifti file of run 2
-    :'mask': Path to mask file
-    :'description': Data description
+:'design_matrix1': Design matrix of run 1
+:'func1': Path to Nifti file of run 1
+:'design_matrix2':  Design matrix of run 2
+:'func2': Path to Nifti file of run 2
+:'mask': Path to mask file
+:'description': Data description
 
 References
 ----------

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -3065,14 +3065,19 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
     data : :obj:`sklearn.utils.Bunch`
         Dictionary-like object, the interest attributes are:
 
-        - 'design_matrix1': :obj:`str`.
-          Path to design matrix .npz file of run 1
+        - 'design_matrix1': :obj:`pandas.DataFrame`.
+          Design matrix for run 1
         - 'func1': :obj:`str`. Path to Nifti file of run 1
-        - 'design_matrix2': :obj:`str`.
-          Path to design matrix .npz file of run 2
+        - 'design_matrix2': :obj:`pandas.DataFrame`.
+          Design matrix for run 2
         - 'func2': :obj:`str`. Path to Nifti file of run 2
         - 'mask': :obj:`str`. Path to mask file
         - 'description': :obj:`str`. Data description
+
+    Notes
+    -----
+    For more information
+    see the :ref:`dataset description <fiac_dataset>`.
 
     """
     check_params(locals())
@@ -3100,7 +3105,12 @@ def fetch_fiac_first_level(data_dir=None, verbose=1):
                 logger.log(f"Missing run file: {sess_dmtx}")
                 return None
 
-            _subject_data[f"design_matrix{int(run)}"] = str(sess_dmtx)
+            design_matrix_data = np.load(str(sess_dmtx))
+            columns = [x.decode() for x in design_matrix_data["conditions"]]
+
+            _subject_data[f"design_matrix{int(run)}"] = pd.DataFrame(
+                design_matrix_data["X"], columns=columns
+            )
 
         # glob for mask data
         mask = subject_dir / "mask.nii.gz"

--- a/nilearn/datasets/tests/test_func.py
+++ b/nilearn/datasets/tests/test_func.py
@@ -1055,7 +1055,13 @@ def test_fiac(tmp_path):
     for run in [1, 2]:
         # glob func data for run + 1
         (fiac0_dir / f"run{int(run)}.nii.gz").touch()
-        (fiac0_dir / f"run{int(run)}_design.npz").touch()
+
+        X = np.ones((2, 2))
+        conditions = [b"cdt_1", b"cdt_2"]
+        np.savez(
+            fiac0_dir / f"run{int(run)}_design.npz", X=X, conditions=conditions
+        )
+
     (fiac0_dir / "mask.nii.gz").touch()
 
     dataset = func.fetch_fiac_first_level(data_dir=tmp_path)
@@ -1064,8 +1070,8 @@ def test_fiac(tmp_path):
     check_type_fetcher(dataset)
     assert isinstance(dataset.func1, str)
     assert isinstance(dataset.func2, str)
-    assert isinstance(dataset.design_matrix1, str)
-    assert isinstance(dataset.design_matrix2, str)
+    assert isinstance(dataset.design_matrix1, pd.DataFrame)
+    assert isinstance(dataset.design_matrix2, pd.DataFrame)
     assert isinstance(dataset.mask, str)
 
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #2400
- Relates to #4218

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- improve doc FIAC dataset
- return design matrices as dataframes with proper column names
- update examples that use this dataset
