### PR TITLE
[MAINT] up timeout of test

### DIFF
--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -143,7 +143,6 @@ def test_glm_fit_valid_mask_img(shape_4d_default):
     assert isinstance(z1, Nifti1Image)
 
 
-@pytest.mark.timeout(60)
 def test_explicit_fixed_effects(shape_3d_default):
     """Test the fixed effects performed manually/explicitly."""
     shapes, rk = [(*shape_3d_default, 4), (*shape_3d_default, 5)], 3
@@ -205,7 +204,6 @@ def test_explicit_fixed_effects(shape_3d_default):
         compute_fixed_effects(contrasts, variance, mask, dofs=[100])
 
 
-@pytest.mark.timeout(60)
 def test_explicit_fixed_effects_without_mask(shape_3d_default):
     """Test the fixed effects performed manually/explicitly with no mask."""
     shapes, rk = [(*shape_3d_default, 4), (*shape_3d_default, 5)], 3

--- a/nilearn/interfaces/tests/test_bids.py
+++ b/nilearn/interfaces/tests/test_bids.py
@@ -559,7 +559,6 @@ def test_save_glm_to_bids_errors(
         )
 
 
-@pytest.mark.timeout(60)
 @pytest.mark.parametrize(
     "prefix", ["sub-01_ses-01_task-nback", "sub-01_task-nback_", 1]
 )
@@ -623,7 +622,6 @@ def test_save_glm_to_bids_contrast_definitions(
         assert (tmpdir / sub_prefix / f"{prefix}{fname}").exists()
 
 
-@pytest.mark.timeout(60)
 @pytest.mark.parametrize("prefix", ["task-nback"])
 def test_save_glm_to_bids_second_level(
     matplotlib_pyplot, tmp_path_factory, prefix

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -222,7 +222,6 @@ def check_ktest_p_values_distribution_and_mse(all_kstest_pvals, all_mse):
     assert_array_less(np.diff(all_mse.mean(1)), 0)
 
 
-@pytest.mark.timeout(60)
 @pytest.mark.parametrize("model_intercept", [True, False])
 def test_permuted_ols_check_h0_noeffect_labelswap_centered(model_intercept):
     """Check distributions of permutations when tested vars are centered."""

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -222,6 +222,7 @@ def check_ktest_p_values_distribution_and_mse(all_kstest_pvals, all_mse):
     assert_array_less(np.diff(all_mse.mean(1)), 0)
 
 
+@pytest.mark.timeout(60)
 @pytest.mark.parametrize("model_intercept", [True, False])
 def test_permuted_ols_check_h0_noeffect_labelswap_centered(model_intercept):
     """Check distributions of permutations when tested vars are centered."""

--- a/nilearn/regions/tests/test_region_extractor.py
+++ b/nilearn/regions/tests/test_region_extractor.py
@@ -74,7 +74,8 @@ extra_valid_checks = [
 
 # Note: some report genetation tests take too long
 # Incresaing the timeout for this one
-@pytest.mark.timeout(60)
+
+
 @pytest.mark.parametrize(
     "estimator, check, name",
     check_estimator(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,12 +165,11 @@ module = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-ra --strict-config --strict-markers --doctest-modules --showlocals -s -vv --template=maint_tools/templates/index.html --timeout=45"
+addopts = "-ra --strict-config --strict-markers --doctest-modules --showlocals -s -vv --template=maint_tools/templates/index.html --timeout=60"
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
 junit_family = "xunit2"
 log_cli_level = "INFO"
 minversion = "6.0"
-timeout = 3600  # test session should not last more than 1 hour
 xfail_strict = true
 
 [tool.ruff]


### PR DESCRIPTION
Still some tests that sometimes fail in CI for being too slow, so I am upping the timeout to 60 seconds globally.