### PR TITLE
[MAINT] start deprecation of fetch_neurovault_motor_task

### DIFF
--- a/doc/get_data_examples.py
+++ b/doc/get_data_examples.py
@@ -97,7 +97,6 @@ def main(args=sys.argv) -> None:
                 n_subjects=n_subjects,
             )
         datasets.fetch_localizer_first_level()
-        datasets.fetch_neurovault_motor_task()
         datasets.fetch_neurovault_ids(
             image_ids=(151, 3041, 3042, 2676, 2675, 2818, 2834)
         )

--- a/examples/00_tutorials/plot_3d_and_4d_niimg.py
+++ b/examples/00_tutorials/plot_3d_and_4d_niimg.py
@@ -14,17 +14,7 @@ Here we discover how to work with 3D and 4D niimgs.
 # Let's first check where the data is downloaded on our disk:
 from nilearn import datasets
 
-print(f"Datasets are stored in: {datasets.get_data_dirs()!r}")
-
-# %%
-# Let's now retrieve a motor :term:`contrast`
-# from a :term:`Neurovault` repository
-motor_images = datasets.fetch_neurovault_motor_task()
-motor_images.images
-
-# %%
-# motor_images is a list of filenames. We need to take the first one
-tmap_filename = motor_images.images[0]
+tmap_filename = datasets.load_sample_motor_activation_image()
 
 
 # %%

--- a/examples/01_plotting/plot_demo_glass_brain_extensive.py
+++ b/examples/01_plotting/plot_demo_glass_brain_extensive.py
@@ -13,8 +13,8 @@ See :ref:`plotting` for more plotting functionalities and
 :ref:`Section 4.3 <display_modules>` for more details about display objects
 in Nilearn.
 
-Also, see :func:`~nilearn.datasets.fetch_neurovault_motor_task` for details
-about the plotting data and associated meta-data.
+Also, see :func:`~nilearn.datasets.load_sample_motor_activation_image`
+for details about the plotting data and associated meta-data.
 """
 
 # %%

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -3157,5 +3157,16 @@ def load_sample_motor_activation_image():
     -------
     str
         Path to the sample functional image.
+
+    Notes
+    -----
+    The 'left vs right button press' contrast is used:
+    https://neurovault.org/images/10426/
+
+    See Also
+    --------
+    nilearn.datasets.fetch_neurovault_ids
+    nilearn.datasets.fetch_neurovault
+    nilearn.datasets.fetch_neurovault_auditory_computation_task"
     """
     return str(Path(__file__).parent / "data" / "image_10426.nii.gz")

--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -3167,6 +3167,6 @@ def load_sample_motor_activation_image():
     --------
     nilearn.datasets.fetch_neurovault_ids
     nilearn.datasets.fetch_neurovault
-    nilearn.datasets.fetch_neurovault_auditory_computation_task"
+    nilearn.datasets.fetch_neurovault_auditory_computation_task
     """
     return str(Path(__file__).parent / "data" / "image_10426.nii.gz")

--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -2851,6 +2851,16 @@ def fetch_neurovault_motor_task(data_dir=None, verbose=1):
     """Fetch left vs right button press \
        group :term:`contrast` map from :term:`Neurovault`.
 
+    .. deprecated:: 0.11.2dev
+
+        This fetcher function will be removed in version>0.13.1
+        as it returns the same data
+        as :func:`nilearn.datasets.load_sample_motor_activation_image`.
+
+        Please use
+        :func:`nilearn.datasets.load_sample_motor_activation_image`
+        instead.
+
     Parameters
     ----------
     %(data_dir)s
@@ -2882,6 +2892,17 @@ def fetch_neurovault_motor_task(data_dir=None, verbose=1):
 
     """
     check_params(locals())
+
+    warnings.warn(
+        (
+            "The 'fetch_neurovault_motor_task' function will be removed "
+            "in version>0.13.1 as it returns the same data "
+            "as 'load_sample_motor_activation_image'.\n"
+            "Please use 'load_sample_motor_activation_image' instead.'"
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     data = fetch_neurovault_ids(
         image_ids=[10426], data_dir=data_dir, verbose=verbose
@@ -2921,7 +2942,6 @@ def fetch_neurovault_auditory_computation_task(data_dir=None, verbose=1):
     --------
     nilearn.datasets.fetch_neurovault_ids
     nilearn.datasets.fetch_neurovault
-    nilearn.datasets.fetch_neurovault_motor_task
 
     """
     check_params(locals())

--- a/nilearn/datasets/tests/test_neurovault.py
+++ b/nilearn/datasets/tests/test_neurovault.py
@@ -1129,3 +1129,8 @@ def _check_no_affine_match_neurovault_affine(data):
     assert not np.any(
         [np.all(affine == neurovault.STD_AFFINE) for affine in affines]
     )
+
+
+def test_fetch_neurovault_motor_task():
+    with pytest.warns(DeprecationWarning, match="will be removed"):
+        neurovault.fetch_neurovault_motor_task(verbose=0)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- fetch_neurovault_motor_task is always used to fetch data from neurovault to load the same single image we ship with nilearn anyway
- should prevent some doc build failure when neurovault does not work (see doc build on main at the moment)


