### PR TITLE
[FIX] plot_mask_large_fmri.py oversubscribing threads

### DIFF
--- a/examples/07_advanced/plot_mask_large_fmri.py
+++ b/examples/07_advanced/plot_mask_large_fmri.py
@@ -74,11 +74,11 @@ fmri_img.to_filename(fmri_path)
 # %%
 # Create a set of binary masks
 # ----------------------------
-# We will now create 6 binary masks from a brain atlas. Here we will use the
+# We will now create 4 binary masks from a brain atlas. Here we will use the
 # multiscale functional brain parcellations via the
 # :func:`~nilearn.datasets.fetch_atlas_basc_multiscale_2015` function.
 # We will fetch a 64-region version of this atlas and then create separate
-# binary masks for the first 6 regions.
+# binary masks for the first 4 regions.
 
 from nilearn.datasets import fetch_atlas_basc_multiscale_2015
 from nilearn.image import load_img, new_img_like, resample_to_img

--- a/examples/07_advanced/plot_mask_large_fmri.py
+++ b/examples/07_advanced/plot_mask_large_fmri.py
@@ -58,7 +58,7 @@ from nilearn.datasets import fetch_adhd
 from nilearn.image import concat_imgs
 
 N_SUBJECTS = 6
-N_REGIONS = 6
+N_REGIONS = 4
 
 fmri_data = fetch_adhd(n_subjects=N_SUBJECTS)
 fmri_img = concat_imgs(fmri_data.func)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but tries to fix the broken doc build on main

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- I think the issue is due to oversubscription of threads
- I am using N_REGIONS=6, so masking 6 regions in parallel
- changing to 4 as github ci runner only has 4 threads