### PR TITLE
[MAINT] use same variable name for `write_fake_fmri_data_and_design` and `generate_fake_fmri_data_and_design`

### DIFF
--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -692,6 +692,7 @@ def test_fmri_inputs_dataframes_as_input(tmp_path, rng, confounds):
 
 
 def test_fmri_pandas_series_as_input(tmp_path, rng):
+    """Use pandas series of file paths as inputs."""
     # prepare correct input dataframe and lists
     p, q = 80, 10
     X = rng.standard_normal(size=(p, q))
@@ -711,6 +712,7 @@ def test_fmri_pandas_series_as_input(tmp_path, rng):
 
 
 def test_fmri_inputs_pandas_errors():
+    """Test wrong second level inputs."""
     # test wrong input for list and pandas requirements
     nii_img = ["01", "02", "03"]
     with pytest.raises(ValueError, match="File not found: "):
@@ -743,11 +745,11 @@ def test_secondlevelmodel_fit_inputs_errors(confounds, shape_4d_default):
     _, fmri_data, _ = generate_fake_fmri_data_and_design(shapes)
     fmri_data = fmri_data[0]
     n_samples = fmri_data.shape[-1]
-    des = pd.DataFrame(np.ones((n_samples, 1)), columns=["a"])
+    design_matrices = pd.DataFrame(np.ones((n_samples, 1)), columns=["a"])
 
     # prepare correct input first level models
     flm = FirstLevelModel(subject_label="01").fit(
-        fmri_data, design_matrices=des
+        fmri_data, design_matrices=design_matrices
     )
 
     # test first level model requirements

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -623,7 +623,7 @@ def confounds():
 
 
 def test_fmri_inputs(rng, confounds, shape_3d_default, shape_4d_default):
