### PR TITLE
[ENH] Make all decomposition methods work with surface data

### DIFF
--- a/nilearn/decomposition/_base.py
+++ b/nilearn/decomposition/_base.py
@@ -31,6 +31,8 @@ from nilearn.maskers import NiftiMapsMasker, SurfaceMapsMasker, SurfaceMasker
 from nilearn.signal import row_sum_of_squares
 from nilearn.surface import SurfaceImage
 
+SURFACE_DATA_EXTENSIONS = ("gii", "gii.gz", "mgz")
+
 
 def _fast_svd(X, n_components, random_state=None):
     """Automatically switch between randomized and lapack SVD (heuristic \
@@ -478,11 +480,18 @@ class _BaseDecomposition(CacheMixin, TransformerMixin, BaseEstimator):
             )
 
         masker_type = "nii"
-        if isinstance(self.mask, (SurfaceMasker, SurfaceImage)) or any(
-            isinstance(x, SurfaceImage) for x in imgs
+        if (
+            isinstance(self.mask, (SurfaceMasker, SurfaceImage))
+            or any(isinstance(x, SurfaceImage) for x in imgs)
+            or any(
+                isinstance(x, str) and x.endswith(SURFACE_DATA_EXTENSIONS)
+                for x in imgs
+            )
         ):
             masker_type = "surface"
         self.masker_ = check_embedded_masker(self, masker_type=masker_type)
+
+        breakpoint()
 
         # Avoid warning with imgs != None
         # if masker_ has been provided a mask_img


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #5093

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- check file type (nifti or surface) from file extension in:
  - fit method of  _BaseDecomposition class
  - concat_imgs
  - seems like a systematic issue, so probably a new separate issue needed?

- check dict_learning, canica.py, _multi_pca.py
- check related examples
- add related tests
