### PR TITLE
[DOC] Add future deprecation directive for 'nearest' interpolation in `vol_to_surf`

### DIFF
--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -645,6 +645,15 @@ def vol_to_surf(
         - 'nearest':
             Use the intensity of the nearest voxel.
 
+            .. versionchanged:: 0.11.2.dev
+
+                The 'nearest' interpolation method will be removed in
+                version 0.13.0. It is recommended to use 'linear' for
+                statistical maps and
+                :term:`probabilistic atlases<Probabilistic atlas>` and
+                'nearest_most_frequent' for
+                :term:`deterministic atlases<Deterministic atlas>`.
+
         - 'nearest_most_frequent':
             Use the most frequent value in the neighborhood (out of the
             `n_samples` samples) instead of the mean value. This is useful


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but follow up on #5169

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- add a version changed directive under 'nearest' interpolation method to say that it will be deprecated in 0.13.0
-
