### PR TITLE
[ENH] add coverage information to Nifti and Surface maskers

### DIFF
--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -432,6 +432,7 @@ def check_masker_fitted(estimator):
     check that after fitting
     - __sklearn_is_fitted__ returns true
     - running sklearn check_fitted throws no error
+    - masker have a n_elements_ attribute that is positive int
     """
     # Failure should happen before the input type is determined
     # so we can pass nifti image to surface maskers.
@@ -453,6 +454,8 @@ def check_masker_fitted(estimator):
     assert estimator.__sklearn_is_fitted__()
 
     check_is_fitted(estimator)
+
+    assert isinstance(estimator.n_elements_, int) and estimator.n_elements_ > 0
 
 
 def check_masker_clean_kwargs(estimator):

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -7,6 +7,7 @@ import itertools
 import warnings
 from functools import partial
 
+import numpy as np
 from joblib import Parallel, delayed
 from sklearn.utils.estimator_checks import check_is_fitted
 
@@ -268,6 +269,8 @@ class MultiNiftiMasker(NiftiMasker):
                 "between the mask and its input image. "
             ),
             "warning_message": None,
+            "n_elements": 0,
+            "coverage": 0,
         }
         self._overlay_text = (
             "\n To see the input Nifti image before resampling, "
@@ -359,6 +362,10 @@ class MultiNiftiMasker(NiftiMasker):
 
         # Infer the number of elements (voxels) in the mask
         self.n_elements_ = int(data.sum())
+        self._report_content["n_elements"] = self.n_elements_
+        self._report_content["coverage"] = (
+            self.n_elements_ / np.prod(data.shape) * 100
+        )
 
         if (self.target_shape is not None) or (
             (self.target_affine is not None) and self.reports

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -4,6 +4,7 @@ import warnings
 from copy import copy as copy_object
 from functools import partial
 
+import numpy as np
 from joblib import Memory
 
 from nilearn import _utils
@@ -440,6 +441,8 @@ class NiftiMasker(BaseMasker):
                 "between the mask and its input image. "
             ),
             "warning_message": None,
+            "n_elements": 0,
+            "coverage": 0,
         }
         self._overlay_text = (
             "\n To see the input Nifti image before resampling, "
@@ -517,6 +520,10 @@ class NiftiMasker(BaseMasker):
 
         # Infer the number of elements (voxels) in the mask
         self.n_elements_ = int(data.sum())
+        self._report_content["n_elements"] = self.n_elements_
+        self._report_content["coverage"] = (
+            self.n_elements_ / np.prod(data.shape) * 100
+        )
 
         logger.log("Finished fit", verbose=self.verbose)
 

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -68,7 +68,7 @@ class SurfaceMasker(_BaseSurfaceMasker):
 
     Attributes
     ----------
-    output_dimension_ : :obj:`int` or None
+    n_elements_ : :obj:`int` or None
         number of vertices included in mask
 
     mask_img_ : :obj:`~nilearn.surface.SurfaceImage` or None
@@ -121,6 +121,8 @@ class SurfaceMasker(_BaseSurfaceMasker):
             "number_of_regions": None,
             "summary": None,
             "warning_message": None,
+            "n_elements": 0,
+            "coverage": 0,
         }
         # data necessary to construct figure for the report
         self._reporting_data = None
@@ -128,9 +130,9 @@ class SurfaceMasker(_BaseSurfaceMasker):
     def __sklearn_is_fitted__(self):
         return (
             hasattr(self, "mask_img_")
-            and hasattr(self, "output_dimension_")
+            and hasattr(self, "n_elements_")
             and self.mask_img_ is not None
-            and self.output_dimension_ is not None
+            and self.n_elements_ is not None
         )
 
     def _fit_mask_img(self, img):
@@ -199,13 +201,17 @@ class SurfaceMasker(_BaseSurfaceMasker):
             stop = start + mask.sum()
             self._slices[part_name] = start, stop
             start = stop
-        self.output_dimension_ = stop
+        self.n_elements_ = int(stop)
 
         if self.reports:
+            self._report_content["n_elements"] = self.n_elements_
             for part in self.mask_img_.data.parts:
                 self._report_content["n_vertices"][part] = (
                     self.mask_img_.mesh.parts[part].n_vertices
                 )
+            self._report_content["coverage"] = (
+                self.n_elements_ / self.mask_img_.mesh.n_vertices * 100
+            )
             self._reporting_data = {
                 "mask": self.mask_img_,
                 "images": img,
@@ -258,9 +264,9 @@ class SurfaceMasker(_BaseSurfaceMasker):
         if self.reports:
             self._reporting_data["images"] = imgs
 
-        output = np.empty((1, self.output_dimension_))
+        output = np.empty((1, self.n_elements_))
         if len(imgs.shape) == 2:
-            output = np.empty((imgs.shape[1], self.output_dimension_))
+            output = np.empty((imgs.shape[1], self.n_elements_))
         for part_name, (start, stop) in self._slices.items():
             mask = self.mask_img_.data.parts[part_name].ravel()
             output[:, start:stop] = imgs.data.parts[part_name][mask].T
@@ -338,10 +344,10 @@ class SurfaceMasker(_BaseSurfaceMasker):
         if signals.ndim == 1:
             signals = np.array([signals])
 
-        if signals.shape[1] != self.output_dimension_:
+        if signals.shape[1] != self.n_elements_:
             raise ValueError(
                 "Input to 'inverse_transform' has wrong shape.\n"
-                f"Last dimension should be {self.output_dimension_}.\n"
+                f"Last dimension should be {self.n_elements_}.\n"
                 f"Got {signals.shape[1]}."
             )
 

--- a/nilearn/maskers/tests/test_surface_masker.py
+++ b/nilearn/maskers/tests/test_surface_masker.py
@@ -95,9 +95,9 @@ def test_transform_list_surf_images(
     surf_mask = surf_mask_1d if surf_mask_dim == 1 else surf_mask_2d()
     masker = SurfaceMasker(surf_mask).fit()
     signals = masker.transform([surf_img_1d, surf_img_1d, surf_img_1d])
-    assert signals.shape == (3, masker.output_dimension_)
+    assert signals.shape == (3, masker.n_elements_)
     signals = masker.transform([surf_img_2d(5), surf_img_2d(4)])
-    assert signals.shape == (9, masker.output_dimension_)
+    assert signals.shape == (9, masker.n_elements_)
 
 
 @pytest.mark.parametrize("surf_mask_dim", [1, 2])
@@ -212,7 +212,7 @@ def test_transform_inverse_transform_with_mask(surf_mesh, n_timepoints):
     signals = masker.transform(img)
 
     # check mask shape is as expected
-    assert signals.shape == (n_timepoints, masker.output_dimension_)
+    assert signals.shape == (n_timepoints, masker.n_elements_)
 
     # check the data for first seven vertices is as expected
     assert np.array_equal(signals.ravel()[:7], [2, 3, 4, 20, 30, 40, 50])

--- a/nilearn/reporting/data/html/report_body_template.html
+++ b/nilearn/reporting/data/html/report_body_template.html
@@ -26,6 +26,13 @@
   </div>
 </div>
 <div class="pure-g">
+  {{if n_elements }}
+  <div class="pure-u-1 pure-u-md-3-3">
+    <p>
+      The mask includes {{ n_elements }} voxels ({{ coverage }} %) of the image.
+    </p>
+  </div>
+  {{endif}}
   <div class="pure-u-1 pure-u-md-3-3 table-container">
     {{if parameters}} {{ parameters|html }} {{endif}}
   </div>

--- a/nilearn/reporting/data/html/report_body_template_surfacemasker.html
+++ b/nilearn/reporting/data/html/report_body_template_surfacemasker.html
@@ -29,6 +29,15 @@
     <p>{{description}}</p>
     {{endif}}
     <!--  -->
+    {{if n_elements }}
+    <div class="pure-u-1 pure-u-md-3-3">
+      <p>
+        The mask includes {{ n_elements }} vertices ({{ coverage }} %) of the
+        image.
+      </p>
+    </div>
+    {{endif}}
+    <!--  -->
     {{if n_vertices}}
     <div>
       <table class="pure-table">

--- a/nilearn/reporting/html_report.py
+++ b/nilearn/reporting/html_report.py
@@ -158,6 +158,9 @@ def _update_template(
     with css_file_path.open(encoding="utf-8") as css_file:
         css = css_file.read()
 
+    if "coverage" in data:
+        data["coverage"] = f"{data['coverage']:0.1f}"
+
     body = tpl.substitute(
         title=title,
         content=content,

--- a/nilearn/reporting/tests/test_html_report.py
+++ b/nilearn/reporting/tests/test_html_report.py
@@ -404,8 +404,11 @@ def test_4d_reports(img_mask_eye, affine_eye):
     masker = NiftiMasker(mask_strategy="epi")
     masker.fit(data_img_4d)
 
+    assert masker._report_content["coverage"] > 0
+
     html = masker.generate_report()
     _check_html(html)
+    assert "The mask includes" in str(html)
 
     # test .fit_transform method
     masker = NiftiMasker(mask_img=img_mask_eye, standardize=True)
@@ -466,7 +469,7 @@ def test_multi_nifti_masker_generate_report_imgs_and_mask(
     masker.fit([img_fmri, img_fmri]).generate_report()
 
 
-def test_mask_img_generate_report(surf_img_1d, surf_mask_1d):
+def test_surface_masker_mask_img_generate_report(surf_img_1d, surf_mask_1d):
     """Smoke test generate report."""
     masker = SurfaceMasker(surf_mask_1d, reports=True).fit()
 
@@ -480,7 +483,7 @@ def test_mask_img_generate_report(surf_img_1d, surf_mask_1d):
     masker.generate_report()
 
 
-def test_mask_img_generate_no_report(surf_img_2d, surf_mask_1d):
+def test_surface_masker_mask_img_generate_no_report(surf_img_2d, surf_mask_1d):
     """Smoke test generate report."""
     masker = SurfaceMasker(surf_mask_1d, reports=False).fit()
 
@@ -520,6 +523,9 @@ def test_surface_masker_minimal_report_fit(
     assert '<div class="image">' in str(report)
     if not reports:
         assert 'src="data:image/svg+xml;base64,"' in str(report)
+    else:
+        assert masker._report_content["coverage"] > 0
+        assert "The mask includes" in str(report)
 
 
 def test_generate_report_engine_error(surf_maps_img, surf_img_2d):


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #5211

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- ensure all makers have an `n_elements_` attribute after fit (rename the output_dimension_ of SurfaceMasker to that effect)
- modify fit and report generation of SurfaceMasker, NiftiMasker, MultiNiftiMasker to include the number of elements and the image coverage of the mask.
