### PR TITLE
[FIX] fetch full history to append new results to older results

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -59,6 +59,9 @@ jobs:
 
         steps:
         -   uses: actions/checkout@v4
+            with:
+                # fetch all branches and tags
+                fetch-depth: 0
         -   uses: actions/setup-python@v5
             with:
                 # TODO bump to 3.10 when minimum python is 3.10


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->

- right now, older commits can't be seen on https://nilearn.github.io/benchmarks
- this is because `asv publish` can't find those commits in the nilearn git history: https://github.com/nilearn/nilearn/actions/runs/14471245839/job/40585467668#step:10:17
- so we fetch full nilearn history with `actions/checkout`
- this allows `asv publish` to find older commits to display in the HTML pages

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- fetch full nilearn history with `actions/checkout`
