### PR TITLE
[MAINT] run doc qc scripts in CI

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -120,6 +120,30 @@ jobs:
             with:
                 args: --validate
 
+    quality_control:
+        # run a couple of scripts to check quality of the docstrings
+        runs-on: ubuntu-latest
+        steps:
+        -   name: Checkout nilearn
+            uses: actions/checkout@v4
+        -   uses: actions/setup-python@v5
+            with:
+                python-version: ${{ env.MIN_PYTHON_VERSION }}
+        -   name: Install tox
+            run: uv tool install tox --with=tox-uv --with=tox-gh-actions
+
+        -   name: Show tox config
+            run: tox c
+
+        -   name: Build docs
+            id: build-docs
+            run: |
+                tox run \
+                    --colored yes \
+                    --list-dependencies \
+                    -e doc_qc
+
+
     check_skip_flags:
         name: Check skip flags
         runs-on: ubuntu-latest

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -126,9 +126,14 @@ jobs:
         steps:
         -   name: Checkout nilearn
             uses: actions/checkout@v4
+
+        -   name: Install the latest version of uv
+            uses: astral-sh/setup-uv@v5
+
         -   uses: actions/setup-python@v5
             with:
                 python-version: ${{ env.MIN_PYTHON_VERSION }}
+
         -   name: Install tox
             run: uv tool install tox --with=tox-uv --with=tox-gh-actions
 

--- a/maint_tools/check_docstrings.py
+++ b/maint_tools/check_docstrings.py
@@ -44,6 +44,8 @@ VALUES = [
 
 def main() -> None:
     """Find missing :obj:`` in doc string type."""
+    print("\n[blue]Finding missing :obj:`` in doc string type.\n")
+
     filenames = list_modules()
 
     n_issues = 0
@@ -60,7 +62,7 @@ def main() -> None:
             for meth_def in list_functions(class_def):
                 n_issues = check_docstring(meth_def, filename, n_issues)
 
-    print(f"{n_issues} detected")
+    print(f"{n_issues} detected\n\n")
 
 
 def check_fill_doc_decorator(

--- a/maint_tools/missing_default_in_docstring.py
+++ b/maint_tools/missing_default_in_docstring.py
@@ -22,6 +22,8 @@ PUBLIC_API_ONLY = True
 
 def main():
     """Flag functions or methods with missing defaults."""
+    print("\n[blue]Flag functions or methods with missing defaults.\n")
+
     filenames = list_modules()
 
     n_issues = 0
@@ -38,7 +40,7 @@ def main():
             for meth_def in list_functions(class_def):
                 n_issues = check_def(meth_def, n_issues, filename)
 
-    print(f"{n_issues} issues detected")
+    print(f"{n_issues} issues detected\n\n")
 
 
 def check_def(ast_def, n_issues, filename):

--- a/maint_tools/show-python-packages-versions.py
+++ b/maint_tools/show-python-packages-versions.py
@@ -1,8 +1,9 @@
-"""Print the versions of python and several packages used in the project."""
+"""Print the versions of Python and several packages used in the project."""
 
+import importlib.metadata
 import sys
 
-import pkg_resources
+from rich import print
 
 DEPENDENCIES = [
     "joblib",
@@ -20,11 +21,10 @@ DEPENDENCIES = [
 def print_package_version(package_name, indent="  "):
     """Print install status and version of a package."""
     try:
-        dist = pkg_resources.get_distribution(package_name)
-    except pkg_resources.DistributionNotFound:
+        version = importlib.metadata.version(package_name)
+        provenance_info = f"{version} installed"
+    except importlib.metadata.PackageNotFoundError:
         provenance_info = "not installed"
-    else:
-        provenance_info = f"{dist.version} installed in {dist.location}"
 
     print(f"{indent}{package_name}: {provenance_info}")
 

--- a/tox.ini
+++ b/tox.ini
@@ -215,13 +215,31 @@ passenv =
     PATTERN
 allowlist_externals =
     make
+    bash
 commands =
+    python maint_tools/show-python-packages-versions.py
     make -C doc clean
     ; Update the authors file and the names file
     ; in case a contributor has been added to citation.cff
     ; but did not run the maint_tools/citation_cff_maint.py script.
     python maint_tools/citation_cff_maint.py
 	make -C doc {posargs:}
+
+[testenv:doc_qc]
+description = Run a couple quality checks of the docstrings...
+extras = plotting
+deps =
+    numpydoc
+    rich
+passenv =
+    {[global_var]passenv}
+    PATTERN
+allowlist_externals =
+    python
+commands =
+    python maint_tools/missing_default_in_docstring.py
+    python maint_tools/check_docstrings.py
+
 
 [testenv:plot_test_timing]
 description = Plot timing of tests.


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- make sure that the couple of doc quality control script we have are run in CI to flag doc strings with missing default and mostly with fixable problems

