### PR TITLE
[FIX] throw warning when meshes are unequal but have compatible number of vertices

### DIFF
--- a/nilearn/_utils/exceptions.py
+++ b/nilearn/_utils/exceptions.py
@@ -84,3 +84,13 @@ class AllVolumesRemovedError(Exception):
 
     def __str__(self):
         return f"[AllVolumesRemoved Error] {self.args[0]}"
+
+
+class MeshDimensionError(ValueError):
+    """Exception raised when meshes have incompatible dimensions."""
+
+    def __init__(self, msg="Meshes have incompatible dimensions."):
+        super().__init__(msg)
+
+    def __str__(self):
+        return f"[MeshDimensionError] {self.args[0]}"

--- a/nilearn/_utils/tests/test_common.py
+++ b/nilearn/_utils/tests/test_common.py
@@ -43,7 +43,7 @@ def test_number_public_functions():
     If this is intentional, then the number should be updated in the test.
     Otherwise it means that the public API of nilearn has changed by mistake.
     """
-    assert len({_[0] for _ in all_functions()}) == 260
+    assert len({_[0] for _ in all_functions()}) == 261
 
 
 @pytest.mark.skipif(

--- a/nilearn/_utils/tests/test_common.py
+++ b/nilearn/_utils/tests/test_common.py
@@ -43,7 +43,7 @@ def test_number_public_functions():
     If this is intentional, then the number should be updated in the test.
     Otherwise it means that the public API of nilearn has changed by mistake.
     """
