### PR TITLE
[REF] refactor doc strings for sample_mask and confounds for maskers

### DIFF
--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -259,7 +259,15 @@ confounds : :class:`numpy.ndarray`, :obj:`str`, :class:`pathlib.Path`, \
             or :obj:`list` of confounds timeseries, default=None
     This parameter is passed to :func:`nilearn.signal.clean`.
     Please see the related documentation for details.
-    shape: list of (number of scans, number of confounds)
+    shape: (number of scans, number of confounds)
+"""
+docdict["confounds_multi"] = """
+confounds : :obj:`list` of confounds, default=None
+    List of confounds (arrays, dataframes,
+    str or path of files loadable into an array).
+    As confounds are passed to :func:`nilearn.signal.clean`,
+    please see the related documentation for details about accepted types.
+    Must be of same length than imgs.
 """
 
 # cut_coords

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -810,9 +810,29 @@ resume : :obj:`bool`, default=True
 # sample_mask
 docdict["sample_mask"] = """
 sample_mask : Any type compatible with numpy-array indexing, default=None
-    shape: (number of scans - number of volumes removed, )
-    Masks the images along time dimension to perform scrubbing
-    (remove volumes with high motion) and/or non-steady-state volumes.
+    ``shape = (total number of scans - number of scans removed)``
+    for explicit index (for example, ``sample_mask=np.asarray([1, 2, 4])``),
+    or ``shape = (number of scans)`` for binary mask
+    (for example,
+    ``sample_mask=np.asarray([False, True, True, False, True])``).
+    Masks the images along the last dimension to perform scrubbing:
+    for example to remove volumes with high motion
+    and/or non-steady-state volumes.
+    This parameter is passed to :func:`nilearn.signal.clean`.
+"""
+docdict["sample_mask_multi"] = """
+sample_mask : :obj:`list` of sample_mask, default=None
+    List of sample_mask (any type compatible with numpy-array indexing)
+    to use for scrubbing outliers.
+    Must be of same length as ``imgs``.
+    ``shape = (total number of scans - number of scans removed)``
+    for explicit index (for example, ``sample_mask=np.asarray([1, 2, 4])``),
+    or ``shape = (number of scans)`` for binary mask
+    (for example,
+    ``sample_mask=np.asarray([False, True, True, False, True])``).
+    Masks the images along the last dimension to perform scrubbing:
+    for example to remove volumes with high motion
+    and/or non-steady-state volumes.
     This parameter is passed to :func:`nilearn.signal.clean`.
 """
 

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -254,7 +254,9 @@ connected : :obj:`bool`, optional
 
 # confounds
 docdict["confounds"] = """
-confounds : CSV file or array-like, optional
+confounds : :class:`numpy.ndarray`, :obj:`str`, :class:`pathlib.Path`, \
+            :class:`pandas.DataFrame` \
+            or :obj:`list` of confounds timeseries, default=None
     This parameter is passed to :func:`nilearn.signal.clean`.
     Please see the related documentation for details.
     shape: list of (number of scans, number of confounds)

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -807,9 +807,9 @@ resume : :obj:`bool`, default=True
 
 # sample_mask
 docdict["sample_mask"] = """
-sample_mask : Any type compatible with numpy-array indexing, optional
+sample_mask : Any type compatible with numpy-array indexing, default=None
     shape: (number of scans - number of volumes removed, )
-    Masks the niimgs along time/fourth dimension to perform scrubbing
+    Masks the images along time dimension to perform scrubbing
     (remove volumes with high motion) and/or non-steady-state volumes.
     This parameter is passed to :func:`nilearn.signal.clean`.
 """

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -614,6 +614,15 @@ def check_multi_masker_transformer_sample_mask(estimator):
     for ts, n_scrub in zip(signals_list, [n_scrub1, n_scrub2]):
         assert ts.shape[0] == length - n_scrub
 
+    with pytest.raises(
+        ValueError,
+        match="number of sample_mask .* unequal to number of images",
+    ):
+        estimator.fit_transform(
+            [_img_4d_rand_eye_medium(), _img_4d_rand_eye_medium()],
+            sample_mask=sample_mask1,
+        )
+
 
 def check_masker_transformer_sample_mask(estimator):
     """Check sample_mask use in maskers.
@@ -672,6 +681,9 @@ def check_multi_masker_with_confounds(estimator):
     """Test multi maskers with a list of confounds.
 
     Ensure results is different than when not using confounds.
