### PR TITLE
DOC Fix binder notebook generation

### DIFF
--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -26,7 +26,7 @@ find . -delete
 GENERATED_NOTEBOOKS_DIR=.generated-notebooks
 cp -r $TMP_CONTENT_DIR/examples $GENERATED_NOTEBOOKS_DIR
 
-find $GENERATED_NOTEBOOKS_DIR -name '*.py' -exec sphx_glr_python_to_jupyter.py '{}' +
+find $GENERATED_NOTEBOOKS_DIR -name '*.py' -exec sphinx_gallery_py2jupyter '{}' +
 NON_NOTEBOOKS=$(find $GENERATED_NOTEBOOKS_DIR -type f | grep -v '\.ipynb')
 rm -f $NON_NOTEBOOKS
 

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -9,9 +9,9 @@ set -e
 # inside a git checkout of the nilearn/nilearn repo. This script is
 # generating notebooks from the nilearn python examples.
 
-if [[ ! -f /.dockerenv ]]; then
-    echo "This script was written for repo2docker and is supposed to run inside a docker container."
-    echo "Exiting because this script can delete data if run outside of a docker container."
+if [[ -z "${REPO_DIR}" ]]; then
+    echo "This script was written for repo2docker and the REPO_DIR environment variable is supposed to be set."
+    echo "Exiting because this script can delete data if run outside of a repo2docker context."
     exit 1
 fi
 


### PR DESCRIPTION
This fixes Binder link similarly to https://github.com/scikit-learn/scikit-learn/pull/30697 and https://github.com/scikit-learn/scikit-learn/pull/30835. Recently Binder is expected to be more reliable, see https://github.com/scikit-learn/scikit-learn/pull/30697#issuecomment-2659881848 for more details.

Fix https://github.com/nilearn/nilearn/issues/4953

Current broken link from [dev doc example](https://nilearn.github.io/dev/auto_examples/07_advanced/plot_mask_large_fmri.html#sphx-glr-download-auto-examples-07-advanced-plot-mask-large-fmri-py):
https://mybinder.org/v2/gh/nilearn/nilearn/main?urlpath=lab/tree/notebooks/auto_examples/07_advanced/plot_mask_large_fmri.ipynb

Test it on my PR branch:
https://mybinder.org/v2/gh/lesteve/nilearn/fix-binder?urlpath=lab/tree/notebooks/auto_examples/07_advanced/plot_mask_large_fmri.ipynb