### PR TITLE
[MAINT] only run some workflows on upstream

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -30,6 +30,7 @@ jobs:
 
     # check the links in the doc
     linkcheck:
+        if: github.repository == 'nilearn/nilearn'
         runs-on: ubuntu-latest
         steps:
         -   name: Checkout nilearn

--- a/.github/workflows/sourcery.yml
+++ b/.github/workflows/sourcery.yml
@@ -11,9 +11,6 @@
 name: Check codebase using Sourcery
 
 on:
-    # TODO Test once after merging PR and see how the action behaves
-    pull_request:
-
     push:
         branches: [main]
 

--- a/.github/workflows/sourcery.yml
+++ b/.github/workflows/sourcery.yml
@@ -11,9 +11,12 @@
 name: Check codebase using Sourcery
 
 on:
-  # TODO Test once after merging PR and see how the action behaves
+    # TODO Test once after merging PR and see how the action behaves
+    pull_request:
+
     push:
         branches: [main]
+
     schedule:
 
         # Uses the cron schedule for github actions
@@ -33,8 +36,16 @@ on:
             # Run first day of the month at midnight UTC
     -   cron: 0 0 1 * *
 
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     review-with-sourcery:
+        if: github.repository == 'nilearn/nilearn'
         runs-on: ubuntu-latest
         steps:
         -   uses: actions/checkout@v4
@@ -46,4 +57,4 @@ jobs:
         -   uses: sourcery-ai/action@v1
             with:
                 token: ${{ secrets.SOURCERY_TOKEN }}
-                fix: true
+                in_place: true

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -13,11 +13,13 @@
 version: '1'
 
 ignore: # A list of paths or files which Sourcery will ignore.
+-   doc
+-   examples
+-   maint_tools
 -   nilearn/_version.py
--   externals/
 -   nilearn/externals/tempita/
 -   nilearn/externals/tempita/__init__.py
--   plotting/data/js/*.js
+-   nilearn/plotting/data/js/*.js
 
 rule_settings:
     enable:


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- run checklink and sourcery checks on upstream only
- tweak sourcery config to avoid ignore some folders
