### PR TITLE
[FIX] allow generation of glm report with no contrasts

### DIFF
--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -680,7 +680,9 @@ class FirstLevelModel(BaseGLM):
 
         tmp = check_and_load_tables(events[run_idx], "events")[0]
         if "trial_type" in tmp.columns:
-            self._reporting_data["trial_types"].extend(tmp["trial_type"])
+            self._reporting_data["trial_types"].extend(
+                x for x in tmp["trial_type"] if x
+            )
 
         start_time = self.slice_time_ref * self.t_r
         end_time = (n_scans - 1 + self.slice_time_ref) * self.t_r

--- a/nilearn/reporting/glm_reporter.py
+++ b/nilearn/reporting/glm_reporter.py
@@ -259,6 +259,8 @@ def make_glm_report(
 
         mask_plot = _mask_to_plot(model, bg_img, cut_coords)
 
+        clusters_tsvs = None
+        statistical_maps = {}
         if output is not None:
             # we try to rely on the content of glm object only
             try:
@@ -273,15 +275,14 @@ def make_glm_report(
                     for contrast_name in output["statistical_maps"]
                 }
             except KeyError:  # pragma: no cover
-                statistical_maps = make_stat_maps(
-                    model, contrasts, output_type="z_score"
-                )
-                clusters_tsvs = None
-        else:
+                if contrasts is not None:
+                    statistical_maps = make_stat_maps(
+                        model, contrasts, output_type="z_score"
+                    )
+        elif contrasts is not None:
             statistical_maps = make_stat_maps(
                 model, contrasts, output_type="z_score"
             )
-            clusters_tsvs = None
 
         logger.log(
             "Generating contrast-level figures...", verbose=model.verbose

--- a/nilearn/reporting/tests/test_glm_reporter.py
+++ b/nilearn/reporting/tests/test_glm_reporter.py
@@ -65,6 +65,18 @@ def test_empty_surface_reports(tmp_path, model, bg_img):
     assert (tmp_path / "tmp.html").exists()
 
 
+def test_flm_reporting_no_contrasts(flm):
+    """Test for model report can be generated with no contrasts."""
+    report = flm.generate_report(
+        plot_type="glass",
+        contrasts=None,
+        min_distance=15,
+        alpha=0.01,
+        threshold=2,
+    )
+    assert "No statistical map was provided." in report.__str__()
+
+
 @pytest.mark.parametrize("height_control", ["fdr", "bonferroni", None])
 def test_flm_reporting_height_control(flm, height_control, contrasts):
     """Test for first level model reporting."""


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- fixes minor bug that would prevent the generation of GLM report when no contrast was passed
