### PR TITLE
[ENH] add surface suport to nilearn.image.high_variance_confounds

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -40,6 +40,10 @@ Enhancements
 
 - :bdg-info:`Plotting` ``transparency`` and ``transparency_range`` parameters have been added to the :meth:`nilearn.plotting.displays.BaseSlicer.add_overlay` (and therefore to the all classes inheriting :class:`~nilearn.plotting.displays.BaseSlicer`). These parameters were also explicitly added to the plotting functions :func:`~nilearn.plotting.plot_img`, :func:`~nilearn.plotting.plot_stat_map`, :func:`~nilearn.plotting.plot_glass_brain`. (:gh:`5151` by `Rémi Gau`_).
 
+- :bdg-dark:`Code` Extend :func:`~nilearn.image.high_variance_confounds` to work with :class:`~nilearn.surface.SurfaceImage` (:gh:`5277` by `Rémi Gau`_).
+
+- :bdg-dark:`Code` Extend :func:`~nilearn.masking.apply_mask` to work with :class:`~nilearn.surface.SurfaceImage` (:gh:`5277` by `Rémi Gau`_).
+
 - :bdg-dark:`Code` Extend :func:`~nilearn.image.threshold_img` to work with :class:`~nilearn.surface.SurfaceImage` (:gh:`4999` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Add different reduction strategies to :class:`nilearn.maskers.SurfaceLabelsMasker` (:gh:`4809` by `Rémi Gau`_).

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -75,18 +75,18 @@ def get_data(img):
 
 def high_variance_confounds(
     imgs, n_confounds=5, percentile=2.0, detrend=True, mask_img=None
-):
+) -> np.ndarray:
     """Return confounds extracted from input signals with highest variance.
 
     Parameters
     ----------
-    imgs : Niimg-like object
-        4D image.
+    imgs : 4D Niimg-like or 2D SurfaceImage object
         See :ref:`extracting_data`.
 
-    mask_img : Niimg-like object or None, default=None
-        If not provided, all voxels are used.
-        If provided, confounds are extracted from voxels inside the mask.
+    mask_img : Niimg-like or SurfaceImage object, or None, default=None
+        If not provided, all voxels / vertices are used.
+        If provided, confounds are extracted
+        from voxels / vertices inside the mask.
         See :ref:`extracting_data`.
 
     n_confounds : :obj:`int`, default=5
@@ -125,15 +125,24 @@ def high_variance_confounds(
     """
     from .. import masking
 
+    check_compatibility_mask_and_images(mask_img, imgs)
+
     if mask_img is not None:
+        if isinstance(imgs, SurfaceImage):
+            check_same_n_vertices(mask_img.mesh, imgs.mesh)
         sigs = masking.apply_mask(imgs, mask_img)
+
+    # Load the data only if it doesn't need to be masked
+    # Not using apply_mask here saves memory in most cases.
+    elif isinstance(imgs, SurfaceImage):
+        sigs = as_ndarray(get_surface_data(imgs))
+        sigs = np.reshape(sigs, (-1, sigs.shape[-1])).T
     else:
-        # Load the data only if it doesn't need to be masked
         imgs = check_niimg_4d(imgs)
         sigs = as_ndarray(get_data(imgs))
-        # Not using apply_mask here saves memory in most cases.
-        del imgs  # help reduce memory consumption
         sigs = np.reshape(sigs, (-1, sigs.shape[-1])).T
