### PR TITLE
[ENH] add vmax to example plot_resample_to_template.py

### DIFF
--- a/examples/06_manipulating_images/plot_resample_to_template.py
+++ b/examples/06_manipulating_images/plot_resample_to_template.py
@@ -75,6 +75,7 @@ plotting.plot_stat_map(
     cut_coords=(36, -27, 66),
     threshold=3,
     title="t-map in original resolution",
+    vmax=8,
 )
 plotting.plot_stat_map(
     resampled_stat_img,
@@ -82,6 +83,7 @@ plotting.plot_stat_map(
     cut_coords=(36, -27, 66),
     threshold=3,
     title="Resampled t-map",
+    vmax=8,
 )
 plotting.show()
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- make it easier to compare images before and after resampling to avoid

![image](https://github.com/user-attachments/assets/82842679-8740-4717-b886-c425c498bc6f)

Note I find it a tad strange that a resampled image would lead to an image with a higher maximum (unless there is another reason that the max of the colorbar was changed).