### PR TITLE
[FIX] rely in `__sklearn_tags__` for sklearn > 1.5.2  and `on _more_tags` otherwise

### DIFF
--- a/.github/workflows/testing_minimum.yml
+++ b/.github/workflows/testing_minimum.yml
@@ -16,7 +16,6 @@ on:
     push:
         branches:
         -   main
-    pull_request:
     # Uses the cron schedule for github actions
     #
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events

--- a/.github/workflows/testing_minimum.yml
+++ b/.github/workflows/testing_minimum.yml
@@ -16,6 +16,7 @@ on:
     push:
         branches:
         -   main
+    pull_request:
     # Uses the cron schedule for github actions
     #
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -310,7 +310,7 @@ def nilearn_check_estimator(estimator):
 
     if SKLEARN_GT_1_5:
         tags = estimator.__sklearn_tags__()
-    else:
+    else:  # pragma: no cover
         tags = estimator._more_tags()
 
     # TODO remove first if when dropping sklearn 1.5

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -273,7 +273,7 @@ def check_estimator(
             for e, check in sklearn_check_estimator(
                 estimator=est, generate_only=True
             ):
-                tags = est._more_tags()
+                tags = est.__sklearn_tags__()
 
                 niimg_input = "niimg_like" in tags["X_types"]
                 surf_img = "surf_img" in tags["X_types"]
@@ -302,7 +302,7 @@ def check_estimator(
 
 
 def nilearn_check_estimator(estimator):
-    tags = estimator._more_tags()
+    tags = estimator.__sklearn_tags__()
 
     is_masker = False
     is_glm = False
@@ -394,7 +394,7 @@ def nilearn_check_estimator(estimator):
 
 
 def is_multimasker(estimator):
-    tags = estimator._more_tags()
+    tags = estimator.__sklearn_tags__()
 
     # TODO remove first if when dropping sklearn 1.5
     #  for sklearn >= 1.6 tags are always a dataclass
@@ -405,7 +405,7 @@ def is_multimasker(estimator):
 
 
 def accept_niimg_input(estimator):
-    tags = estimator._more_tags()
+    tags = estimator.__sklearn_tags__()
 
     # TODO remove first if when dropping sklearn 1.5
     #  for sklearn >= 1.6 tags are always a dataclass


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #5373 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- only rely on __sklearn_tags__ to get tags of an estimator

