### PR TITLE
[FIX] Failing benchmark workflow on schedule

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,8 +40,8 @@ on:
         branches:
         -   main
     schedule:
-    # everday at 10pm UTC
-    -   cron: 0 22 * * 0
+    # every Monday at 9am UTC
+    -   cron: 0 9 * * MON
 
     workflow_dispatch:  # This enables manual triggering from GitHub UI
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes None but fixes the failing benchmark workflow on schedule: https://github.com/nilearn/nilearn/actions/runs/14825724575/job/41618562617#step:9:1851

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- The error code suggests it's a timeout error in setup_cache step
- We download a dataset in that step
- So my guess is that downloading the dataset jus tfails for some reason on Sunday 10pm UTC
- changing to every Monday at 9am UTC (should run at 11am Paris time)
