### PR TITLE
[FIX] prevent range overrun

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -772,3 +772,9 @@ authors:
     family-names: Nájera
     website: https://github.com/Titan-C
     affiliation: Checkmk
+  - given-names: Lee
+    family-names: Newberg
+    website: https://github.com/Leengit
+    affiliation: Kitware, Inc., USA
+    email: leengit@quantconsulting.com
+    orcid: https://orcid.org/0000-0003-4644-8874

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -13,6 +13,10 @@ HIGHLIGHTS
 Fixes
 -----
 
+- :bdg-dark:`Code` Prevent range overrun in TFCE (:gh:`5179` by `Lee Newberg`_).
+
+- :bdg-dark:`Code` Bound the number of thresholds in TFCE calculation (:gh:`5179` by `Lee Newberg`_).
+
 - :bdg-dark:`Code` Ensure that all figures are generated with a color bar by default (:gh:`5172` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Fixes datasets that returned numpy arrays instead of pandas dataframes (:gh:`5109` by `Rémi Gau`_).

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -1011,6 +1011,13 @@ tfce : :obj:`bool`, default=False
     The TFCE calculation is implemented
     as described in :footcite:t:`Smith2009a`.
 
+    .. note::
+
+       The number of thresholds used in the TFCE procedure
+       will set between 10 and 1000.
+
+       .. versionadded:: 0.11.2dev
+
     .. warning::
 
         Performing TFCE-based inference

--- a/nilearn/mass_univariate/_utils.py
+++ b/nilearn/mass_univariate/_utils.py
@@ -69,6 +69,7 @@ def calculate_tfce(
         arr3d = arr4d[..., i_regressor]
 
         signs = [-1, 1] if two_sided_test else [1]
+        score_threshs = _return_score_threshs(arr3d, dh, two_sided_test)
 
         # If we apply the sign first...
         for sign in signs:
@@ -78,7 +79,6 @@ def calculate_tfce(
             # is incrementally larger
             temp_arr3d = arr3d * sign
 
-            score_threshs = _return_score_threshs(arr3d, dh, two_sided_test)
             # Prep step
             for score_thresh in score_threshs:
                 temp_arr3d[temp_arr3d < score_thresh] = 0
@@ -135,7 +135,9 @@ def _return_score_threshs(arr3d, dh, two_sided_test):
     max_score = (
         np.nanmax(np.abs(arr3d)) if two_sided_test else np.nanmax(arr3d)
     )
-    number_steps = 100 if dh == "auto" else max(1, round(max_score / dh))
+    number_steps = (
+        100 if dh == "auto" else np.clip(round(max_score / dh), 10, 1000)
+    )
     return np.linspace(0, max_score, number_steps + 1)[1:]
 
 

--- a/nilearn/mass_univariate/_utils.py
+++ b/nilearn/mass_univariate/_utils.py
@@ -76,10 +76,9 @@ def calculate_tfce(
             signs = [1]
             max_score = np.max(arr3d)
 
-        step = max_score / 100 if dh == "auto" else dh
-
         # Set based on determined step size
-        score_threshs = np.arange(step, max_score + step, step)
+        number_steps = 100 if dh == "auto" else max(1, round(max_score / dh))
+        score_threshs = np.linspace(0, max_score, number_steps + 1)[1:]
 
         # If we apply the sign first...
         for sign in signs:

--- a/nilearn/mass_univariate/_utils.py
+++ b/nilearn/mass_univariate/_utils.py
@@ -68,17 +68,7 @@ def calculate_tfce(
     for i_regressor in range(arr4d.shape[3]):
         arr3d = arr4d[..., i_regressor]
 
-        # Get signs / threshs
-        if two_sided_test:
-            signs = [-1, 1]
-            max_score = np.max(np.abs(arr3d))
-        else:
-            signs = [1]
-            max_score = np.max(arr3d)
-
-        # Set based on determined step size
-        number_steps = 100 if dh == "auto" else max(1, round(max_score / dh))
-        score_threshs = np.linspace(0, max_score, number_steps + 1)[1:]
+        signs = [-1, 1] if two_sided_test else [1]
 
         # If we apply the sign first...
         for sign in signs:
@@ -88,6 +78,7 @@ def calculate_tfce(
             # is incrementally larger
             temp_arr3d = arr3d * sign
 
+            score_threshs = _return_score_threshs(arr3d, dh, two_sided_test)
             # Prep step
             for score_thresh in score_threshs:
                 temp_arr3d[temp_arr3d < score_thresh] = 0
@@ -137,6 +128,15 @@ def calculate_tfce(
                 )
 
     return tfce_4d
+
+
+def _return_score_threshs(arr3d, dh, two_sided_test):
+    """Compute list of score threshold to use for TFCE."""
+    max_score = (
+        np.nanmax(np.abs(arr3d)) if two_sided_test else np.nanmax(arr3d)
+    )
+    number_steps = 100 if dh == "auto" else max(1, round(max_score / dh))
+    return np.linspace(0, max_score, number_steps + 1)[1:]
 
 
 def null_to_p(test_values, null_array, alternative="two-sided"):

--- a/nilearn/mass_univariate/_utils.py
+++ b/nilearn/mass_univariate/_utils.py
@@ -1,5 +1,7 @@
 """Utility functions for the permuted least squares method."""
 
+from warnings import warn
+
 import numpy as np
 from scipy import linalg
 from scipy.ndimage import label
@@ -135,9 +137,23 @@ def _return_score_threshs(arr3d, dh, two_sided_test):
     max_score = (
         np.nanmax(np.abs(arr3d)) if two_sided_test else np.nanmax(arr3d)
     )
-    number_steps = (
-        100 if dh == "auto" else np.clip(round(max_score / dh), 10, 1000)
-    )
+
+    number_steps = 100 if dh == "auto" else round(max_score / dh)
+    if number_steps < 10:
+        warn(
+            f"Not enough steps for TFCE. Got: {number_steps=}. "
+            "Setting it to 10.",
+            stacklevel=4,
+        )
+        number_steps = 10
+    if number_steps > 1000:
+        warn(
+            f"Too many steps for TFCE. Got: {number_steps=}. "
+            "Setting it to 1000.",
+            stacklevel=4,
+        )
+        number_steps = 1000
+
     return np.linspace(0, max_score, number_steps + 1)[1:]
 
 

--- a/nilearn/mass_univariate/tests/test_utils.py
+++ b/nilearn/mass_univariate/tests/test_utils.py
@@ -303,4 +303,4 @@ def test_return_score_threshs(arr3d, two_sided_test, dh):
     max_score = (
         np.nanmax(np.abs(arr3d)) if two_sided_test else np.nanmax(arr3d)
     )
-    assert np.sum(score_threshs > max_score) == 0
+    assert (score_threshs <= max_score).all()

--- a/nilearn/mass_univariate/tests/test_utils.py
+++ b/nilearn/mass_univariate/tests/test_utils.py
@@ -304,3 +304,22 @@ def test_return_score_threshs(arr3d, two_sided_test, dh):
         np.nanmax(np.abs(arr3d)) if two_sided_test else np.nanmax(arr3d)
     )
     assert (score_threshs <= max_score).all()
+
+    assert len(score_threshs) >= 10
+
+
+def test_warning_n_steps_return_score_threshs():
+    """Check that warning is thrown when less than 10 steps for TFCE."""
+    arr3d = np.ones((10, 11), dtype="float")
+
+    with pytest.warns(UserWarning, match="Setting it to 10"):
+        score_threshs = _utils._return_score_threshs(
+            arr3d, dh=0.9, two_sided_test=False
+        )
+        assert len(score_threshs) == 10
+
+    with pytest.warns(UserWarning, match="Setting it to 1000"):
+        score_threshs = _utils._return_score_threshs(
+            arr3d, dh=0.0001, two_sided_test=False
+        )
+        assert len(score_threshs) == 1000

--- a/nilearn/mass_univariate/tests/test_utils.py
+++ b/nilearn/mass_univariate/tests/test_utils.py
@@ -7,6 +7,7 @@ import pytest
 from numpy.testing import assert_array_almost_equal
 from scipy.ndimage import generate_binary_structure
 
+from nilearn.conftest import _rng
 from nilearn.mass_univariate import _utils
 from nilearn.mass_univariate.tests._testing import (
     get_tvalue_with_alternative_library,
@@ -268,3 +269,38 @@ def test_t_score_with_covars_and_normalized_design_withcovar(rng):
     # compute t-scores with linalg or statmodels
     ref_score = get_tvalue_with_alternative_library(var1, var2, covars)
     assert_array_almost_equal(own_score, ref_score)
+
+
+@pytest.mark.parametrize("two_sided_test", [True, False])
+@pytest.mark.parametrize(
+    "dh",
+    [
+        1 / 49,
+        0.1,
+        0.9,
+        "auto",
+    ],
+)
+@pytest.mark.parametrize(
+    "arr3d",
+    [
+        np.ones((10, 11), dtype="float"),
+        _rng().random((10, 11), dtype="float"),
+        _rng().normal(size=(10, 11)),
+    ],
+)
+def test_return_score_threshs(arr3d, two_sided_test, dh):
+    """Check that the range of thresholds to test.
+
+    Also test for robustness to nan values.
+    """
+    arr3d[0, 0] = np.nan
+
+    score_threshs = _utils._return_score_threshs(
+        arr3d, dh=dh, two_sided_test=two_sided_test
+    )
+
+    max_score = (
+        np.nanmax(np.abs(arr3d)) if two_sided_test else np.nanmax(arr3d)
+    )
+    assert np.sum(score_threshs > max_score) == 0


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #5178 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Changed the floating-point upper bound value of an `np.arange` call so that the range terminates with the correct value.