+
+    Check that error is raised if number of confounds
+    does not match number of images
     """
     length = _img_4d_rand_eye_medium().shape[3]
 
@@ -687,6 +699,14 @@ def check_multi_masker_with_confounds(estimator):
 
     for signal_1, signal_2 in zip(signals_list_1, signals_list_2):
         assert_raises(AssertionError, assert_array_equal, signal_1, signal_2)
+
+    with pytest.raises(
+        ValueError, match="number of confounds .* unequal to number of images"
+    ):
+        estimator.fit_transform(
+            [_img_4d_rand_eye_medium(), _img_4d_rand_eye_medium()],
+            confounds=array,
+        )
 
 
 def check_masker_with_confounds(estimator):

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -11,6 +11,7 @@ from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn._utils import repr_niimgs
 from nilearn._utils.cache_mixin import CacheMixin, cache
+from nilearn._utils.docs import fill_doc
 from nilearn._utils.helpers import stringify_path
 from nilearn._utils.logger import find_stack_level, log
 from nilearn._utils.masker_validation import (
@@ -185,10 +186,7 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.
 
-        confounds : CSV file or array-like, default=None
-            This parameter is passed to :func:`nilearn.signal.clean`.
-            Please see the related documentation for details.
-            shape: (number of scans, number of confounds)
+        %(confounds)s
 
         %(sample_mask)s
 
@@ -245,6 +243,7 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
         """Present only to comply with sklearn estimators checks."""
         ...
 
+    @fill_doc
     def transform(self, imgs, confounds=None, sample_mask=None):
         """Apply mask, spatial and temporal preprocessing.
 
@@ -256,10 +255,7 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.
 
-        confounds : CSV file or array-like, default=None
-            This parameter is passed to :func:`nilearn.signal.clean`.
-            Please see the related documentation for details.
-            shape: (number of scans, number of confounds)
+        %(confounds)s
 
         %(sample_mask)s
 
@@ -302,6 +298,7 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
             imgs, confounds=all_confounds, sample_mask=sample_mask
         )
 
+    @fill_doc
     def fit_transform(
         self, X, y=None, confounds=None, sample_mask=None, **fit_params
     ):
@@ -315,9 +312,7 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
         y : numpy array of shape [n_samples], default=None
             Target values.
 
-        confounds : :obj:`list` of confounds, default=None
-            List of confounds (2D arrays or filenames pointing to CSV
-            files). Must be of same length than imgs_list.
+        %(confounds)s
 
         %(sample_mask)s
 
@@ -424,6 +419,7 @@ class _BaseSurfaceMasker(TransformerMixin, CacheMixin, BaseEstimator):
         )
         return tags
 
