### PR TITLE
[ENH] ensure estimators have a y parameter

### DIFF
--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -87,6 +87,7 @@ VALID_CHECKS = [
     "check_fit2d_1sample",
     "check_fit2d_predict1d",
     "check_fit_check_is_fitted",
+    "check_fit_score_takes_y",
     "check_get_params_invariance",
     "check_methods_sample_order_invariance",
     "check_methods_subset_invariance",
@@ -142,6 +143,7 @@ CHECKS_TO_SKIP_IF_IMG_INPUT = {
     "check_transformer_preserve_dtypes": (
         "replaced by check_masker_transformer"
     ),
+    "check_fit_score_takes_y": {"replaced by check_masker_fit_score_takes_y"},
     # Those are skipped for now they fail
     # for unknown reasons
     #  most often because sklearn inputs expect a numpy array
@@ -155,7 +157,6 @@ CHECKS_TO_SKIP_IF_IMG_INPUT = {
     "check_estimators_nan_inf": "TODO",
     "check_estimators_overwrite_params": "TODO",
     "check_estimators_pickle": "TODO",
-    "check_fit_score_takes_y": "TODO",
     "check_fit_idempotent": "TODO",
     "check_methods_sample_order_invariance": "TODO",
     "check_methods_subset_invariance": "TODO",
@@ -315,6 +316,7 @@ def nilearn_check_estimator(estimator):
         yield (clone(estimator), check_masker_generate_report)
         yield (clone(estimator), check_masker_generate_report_false)
         yield (clone(estimator), check_masker_refit)
+        yield (clone(estimator), check_masker_fit_score_takes_y)
         yield (clone(estimator), check_masker_transformer)
         yield (clone(estimator), check_masker_compatibility_mask_image)
         yield (clone(estimator), check_masker_fit_with_mask_too_many_samples)
@@ -894,6 +896,28 @@ def check_masker_smooth(estimator):
 
     assert isinstance(signal, np.ndarray)
     assert signal.shape[0] == n_sample
+
+
+def check_masker_fit_score_takes_y(estimator):
+    """Replace sklearn check_fit_score_takes_y for maskers.
+
+    Check that all estimators accept an optional y
+    in fit and score so they can be used in pipelines.
+    """
+    for attr in ["fit", "fit_transform"]:
+        tmp = {
+            k: v.default
+            for k, v in inspect.signature(
+                getattr(estimator, attr)
+            ).parameters.items()
+            if v.default is not inspect.Parameter.empty
+        }
+        if "y" not in tmp:
+            raise ValueError(
+                f"{estimator.__class__.__name__} "
+                f"is missing 'y=None' for the method '{attr}'."
+            )
+        assert tmp["y"] is None
 
 
 # ------------------ SURFACE MASKER CHECKS ------------------

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -479,11 +479,7 @@ class ConnectivityMeasure(TransformerMixin, BaseEstimator):
                 f"You provided {confounds.__class__}"
             )
 
-    def fit(
-        self,
-        X,
-        y=None,  # noqa: ARG002
-    ):
+    def fit(self, X, y=None):
         """Fit the covariance estimator to the given time series for each \
         subject.
 
@@ -500,6 +496,7 @@ class ConnectivityMeasure(TransformerMixin, BaseEstimator):
             The object itself. Useful for chaining operations.
 
         """
+        del y
         self._fit_transform(X, do_fit=True)
         return self
 
@@ -598,12 +595,7 @@ class ConnectivityMeasure(TransformerMixin, BaseEstimator):
 
         return connectivities
 
-    def fit_transform(
-        self,
-        X,
-        y=None,  # noqa: ARG002
-        confounds=None,
-    ):
+    def fit_transform(self, X, y=None, confounds=None):
         """Fit the covariance estimator to the given time series \
         for each subject. \
         Then apply transform to covariance matrices for the chosen kind.
@@ -631,6 +623,7 @@ class ConnectivityMeasure(TransformerMixin, BaseEstimator):
             Vectors are cleaned when vectorize=True and confounds are provided.
 
         """
+        del y
         if self.kind == "tangent" and len(X) <= 1:
             # Check that people are applying fit_transform to a group of
             # subject

--- a/nilearn/connectome/group_sparse_cov.py
+++ b/nilearn/connectome/group_sparse_cov.py
@@ -601,11 +601,7 @@ class GroupSparseCovariance(CacheMixin, BaseEstimator):
         self.memory_level = memory_level
         self.verbose = verbose
 
-    def fit(
-        self,
-        subjects,
-        y=None,  # noqa: ARG002
-    ):
+    def fit(self, subjects, y=None):
         """Fits the group sparse precision model according \
         to the given training data and parameters.
 
@@ -623,6 +619,7 @@ class GroupSparseCovariance(CacheMixin, BaseEstimator):
             the object itself. Useful for chaining operations.
 
         """
+        del y
         check_params(self.__dict__)
         for x in subjects:
             check_array(x, accept_sparse=False)
@@ -1080,11 +1077,7 @@ class GroupSparseCovarianceCV(CacheMixin, BaseEstimator):
         self.debug = debug
         self.early_stopping = early_stopping
 
-    def fit(
-        self,
-        subjects,
-        y=None,  # noqa: ARG002
-    ):
+    def fit(self, subjects, y=None):
         """Compute cross-validated group-sparse precisions.
 
         Parameters
@@ -1101,6 +1094,7 @@ class GroupSparseCovarianceCV(CacheMixin, BaseEstimator):
             the object instance itself.
 
         """
+        del y
         check_params(self.__dict__)
 
         for x in subjects:

--- a/nilearn/connectome/tests/test_connectivity_matrices.py
+++ b/nilearn/connectome/tests/test_connectivity_matrices.py
@@ -61,6 +61,7 @@ expected_failed_checks = {
     "check_estimators_overwrite_params": "TODO",
     "check_f_contiguous_array_estimator": "TODO",
     "check_fit_check_is_fitted": "handled by nilearn checks",
+    "check_fit_score_takes_y": "not applicable",
     "check_fit2d_1feature": "TODO",
     "check_fit2d_1sample": "TODO",
     "check_fit2d_predict1d": "TODO",

--- a/nilearn/connectome/tests/test_group_sparse_cov.py
+++ b/nilearn/connectome/tests/test_group_sparse_cov.py
@@ -21,6 +21,7 @@ expected_failed_checks = {
     "check_estimators_overwrite_params": "TODO",
     "check_f_contiguous_array_estimator": "TODO",
     "check_fit_check_is_fitted": "handled by nilearn checks",
+    "check_fit_score_takes_y": "not applicable",
     "check_fit2d_1feature": "TODO",
     "check_fit2d_1sample": "TODO",
     "check_fit2d_predict1d": "TODO",

--- a/nilearn/decomposition/_base.py
+++ b/nilearn/decomposition/_base.py
@@ -425,12 +425,7 @@ class _BaseDecomposition(CacheMixin, TransformerMixin, BaseEstimator):
         tags.input_tags = InputTags()
         return tags
 
-    def fit(
-        self,
-        imgs,
-        y=None,  # noqa: ARG002
-        confounds=None,
-    ):
+    def fit(self, imgs, y=None, confounds=None):
         """Compute the mask and the components across subjects.
 
         Parameters
@@ -455,6 +450,7 @@ class _BaseDecomposition(CacheMixin, TransformerMixin, BaseEstimator):
             at the object level.
 
         """
+        del y
         # Base fit for decomposition estimators : compute the embedded masker
         check_params(self.__dict__)
 

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -240,7 +240,7 @@ class MultiNiftiMasker(NiftiMasker):
     def fit(
         self,
         imgs=None,
-        y=None,  # noqa: ARG002
+        y=None,
     ):
         """Compute the mask corresponding to the data.
 
@@ -257,6 +257,7 @@ class MultiNiftiMasker(NiftiMasker):
             compatibility.
 
         """
+        del y
         check_params(self.__dict__)
         if getattr(self, "_shelving", None) is None:
             self._shelving = False

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -484,11 +484,7 @@ class NiftiLabelsMasker(BaseMasker):
 
         return [display]
 
-    def fit(
-        self,
-        imgs=None,
-        y=None,  # noqa: ARG002
-    ):
+    def fit(self, imgs=None, y=None):
         """Prepare signal extraction from regions.
 
         Parameters
@@ -501,6 +497,7 @@ class NiftiLabelsMasker(BaseMasker):
             This parameter is unused. It is solely included for scikit-learn
             compatibility.
         """
+        del y
         check_params(self.__dict__)
         check_reduction_strategy(self.strategy)
 
@@ -683,7 +680,7 @@ class NiftiLabelsMasker(BaseMasker):
         return sanitize_look_up_table(lut, atlas=self.labels_img_)
 
     @fill_doc
-    def fit_transform(self, imgs, confounds=None, sample_mask=None):
+    def fit_transform(self, imgs, y=None, confounds=None, sample_mask=None):
         """Prepare and perform signal extraction from regions.
 
         Parameters
@@ -693,6 +690,10 @@ class NiftiLabelsMasker(BaseMasker):
             Images to process.
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.
+
+        y : None
+            This parameter is unused. It is solely included for scikit-learn
+            compatibility.
 
         %(confounds)s
 
@@ -707,6 +708,7 @@ class NiftiLabelsMasker(BaseMasker):
             shape: (number of scans, number of labels)
 
         """
+        del y
         return self.fit(imgs).transform(
             imgs, confounds=confounds, sample_mask=sample_mask
         )

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -375,11 +375,7 @@ class NiftiMapsMasker(BaseMasker):
             display.close()
         return embeded_images
 
-    def fit(
-        self,
-        imgs=None,
-        y=None,  # noqa: ARG002
-    ):
+    def fit(self, imgs=None, y=None):
         """Prepare signal extraction from regions.
 
         Parameters
@@ -392,6 +388,7 @@ class NiftiMapsMasker(BaseMasker):
             This parameter is unused. It is solely included for scikit-learn
             compatibility.
         """
+        del y
         check_params(self.__dict__)
         if self.resampling_target not in ("mask", "maps", "data", None):
             raise ValueError(
@@ -495,8 +492,34 @@ class NiftiMapsMasker(BaseMasker):
     def __sklearn_is_fitted__(self):
         return hasattr(self, "maps_img_") and hasattr(self, "n_elements_")
 
-    def fit_transform(self, imgs, confounds=None, sample_mask=None):
-        """Prepare and perform signal extraction."""
+    def fit_transform(self, imgs, y=None, confounds=None, sample_mask=None):
+        """Prepare and perform signal extraction.
+
+        Parameters
+        ----------
+        imgs : 3D/4D Niimg-like object
+            See :ref:`extracting_data`.
+            Images to process.
+            If a 3D niimg is provided, a singleton dimension will be added to
+            the output to represent the single scan in the niimg.
+
+        y : None
+            This parameter is unused. It is solely included for scikit-learn
+            compatibility.
+
+        %(confounds)s
+
+        %(sample_mask)s
+
+                .. versionadded:: 0.8.0
+
+        Returns
+        -------
+        region_signals : 2D numpy.ndarray
+            Signal for each map.
+            shape: (number of scans, number of maps)
+        """
+        del y
         return self.fit(imgs).transform(
             imgs, confounds=confounds, sample_mask=sample_mask
         )

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -413,11 +413,7 @@ class NiftiMasker(BaseMasker):
     def __sklearn_is_fitted__(self):
         return hasattr(self, "mask_img_")
 
-    def fit(
-        self,
-        imgs=None,
-        y=None,  # noqa: ARG002
-    ):
+    def fit(self, imgs=None, y=None):
         """Compute the mask corresponding to the data.
 
         Parameters
@@ -432,6 +428,7 @@ class NiftiMasker(BaseMasker):
             compatibility.
 
         """
+        del y
         check_params(self.__dict__)
 
         self._report_content = {

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -538,13 +538,14 @@ class NiftiSpheresMasker(BaseMasker):
     def fit(
         self,
         imgs=None,
-        y=None,  # noqa: ARG002
+        y=None,
     ):
         """Prepare signal extraction from regions.
 
         All parameters are unused; they are for scikit-learn compatibility.
 
         """
+        del y
         self._report_content = {
             "description": (
                 "This reports shows the regions defined "
@@ -621,7 +622,7 @@ class NiftiSpheresMasker(BaseMasker):
         return self
 
     @fill_doc
-    def fit_transform(self, imgs, confounds=None, sample_mask=None):
+    def fit_transform(self, imgs, y=None, confounds=None, sample_mask=None):
         """Prepare and perform signal extraction.
 
         Parameters
@@ -631,6 +632,10 @@ class NiftiSpheresMasker(BaseMasker):
             Images to process.
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.
+
+        y : None
+            This parameter is unused. It is solely included for scikit-learn
+            compatibility.
 
         %(confounds)s
 
@@ -645,6 +650,7 @@ class NiftiSpheresMasker(BaseMasker):
             shape: (number of scans, number of spheres)
 
         """
+        del y
         return self.fit(imgs).transform(
             imgs, confounds=confounds, sample_mask=sample_mask
         )

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -250,8 +250,8 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
         -------
         SurfaceLabelsMasker object
         """
-        check_params(self.__dict__)
         del y
+        check_params(self.__dict__)
 
         check_reduction_strategy(self.strategy)
 

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -164,8 +164,8 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
         -------
         SurfaceMapsMasker object
         """
-        check_params(self.__dict__)
         del y
+        check_params(self.__dict__)
 
         if self.maps_img is None:
             raise ValueError(

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -192,8 +192,8 @@ class SurfaceMasker(_BaseSurfaceMasker):
         -------
         SurfaceMasker object
         """
-        check_params(self.__dict__)
         del y
+        check_params(self.__dict__)
         self._fit_mask_img(imgs)
         assert self.mask_img_ is not None
 

--- a/nilearn/regions/hierarchical_kmeans_clustering.py
+++ b/nilearn/regions/hierarchical_kmeans_clustering.py
@@ -255,11 +255,7 @@ class HierarchicalKMeans(ClusterMixin, TransformerMixin, BaseEstimator):
         tags.input_tags = InputTags()
         return tags
 
-    def fit(
-        self,
-        X,
-        y=None,  # noqa: ARG002
-    ):
+    def fit(self, X, y=None):
         """Compute clustering of the data.
 
         Parameters
@@ -272,6 +268,7 @@ class HierarchicalKMeans(ClusterMixin, TransformerMixin, BaseEstimator):
         -------
         self
         """
+        del y
         X = check_array(
             X, ensure_min_features=2, ensure_min_samples=2, estimator=self
         )

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -444,12 +444,9 @@ class RegionExtractor(NiftiMapsMasker):
         self.smoothing_fwhm = smoothing_fwhm
 
     @rename_parameters(replacement_params={"X": "imgs"}, end_version="0.13.2")
-    def fit(
-        self,
-        imgs=None,
-        y=None,  # noqa: ARG002
-    ):
+    def fit(self, imgs=None, y=None):
         """Prepare the data and setup for the region extraction."""
+        del y
         check_params(self.__dict__)
         maps_img = check_niimg_4d(self.maps_img)
 

--- a/nilearn/regions/rena_clustering.py
+++ b/nilearn/regions/rena_clustering.py
@@ -685,11 +685,7 @@ class ReNA(ClusterMixin, TransformerMixin, BaseEstimator):
         tags.input_tags = InputTags()
         return tags
 
-    def fit(
-        self,
-        X,
-        y=None,  # noqa: ARG002
-    ):
+    def fit(self, X, y=None):
         """Compute clustering of the data.
 
         Parameters
@@ -704,6 +700,7 @@ class ReNA(ClusterMixin, TransformerMixin, BaseEstimator):
         self : `ReNA` object
 
         """
+        del y
         check_params(self.__dict__)
         X = check_array(
             X, ensure_min_features=2, ensure_min_samples=2, estimator=self


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but relates to https://github.com/nilearn/nilearn/issues/4538

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- add estimator check to make all our estimators have a y parameter for fit() and fit_transform()