-    assert len({_[0] for _ in all_functions()}) == 258
+    assert len({_[0] for _ in all_functions()}) == 260
 
 
 @pytest.mark.skipif(

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -41,7 +41,7 @@ from nilearn.mass_univariate import permuted_ols
 from nilearn.surface.surface import (
     SurfaceImage,
 )
-from nilearn.surface.utils import assert_polymesh_equal
+from nilearn.surface.utils import check_polymesh_equal
 from nilearn.typing import NiimgLike
 
 
@@ -244,7 +244,7 @@ def _check_input_as_surface_images(second_level_input, none_design_matrix):
 
     if isinstance(second_level_input, list):
         for img in second_level_input[1:]:
-            assert_polymesh_equal(second_level_input[0].mesh, img.mesh)
+            check_polymesh_equal(second_level_input[0].mesh, img.mesh)
         if none_design_matrix:
             raise ValueError(
                 "List of SurfaceImage objects as second_level_input"

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -49,7 +49,7 @@ from nilearn.surface.surface import (
     extract_data,
 )
 from nilearn.surface.surface import get_data as get_surface_data
-from nilearn.surface.utils import assert_polymesh_equal
+from nilearn.surface.utils import check_polymesh_equal
 from nilearn.typing import NiimgLike
 
 
@@ -130,7 +130,7 @@ def high_variance_confounds(
 
     if mask_img is not None:
         if isinstance(imgs, SurfaceImage):
-            assert_polymesh_equal(mask_img.mesh, imgs.mesh)
+            check_polymesh_equal(mask_img.mesh, imgs.mesh)
         sigs = masking.apply_mask(imgs, mask_img)
 
     # Load the data only if it doesn't need to be masked
@@ -1065,7 +1065,7 @@ def threshold_img(
         check_compatibility_mask_and_images(mask_img, img)
 
     if isinstance(img, SurfaceImage) and isinstance(mask_img, SurfaceImage):
-        assert_polymesh_equal(mask_img.mesh, img.mesh)
+        check_polymesh_equal(mask_img.mesh, img.mesh)
 
     if isinstance(img, SurfaceImage) and cluster_threshold > 0:
         warnings.warn(
@@ -1679,7 +1679,7 @@ def concat_imgs(
             return niimgs[0]
 
         for i, img in enumerate(niimgs):
-            assert_polymesh_equal(img.mesh, niimgs[0].mesh)
+            check_polymesh_equal(img.mesh, niimgs[0].mesh)
             niimgs[i] = at_least_2d(img)
 
         if dtype is None:

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -33,7 +33,7 @@ from nilearn.surface.surface import (
     SurfaceImage,
     at_least_2d,
 )
-from nilearn.surface.utils import assert_polymesh_equal
+from nilearn.surface.utils import check_polymesh_equal
 
 
 def _apply_surf_mask_on_labels(mask_data, labels_data, background_label=0):
@@ -300,7 +300,7 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
         if self.mask_img is not None:
             if img is not None:
                 check_compatibility_mask_and_images(self.mask_img, img)
-            assert_polymesh_equal(self.labels_img.mesh, self.mask_img.mesh)
+            check_polymesh_equal(self.labels_img.mesh, self.mask_img.mesh)
         self.mask_img_ = self.mask_img
 
         self._shelving = False
@@ -403,7 +403,7 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
             img = [img]
         img = concat_imgs(img)
         check_compatibility_mask_and_images(self.labels_img, img)
-        assert_polymesh_equal(self.labels_img.mesh, img.mesh)
+        check_polymesh_equal(self.labels_img.mesh, img.mesh)
         img = at_least_2d(img)
         # concatenate data over hemispheres
         img_data = np.concatenate(list(img.data.parts.values()), axis=0)

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -24,7 +24,7 @@ from nilearn.surface.surface import (
     SurfaceImage,
     get_data,
 )
-from nilearn.surface.utils import assert_polymesh_equal
+from nilearn.surface.utils import check_polymesh_equal
 
 
 @fill_doc
@@ -181,7 +181,7 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
                 msg=f"loading regions from {self.mask_img.__repr__()}",
                 verbose=self.verbose,
             )
-            assert_polymesh_equal(self.maps_img.mesh, self.mask_img.mesh)
+            check_polymesh_equal(self.maps_img.mesh, self.mask_img.mesh)
             self.mask_img_ = self.mask_img
             # squeeze the mask data if it is 2D and has a single column
             for part in self.mask_img_.data.parts:
@@ -276,7 +276,7 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
         img = concat_imgs(img)
         # check img data is 2D
         img.data._check_ndims(2, "img")
-        assert_polymesh_equal(self.maps_img.mesh, img.mesh)
+        check_polymesh_equal(self.maps_img.mesh, img.mesh)
         img_data = np.concatenate(
             list(img.data.parts.values()), axis=0
         ).astype(np.float32)

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -21,7 +21,7 @@ from nilearn.maskers.base_masker import _BaseSurfaceMasker
 from nilearn.surface.surface import (
     SurfaceImage,
 )
-from nilearn.surface.utils import assert_polymesh_equal
+from nilearn.surface.utils import check_polymesh_equal
 
 
 @fill_doc
@@ -160,7 +160,7 @@ class SurfaceMasker(_BaseSurfaceMasker):
 
         if self.mask_img is not None:
             check_compatibility_mask_and_images(self.mask_img, img)
-            assert_polymesh_equal(self.mask_img.mesh, img.mesh)
+            check_polymesh_equal(self.mask_img.mesh, img.mesh)
             self.mask_img_ = self.mask_img
             return
 
@@ -278,7 +278,7 @@ class SurfaceMasker(_BaseSurfaceMasker):
 
         check_compatibility_mask_and_images(self.mask_img_, img)
 
-        assert_polymesh_equal(self.mask_img_.mesh, img.mesh)
+        check_polymesh_equal(self.mask_img_.mesh, img.mesh)
 
         if self.reports:
             self._reporting_data["images"] = img

--- a/nilearn/maskers/tests/test_surface_masker.py
+++ b/nilearn/maskers/tests/test_surface_masker.py
@@ -56,14 +56,14 @@ def test_mask_img_fit_shape_mismatch(
         and that of image to fit.
     """
     masker = SurfaceMasker(surf_mask_1d)
-    with pytest.raises(ValueError, match="number of vertices"):
+    with pytest.raises(ValueError, match="Number of vertices"):
         masker.fit(flip_surf_img(surf_img_2d(shape)))
     masker.fit(surf_img_2d(shape))
     assert_polydata_equal(surf_mask_1d.data, masker.mask_img_.data)
 
 
 def test_mask_img_fit_keys_mismatch(surf_mask_1d, drop_surf_img_part):
-    """Check fitr fails if one hemisphere is missing."""
+    """Check fit fails if one hemisphere is missing."""
     masker = SurfaceMasker(surf_mask_1d)
     with pytest.raises(ValueError, match="key"):
         masker.fit(drop_surf_img_part(surf_mask_1d))
@@ -132,7 +132,7 @@ def test_mask_img_transform_shape_mismatch(
         and that of image to transform.
     """
     masker = SurfaceMasker(surf_mask_1d).fit()
-    with pytest.raises(ValueError, match="number of vertices"):
+    with pytest.raises(ValueError, match="Number of vertices"):
         masker.transform(flip_surf_img(surf_img_1d))
     # non-flipped is ok
     masker.transform(surf_img_1d)

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -29,7 +29,7 @@ from nilearn.surface.surface import (
     SurfaceImage,
 )
 from nilearn.surface.surface import get_data as get_surface_data
-from nilearn.surface.utils import assert_polymesh_equal
+from nilearn.surface.utils import check_polymesh_equal
 from nilearn.typing import NiimgLike
 
 __all__ = [
@@ -893,7 +893,7 @@ def apply_mask_fmri(
     :func:`nilearn.masking.apply_mask`, not in this function).
     """
     if isinstance(imgs, SurfaceImage) and isinstance(mask_img, SurfaceImage):
-        assert_polymesh_equal(mask_img.mesh, imgs.mesh)
+        check_polymesh_equal(mask_img.mesh, imgs.mesh)
 
         if smoothing_fwhm is not None:
             warnings.warn(

--- a/nilearn/plotting/img_comparison.py
+++ b/nilearn/plotting/img_comparison.py
@@ -19,7 +19,7 @@ from nilearn._utils.masker_validation import (
 from nilearn.maskers import NiftiMasker, SurfaceMasker
 from nilearn.plotting._utils import save_figure_if_needed
 from nilearn.surface.surface import SurfaceImage
-from nilearn.surface.utils import assert_polymesh_equal
+from nilearn.surface.utils import check_polymesh_equal
 from nilearn.typing import NiimgLike
 
 
@@ -436,7 +436,7 @@ def _extract_data_2_images(ref_img, src_img, masker=None):
         image_type = "surface"
         ref_img.data._check_ndims(1)
         src_img.data._check_ndims(1)
-        assert_polymesh_equal(ref_img.mesh, src_img.mesh)
+        check_polymesh_equal(ref_img.mesh, src_img.mesh)
 
     else:
         raise TypeError(
@@ -480,7 +480,7 @@ def _sanitize_masker(masker, image_type, ref_img):
             target_shape=ref_img.shape,
         )
     elif isinstance(masker, SurfaceImage):
-        assert_polymesh_equal(ref_img.mesh, masker.mesh)
+        check_polymesh_equal(ref_img.mesh, masker.mesh)
         masker = SurfaceMasker(
             mask_img=masker,
         )

--- a/nilearn/plotting/surface/_utils.py
+++ b/nilearn/plotting/surface/_utils.py
@@ -5,6 +5,7 @@ from nilearn.surface import (
     SurfaceImage,
 )
 from nilearn.surface.surface import combine_hemispheres_meshes, get_data
+from nilearn.surface.utils import check_polymesh_equal
 
 
 def _check_bg_map(bg_map, hemi):
@@ -15,6 +16,8 @@ def _check_bg_map(bg_map, hemi):
     bg_map : Any
 
     hemi : str
+
+    surf_map: SurfaceImage
 
     Returns
     -------
@@ -98,6 +101,7 @@ def check_surface_plotting_inputs(
     if isinstance(surf_map, SurfaceImage):
         if surf_mesh is None:
             surf_mesh = _get_hemi(surf_map.mesh, hemi)
+
         if len(surf_map.shape) > 1 and surf_map.shape[1] > 1:
             raise TypeError(
                 "Input data has incompatible dimensionality. "
@@ -105,13 +109,17 @@ def check_surface_plotting_inputs(
                 f"or ({surf_map.shape[0]}, 1) "
                 f"and you provided a {surf_map.shape} surface image."
             )
+
+        if isinstance(bg_map, SurfaceImage):
+            check_polymesh_equal(bg_map.mesh, surf_map.mesh)
+
         # concatenate the left and right data if hemi is "both"
         if hemi == "both":
             surf_map = get_data(surf_map).T
         else:
             surf_map = surf_map.data.parts[hemi].T
 
-    bg_map = _check_bg_map(bg_map, hemi)
+    bg_map = _check_bg_map(bg_map, hemi, surf_map)
 
     return surf_map, surf_mesh, bg_map
 

--- a/nilearn/plotting/surface/_utils.py
+++ b/nilearn/plotting/surface/_utils.py
@@ -119,7 +119,7 @@ def check_surface_plotting_inputs(
         else:
             surf_map = surf_map.data.parts[hemi].T
 
-    bg_map = _check_bg_map(bg_map, hemi, surf_map)
+    bg_map = _check_bg_map(bg_map, hemi)
 
     return surf_map, surf_mesh, bg_map
 

--- a/nilearn/plotting/surface/tests/test_surf_plotting.py
+++ b/nilearn/plotting/surface/tests/test_surf_plotting.py
@@ -13,6 +13,7 @@ import pytest
 from matplotlib.figure import Figure
 from numpy.testing import assert_array_equal
 
+from nilearn._utils.exceptions import MeshDimensionError
 from nilearn._utils.helpers import is_kaleido_installed, is_plotly_installed
 from nilearn.datasets import fetch_surf_fsaverage
 from nilearn.plotting import (
@@ -473,6 +474,23 @@ def test_plot_surf_hemi_views_plotly(
     plot_surf(
         in_memory_mesh, bg_map=bg_map, hemi=hemi, view=view, engine="plotly"
     )
+
+
+@pytest.mark.parametrize("hemi", ["left", "right", "both"])
+def test_plot_surf_swap_hemi(
+    matplotlib_pyplot, surf_img_1d, hemi, flip_surf_img
+):
+    """Check error is raised if background image is incompatible."""
+    with pytest.raises(
+        MeshDimensionError,
+        match="Number of vertices do not match for between meshes.",
+    ):
+        plot_surf(
+            surf_map=surf_img_1d,
+            bg_map=flip_surf_img(surf_img_1d),
+            hemi=hemi,
+            surf_mesh=None,
+        )
 
 
 def test_plot_surf_with_title(matplotlib_pyplot, in_memory_mesh, bg_map):

--- a/nilearn/surface/utils.py
+++ b/nilearn/surface/utils.py
@@ -1,6 +1,11 @@
 """Utilities for surface mesh, data, images."""
 
+from warnings import warn
+
 import numpy as np
+
+from nilearn._utils.exceptions import MeshDimensionError
+from nilearn._utils.logger import find_stack_level
 
 
 def assert_polydata_equal(data_1, data_2):
@@ -26,28 +31,42 @@ def assert_polymesh_equal(mesh_1, mesh_2):
     set_2 = set(mesh_2.parts.keys())
     if set_1 != set_2:
         diff = set_1.symmetric_difference(set_2)
-        raise ValueError(
+        raise MeshDimensionError(
             f"PolyMeshes do not have the same keys. Offending keys: {diff}"
         )
 
     for key in mesh_1.parts:
-        if mesh_1.parts[key].n_vertices != mesh_2.parts[key].n_vertices:
-            raise ValueError(
-                f"Number of vertices do not match for '{key}'."
-                "number of vertices in mesh_1: "
-                f"{mesh_1.parts[key].n_vertices}; "
-                f"in mesh_2: {mesh_2.parts[key].n_vertices}"
-            )
-
         assert_surface_mesh_equal(mesh_1.parts[key], mesh_2.parts[key])
+
+
+def assert_same_number_vertices(mesh_1, mesh_2):
+    """Assert 2 meshes or polymeshes have the same number of vertices."""
+    if mesh_1.n_vertices != mesh_2.n_vertices:
+        raise MeshDimensionError(
+            f"Number of vertices do not match for between meshes.\n"
+            f"{mesh_1.n_vertices=} and {mesh_2.n_vertices=}"
+        )
+
+
+def check_polymesh_equal(mesh_1, mesh_2):
+    """Check polymesh at-least have same number of vertices if not equal."""
+    try:
+        assert_polymesh_equal(mesh_1, mesh_2)
+    except MeshDimensionError:
+        for key in mesh_1.parts:
+            assert_same_number_vertices(mesh_1.parts[key], mesh_2.parts[key])
+        warn(
+            "Meshes are not identical but have compatible number of vertices.",
+            stacklevel=find_stack_level(),
+        )
 
 
 def assert_surface_mesh_equal(mesh_1, mesh_2):
     """Check that 2 SurfaceMeshes are equal."""
     if not np.array_equal(mesh_1.coordinates, mesh_2.coordinates):
-        raise ValueError("Meshes do not have the same coordinates.")
+        raise MeshDimensionError("Meshes do not have the same coordinates.")
     if not np.array_equal(mesh_1.faces, mesh_2.faces):
-        raise ValueError("Meshes do not have the same faces.")
+        raise MeshDimensionError("Meshes do not have the same faces.")
 
 
 def assert_surface_image_equal(img_1, img_2):

--- a/nilearn/surface/utils.py
+++ b/nilearn/surface/utils.py
@@ -27,6 +27,13 @@ def assert_polydata_equal(data_1, data_2):
 
 def assert_polymesh_equal(mesh_1, mesh_2):
     """Check that 2 PolyMeshes are equal."""
+    assert_polymesh_have_same_keys(mesh_1, mesh_2)
+    for key in mesh_1.parts:
+        assert_surface_mesh_equal(mesh_1.parts[key], mesh_2.parts[key])
+
+
+def assert_polymesh_have_same_keys(mesh_1, mesh_2):
+    """Check that 2 polymeshes have the same keys."""
     set_1 = set(mesh_1.parts.keys())
     set_2 = set(mesh_2.parts.keys())
     if set_1 != set_2:
@@ -35,8 +42,19 @@ def assert_polymesh_equal(mesh_1, mesh_2):
             f"PolyMeshes do not have the same keys. Offending keys: {diff}"
         )
 
-    for key in mesh_1.parts:
-        assert_surface_mesh_equal(mesh_1.parts[key], mesh_2.parts[key])
+
+def check_polymesh_equal(mesh_1, mesh_2):
+    """Check polymesh at-least have same number of vertices if not equal."""
+    try:
+        assert_polymesh_equal(mesh_1, mesh_2)
+    except MeshDimensionError:
+        assert_polymesh_have_same_keys(mesh_1, mesh_2)
+        for key in mesh_1.parts:
+            assert_same_number_vertices(mesh_1.parts[key], mesh_2.parts[key])
+        warn(
+            "Meshes are not identical but have compatible number of vertices.",
+            stacklevel=find_stack_level(),
+        )
 
 
 def assert_same_number_vertices(mesh_1, mesh_2):
@@ -45,19 +63,6 @@ def assert_same_number_vertices(mesh_1, mesh_2):
         raise MeshDimensionError(
             f"Number of vertices do not match for between meshes.\n"
             f"{mesh_1.n_vertices=} and {mesh_2.n_vertices=}"
-        )
-
-
-def check_polymesh_equal(mesh_1, mesh_2):
-    """Check polymesh at-least have same number of vertices if not equal."""
-    try:
-        assert_polymesh_equal(mesh_1, mesh_2)
-    except MeshDimensionError:
-        for key in mesh_1.parts:
-            assert_same_number_vertices(mesh_1.parts[key], mesh_2.parts[key])
-        warn(
-            "Meshes are not identical but have compatible number of vertices.",
-            stacklevel=find_stack_level(),
         )
 
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #5303

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- check if meshes are equal in most cases and fall back to checking if they have the same number of vertices if that fails