+    @fill_doc
     def transform(self, imgs, confounds=None, sample_mask=None):
         """Apply mask, spatial and temporal preprocessing.
 
@@ -433,10 +429,7 @@ class _BaseSurfaceMasker(TransformerMixin, CacheMixin, BaseEstimator):
               iterable of :obj:`~nilearn.surface.SurfaceImage`
             Images to process.
 
-        confounds : CSV file or array-like, default=None
-            This parameter is passed to :func:`nilearn.signal.clean`.
-            Please see the related documentation for details.
-            shape: (number of scans, number of confounds)
+        %(confounds)s
 
         %(sample_mask)s
 

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -190,12 +190,7 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
             Please see the related documentation for details.
             shape: (number of scans, number of confounds)
 
-        sample_mask : Any type compatible with numpy-array indexing, \
-            default=None
-            shape: (number of scans - number of volumes removed, )
-            Masks the niimgs along time/fourth dimension to perform scrubbing
-            (remove volumes with high motion) and/or non-steady-state volumes.
-            This parameter is passed to signal.clean.
+        %(sample_mask)s
 
                 .. versionadded:: 0.8.0
 
@@ -266,12 +261,7 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
             Please see the related documentation for details.
             shape: (number of scans, number of confounds)
 
-        sample_mask : Any type compatible with numpy-array indexing, \
-            default=None
-            shape: (number of scans - number of volumes removed, )
-            Masks the niimgs along time/fourth dimension to perform scrubbing
-            (remove volumes with high motion) and/or non-steady-state volumes.
-            This parameter is passed to signal.clean.
+        %(sample_mask)s
 
                 .. versionadded:: 0.8.0
 
@@ -329,9 +319,7 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
             List of confounds (2D arrays or filenames pointing to CSV
             files). Must be of same length than imgs_list.
 
-        sample_mask : :obj:`list` of sample_mask, default=None
-            List of sample_mask (1D arrays) if scrubbing motion outliers.
-            Must be of same length than imgs_list.
+        %(sample_mask)s
 
                 .. versionadded:: 0.8.0
 
@@ -450,12 +438,7 @@ class _BaseSurfaceMasker(TransformerMixin, CacheMixin, BaseEstimator):
             Please see the related documentation for details.
             shape: (number of scans, number of confounds)
 
-        sample_mask : Any type compatible with numpy-array indexing, \
-            default=None
-            shape: (number of scans - number of volumes removed, )
-            Masks the niimgs along time/fourth dimension to perform scrubbing
-            (remove volumes with high motion) and/or non-steady-state volumes.
-            This parameter is passed to clean.
+        %(sample_mask)s
 
         Returns
         -------

--- a/nilearn/maskers/multi_nifti_labels_masker.py
+++ b/nilearn/maskers/multi_nifti_labels_masker.py
@@ -190,7 +190,7 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
         %(imgs)s
             Images to process. Each element of the list is a 4D image.
 
-        %(confounds)s
+        %(confounds_multi)s
 
         %(n_jobs)s
 
@@ -238,7 +238,7 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
         %(imgs)s
             Images to process. Each element of the list is a 4D image.
 
-        %(confounds)s
+        %(confounds_multi)s
 
         %(sample_mask_multi)s
 

--- a/nilearn/maskers/multi_nifti_labels_masker.py
+++ b/nilearn/maskers/multi_nifti_labels_masker.py
@@ -217,9 +217,19 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
 
         if confounds is None:
             confounds = itertools.repeat(None, len(imgs_list))
+        elif len(confounds) != len(imgs_list):
+            raise ValueError(
+                f"number of confounds ({len(confounds)}) unequal to "
+                f"number of images ({len(imgs_list)})."
+            )
 
         if sample_mask is None:
             sample_mask = itertools.repeat(None, len(imgs_list))
+        elif len(sample_mask) != len(imgs_list):
+            raise ValueError(
+                f"number of sample_mask ({len(sample_mask)}) unequal to "
+                f"number of images ({len(imgs_list)})."
+            )
 
         func = self._cache(self.transform_single_imgs)
 

--- a/nilearn/maskers/multi_nifti_labels_masker.py
+++ b/nilearn/maskers/multi_nifti_labels_masker.py
@@ -194,7 +194,7 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
 
         %(n_jobs)s
 
-        %(sample_mask)s
+        %(sample_mask_multi)s
 
         Returns
         -------
@@ -237,8 +237,10 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
         ----------
         %(imgs)s
             Images to process. Each element of the list is a 4D image.
+
         %(confounds)s
-        %(sample_mask)s
+
+        %(sample_mask_multi)s
 
         Returns
         -------

--- a/nilearn/maskers/multi_nifti_maps_masker.py
+++ b/nilearn/maskers/multi_nifti_maps_masker.py
@@ -226,9 +226,19 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
 
         if confounds is None:
             confounds = itertools.repeat(None, len(imgs_list))
+        elif len(confounds) != len(imgs_list):
+            raise ValueError(
+                f"number of confounds ({len(confounds)}) unequal to "
+                f"number of images ({len(imgs_list)})."
+            )
 
         if sample_mask is None:
             sample_mask = itertools.repeat(None, len(imgs_list))
+        elif len(sample_mask) != len(imgs_list):
+            raise ValueError(
+                f"number of sample_mask ({len(sample_mask)}) unequal to "
+                f"number of images ({len(imgs_list)})."
+            )
 
         func = self._cache(self.transform_single_imgs)
 

--- a/nilearn/maskers/multi_nifti_maps_masker.py
+++ b/nilearn/maskers/multi_nifti_maps_masker.py
@@ -246,8 +246,10 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
         ----------
         %(imgs)s
             Images to process. Each element of the list is a 4D image.
+
         %(confounds)s
-        %(sample_mask)s
+
+        %(sample_mask_multi)s
 
         Returns
         -------

--- a/nilearn/maskers/multi_nifti_maps_masker.py
+++ b/nilearn/maskers/multi_nifti_maps_masker.py
@@ -197,11 +197,11 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
         %(imgs)s
             Images to process. Each element of the list is a 4D image.
 
-        %(confounds)s
+        %(confounds_multi)s
 
         %(n_jobs)s
 
-        %(sample_mask)s
+        %(sample_mask_multi)s
 
         Returns
         -------
@@ -247,7 +247,7 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
         %(imgs)s
             Images to process. Each element of the list is a 4D image.
 
-        %(confounds)s
+        %(confounds_multi)s
 
         %(sample_mask_multi)s
 

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -395,9 +395,7 @@ class MultiNiftiMasker(NiftiMasker):
             List of confounds (2D arrays or filenames pointing to CSV
             files or pandas DataFrames). Must be of same length than imgs_list.
 
-        sample_mask : :obj:`list` of sample_mask, default=None
-            List of sample_mask (1D arrays) if scrubbing motion outliers.
-            Must be of same length than imgs_list.
+        %(sample_mask)s
 
                 .. versionadded:: 0.8.0
 
@@ -504,9 +502,7 @@ class MultiNiftiMasker(NiftiMasker):
             This parameter is passed to signal.clean. Please see the
             corresponding documentation for details.
 
-        sample_mask : :obj:`list` of 1D :obj:`numpy.ndarray`, default=None
-            List of sample_mask (1D arrays) if scrubbing motion outliers.
-            Must be of same length than imgs_list.
+        %(sample_mask)s
 
                 .. versionadded:: 0.8.0
 

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -393,7 +393,7 @@ class MultiNiftiMasker(NiftiMasker):
 
         %(confounds)s
 
-        %(sample_mask)s
+        %(sample_mask_multi)s
 
                 .. versionadded:: 0.8.0
 
@@ -497,7 +497,7 @@ class MultiNiftiMasker(NiftiMasker):
 
         %(confounds)s
 
-        %(sample_mask)s
+        %(sample_mask_multi)s
 
                 .. versionadded:: 0.8.0
 

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -391,9 +391,7 @@ class MultiNiftiMasker(NiftiMasker):
             See :ref:`extracting_data`.
             List of imgs file to prepare. One item per subject.
 
-        confounds : :obj:`list` of confounds, default=None
-            List of confounds (2D arrays or filenames pointing to CSV
-            files or pandas DataFrames). Must be of same length than imgs_list.
+        %(confounds)s
 
         %(sample_mask)s
 
@@ -497,10 +495,7 @@ class MultiNiftiMasker(NiftiMasker):
             See :ref:`extracting_data`.
             Data to be preprocessed
 
-        confounds : CSV file or 2D :obj:`numpy.ndarray` or \
-                :obj:`pandas.DataFrame`, default=None
-            This parameter is passed to signal.clean. Please see the
-            corresponding documentation for details.
+        %(confounds)s
 
         %(sample_mask)s
 

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -437,9 +437,19 @@ class MultiNiftiMasker(NiftiMasker):
 
         if confounds is None:
             confounds = itertools.repeat(None, len(imgs_list))
+        elif len(confounds) != len(imgs_list):
+            raise ValueError(
+                f"number of confounds ({len(confounds)}) unequal to "
+                f"number of images ({len(imgs_list)})."
+            )
 
         if sample_mask is None:
             sample_mask = itertools.repeat(None, len(imgs_list))
+        elif len(sample_mask) != len(imgs_list):
+            raise ValueError(
+                f"number of sample_mask ({len(sample_mask)}) unequal to "
+                f"number of images ({len(imgs_list)})."
+            )
 
         # Ignore the mask-computing params: they are not useful and will
         # just invalidate the cache for no good reason

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -391,7 +391,7 @@ class MultiNiftiMasker(NiftiMasker):
             See :ref:`extracting_data`.
             List of imgs file to prepare. One item per subject.
 
-        %(confounds)s
+        %(confounds_multi)s
 
         %(sample_mask_multi)s
 
@@ -495,7 +495,7 @@ class MultiNiftiMasker(NiftiMasker):
             See :ref:`extracting_data`.
             Data to be preprocessed
 
-        %(confounds)s
+        %(confounds_multi)s
 
         %(sample_mask_multi)s
 

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -695,12 +695,7 @@ class NiftiLabelsMasker(BaseMasker):
             Please see the related documentation for details.
             shape: (number of scans, number of confounds)
 
-        sample_mask : Any type compatible with numpy-array indexing, \
-            default=None
-            shape: (number of scans - number of volumes removed, )
-            Masks the niimgs along time/fourth dimension to perform scrubbing
-            (remove volumes with high motion) and/or non-steady-state volumes.
-            This parameter is passed to signal.clean.
+        %(sample_mask)s
 
                 .. versionadded:: 0.8.0
 
@@ -735,12 +730,7 @@ class NiftiLabelsMasker(BaseMasker):
             Please see the related documentation for details.
             shape: (number of scans, number of confounds)
 
-        sample_mask : Any type compatible with numpy-array indexing, \
-            default=None
-            shape: (number of scans - number of volumes removed, )
-            Masks the niimgs along time/fourth dimension to perform scrubbing
-            (remove volumes with high motion) and/or non-steady-state volumes.
-            This parameter is passed to signal.clean.
+        %(sample_mask)s
 
                 .. versionadded:: 0.8.0
 

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -689,11 +689,7 @@ class NiftiLabelsMasker(BaseMasker):
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.
 
-        confounds : CSV file or array-like or :obj:`pandas.DataFrame`, \
-            default=None
-            This parameter is passed to :func:`nilearn.signal.clean`.
-            Please see the related documentation for details.
-            shape: (number of scans, number of confounds)
+        %(confounds)s
 
         %(sample_mask)s
 
@@ -724,11 +720,7 @@ class NiftiLabelsMasker(BaseMasker):
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.
 
-        confounds : CSV file or array-like or :obj:`pandas.DataFrame`, \
-            default=None
-            This parameter is passed to :func:`nilearn.signal.clean`.
-            Please see the related documentation for details.
-            shape: (number of scans, number of confounds)
+        %(confounds)s
 
         %(sample_mask)s
 

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -524,12 +524,7 @@ class NiftiMapsMasker(BaseMasker):
             Please see the related documentation for details.
             shape: (number of scans, number of confounds)
 
-        sample_mask : Any type compatible with numpy-array indexing, \
-            default=None
-            shape: (number of scans - number of volumes removed, )
-            Masks the niimgs along time/fourth dimension to perform scrubbing
-            (remove volumes with high motion) and/or non-steady-state volumes.
-            This parameter is passed to signal.clean.
+        %(sample_mask)s
 
                 .. versionadded:: 0.8.0
 

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -565,12 +565,7 @@ class NiftiMasker(BaseMasker):
             Please see the related documentation for details.
             shape: (number of scans, number of confounds)
 
-        sample_mask : Any type compatible with numpy-array indexing, \
-            default=None
-            shape: (number of scans - number of volumes removed, )
-            Masks the niimgs along time/fourth dimension to perform scrubbing
-            (remove volumes with high motion) and/or non-steady-state volumes.
-            This parameter is passed to signal.clean.
+        %(sample_mask)s
 
         copy : :obj:`bool`, default=True
             Indicates whether a copy is returned or not.

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -559,11 +559,7 @@ class NiftiMasker(BaseMasker):
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.
 
-        confounds : CSV file or array-like or :obj:`pandas.DataFrame`, \
-            default=None
-            This parameter is passed to :func:`nilearn.signal.clean`.
-            Please see the related documentation for details.
-            shape: (number of scans, number of confounds)
+        %(confounds)s
 
         %(sample_mask)s
 

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -638,12 +638,7 @@ class NiftiSpheresMasker(BaseMasker):
             Please see the related documentation for details.
             shape: (number of scans, number of confounds)
 
-        sample_mask : Any type compatible with numpy-array indexing, \
-            default=None
-            Masks the niimgs along time/fourth dimension to perform scrubbing
-            (remove volumes with high motion) and/or non-steady-state volumes.
-            This parameter is passed to signal.clean.
-            shape: (number of scans - number of volumes removed, )
+        %(sample_mask)s
 
                 .. versionadded:: 0.8.0
 
@@ -678,12 +673,7 @@ class NiftiSpheresMasker(BaseMasker):
             Please see the related documentation for details.
             shape: (number of scans, number of confounds)
 
-        sample_mask : Any type compatible with numpy-array indexing, \
-            default=None
-            Masks the niimgs along time/fourth dimension to perform scrubbing
-            (remove volumes with high motion) and/or non-steady-state volumes.
-            This parameter is passed to signal.clean.
-            shape: (number of scans - number of volumes removed, )
+        %(sample_mask)s
 
                 .. versionadded:: 0.8.0
 

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -632,11 +632,7 @@ class NiftiSpheresMasker(BaseMasker):
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.
 
-        confounds : CSV file or array-like or :obj:`pandas.DataFrame`, \
-            default=None
-            This parameter is passed to :func:`nilearn.signal.clean`.
-            Please see the related documentation for details.
-            shape: (number of scans, number of confounds)
+        %(confounds)s
 
         %(sample_mask)s
 
@@ -667,11 +663,7 @@ class NiftiSpheresMasker(BaseMasker):
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.
 
-        confounds : CSV file or array-like or :obj:`pandas.DataFrame`, \
-            default=None
-            This parameter is passed to :func:`nilearn.signal.clean`.
-            Please see the related documentation for details.
-            shape: (number of scans, number of confounds)
+        %(confounds)s
 
         %(sample_mask)s
 

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -382,12 +382,7 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
                     or :obj:`list` of confounds timeseries, default=None
             Confounds to pass to :func:`nilearn.signal.clean`.
 
-        sample_mask : None, Any type compatible with numpy-array indexing, \
-                  or :obj:`list` of \
-                  shape: (total number of scans - number of scans removed) \
-                  for explicit index, or (number of scans) for binary mask, \
-                  default=None
-            sample_mask to pass to :func:`nilearn.signal.clean`.
+        %(sample_mask)s
 
         Returns
         -------
@@ -487,12 +482,7 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
                     or :obj:`list` of confounds timeseries, default=None
             Confounds to pass to :func:`nilearn.signal.clean`.
 
-        sample_mask : None, Any type compatible with numpy-array indexing, \
-                  or :obj:`list` of \
-                  shape: (total number of scans - number of scans removed) \
-                  for explicit index, or (number of scans) for binary mask, \
-                  default=None
-            sample_mask to pass to :func:`nilearn.signal.clean`.
+        %(sample_mask)s
 
         Returns
         -------

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -376,11 +376,7 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
             Images to process.
             Mesh and data for both hemispheres.
 
-        confounds : :class:`numpy.ndarray`, :obj:`str`,\
-                    :class:`pathlib.Path`, \
-                    :class:`pandas.DataFrame` \
-                    or :obj:`list` of confounds timeseries, default=None
-            Confounds to pass to :func:`nilearn.signal.clean`.
+        %(confounds)s
 
         %(sample_mask)s
 
@@ -476,11 +472,7 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
             This parameter is unused.
             It is solely included for scikit-learn compatibility.
 
-        confounds : :class:`numpy.ndarray`, :obj:`str`,\
-                    :class:`pathlib.Path`, \
-                    :class:`pandas.DataFrame` \
-                    or :obj:`list` of confounds timeseries, default=None
-            Confounds to pass to :func:`nilearn.signal.clean`.
+        %(confounds)s
 
         %(sample_mask)s
 

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -252,12 +252,7 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
                     or :obj:`list` of confounds timeseries, default=None
             Confounds to pass to :func:`nilearn.signal.clean`.
 
-        sample_mask : None, Any type compatible with numpy-array indexing, \
-                  or :obj:`list` of \
-                  shape: (number of scans - number of volumes removed) \
-                  for explicit index, or (number of scans) for binary mask, \
-                  default=None
-            sample_mask to pass to :func:`nilearn.signal.clean`.
+        %(sample_mask)s
 
         Returns
         -------
@@ -363,12 +358,7 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
                     or :obj:`list` of confounds timeseries, default=None
             Confounds to pass to :func:`nilearn.signal.clean`.
 
-        sample_mask : None, Any type compatible with numpy-array indexing, \
-                  or :obj:`list` of \
-                  shape: (number of scans - number of volumes removed) \
-                  for explicit index, or (number of scans) for binary mask, \
-                  default=None
-            sample_mask to pass to :func:`nilearn.signal.clean`.
+        %(sample_mask)s
 
 
         Returns

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -246,11 +246,7 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
             Mesh and data for both hemispheres/parts. The data for each \
             hemisphere is of shape (n_vertices_per_hemisphere, n_timepoints).
 
-        confounds : :class:`numpy.ndarray`, :obj:`str`,\
-                    :class:`pathlib.Path`, \
-                    :class:`pandas.DataFrame` \
-                    or :obj:`list` of confounds timeseries, default=None
-            Confounds to pass to :func:`nilearn.signal.clean`.
+        %(confounds)s
 
         %(sample_mask)s
 
@@ -352,11 +348,7 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
             This parameter is unused.
             It is solely included for scikit-learn compatibility.
 
-        confounds : :class:`numpy.ndarray`, :obj:`str`,\
-                    :class:`pathlib.Path`, \
-                    :class:`pandas.DataFrame` \
-                    or :obj:`list` of confounds timeseries, default=None
-            Confounds to pass to :func:`nilearn.signal.clean`.
+        %(confounds)s
 
         %(sample_mask)s
 

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -229,11 +229,7 @@ class SurfaceMasker(_BaseSurfaceMasker):
             Mesh and data for both hemispheres/parts. The data for each \
             hemisphere is of shape (n_vertices_per_hemisphere, n_timepoints).
 
-        confounds : :class:`numpy.ndarray`, :obj:`str`,\
-                    :class:`pathlib.Path`, \
-                    :class:`pandas.DataFrame` \
-                    or :obj:`list` of confounds timeseries, default=None
-            Confounds to pass to :func:`nilearn.signal.clean`.
+        %(confounds)s
 
         %(sample_mask)s
 
@@ -311,11 +307,7 @@ class SurfaceMasker(_BaseSurfaceMasker):
             This parameter is unused. It is solely included for scikit-learn
             compatibility.
 
-        confounds : :class:`numpy.ndarray`, :obj:`str`,\
-                    :class:`pathlib.Path`, \
-                    :class:`pandas.DataFrame` \
-                    or :obj:`list` of confounds timeseries, default=None
-            Confounds to pass to :func:`nilearn.signal.clean`.
+        %(confounds)s
 
         %(sample_mask)s
 

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -235,12 +235,7 @@ class SurfaceMasker(_BaseSurfaceMasker):
                     or :obj:`list` of confounds timeseries, default=None
             Confounds to pass to :func:`nilearn.signal.clean`.
 
-        sample_mask : None, Any type compatible with numpy-array indexing, \
-                  or :obj:`list` of \
-                  shape: (number of scans - number of volumes removed, ) \
-                  for explicit index, or (number of scans, ) for binary mask, \
-                  default=None
-            sample_mask to pass to :func:`nilearn.signal.clean`.
+        %(sample_mask)s
 
         Returns
         -------
@@ -322,11 +317,7 @@ class SurfaceMasker(_BaseSurfaceMasker):
                     or :obj:`list` of confounds timeseries, default=None
             Confounds to pass to :func:`nilearn.signal.clean`.
 
-        sample_mask : None, or any type compatible with numpy-array indexing, \
-                  or :obj:`list` of \
-                  shape: (number of scans - number of volumes removed) \
-                  default=None
-            sample_mask to pass to :func:`nilearn.signal.clean`.
+        %(sample_mask)s
 
         Returns
         -------

--- a/nilearn/maskers/tests/test_multi_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_labels_masker.py
@@ -356,27 +356,3 @@ def test_multi_nifti_labels_masker_resampling_target():
         compressed_img2 = masker.inverse_transform(transformed2)
 
         assert_array_equal(get_data(compressed_img), get_data(compressed_img2))
-
-
-def test_multi_nifti_labels_masker_list_of_sample_mask(
-    img_labels, n_regions, length, img_fmri
-):
-    """Tests MultiNiftiLabelsMasker.fit_transform with a list of "sample_mask".
-
-    "sample_mask" was directly sent as input to the parallel calls of
-    "transform_single_imgs" instead of sending iterations.
-    See https://github.com/nilearn/nilearn/issues/3967 for more details.
-    """
-    n_scrub1 = 3
-    n_scrub2 = 2
-
-    sample_mask1 = np.arange(length - n_scrub1)
-    sample_mask2 = np.arange(length - n_scrub2)
-
-    masker = MultiNiftiLabelsMasker(img_labels)
-    ts_list = masker.fit_transform(
-        [img_fmri, img_fmri], sample_mask=[sample_mask1, sample_mask2]
-    )
-
-    for ts, n_scrub in zip(ts_list, [n_scrub1, n_scrub2]):
-        assert ts.shape == (length - n_scrub, n_regions)

--- a/nilearn/maskers/tests/test_multi_nifti_maps_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_maps_masker.py
@@ -314,27 +314,3 @@ def test_multi_nifti_maps_masker_resampling_clipped_mask(
 
         assert_almost_equal(fmri11_img_r.affine, masker.maps_img_.affine)
         assert fmri11_img_r.shape == (masker.maps_img_.shape[:3] + (length,))
-
-
-def test_multi_nifti_maps_masker_list_of_sample_mask(
-    length, n_regions, img_maps, img_fmri
-):
-    """Tests MultiNiftiMapsMasker.fit_transform with a list of "sample_mask".
-
-    "sample_mask" was directly sent as input to the parallel calls of
-    "transform_single_imgs" instead of sending iterations.
-    See https://github.com/nilearn/nilearn/issues/3967 for more details.
-    """
-    n_scrub1 = 3
-    n_scrub2 = 2
-
-    sample_mask1 = np.arange(length - n_scrub1)
-    sample_mask2 = np.arange(length - n_scrub2)
-
-    masker = MultiNiftiMapsMasker(img_maps)
-    ts_list = masker.fit_transform(
-        [img_fmri, img_fmri], sample_mask=[sample_mask1, sample_mask2]
-    )
-
-    for ts, n_scrub in zip(ts_list, [n_scrub1, n_scrub2]):
-        assert ts.shape == (length - n_scrub, n_regions)

--- a/nilearn/maskers/tests/test_surface_labels_masker.py
+++ b/nilearn/maskers/tests/test_surface_labels_masker.py
@@ -526,20 +526,6 @@ def test_surface_labels_masker_confounds_to_fit_transform(
     assert signals.shape == (20, masker.n_elements_)
 
 
-def test_surface_labels_masker_sample_mask_to_fit_transform(
-    surf_label_img, surf_img_2d
-):
-    """Test transform with sample_mask."""
-    masker = SurfaceLabelsMasker(surf_label_img)
-    masker = masker.fit()
-    signals = masker.transform(
-        surf_img_2d(5),
-        sample_mask=np.asarray([True, False, True, False, True]),
-    )
-    # we remove two samples via sample_mask so we should have 3 samples
-    assert signals.shape == (3, masker.n_elements_)
-
-
 def test_surface_label_masker_labels_img_none():
     """Test that an error is raised when labels_img is None."""
     with pytest.raises(

--- a/nilearn/maskers/tests/test_surface_labels_masker.py
+++ b/nilearn/maskers/tests/test_surface_labels_masker.py
@@ -1,6 +1,3 @@
-from os.path import join
-from pathlib import Path
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -502,28 +499,6 @@ def test_surface_label_masker_inverse_transform_list_surf_images(
     signals = masker.transform([surf_img_2d(3), surf_img_2d(4)])
     img = masker.inverse_transform(signals)
     assert img.shape == (surf_label_img.mesh.n_vertices, 7)
-
-
-@pytest.mark.parametrize("confounds", [None, np.ones((20, 3)), "str", "Path"])
-def test_surface_labels_masker_confounds_to_fit_transform(
-    surf_label_img, surf_img_2d, confounds
-):
-    """Test fit_transform with confounds."""
-    masker = SurfaceLabelsMasker(surf_label_img)
-    if isinstance(confounds, str):
-        if confounds == "Path":
-            nilearn_dir = Path(__file__).parent.parent.parent
-            confounds = nilearn_dir / "tests" / "data" / "spm_confounds.txt"
-        elif confounds == "str":
-            # we need confound to be a string so using os.path.join
-            confounds = join(  # noqa: PTH118
-                Path(__file__).parent.parent.parent,
-                "tests",
-                "data",
-                "spm_confounds.txt",
-            )
-    signals = masker.fit_transform(surf_img_2d(20), confounds=confounds)
-    assert signals.shape == (20, masker.n_elements_)
 
 
 def test_surface_label_masker_labels_img_none():

--- a/nilearn/maskers/tests/test_surface_maps_masker.py
+++ b/nilearn/maskers/tests/test_surface_maps_masker.py
@@ -1,6 +1,3 @@
-from os.path import join
-from pathlib import Path
-
 import numpy as np
 import pytest
 
@@ -174,25 +171,3 @@ def test_surface_maps_masker_labels_img_none():
         match="provide a maps_img during initialization",
     ):
         SurfaceMapsMasker(maps_img=None).fit()
-
-
-@pytest.mark.parametrize("confounds", [None, np.ones((20, 3)), "str", "Path"])
-def test_surface_maps_masker_confounds_to_fit_transform(
-    surf_maps_img, surf_img_2d, confounds
-):
-    """Test fit_transform with confounds."""
-    masker = SurfaceMapsMasker(surf_maps_img)
-    if isinstance(confounds, str):
-        if confounds == "Path":
-            nilearn_dir = Path(__file__).parent.parent.parent
-            confounds = nilearn_dir / "tests" / "data" / "spm_confounds.txt"
-        elif confounds == "str":
-            # we need confound to be a string so using os.path.join
-            confounds = join(  # noqa: PTH118
-                Path(__file__).parent.parent.parent,
-                "tests",
-                "data",
-                "spm_confounds.txt",
-            )
-    signals = masker.fit_transform(surf_img_2d(20), confounds=confounds)
-    assert signals.shape == (20, masker.n_elements_)

--- a/nilearn/maskers/tests/test_surface_maps_masker.py
+++ b/nilearn/maskers/tests/test_surface_maps_masker.py
@@ -196,17 +196,3 @@ def test_surface_maps_masker_confounds_to_fit_transform(
             )
     signals = masker.fit_transform(surf_img_2d(20), confounds=confounds)
     assert signals.shape == (20, masker.n_elements_)
-
-
-def test_surface_maps_masker_sample_mask_to_fit_transform(
-    surf_maps_img, surf_img_2d
-):
-    """Test transform with sample_mask."""
-    masker = SurfaceMapsMasker(surf_maps_img)
-    masker = masker.fit()
-    signals = masker.transform(
-        surf_img_2d(5),
-        sample_mask=np.asarray([True, False, True, False, True]),
-    )
-    # we remove two samples via sample_mask so we should have 3 samples
-    assert signals.shape == (3, masker.n_elements_)

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -1101,7 +1101,7 @@ def _sanitize_confound_dtype(n_signal, confound):
             confound = csv_to_array(filename, skip_header=1)
         if confound.shape[0] != n_signal:
             raise ValueError(
-                "Confound signal has an incorrect length.\n"
+                "Confound signal has an incorrect length. \n"
                 f"Signal length: {n_signal}; "
                 f"confound length: {confound.shape[0]}"
             )


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- use single doc strings for confounds and sample_mask for maskers methods
- add estimator checks 'tests' for maskers to transform iamges using sample_mask and confounds