-    # Test processing of FMRI inputs
+    """Test processing of FMRI inputs."""
     # prepare fake data
     mask, fmri_data, design_matrices = generate_fake_fmri_data_and_design(
         [shape_4d_default], rk=1
@@ -845,13 +845,13 @@ def test_fmri_inputs_for_non_parametric_inference_errors(
 ):
     # Test processing of FMRI inputs
     # prepare fake data
-    _, fmri_data, des = generate_fake_fmri_data_and_design(
+    _, fmri_data, design_matrices = generate_fake_fmri_data_and_design(
         [shape_4d_default], rk=1
     )
 
     # prepare correct input first level models
     flm = FirstLevelModel(subject_label="01").fit(
-        fmri_data, design_matrices=des
+        fmri_data, design_matrices=design_matrices
     )
 
     # prepare correct input dataframe and lists

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -94,8 +94,8 @@ def input_df():
 
 def fake_fmri_data(shape=SHAPE):
     shapes = (shape,)
-    mask, func_img, _ = generate_fake_fmri_data_and_design(shapes)
-    return func_img[0], mask
+    mask, fmri_data, _ = generate_fake_fmri_data_and_design(shapes)
+    return fmri_data[0], mask
 
 
 def test_non_parametric_inference_with_flm_objects(shape_3d_default):
@@ -462,20 +462,20 @@ def test_infer_effect_maps(tmp_path, shape_4d_default):
     """
     rk = 3
     shapes = [SHAPE, shape_4d_default]
-    mask, fmri_data, design_matrices = write_fake_fmri_data_and_design(
+    mask_file, fmri_files, design_files = write_fake_fmri_data_and_design(
         shapes, rk=rk, file_path=tmp_path
     )
     second_level_input = pd.DataFrame(
-        {"map_name": ["a", "b"], "effects_map_path": [fmri_data[0], "bar"]}
+        {"map_name": ["a", "b"], "effects_map_path": [fmri_files[0], "bar"]}
     )
 
-    assert _infer_effect_maps(second_level_input, "a") == [fmri_data[0]]
-    assert _infer_effect_maps([fmri_data[0]], None) == [fmri_data[0]]
+    assert _infer_effect_maps(second_level_input, "a") == [fmri_files[0]]
+    assert _infer_effect_maps([fmri_files[0]], None) == [fmri_files[0]]
 
     contrast = np.eye(rk)[1]
-    second_level_input = [FirstLevelModel(mask_img=mask)] * 2
+    second_level_input = [FirstLevelModel(mask_img=mask_file)] * 2
     for i, model in enumerate(second_level_input):
-        model.fit(fmri_data[i], design_matrices=design_matrices[i])
+        model.fit(fmri_files[i], design_matrices=design_files[i])
 
     assert len(_infer_effect_maps(second_level_input, contrast)) == 2
 
@@ -486,11 +486,11 @@ def test_infer_effect_maps_error(tmp_path, shape_3d_default):
     For example if the image mapped in a dataframe does not exist.
     """
     shapes = [(*shape_3d_default, 5), (*shape_3d_default, 6)]
-    _, fmri_data, _ = write_fake_fmri_data_and_design(
+    _, fmri_files, _ = write_fake_fmri_data_and_design(
         shapes, file_path=tmp_path
     )
     second_level_input = pd.DataFrame(
-        {"map_name": ["a", "b"], "effects_map_path": [fmri_data[0], "bar"]}
+        {"map_name": ["a", "b"], "effects_map_path": [fmri_files[0], "bar"]}
     )
     with pytest.raises(ValueError, match="File not found: 'bar'"):
         _infer_effect_maps(second_level_input, "b")
@@ -555,18 +555,18 @@ def test_high_level_glm_with_paths_errors():
 
 
 def test_high_level_non_parametric_inference_with_paths(tmp_path):
-    mask, FUNCFILE, _ = write_fake_fmri_data_and_design(
+    mask_file, fmri_files, _ = write_fake_fmri_data_and_design(
         (SHAPE,), file_path=tmp_path
     )
-    FUNCFILE = FUNCFILE[0]
+    fmri_files = fmri_files[0]
     df_input = pd.DataFrame(
         {
             "subject_label": [f"sub-{i}" for i in range(4)],
-            "effects_map_path": [FUNCFILE] * 4,
-            "map_name": [FUNCFILE] * 4,
+            "effects_map_path": [fmri_files] * 4,
+            "map_name": [fmri_files] * 4,
         }
     )
-    func_img = load(FUNCFILE)
+    func_img = load(fmri_files)
     Y = [func_img] * 4
     X = pd.DataFrame([[1]] * 4, columns=["intercept"])
     c1 = np.eye(len(X.columns))[0]
@@ -575,8 +575,8 @@ def test_high_level_non_parametric_inference_with_paths(tmp_path):
             second_level_input,
             design_matrix=X,
             second_level_contrast=c1,
-            first_level_contrast=FUNCFILE,
-            mask=mask,
+            first_level_contrast=fmri_files,
+            mask=mask_file,
             n_perm=N_PERM,
             verbose=1,
         )
@@ -585,7 +585,7 @@ def test_high_level_non_parametric_inference_with_paths(tmp_path):
 
     assert all(isinstance(img, Nifti1Image) for img in neg_log_pvals_imgs)
     for img in neg_log_pvals_imgs:
-        assert_array_equal(img.affine, load(mask).affine)
+        assert_array_equal(img.affine, load(mask_file).affine)
 
     neg_log_pvals_list = [get_data(i) for i in neg_log_pvals_imgs]
     for neg_log_pvals in neg_log_pvals_list:
@@ -625,12 +625,14 @@ def confounds():
 def test_fmri_inputs(rng, confounds, shape_3d_default, shape_4d_default):
     # Test processing of FMRI inputs
     # prepare fake data
-    mask, niimg, des = generate_fake_fmri_data_and_design(
+    mask, fmri_data, design_matrices = generate_fake_fmri_data_and_design(
         [shape_4d_default], rk=1
     )
 
     # prepare correct input first level models
-    flm = FirstLevelModel(subject_label="01").fit(niimg, design_matrices=des)
+    flm = FirstLevelModel(subject_label="01").fit(
+        fmri_data, design_matrices=design_matrices
+    )
 
     # prepare correct input dataframe and lists
     p, q = 80, 10
@@ -641,9 +643,9 @@ def test_fmri_inputs(rng, confounds, shape_3d_default, shape_4d_default):
     flms = [flm, flm, flm]
 
     shape_3d = [(*shape_3d_default, 1)]
-    _, niimg, _ = generate_fake_fmri_data_and_design(shape_3d)
-    niimg = niimg[0]
-    niimgs = [niimg, niimg, niimg]
+    _, fmri_data, _ = generate_fake_fmri_data_and_design(shape_3d)
+    fmri_data = fmri_data[0]
+    niimgs = [fmri_data, fmri_data, fmri_data]
     niimg_4d = concat_imgs(niimgs)
 
     # First level models as input
@@ -667,19 +669,19 @@ def test_fmri_inputs_dataframes_as_input(tmp_path, rng, confounds):
     X = rng.standard_normal(size=(p, q))
 
     # prepare correct input dataframe and lists
-    _, FUNCFILE, _ = write_fake_fmri_data_and_design(
+    _, fmri_files, _ = write_fake_fmri_data_and_design(
         (SHAPE,), file_path=tmp_path
     )
-    FUNCFILE = FUNCFILE[0]
+    fmri_files = fmri_files[0]
 
     sdes = pd.DataFrame(X[:3, :3], columns=["intercept", "b", "c"])
 
     # dataframes as input
     dfcols = ["subject_label", "map_name", "effects_map_path"]
     dfrows = [
-        ["01", "a", FUNCFILE],
-        ["02", "a", FUNCFILE],
-        ["03", "a", FUNCFILE],
+        ["01", "a", fmri_files],
+        ["02", "a", fmri_files],
+        ["03", "a", fmri_files],
     ]
     niidf = pd.DataFrame(dfrows, columns=dfcols)
 
@@ -693,14 +695,14 @@ def test_fmri_pandas_series_as_input(tmp_path, rng):
     # prepare correct input dataframe and lists
     p, q = 80, 10
     X = rng.standard_normal(size=(p, q))
-    _, FUNCFILE, _ = write_fake_fmri_data_and_design(
+    _, fmri_files, _ = write_fake_fmri_data_and_design(
         (SHAPE,), file_path=tmp_path
     )
-    FUNCFILE = FUNCFILE[0]
+    fmri_files = fmri_files[0]
 
     # dataframes as input
     sdes = pd.DataFrame(X[:3, :3], columns=["intercept", "b", "c"])
-    niidf = pd.DataFrame({"filepaths": [FUNCFILE, FUNCFILE, FUNCFILE]})
+    niidf = pd.DataFrame({"filepaths": [fmri_files, fmri_files, fmri_files]})
     SecondLevelModel().fit(
         second_level_input=niidf["filepaths"],
         confounds=None,
@@ -738,14 +740,14 @@ def test_secondlevelmodel_fit_inputs_errors(confounds, shape_4d_default):
     """Raise the proper errors when invalid inputs are passed to fit."""
     # prepare fake data
     shapes = (shape_4d_default,)
-    _, func_img, _ = generate_fake_fmri_data_and_design(shapes)
-    func_img = func_img[0]
-    n_samples = func_img.shape[-1]
+    _, fmri_data, _ = generate_fake_fmri_data_and_design(shapes)
+    fmri_data = fmri_data[0]
+    n_samples = fmri_data.shape[-1]
     des = pd.DataFrame(np.ones((n_samples, 1)), columns=["a"])
 
     # prepare correct input first level models
     flm = FirstLevelModel(subject_label="01").fit(
-        func_img, design_matrices=des
+        fmri_data, design_matrices=des
     )
 
     # test first level model requirements
@@ -824,11 +826,11 @@ def test_secondlevelmodel_design_matrix_error_type(img_3d_mni, design_matrix):
 
 def test_fmri_img_inputs_errors(confounds):
     # prepare correct input
-    _, FUNCFILE, _ = generate_fake_fmri_data_and_design((SHAPE,))
-    FUNCFILE = FUNCFILE[0]
+    _, fmri_data, _ = generate_fake_fmri_data_and_design((SHAPE,))
+    fmri_data = fmri_data[0]
 
     # test niimgs requirements
-    niimgs = [FUNCFILE, FUNCFILE, FUNCFILE]
+    niimgs = [fmri_data, fmri_data, fmri_data]
     with pytest.raises(ValueError, match="require a design matrix"):
         SecondLevelModel().fit(niimgs)
     with pytest.raises(
@@ -843,12 +845,14 @@ def test_fmri_inputs_for_non_parametric_inference_errors(
 ):
     # Test processing of FMRI inputs
     # prepare fake data
-    _, niimg, des = generate_fake_fmri_data_and_design(
+    _, fmri_data, des = generate_fake_fmri_data_and_design(
         [shape_4d_default], rk=1
     )
 
     # prepare correct input first level models
-    flm = FirstLevelModel(subject_label="01").fit(niimg, design_matrices=des)
+    flm = FirstLevelModel(subject_label="01").fit(
+        fmri_data, design_matrices=des
+    )
 
     # prepare correct input dataframe and lists
     p, q = 80, 10
@@ -856,9 +860,9 @@ def test_fmri_inputs_for_non_parametric_inference_errors(
     sdes = pd.DataFrame(X[:3, :3], columns=["intercept", "b", "c"])
 
     shape_3d = [(*shape_3d_default, 1)]
-    _, niimg, _ = generate_fake_fmri_data_and_design(shape_3d)
-    niimg = niimg[0]
-    niimgs = [niimg, niimg, niimg]
+    _, fmri_data, _ = generate_fake_fmri_data_and_design(shape_3d)
+    fmri_data = fmri_data[0]
+    niimgs = [fmri_data, fmri_data, fmri_data]
     niimg_4d = concat_imgs(niimgs)
 
     # test missing second-level contrast
@@ -879,7 +883,7 @@ def test_fmri_inputs_for_non_parametric_inference_errors(
 
     # test list of less than two niimgs
     with pytest.raises(TypeError, match="at least two"):
-        non_parametric_inference([niimg])
+        non_parametric_inference([fmri_data])
 
     # test niimgs requirements
     with pytest.raises(ValueError, match="require a design matrix"):
@@ -981,11 +985,11 @@ def test_non_parametric_inference_permutation_computation():
 def test_non_parametric_inference_tfce():
     """Test non-parametric inference with TFCE inference."""
     shapes = [SHAPE] * 4
-    mask, func_files, _ = generate_fake_fmri_data_and_design(shapes)
+    mask, fmri_data, _ = generate_fake_fmri_data_and_design(shapes)
     X = pd.DataFrame([[1]] * 4, columns=["intercept"])
 
     out = non_parametric_inference(
-        func_files,
+        fmri_data,
         design_matrix=X,
         model_intercept=False,
         mask=mask,
@@ -1036,7 +1040,7 @@ def test_non_parametric_inference_cluster_level_with_covariates(
     the context of covariates.
     """
     shapes = ((*shape_3d_default, 1),)
-    mask, func_img, _ = generate_fake_fmri_data_and_design(shapes)
+    mask, fmri_data, _ = generate_fake_fmri_data_and_design(shapes)
 
     unc_pval = 0.1
     n_subjects = 2
@@ -1048,7 +1052,7 @@ def test_non_parametric_inference_cluster_level_with_covariates(
 
     # make sure there is variability in the images
     kernels = rng.uniform(low=0, high=5, size=n_subjects)
-    Y = [smooth_img(func_img[0], kernel) for kernel in kernels]
+    Y = [smooth_img(fmri_data[0], kernel) for kernel in kernels]
 
     # Set up non-parametric test
     out = non_parametric_inference(
@@ -1090,14 +1094,14 @@ def test_non_parametric_inference_cluster_level_with_single_covariates(
     the context of covariates.
     """
     shapes = ((*shape_3d_default, 1),)
-    mask, func_img, _ = generate_fake_fmri_data_and_design(shapes)
+    mask, fmri_data, _ = generate_fake_fmri_data_and_design(shapes)
 
     unc_pval = 0.1
     n_subjects = 2
 
     # make sure there is variability in the images
     kernels = rng.uniform(low=0, high=5, size=n_subjects)
-    Y = [smooth_img(func_img[0], kernel) for kernel in kernels]
+    Y = [smooth_img(fmri_data[0], kernel) for kernel in kernels]
 
     # Test single covariate
     X = pd.DataFrame({"intercept": [1] * len(Y)})

--- a/nilearn/interfaces/tests/test_bids.py
+++ b/nilearn/interfaces/tests/test_bids.py
@@ -652,17 +652,17 @@ def test_save_glm_to_bids_second_level(
 
     shapes = ((3, 3, 3, 1),)
     rk = 3
-    mask, func_img, _ = generate_fake_fmri_data_and_design(
+    mask, fmri_data, _ = generate_fake_fmri_data_and_design(
         shapes,
         rk,
     )
-    func_img = func_img[0]
+    fmri_data = fmri_data[0]
 
     # Ordinary Least Squares case
     model = SecondLevelModel(mask_img=mask, minimize_memory=False)
 
     # fit model
-    Y = [func_img] * 2
+    Y = [fmri_data] * 2
     X = pd.DataFrame([[1]] * 2, columns=["intercept"])
     model = model.fit(Y, design_matrix=X)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- use same variable name for `write_fake_fmri_data_and_design` and `generate_fake_fmri_data_and_design`
- try to make clearer in the tests when we are dealing with files or in memory objects