+
+    del imgs  # help reduce memory consumption
 
     return signal.high_variance_confounds(
         sigs, n_confounds=n_confounds, percentile=percentile, detrend=detrend

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -191,10 +191,12 @@ def test_get_data(tmp_path, shape_3d_default):
 
 
 def test_high_variance_confounds(shape_3d_default):
-    # See also test_signals.test_high_variance_confounds()
-    # There is only tests on what is added by high_variance_confounds()
-    # compared to signal.high_variance_confounds()
+    """Check high_variance_confounds returns proper shape.
 
+    See also test_signals.test_high_variance_confounds()
+    There is only tests on what is added by high_variance_confounds()
+    compared to signal.high_variance_confounds()
+    """
     length = 17
     n_confounds = 10
 
@@ -202,6 +204,27 @@ def test_high_variance_confounds(shape_3d_default):
 
     confounds1 = high_variance_confounds(
         img, mask_img=mask_img, percentile=10.0, n_confounds=n_confounds
+    )
+
+    assert confounds1.shape == (length, n_confounds)
+
+    # No mask.
+    confounds2 = high_variance_confounds(
+        img, percentile=10.0, n_confounds=n_confounds
+    )
+
+    assert confounds2.shape == (length, n_confounds)
+
+
+def test_high_variance_confounds_surface(surf_mask_1d, surface_glm_data):
+    """Check high_variance_confounds returns proper shape from surface."""
+    length = 17
+    n_confounds = 10
+
+    img, _ = surface_glm_data(length)
+
+    confounds1 = high_variance_confounds(
+        img, mask_img=surf_mask_1d, percentile=10.0, n_confounds=n_confounds
     )
 
     assert confounds1.shape == (length, n_confounds)

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -64,7 +64,7 @@ def load_mask_img(
 ) -> tuple[SurfaceImage, None]: ...
 
 
-def load_mask_img(mask_img, allow_empty):
+def load_mask_img(mask_img, allow_empty=False):
     """Check that a mask is valid.
 
     This checks if it contains two values including 0 and load it.
@@ -880,11 +880,12 @@ def apply_mask(
     When using smoothing, ``ensure_finite`` is set to True, as non-finite
     values would spread across the image.
     """
-    mask_img = _utils.check_niimg_3d(mask_img)
-    mask, mask_affine = load_mask_img(mask_img)
     if not isinstance(imgs, SurfaceImage):
+        mask_img = _utils.check_niimg_3d(mask_img)
+        mask, mask_affine = load_mask_img(mask_img)
         mask_img = new_img_like(mask_img, mask, mask_affine)
     else:
+        mask, mask_affine = load_mask_img(mask_img)
         mask_img = mask
     return apply_mask_fmri(
         imgs,

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -863,7 +863,7 @@ def apply_mask(
 
         .. warning::
 
-            Not yet implemented to for surface images
+            Not yet implemented for surface images
 
     ensure_finite : :obj:`bool`, default=True
         If ensure_finite is True, the non-finite values (NaNs and

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -848,7 +848,7 @@ def apply_mask(
 
     mask_img : Niimg-like or SurfaceImage object
         See :ref:`extracting_data`.
-        Mask array with True where a voxel / vertex should be used.
+        Mask array with True value where a voxel / vertex should be used.
 
     dtype : numpy dtype or 'f', default="f"
         The dtype of the output, if 'f', any float output is acceptable

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -2,12 +2,9 @@
 
 import numbers
 import warnings
-from pathlib import Path
-from typing import Union, overload
 
 import numpy as np
 from joblib import Parallel, delayed
-from nibabel import Nifti1Image
 from scipy.ndimage import binary_dilation, binary_erosion
 
 from nilearn._utils import (
@@ -52,20 +49,6 @@ class _MaskWarning(UserWarning):
 
 
 warnings.simplefilter("always", _MaskWarning)
-
-
-@overload
-def load_mask_img(
-    mask_img: Union[str, Path, Nifti1Image],
-    allow_empty: bool = ...,
-) -> tuple[np.ndarray, np.ndarray]: ...
-
-
-@overload
-def load_mask_img(
-    mask_img: SurfaceImage,
-    allow_empty: bool = ...,
-) -> tuple[SurfaceImage, None]: ...
 
 
 def load_mask_img(mask_img, allow_empty=False):

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -467,7 +467,7 @@ def butterworth(
 @fill_doc
 def high_variance_confounds(
     series, n_confounds=5, percentile=2.0, detrend=True
-):
+) -> np.ndarray:
     """Return confounds time series extracted from series \
     with highest variance.
 

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -378,6 +378,15 @@ def test_apply_mask(tmp_path, create_files, affine):
         assert_equal(proj.sum(), 9 / np.abs(affine[axis, axis]))
 
 
+def test_apply_mask_surface(surf_img_2d, surf_mask_1d):
+    """Test apply_mask on surface."""
+    length = 5
+    series = apply_mask(surf_img_2d(length), surf_mask_1d)
+
+    assert isinstance(series, np.ndarray)
+    assert series.shape[0] == length
+
+
 def test_apply_mask_nan(affine_eye):
     """Check that NaNs in the data do not propagate."""
     data = np.zeros((40, 40, 40, 2))


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #5275

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- add support for SurfaceImage input to 
  - nilearn.image.high_variance_confounds
  - nilearn.masking.apply_mask
