### PR TITLE
[MAINT] ensure transform on 3D volume (1D surface) images returns 1D arrays

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -116,3 +116,7 @@ Changes
 - :bdg-dark:`Code` Move ``nilearn.plotting.matrix_plotting`` under ``nilearn.plotting.matrix`` (:gh:`5240` by `Hande Gözükan`_).
 
 - :bdg-danger:`Deprecation` For version >=0.13.2 :func:`~nilearn.interfaces.bids.parse_bids_filename` will return a dictionary whose keys correspond to valid BIDS terms. (:gh:`5320` by `Rémi Gau`_).
+
+- :bdg-danger:`Deprecation` Using the transform method of nifti maskers on 3D images now returns 1D arrays. Similarly, using the transform method of surface maskers on 1D surface images now returns 1D arrays.  (:gh:`5381` by `Rémi Gau`_).
+
+- :bdg-danger:`Deprecation` Using the inverse_transform method of surface maskers on 1D arrays now returns surface images  (:gh:`5381` by `Rémi Gau`_).

--- a/doc/manipulating_images/manipulating_images.rst
+++ b/doc/manipulating_images/manipulating_images.rst
@@ -1,8 +1,8 @@
 .. _data_manipulation:
 
-=====================================================================
+=============================================================
 Manipulating images: resampling, smoothing, masking, ROIs...
-=====================================================================
+=============================================================
 
 This chapter discusses how nilearn can be used to do simple operations on
 brain images.
@@ -11,7 +11,7 @@ brain images.
 .. _preprocessing_functions:
 
 Functions for data preparation and image transformation
-=========================================================
+=======================================================
 
 Nilearn comes with many simple functions for simple data preparation and
 transformation. Note that if you want to perform these operations while
@@ -106,7 +106,7 @@ of the transformation matrix (i.e., affine).
   :ref:`An example illustrating affine transforms on data and bounding boxes <sphx_glr_auto_examples_06_manipulating_images_plot_affine_transformation.py>`
 
 Accessing individual volumes in 4D images
-===========================================
+=========================================
 
 * :func:`nilearn.image.index_img`: selects one or more volumes in a 4D
   image.
@@ -139,7 +139,7 @@ Accessing individual volumes in 4D images
 .. _computing_and_applying_mask:
 
 Computing and applying spatial masks
-=====================================
+====================================
 
 Relevant functions:
 
@@ -157,7 +157,7 @@ Relevant functions:
 
 
 Extracting a brain mask
-------------------------
+-----------------------
 
 If we do not have a spatial mask of the target regions, a brain mask
 can be computed from the data:
@@ -183,7 +183,7 @@ can be computed from the data:
 .. _mask_4d_2_3d:
 
 Masking data: from 4D Nifti images to 2D data arrays
----------------------------------------------------------------
+----------------------------------------------------
 
 :term:`fMRI` data is usually represented as a 4D block of data: 3 spatial
 dimensions and one time dimension. In practice, we are usually
@@ -211,7 +211,7 @@ do it manually below:
 
 
 Image operations: creating a ROI mask manually
-===============================================
+==============================================
 
 A region of interest (ROI) mask can be computed for instance with a
 statistical test. This requires a chain of image

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -25,9 +25,8 @@ relevant for the research questions at hand.
 
 .. tip::
     Masker objects can transform both 3D and 4D image objects.
-    Transforming a 4D image produces a 2D (samples x features) matrix.
-    Currently, transforming a 3D image also produces a 2D (1 x features) matrix,
-    but starting in version 0.12, it will produce a 1D (features) array.
+    Transforming a 4D image produces a 2D (samples, features) array.
+    Transforming a 3D image produces a 1D (features,) array.
 
 
 .. |niimgs| image:: ../images/niimgs.jpg

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -25,8 +25,8 @@ relevant for the research questions at hand.
 
 .. tip::
     Masker objects can transform both 3D and 4D image objects.
-    Transforming a 4D image produces a 2D (samples, features) array.
     Transforming a 3D image produces a 1D (features,) array.
+    Transforming a 4D image produces a 2D (samples, features) array.
 
 
 .. |niimgs| image:: ../images/niimgs.jpg
@@ -293,8 +293,6 @@ properties, before conversion to :term:`voxel` signals.
    :func:`nilearn.signal.clean`
 
 
-
-
 Resampling: resizing and changing resolutions of images
 .......................................................
 
@@ -444,8 +442,16 @@ as to facilitate the computation of :term:`voxel` signals in multi-subjects sett
 While :class:`NiftiMasker`, :class:`NiftiLabelsMasker` and
 :class:`NiftiMapsMasker` work with 3D inputs (single brain volume) or 4D inputs
 (sequence of brain volumes in time for one subject), :class:`MultiNiftiMasker`,
-:class:`MultiNiftiLabelsMasker` and :class:`MultiNiftiMapsMasker` expect 5D
-inputs (list of sequences of brain volumes).
+:class:`MultiNiftiLabelsMasker` and :class:`MultiNiftiMapsMasker`
+can also handle list of 3D or 4D image objects.
+
+.. tip::
+    MultiMasker objects can transform both 3D, 4D,
+    as well as list of 3D or 4D image objects.
+    Transforming a 3D image produces a 1D (features,) array.
+    Transforming a 4D image produces a 2D (samples, features) array.
+    Transforming a list of 3D image produces a list of 1D (features,) array.
+    Transforming a list of 4D image produces a list of 2D (samples, features) array.
 
 :class:`MultiNiftiMasker` Usage
 -------------------------------
@@ -503,3 +509,22 @@ seed position is used.
 .. topic:: **Examples**
 
   * :ref:`sphx_glr_auto_examples_03_connectivity_plot_sphere_based_connectome.py`
+
+
+Extraction of signals from surface images\  :class:`SurfaceMasker`, :class:`SurfaceLabelsMasker`, :class:`SurfaceMapsMasker`
+============================================================================================================================
+
+The purpose of :class:`SurfaceMasker`, :class:`SurfaceLabelsMasker`, :class:`SurfaceMapsMasker`
+is to mirror the capabilities of
+:class:`NiftiMasker`, :class:`NiftiLabelsMasker` and :class:`NiftiMapsMasker`
+but to extract data from :class:`~nilearn.surface.SurfaceImage`.
+
+They can perform data extraction from 1D surface data (n_vertices),
+2D surface data (n_vertices x samples)
+as well as list of 1D or 2D surface data with the same underlying mesh.
+
+.. tip::
+    Surface objects can transform both 1D, 2D,
+    as well as list of 1D or 2D surface image objects.
+    Transforming a 1D image produces a 1D (features,) array.
+    All other input will produce a 1D (samples, features) array..

--- a/doc/manipulating_images/masker_objects.rst
+++ b/doc/manipulating_images/masker_objects.rst
@@ -1,8 +1,8 @@
 .. _masker_objects:
 
-=====================================================================
+================================================================
 From neuroimaging volumes to data matrices: the masker objects
-=====================================================================
+================================================================
 
 This chapter introduces the maskers: objects that go from
 neuroimaging volumes, on the disk or in memory, to data matrices, eg of
@@ -24,9 +24,10 @@ the raw neuroimaging data in 3D space into the units of observation
 relevant for the research questions at hand.
 
 .. tip::
-    Masker objects can transform both 3D and 4D image objects.
-    Transforming a 3D image produces a 1D (features,) array.
-    Transforming a 4D image produces a 2D (samples, features) array.
+    Masker objects can transform both 3D and 4D image objects :
+
+    - transforming a 3D image produces a 1D (features,) array,
+    - transforming a 4D image produces a 2D (samples, features) array.
 
 
 .. |niimgs| image:: ../images/niimgs.jpg
@@ -340,9 +341,10 @@ an excerpt of :ref:`the example performing Anova-SVM on the Haxby data
 |
 
 .. tip::
-    Masker objects can inverse-transform both 1D and 2D arrays.
-    Inverse-transforming a 2D array produces a 4D (X x Y x Z x samples) image,
-    while inverse-transforming a 1D array produces a 3D (X x Y x Z) image.
+    Masker objects can inverse-transform both 1D and 2D arrays :
+
+    - inverse-transforming a 2D array produces a 4D (X x Y x Z x samples) image,
+    - inverse-transforming a 1D array produces a 3D (X x Y x Z) image.
 
 .. topic:: **Examples to better understand the NiftiMasker**
 
@@ -447,11 +449,12 @@ can also handle list of 3D or 4D image objects.
 
 .. tip::
     MultiMasker objects can transform both 3D, 4D,
-    as well as list of 3D or 4D image objects.
-    Transforming a 3D image produces a 1D (features,) array.
-    Transforming a 4D image produces a 2D (samples, features) array.
-    Transforming a list of 3D image produces a list of 1D (features,) array.
-    Transforming a list of 4D image produces a list of 2D (samples, features) array.
+    as well as list of 3D or 4D image objects :
+
+    - transforming a 3D image produces a 1D (features,) array,
+    - transforming a 4D image produces a 2D (samples, features) array,
+    - transforming a list of 3D image produces a list of 1D (features,) array,
+    - transforming a list of 4D image produces a list of 2D (samples, features) array.
 
 :class:`MultiNiftiMasker` Usage
 -------------------------------
@@ -475,7 +478,7 @@ for each subject.
     * :ref:`sphx_glr_auto_examples_03_connectivity_plot_atlas_comparison.py`
 
 :class:`MultiNiftiMapsMasker` Usage
--------------------------------------
+-----------------------------------
 
 :class:`MultiNiftiMapsMasker` extracts signals regions defined by maps
 for each subject.
@@ -524,7 +527,12 @@ They can perform data extraction from 1D surface data (n_vertices),
 as well as list of 1D or 2D surface data with the same underlying mesh.
 
 .. tip::
-    Surface objects can transform both 1D, 2D,
+    Surface masker objects can transform both 1D, 2D,
     as well as list of 1D or 2D surface image objects.
     Transforming a 1D image produces a 1D (features,) array.
     All other input will produce a 1D (samples, features) array..
+
+    Surface masker objects can inverse-transform both 1D and 2D arrays :
+
+    - inverse-transforming a 1D array produces a 1D (n_vertices,) image,
+    - inverse-transforming a 2D array produces a 2D (n_vertices, samples) image.

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -1239,7 +1239,7 @@ y : None
 
 ##############################################################################
 #
-# Other values definitions
+# Other values definitions: return values, attributes...
 #
 
 # atlas_type
@@ -1379,6 +1379,17 @@ docdict["lut"] = """lut : :obj:`pandas.DataFrame`
         with at least columns 'index' and 'name'.
         Formatted according to 'dseg.tsv' format from
         `BIDS <https://bids-specification.readthedocs.io/en/latest/derivatives/imaging.html#common-image-derived-labels>`_."""
+
+# signals returned Nifti maskers by transform, fit_transform...
+docdict["signals_transform_nifti"] = """signals : :obj:`numpy.ndarray`
+        Signal for each :term:`voxel`.
+        shape for 4D images : (number of scans, number of elements)
+        shape for 3D images : (number of elements,)"""
+# signals returned surface maskers by transform, fit_transform...
+docdict["signals_transform_surface"] = """signals : :obj:`numpy.ndarray`
+        Signal for each element.
+        shape for 2D images : (number of scans, number of elements)
+        shape for 1D images : (number of elements,)"""
 
 # template
 docdict["template"] = """'template' : :obj:`str`

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -1358,6 +1358,29 @@ docdict["fsaverage_options"] = """
 
 """
 
+# image returned Nifti maskers by inverse_transform
+docdict["img_inv_transform_nifti"] = """img : :obj:`nibabel.nifti1.Nifti1Image`
+        Transformed image in brain space.
+        Output shape for :
+
+        - 1D array : 3D :obj:`nibabel.nifti1.Nifti1Image` will be returned.
+        - 2D array : 4D :obj:`nibabel.nifti1.Nifti1Image` will be returned.
+
+        See :ref:`extracting_data`.
+        """
+# image returned surface maskers by inverse_transform
+docdict[
+    "img_inv_transform_surface"
+] = """img : :obj:`~nilearn.surface.SurfaceImage`
+        Signal for each vertex projected on the mesh.
+        Output shape for :
+
+        - 1D array : 1D :obj:`~nilearn.surface.SurfaceImage` will be returned.
+        - 2D array : 2D :obj:`~nilearn.surface.SurfaceImage` will be returned.
+
+        See :ref:`extracting_data`.
+        """
+
 # atlas labels
 docdict["labels"] = """'labels' : :obj:`list` of :obj:`str`
         List of the names of the regions."""

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -973,6 +973,19 @@ docdict["second_level_mask"] = docdict["second_level_mask_img"].replace(
     "mask_img :", "mask :"
 )
 
+# signals for inverse transform
+docdict["signals_inv_transform"] = """
+signals : 1D/2D :obj:`numpy.ndarray`
+    Extracted signal.
+    If a 1D array is provided,
+    then the shape should be (number of elements,).
+    If a 2D array is provided,
+    then the shape should be (number of scans, number of elements).
+"""
+docdict["region_signals_inv_transform"] = docdict["signals_inv_transform"]
+docdict["x_inv_transform"] = docdict["signals_inv_transform"]
+
+
 # smoothing_fwhm
 docdict["smoothing_fwhm"] = """
 smoothing_fwhm : :obj:`float` or :obj:`int` or None, optional.

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -1383,13 +1383,43 @@ docdict["lut"] = """lut : :obj:`pandas.DataFrame`
 # signals returned Nifti maskers by transform, fit_transform...
 docdict["signals_transform_nifti"] = """signals : :obj:`numpy.ndarray`
         Signal for each :term:`voxel`.
-        shape for 4D images : (number of scans, number of elements)
-        shape for 3D images : (number of elements,)"""
+        Output shape for :
+
+        - 3D images: (number of elements,) array
+        - 4D images: (number of scans, number of elements) array
+        """
+# signals returned Mulit Nifti maskers by transform, fit_transform...
+docdict[
+    "signals_transform_multi_nifti"
+] = """signals : :obj:`list` of :obj:`numpy.ndarray` or :obj:`numpy.ndarray`
+        Signal for each :term:`voxel`.
+        Output shape for :
+
+        - 3D images: (number of elements,) array
+        - 4D images: (number of scans, number of elements) array
+        - list of 3D images: list of (number of elements,) array
+        - list of 4D images: list of (number of scans, number of elements)
+          array
+        """
+# signals returned Mulit Nifti maskers by transform, fit_transform...
+docdict[
+    "signals_transform_imgs_multi_nifti"
+] = """signals : :obj:`list` of :obj:`numpy.ndarray`
+        Signal for each :term:`voxel`.
+        Output shape for :
+
+        - list of 3D images: list of (number of elements,) array
+        - list of 4D images: list of (number of scans, number of elements)
+          array
+        """
 # signals returned surface maskers by transform, fit_transform...
 docdict["signals_transform_surface"] = """signals : :obj:`numpy.ndarray`
         Signal for each element.
-        shape for 2D images : (number of scans, number of elements)
-        shape for 1D images : (number of elements,)"""
+        Output shape for :
+
+        - 1D images: (number of elements,) array
+        - 2D images: (number of scans, number of elements) array
+        """
 
 # template
 docdict["template"] = """'template' : :obj:`str`

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1203,7 +1203,7 @@ def check_masker_inverse_transform(estimator):
         mask_img = _make_surface_mask()
 
         expected_shapes = [
-            (imgs.shape[0], 1),
+            (imgs.shape[0],),
             (imgs.shape[0], 1),
             (imgs.shape[0], 10),
         ]

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1203,7 +1203,7 @@ def check_masker_inverse_transform(estimator):
         - 2D arrays -> 4D images
 
     For surface maskers:
-        - 1D arrays -> 2D images (Should we return 1D?)
+        - 1D arrays -> 1D
         - 2D arrays -> 2D images
 
     Check that running transform() is not required to run inverse_transform().

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1122,9 +1122,6 @@ def check_masker_smooth(estimator):
 
     signal = estimator.fit_transform(imgs)
 
-    assert isinstance(signal, np.ndarray)
-    assert signal.shape == (estimator.n_elements_,)
-
     estimator.smoothing_fwhm = 3
     estimator.fit(imgs)
 
@@ -1140,9 +1137,6 @@ def check_masker_smooth(estimator):
             smoothed_signal = estimator.transform(imgs)
 
         assert_array_equal(smoothed_signal, signal)
-
-    assert isinstance(signal, np.ndarray)
-    assert signal.shape == (estimator.n_elements_,)
 
 
 def check_masker_inverse_transform(estimator):

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1287,15 +1287,27 @@ def check_nifti_masker_fit_transform(estimator):
     # 4D images
     signal = estimator.transform([_img_3d_rand(), _img_3d_rand()])
 
+    if is_multimasker(estimator):
+        signal = signal[0]
     assert isinstance(signal, np.ndarray)
-    assert signal.ndim == 2
-    assert signal.shape[1] == estimator.n_elements_
+    if is_multimasker(estimator):
+        assert signal.ndim == 1
+        assert signal.shape == (estimator.n_elements_,)
+    else:
+        assert signal.ndim == 2
+        assert signal.shape[1] == estimator.n_elements_
 
     signal = estimator.transform(_img_4d_rand_eye())
 
+    if is_multimasker(estimator):
+        signal = signal[0]
     assert isinstance(signal, np.ndarray)
-    assert signal.ndim == 2
-    assert signal.shape[1] == estimator.n_elements_
+    if is_multimasker(estimator):
+        assert signal.ndim == 1
+        assert signal.shape == (estimator.n_elements_,)
+    else:
+        assert signal.ndim == 2
+        assert signal.shape[1] == estimator.n_elements_
 
 
 def check_nifti_masker_fit_transform_5d(estimator):

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -39,6 +39,7 @@ from nilearn.conftest import (
     _img_4d_rand_eye,
     _img_4d_rand_eye_medium,
     _img_mask_mni,
+    _make_mesh,
     _make_surface_img,
     _make_surface_img_and_design,
     _make_surface_mask,
@@ -1293,7 +1294,7 @@ def check_surface_masker_fit_with_mask(estimator):
 
     Check with 2D and 1D images.
 
-    1D image -> 2D array
+    1D image -> 1D array
     2D image -> 2D array
 
     Also check 'shape' errors between images to fit and mask.
@@ -1301,6 +1302,21 @@ def check_surface_masker_fit_with_mask(estimator):
     mask_img = _make_surface_mask()
 
     # 1D image
+    mesh = _make_mesh()
+    data = {}
+    for k, v in mesh.parts.items():
+        data_shape = (v.n_vertices,)
+        data[k] = _rng().random(data_shape)
+    imgs = SurfaceImage(mesh, data)
+    assert imgs.shape == (9,)
+    estimator.fit(imgs)
+
+    signal = estimator.transform(imgs)
+
+    assert isinstance(signal, np.ndarray)
+    assert signal.shape == (estimator.n_elements_,)
+
+    # 2D image with 1 sample
     imgs = _make_surface_img(1)
     estimator.mask_img = mask_img
     estimator.fit(imgs)
@@ -1310,7 +1326,7 @@ def check_surface_masker_fit_with_mask(estimator):
     assert isinstance(signal, np.ndarray)
     assert signal.shape == (1, estimator.n_elements_)
 
-    # 2D image
+    # 2D image with several samples
     imgs = _make_surface_img(5)
     estimator = clone(estimator)
     estimator.mask_img = mask_img

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1383,16 +1383,14 @@ def check_nifti_masker_fit_transform(estimator):
     # 4D images
     signal = estimator.transform(_img_4d_rand_eye())
 
-    if is_multimasker(estimator):
-        assert len(signal) == _img_4d_rand_eye().shape[3]
-        signal = signal[0]
-
     assert isinstance(signal, np.ndarray)
+    assert signal.ndim == 2
     if is_multimasker(estimator):
-        assert signal.ndim == 1
-        assert signal.shape == (estimator.n_elements_,)
+        assert signal.shape == (
+            _img_4d_rand_eye().shape[3],
+            estimator.n_elements_,
+        )
     else:
-        assert signal.ndim == 2
         assert signal.shape[1] == estimator.n_elements_
 
 

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1344,11 +1344,10 @@ def check_surface_masker_fit_with_mask(estimator):
 def check_nifti_masker_fit_transform(estimator):
     """Run several checks on maskers.
 
-    - can fit 3D image
+    - can fit 3D / 4D image
     - fitted maskers can transform:
       - 3D image
       - list of 3D images with same affine
-    - can fit transform 3D image
     - array from transformed 3D images should have 1D
     - array from transformed 4D images should have 2D
     """
@@ -1365,11 +1364,14 @@ def check_nifti_masker_fit_transform(estimator):
     assert isinstance(signal, np.ndarray)
     assert signal.shape == (estimator.n_elements_,)
 
-    # 4D images
+    # list of 3D images
     signal = estimator.transform([_img_3d_rand(), _img_3d_rand()])
 
     if is_multimasker(estimator):
+        assert isinstance(signal, list)
+        assert len(signal) == 2
         signal = signal[0]
+
     assert isinstance(signal, np.ndarray)
     if is_multimasker(estimator):
         assert signal.ndim == 1
@@ -1378,10 +1380,13 @@ def check_nifti_masker_fit_transform(estimator):
         assert signal.ndim == 2
         assert signal.shape[1] == estimator.n_elements_
 
+    # 4D images
     signal = estimator.transform(_img_4d_rand_eye())
 
     if is_multimasker(estimator):
+        assert len(signal) == _img_4d_rand_eye().shape[3]
         signal = signal[0]
+
     assert isinstance(signal, np.ndarray)
     if is_multimasker(estimator):
         assert signal.ndim == 1
@@ -1395,7 +1400,7 @@ def check_nifti_masker_fit_transform_5d(estimator):
     """Run checks on nifti maskers for transforming 5D images.
 
     - multi masker should be fine
-      and return a list of numpy arrays
+      and return a list of 2D numpy arrays
     - non multimasker should fail
     """
     n_subject = 3

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1114,18 +1114,16 @@ def check_masker_smooth(estimator):
     """
     assert hasattr(estimator, "smoothing_fwhm")
 
+    n_sample = 1
     if accept_niimg_input(estimator):
-        n_sample = 1
         imgs = _img_3d_rand()
     else:
-        n_sample = 10
         imgs = _make_surface_img(n_sample)
 
     signal = estimator.fit_transform(imgs)
 
     assert isinstance(signal, np.ndarray)
-    n_elements = estimator.n_elements_
-    assert signal.shape == (n_sample, n_elements)
+    assert signal.shape == (estimator.n_elements_,)
 
     estimator.smoothing_fwhm = 3
     estimator.fit(imgs)
@@ -1144,7 +1142,7 @@ def check_masker_smooth(estimator):
         assert_array_equal(smoothed_signal, signal)
 
     assert isinstance(signal, np.ndarray)
-    assert signal.shape == (n_sample, estimator.n_elements_)
+    assert signal.shape == (estimator.n_elements_,)
 
 
 def check_masker_inverse_transform(estimator):
@@ -1270,28 +1268,34 @@ def check_nifti_masker_fit_transform(estimator):
       - 3D image
       - list of 3D images with same affine
     - can fit transform 3D image
+    - array from transformed 3D images should have 1D
+    - array from transformed 4D images should have 2D
     """
     estimator.fit(_img_3d_rand())
 
+    # 3D images
     signal = estimator.transform(_img_3d_rand())
 
     assert isinstance(signal, np.ndarray)
-    assert signal.shape == (1, estimator.n_elements_)
+    assert signal.shape == (estimator.n_elements_,)
 
-    estimator.transform([_img_3d_rand(), _img_3d_rand()])
-
-    assert isinstance(signal, np.ndarray)
-    assert signal.shape == (1, estimator.n_elements_)
-
-    estimator.transform(_img_4d_rand_eye())
+    signal = estimator.fit_transform(_img_3d_rand())
 
     assert isinstance(signal, np.ndarray)
-    assert signal.shape == (1, estimator.n_elements_)
+    assert signal.shape == (estimator.n_elements_,)
 
-    estimator.fit_transform(_img_3d_rand())
+    # 4D images
+    signal = estimator.transform([_img_3d_rand(), _img_3d_rand()])
 
     assert isinstance(signal, np.ndarray)
-    assert signal.shape == (1, estimator.n_elements_)
+    assert signal.ndim == 2
+    assert signal.shape[1] == estimator.n_elements_
+
+    signal = estimator.transform(_img_4d_rand_eye())
+
+    assert isinstance(signal, np.ndarray)
+    assert signal.ndim == 2
+    assert signal.shape[1] == estimator.n_elements_
 
 
 def check_nifti_masker_fit_transform_5d(estimator):

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1340,14 +1340,14 @@ def check_nifti_masker_fit_transform_5d(estimator):
         assert isinstance(signal, list)
         assert all(isinstance(x, np.ndarray) for x in signal)
         assert len(signal) == n_subject
-        assert all(x.dim == 2 for x in signal)
+        assert all(x.ndim == 2 for x in signal)
 
         signal = estimator.fit_transform(input_5d_img)
 
         assert isinstance(signal, list)
         assert all(isinstance(x, np.ndarray) for x in signal)
         assert len(signal) == n_subject
-        assert all(x.dim == 2 for x in signal)
+        assert all(x.ndim == 2 for x in signal)
 
 
 def check_nifti_masker_clean_error(estimator):

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1346,12 +1346,14 @@ def check_nifti_masker_fit_transform_5d(estimator):
         assert isinstance(signal, list)
         assert all(isinstance(x, np.ndarray) for x in signal)
         assert len(signal) == n_subject
+        assert all(x.dim == 2 for x in signal)
 
         signal = estimator.fit_transform(input_5d_img)
 
         assert isinstance(signal, list)
         assert all(isinstance(x, np.ndarray) for x in signal)
         assert len(signal) == n_subject
+        assert all(x.dim == 2 for x in signal)
 
 
 def check_nifti_masker_clean_error(estimator):

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1203,7 +1203,7 @@ def check_masker_inverse_transform(estimator):
         - 2D arrays -> 4D images
 
     For surface maskers:
-        - 1D arrays -> 1D
+        - 1D arrays -> 1D images
         - 2D arrays -> 2D images
 
     Check that running transform() is not required to run inverse_transform().

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1420,13 +1420,12 @@ def check_nifti_masker_fit_transform(estimator):
     if is_multimasker(estimator):
         assert isinstance(signal, list)
         assert len(signal) == 2
-        signal = signal[0]
-
-    assert isinstance(signal, np.ndarray)
-    if is_multimasker(estimator):
-        assert signal.ndim == 1
-        assert signal.shape == (estimator.n_elements_,)
+        for x in signal:
+            assert isinstance(x, np.ndarray)
+            assert x.ndim == 1
+            assert x.shape == (estimator.n_elements_,)
     else:
+        assert isinstance(signal, np.ndarray)
         assert signal.ndim == 2
         assert signal.shape[1] == estimator.n_elements_
 

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1385,13 +1385,7 @@ def check_nifti_masker_fit_transform(estimator):
 
     assert isinstance(signal, np.ndarray)
     assert signal.ndim == 2
-    if is_multimasker(estimator):
-        assert signal.shape == (
-            _img_4d_rand_eye().shape[3],
-            estimator.n_elements_,
-        )
-    else:
-        assert signal.shape[1] == estimator.n_elements_
+    assert signal.shape == (_img_4d_rand_eye().shape[3], estimator.n_elements_)
 
 
 def check_nifti_masker_fit_transform_5d(estimator):

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1194,7 +1194,7 @@ def check_masker_smooth(estimator):
 
 
 def check_masker_inverse_transform(estimator):
-    """Check output of inverse transform.
+    """Check output of inverse_transform.
 
     For signal with 1 or more samples.
 

--- a/nilearn/conftest.py
+++ b/nilearn/conftest.py
@@ -636,8 +636,7 @@ def _make_surface_mask(n_zeros=4):
     return SurfaceImage(mesh, data)
 
 
-@pytest.fixture
-def surf_mask_1d():
+def _surf_mask_1d():
     """Create a sample surface mask using the sample mesh.
     This will create a mask with n_zeros zeros (default is 4) and the
     rest ones.
@@ -649,6 +648,17 @@ def surf_mask_1d():
     mask.data.parts["right"] = np.squeeze(mask.data.parts["right"])
 
     return mask
+
+
+@pytest.fixture
+def surf_mask_1d():
+    """Create a sample surface mask using the sample mesh.
+    This will create a mask with n_zeros zeros (default is 4) and the
+    rest ones.
+
+    The shape of the data will be (n_vertices,).
+    """
+    return _surf_mask_1d()
 
 
 @pytest.fixture

--- a/nilearn/decomposition/_base.py
+++ b/nilearn/decomposition/_base.py
@@ -234,6 +234,7 @@ def _mask_and_reduce_single(
 ):
     """Implement multiprocessing from MaskReducer."""
     this_data = masker.transform(img, confound)
+    this_data = np.atleast_2d(this_data)
     # Now get rid of the img as fast as possible, to free a
     # reference count on it, and possibly free the corresponding
     # data

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -285,8 +285,7 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
         imgs : 3D/4D Niimg-like object
             See :ref:`extracting_data`.
             Images to process.
-            If a 3D niimg is provided, a singleton dimension will be added to
-            the output to represent the single scan in the niimg.
+            If a 3D niimg is provided, a 1D array is returned.
 
         %(confounds)s
 
@@ -296,10 +295,10 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
 
         Returns
         -------
-        region_signals : 2D numpy.ndarray
+        region_signals : numpy.ndarray
             Signal for each element.
-            shape: (number of scans, number of elements)
-
+            shape for 4D images : (number of scans, number of elements)
+            shape for 3D images : (number of elements,)
         """
         check_is_fitted(self)
 
@@ -346,7 +345,7 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
 
         Returns
         -------
-        X_new : numpy array of shape [n_samples, n_features_new]
+        X_new : numpy array
             Transformed array.
 
         """

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -398,7 +398,9 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
         """
         check_is_fitted(self)
 
-        X = self._check_array(X)
+        # do not run sklearn_check as they may cause some failure
+        # with some GLM inputs
+        X = self._check_array(X, sklearn_check=False)
 
         img = self._cache(unmask)(X, self.mask_img_)
         # Be robust again memmapping that will create read-only arrays in
@@ -407,10 +409,21 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
             img._header._structarr = np.array(img._header._structarr).copy()
         return img
 
-    def _check_array(self, signals: np.ndarray):
-        """Check array to inverse transform."""
+    def _check_array(self, signals: np.ndarray, sklearn_check: bool = True):
+        """Check array to inverse transform.
+
+        Parameters
+        ----------
+        signals : :obj:`numpy.ndarray`
+
+        sklearn_check : :obj:`bool`
+            Run scikit learn check on input
+        """
         signals = np.atleast_1d(signals)
-        signals = check_array(signals, ensure_2d=False)
+
+        if sklearn_check:
+            signals = check_array(signals, ensure_2d=False)
+
         assert signals.ndim <= 2
 
         expected_shape = (
@@ -613,9 +626,21 @@ class _BaseSurfaceMasker(TransformerMixin, CacheMixin, BaseEstimator):
         del y
         return self.fit(imgs).transform(imgs, confounds, sample_mask)
 
-    def _check_array(self, signals: np.ndarray):
+    def _check_array(self, signals: np.ndarray, sklearn_check: bool = True):
+        """Check array to inverse transform.
+
+        Parameters
+        ----------
+        signals : :obj:`numpy.ndarray`
+
+        sklearn_check : :obj:`bool`
+            Run scikit learn check on input
+        """
         signals = np.atleast_2d(signals)
-        signals = check_array(signals, ensure_2d=True)
+
+        if sklearn_check:
+            signals = check_array(signals, ensure_2d=False)
+
         if signals.shape[-1] != self.n_elements_:
             raise ValueError(
                 "Input to 'inverse_transform' has wrong shape.\n"

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -227,7 +227,6 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
         imgs : 3D/4D Niimg-like object
             See :ref:`extracting_data`.
             Images to process.
-            If a 3D niimg is provided, a 1D array is returned.
 
         %(confounds)s
 

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -405,8 +405,9 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
             imgs, confounds=confounds, sample_mask=sample_mask
         )
 
+    @fill_doc
     def inverse_transform(self, X):
-        """Transform the 2D data matrix back to an image in brain space.
+        """Transform the data matrix back to an image in brain space.
 
         This step only performs spatial unmasking,
         without inverting any additional processing performed by ``transform``,
@@ -414,9 +415,7 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : 1D/2D :obj:`numpy.ndarray`
-            Signal for each element in the mask.
-
+        %(x_inv_transform)s
 
         Returns
         -------

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -407,11 +407,12 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
         return img
 
     def _check_signal_shape(self, signals: np.ndarray):
-        expected_shape = (
-            (signals.shape[0], self.n_elements_)
-            if signals.ndim == 2
-            else (self.n_elements_,)
-        )
+        if signals.ndim == 2:
+            expected_shape = (signals.shape[0], self.n_elements_)
+        elif signals.ndim == 1:
+            expected_shape = (self.n_elements_,)
+        elif signals.ndim == 0:
+            expected_shape = ()
         if signals.shape != expected_shape:
             raise ValueError(
                 "Input to 'inverse_transform' has wrong shape.\n"

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -407,12 +407,13 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
         return img
 
     def _check_signal_shape(self, signals: np.ndarray):
-        if signals.ndim == 2:
-            expected_shape = (signals.shape[0], self.n_elements_)
-        elif signals.ndim == 1:
-            expected_shape = (self.n_elements_,)
-        elif signals.ndim == 0:
-            expected_shape = ()
+        assert signals.ndim in [1, 2]
+        expected_shape = (
+            (self.n_elements_,)
+            if signals.ndim == 1
+            else (signals.shape[0], self.n_elements_)
+        )
+
         if signals.shape != expected_shape:
             raise ValueError(
                 "Input to 'inverse_transform' has wrong shape.\n"

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -179,15 +179,14 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
     def transform_single_imgs(
         self, imgs, confounds=None, sample_mask=None, copy=True
     ):
-        """Extract signals from a single 4D niimg.
+        """Extract signals from a single niimg.
 
         Parameters
         ----------
         imgs : 3D/4D Niimg-like object
             See :ref:`extracting_data`.
             Images to process.
-            If a 3D niimg is provided, a singleton dimension will be added to
-            the output to represent the single scan in the niimg.
+            If a 3D niimg is provided, a 1D array is returned.
 
         %(confounds)s
 
@@ -200,17 +199,10 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
 
         Returns
         -------
-        region_signals : 2D numpy.ndarray
+        signals : numpy.ndarray
             Signal for each element.
-            shape: (number of scans, number of elements)
-
-        Warns
-        -----
-        DeprecationWarning
-            If a 3D niimg input is provided, the current behavior
-            (adding a singleton dimension to produce a 2D array) is deprecated.
-            Starting in version 0.12, a 1D array will be returned for 3D
-            inputs.
+            shape for 4D images : (number of scans, number of elements)
+            shape for 3D images : (number of elements,)
 
         """
         raise NotImplementedError()

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -240,10 +240,7 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
 
         Returns
         -------
-        signals : numpy.ndarray
-            Signal for each element.
-            shape for 4D images : (number of scans, number of elements)
-            shape for 3D images : (number of elements,)
+        %(signals_transform_nifti)s
 
         """
         raise NotImplementedError()
@@ -328,10 +325,7 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
 
         Returns
         -------
-        region_signals : numpy.ndarray
-            Signal for each element.
-            shape for 4D images : (number of scans, number of elements)
-            shape for 3D images : (number of elements,)
+        %(signals_transform_nifti)s
         """
         check_is_fitted(self)
 
@@ -378,8 +372,7 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
 
         Returns
         -------
-        X_new : numpy array
-            Transformed array.
+        %(signals_transform_nifti)s
 
         """
         # non-optimized default implementation; override when a better
@@ -587,10 +580,7 @@ class _BaseSurfaceMasker(TransformerMixin, CacheMixin, BaseEstimator):
 
         Returns
         -------
-        region_signals : numpy.ndarray
-            Signal for each element.
-            shape for 2D images : (number of scans, number of elements)
-            shape for 1D images : (number of elements,)
+        %(signals_transform_surface)s
         """
         check_is_fitted(self)
 
@@ -671,13 +661,7 @@ class _BaseSurfaceMasker(TransformerMixin, CacheMixin, BaseEstimator):
 
         Returns
         -------
-        signals: :obj:`numpy.ndarray`
-            Signal for each region as provided
-            in the mask, label or maps image.
-            The shape will vary depending on the masker type:
-            - SurfaceMasker: (n_timepoints, n_vertices_in_mask)
-            - SurfaceLabelsMasker: (n_timepoints, n_regions)
-            - SurfaceMapssMasker: (n_timepoints, n_maps)
+        %(signals_transform_surface)s
         """
         del y
         return self.fit(imgs).transform(imgs, confounds, sample_mask)

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -545,10 +545,10 @@ class _BaseSurfaceMasker(TransformerMixin, CacheMixin, BaseEstimator):
 
         Returns
         -------
-        region_signals : 2D numpy.ndarray
+        region_signals : numpy.ndarray
             Signal for each element.
-            shape: (number of scans, number of elements)
-
+            shape for 2D images : (number of scans, number of elements)
+            shape for 1D images : (number of elements,)
         """
         check_is_fitted(self)
 

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -451,7 +451,6 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
         raise NotImplementedError()
 
 
-
 class _BaseSurfaceMasker(TransformerMixin, CacheMixin, BaseEstimator):
     """Class from which all surface maskers should inherit."""
 
@@ -659,7 +658,6 @@ class _BaseSurfaceMasker(TransformerMixin, CacheMixin, BaseEstimator):
             )
 
         return signals
-
 
     def set_output(self, *, transform=None):
         """Set the output container when ``"transform"`` is called.

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -92,17 +92,6 @@ def filter_and_extract(
     # coerce 5D data to 4D, which we don't want.
     temp_imgs = check_niimg(imgs)
 
-    # Raise warning if a 3D niimg is provided.
-    if temp_imgs.ndim == 3:
-        warnings.warn(
-            "Starting in version 0.12, 3D images will be transformed to "
-            "1D arrays. "
-            "Until then, 3D images will be coerced to 2D arrays, with a "
-            "singleton first dimension representing time.",
-            DeprecationWarning,
-            stacklevel=find_stack_level(),
-        )
-
     imgs = check_niimg(imgs, atleast_4d=True, ensure_ndim=4, dtype=dtype)
 
     target_shape = parameters.get("target_shape")
@@ -174,6 +163,9 @@ def filter_and_extract(
         runs=runs,
         **parameters["clean_kwargs"],
     )
+
+    if temp_imgs.ndim == 3:
+        region_signals = region_signals.squeeze()
 
     return region_signals, aux
 
@@ -307,14 +299,6 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
         region_signals : 2D numpy.ndarray
             Signal for each element.
             shape: (number of scans, number of elements)
-
-        Warns
-        -----
-        DeprecationWarning
-            If a 3D niimg input is provided, the current behavior
-            (adding a singleton dimension to produce a 2D array) is deprecated.
-            Starting in version 0.12, a 1D array will be returned for 3D
-            inputs.
 
         """
         check_is_fitted(self)

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -407,11 +407,16 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
         return img
 
     def _check_signal_shape(self, signals: np.ndarray):
-        if signals.shape[-1] != self.n_elements_:
+        expected_shape = (
+            (signals.shape[0], self.n_elements_)
+            if signals.ndim == 2
+            else (self.n_elements_,)
+        )
+        if signals.shape != expected_shape:
             raise ValueError(
                 "Input to 'inverse_transform' has wrong shape.\n"
-                f"Last dimension should be {self.n_elements_}.\n"
-                f"Got {signals.shape[-1]}."
+                f"Expected {expected_shape}.\n"
+                f"Got {signals.shape}."
             )
 
 

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -417,16 +417,11 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
         ----------
         X : 1D/2D :obj:`numpy.ndarray`
             Signal for each element in the mask.
-            If a 1D array is provided, then the shape should be
-            (number of elements,), and a 3D img will be returned.
-            If a 2D array is provided, then the shape should be
-            (number of scans, number of elements), and a 4D img will be
-            returned.
-            See :ref:`extracting_data`.
+
 
         Returns
         -------
-        img : Transformed image in brain space.
+        %(img_inv_transform_nifti)s
 
         """
         check_is_fitted(self)

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -613,10 +613,13 @@ class _BaseSurfaceMasker(TransformerMixin, CacheMixin, BaseEstimator):
         del y
         return self.fit(imgs).transform(imgs, confounds, sample_mask)
 
-    def _check_signal_shape(self, signals: np.ndarray):
+    def _check_array(self, signals: np.ndarray):
+        signals = np.atleast_2d(signals)
+        signals = check_array(signals, ensure_2d=True)
         if signals.shape[-1] != self.n_elements_:
             raise ValueError(
                 "Input to 'inverse_transform' has wrong shape.\n"
                 f"Last dimension should be {self.n_elements_}.\n"
                 f"Got {signals.shape[-1]}."
             )
+        return signals

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -409,7 +409,9 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
             img._header._structarr = np.array(img._header._structarr).copy()
         return img
 
-    def _check_array(self, signals: np.ndarray, sklearn_check: bool = True):
+    def _check_array(
+        self, signals: np.ndarray, sklearn_check: bool = True
+    ) -> np.ndarray:
         """Check array to inverse transform.
 
         Parameters
@@ -640,7 +642,9 @@ class _BaseSurfaceMasker(TransformerMixin, CacheMixin, BaseEstimator):
         del y
         return self.fit(imgs).transform(imgs, confounds, sample_mask)
 
-    def _check_array(self, signals: np.ndarray, sklearn_check: bool = True):
+    def _check_array(
+        self, signals: np.ndarray, sklearn_check: bool = True
+    ) -> np.ndarray:
         """Check array to inverse transform.
 
         Parameters

--- a/nilearn/maskers/multi_nifti_labels_masker.py
+++ b/nilearn/maskers/multi_nifti_labels_masker.py
@@ -194,9 +194,11 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
 
         Returns
         -------
-        region_signals: list of 2D :obj:`numpy.ndarray`
+        region_signals: list of :obj:`numpy.ndarray`
             List of signals for each label per subject.
-            shape: list of (number of scans, number of labels)
+            Arrays from 4D images
+            have shape (number of scans, number of labels)
+            while those from 3D images have shape (number of labels,).
 
         """
         # We handle the resampling of labels separately because the affine of
@@ -250,9 +252,11 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
 
         Returns
         -------
-        region_signals : list of 2D :obj:`numpy.ndarray`
+        signals : list of :obj:`numpy.ndarray`
             List of signals for each label per subject.
-            shape: list of (number of scans, number of labels)
+            Arrays from 4D images
+            have shape (number of scans, number of labels)
+            while those from 3D images have shape (number of labels,).
 
         """
         check_is_fitted(self)

--- a/nilearn/maskers/multi_nifti_labels_masker.py
+++ b/nilearn/maskers/multi_nifti_labels_masker.py
@@ -198,11 +198,7 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
 
         Returns
         -------
-        region_signals: list of :obj:`numpy.ndarray`
-            List of signals for each label per subject.
-            Arrays from 4D images
-            have shape (number of scans, number of labels)
-            while those from 3D images have shape (number of labels,).
+        %(signals_transform_imgs_multi_nifti)s
 
         """
         # We handle the resampling of labels separately because the affine of
@@ -251,11 +247,7 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
 
         Returns
         -------
-        signals : list of :obj:`numpy.ndarray`
-            List of signals for each label per subject.
-            Arrays from 4D images
-            have shape (number of scans, number of labels)
-            while those from 3D images have shape (number of labels,).
+        %(signals_transform_multi_nifti)s
 
         """
         check_is_fitted(self)
@@ -309,12 +301,7 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
 
         Returns
         -------
-        signals : :obj:`numpy.ndarray` if a Niimg-like object was passed, \
-                  a :obj:`list` of :obj:`numpy.ndarray` otherwise \
-                  (one array for each subject)
-            Extracted signals.
-            All :obj:`numpy.ndarray`
-            have a shape (number of scans, number of elements in the mask)
+        %(signals_transform_multi_nifti)s
         """
         return self.fit(imgs, y=y).transform(
             imgs, confounds=confounds, sample_mask=sample_mask

--- a/nilearn/maskers/multi_nifti_labels_masker.py
+++ b/nilearn/maskers/multi_nifti_labels_masker.py
@@ -315,14 +315,6 @@ class MultiNiftiLabelsMasker(NiftiLabelsMasker):
             Extracted signals.
             All :obj:`numpy.ndarray`
             have a shape (number of scans, number of elements in the mask)
-
-        Warns
-        -----
-        DeprecationWarning
-            If 3D niimg inputs are provided, the current behavior
-            (adding a singleton dimension to produce 2D arrays) is deprecated.
-            Starting in version 0.12, 1D arrays will be returned for 3D
-            inputs.
         """
         return self.fit(imgs, y=y).transform(
             imgs, confounds=confounds, sample_mask=sample_mask

--- a/nilearn/maskers/multi_nifti_maps_masker.py
+++ b/nilearn/maskers/multi_nifti_maps_masker.py
@@ -209,11 +209,7 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
 
         Returns
         -------
-        signals : list of :obj:`numpy.ndarray`
-            List of signals for each map per subject.
-            Arrays from 4D images
-            have shape (number of scans, number of maps)
-            while those from 3D images have shape (number of maps,).
+        %(signals_transform_imgs_multi_nifti)s
 
         """
         # We handle the resampling of maps and mask separately because the
@@ -264,11 +260,7 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
 
         Returns
         -------
-        region_signals : :obj:`list` of :obj:`numpy.ndarray`
-            List of signals for each map per subject.
-            Arrays from 4D images
-            have shape (number of scans, number of maps)
-            while those from 3D images have shape (number of maps,).
+        %(signals_transform_multi_nifti)s
 
         """
         check_is_fitted(self)
@@ -322,12 +314,7 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
 
         Returns
         -------
-        signals : :obj:`numpy.ndarray` if a Niimg-like object was passed, \
-                  a :obj:`list` of :obj:`numpy.ndarray` otherwise \
-                  (one array for each subject)
-            Extracted signals.
-            All :obj:`numpy.ndarray`
-            have a shape (number of scans, number of elements in the mask)
+        %(signals_transform_multi_nifti)s
         """
         return self.fit(imgs, y=y).transform(
             imgs, confounds=confounds, sample_mask=sample_mask

--- a/nilearn/maskers/multi_nifti_maps_masker.py
+++ b/nilearn/maskers/multi_nifti_maps_masker.py
@@ -328,14 +328,6 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
             Extracted signals.
             All :obj:`numpy.ndarray`
             have a shape (number of scans, number of elements in the mask)
-
-        Warns
-        -----
-        DeprecationWarning
-            If 3D niimg inputs are provided, the current behavior
-            (adding a singleton dimension to produce 2D arrays) is deprecated.
-            Starting in version 0.12, 1D arrays will be returned for 3D
-            inputs.
         """
         return self.fit(imgs, y=y).transform(
             imgs, confounds=confounds, sample_mask=sample_mask

--- a/nilearn/maskers/multi_nifti_maps_masker.py
+++ b/nilearn/maskers/multi_nifti_maps_masker.py
@@ -207,9 +207,11 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
 
         Returns
         -------
-        region_signals : list of 2D :obj:`numpy.ndarray`
+        signals : list of :obj:`numpy.ndarray`
             List of signals for each map per subject.
-            shape: list of (number of scans, number of maps)
+            Arrays from 4D images
+            have shape (number of scans, number of maps)
+            while those from 3D images have shape (number of maps,).
 
         """
         # We handle the resampling of maps and mask separately because the
@@ -265,9 +267,11 @@ class MultiNiftiMapsMasker(NiftiMapsMasker):
 
         Returns
         -------
-        region_signals : list of 2D :obj:`numpy.ndarray`
+        region_signals : :obj:`list` of :obj:`numpy.ndarray`
             List of signals for each map per subject.
-            shape: list of (number of scans, number of maps)
+            Arrays from 4D images
+            have shape (number of scans, number of maps)
+            while those from 3D images have shape (number of maps,).
 
         """
         check_is_fitted(self)

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -420,9 +420,11 @@ class MultiNiftiMasker(NiftiMasker):
 
         Returns
         -------
-        region_signals : :obj:`list` of 2D :obj:`numpy.ndarray`
+        signals : :obj:`list` of :obj:`numpy.ndarray`
             List of signal for each element per subject.
-            shape: list of (number of scans, number of elements)
+            Arrays from 4D images
+            have shape (number of scans, number of elements)
+            while those from 3D images have shape (number of elements,).
 
         """
         if not hasattr(self, "mask_img_"):
@@ -521,8 +523,11 @@ class MultiNiftiMasker(NiftiMasker):
 
         Returns
         -------
-        data : :obj:`list` of :obj:`numpy.ndarray`
-            preprocessed images
+        signals : :obj:`list` of :obj:`numpy.ndarray`
+            List of signals per subject.
+            Arrays from 4D images
+            have shape (number of scans, number of elements)
+            while those from 3D images have shape (number of elements,).
 
         """
         check_is_fitted(self)

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -424,14 +424,6 @@ class MultiNiftiMasker(NiftiMasker):
             List of signal for each element per subject.
             shape: list of (number of scans, number of elements)
 
-        Warns
-        -----
-        DeprecationWarning
-            If a 3D niimg input is provided, the current behavior
-            (adding a singleton dimension to produce a 2D array) is deprecated.
-            Starting in version 0.12, a 1D array will be returned for 3D
-            inputs.
-
         """
         if not hasattr(self, "mask_img_"):
             raise ValueError(
@@ -531,14 +523,6 @@ class MultiNiftiMasker(NiftiMasker):
         -------
         data : :obj:`list` of :obj:`numpy.ndarray`
             preprocessed images
-
-        Warns
-        -----
-        DeprecationWarning
-            If 3D niimg inputs are provided, the current behavior
-            (adding a singleton dimension to produce 2D arrays) is deprecated.
-            Starting in version 0.12, 1D arrays will be returned for 3D
-            inputs.
 
         """
         check_is_fitted(self)

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -422,11 +422,7 @@ class MultiNiftiMasker(NiftiMasker):
 
         Returns
         -------
-        signals : :obj:`list` of :obj:`numpy.ndarray`
-            List of signal for each element per subject.
-            Arrays from 4D images
-            have shape (number of scans, number of elements)
-            while those from 3D images have shape (number of elements,).
+        %(signals_transform_imgs_multi_nifti)s
 
         """
         if not hasattr(self, "mask_img_"):
@@ -519,11 +515,7 @@ class MultiNiftiMasker(NiftiMasker):
 
         Returns
         -------
-        signals : :obj:`list` of :obj:`numpy.ndarray`
-            List of signals per subject.
-            Arrays from 4D images
-            have shape (number of scans, number of elements)
-            while those from 3D images have shape (number of elements,).
+        %(signals_transform_multi_nifti)s
 
         """
         check_is_fitted(self)
@@ -577,12 +569,7 @@ class MultiNiftiMasker(NiftiMasker):
 
         Returns
         -------
-        signals : :obj:`numpy.ndarray` if a Niimg-like object was passed, \
-                  a :obj:`list` of :obj:`numpy.ndarray` otherwise \
-                  (one array for each subject)
-            Extracted signals.
-            All :obj:`numpy.ndarray`
-            have a shape (number of scans, number of elements in the mask)
+        %(signals_transform_multi_nifti)s
         """
         return self.fit(imgs, y=y).transform(
             imgs, confounds=confounds, sample_mask=sample_mask

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -583,14 +583,6 @@ class MultiNiftiMasker(NiftiMasker):
             Extracted signals.
             All :obj:`numpy.ndarray`
             have a shape (number of scans, number of elements in the mask)
-
-        Warns
-        -----
-        DeprecationWarning
-            If 3D niimg inputs are provided, the current behavior
-            (adding a singleton dimension to produce 2D arrays) is deprecated.
-            Starting in version 0.12, 1D arrays will be returned for 3D
-            inputs.
         """
         return self.fit(imgs, y=y).transform(
             imgs, confounds=confounds, sample_mask=sample_mask

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -723,7 +723,6 @@ class NiftiLabelsMasker(BaseMasker):
         imgs : 3D/4D Niimg-like object
             See :ref:`extracting_data`.
             Images to process.
-            If a 3D niimg is provided, a 1D array is returned.
 
         %(confounds)s
 

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -853,6 +853,7 @@ class NiftiLabelsMasker(BaseMasker):
 
         return resampled_labels_img
 
+    @fill_doc
     def inverse_transform(self, signals):
         """Compute :term:`voxel` signals from region signals.
 
@@ -864,12 +865,7 @@ class NiftiLabelsMasker(BaseMasker):
 
         Parameters
         ----------
-        signals : 1D/2D :obj:`numpy.ndarray`
-            Signal for each region.
-            If a 1D array is provided, then the shape should be
-            (number of elements,).
-            If a 2D array is provided, then the shape should be
-            (number of scans, number of elements).
+        %(signals_inv_transform)s
 
         Returns
         -------

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -690,8 +690,7 @@ class NiftiLabelsMasker(BaseMasker):
         imgs : 3D/4D Niimg-like object
             See :ref:`extracting_data`.
             Images to process.
-            If a 3D niimg is provided, a singleton dimension will be added to
-            the output to represent the single scan in the niimg.
+            If a 3D niimg is provided, a 1D array is returned.
 
         y : None
             This parameter is unused. It is solely included for scikit-learn
@@ -705,9 +704,10 @@ class NiftiLabelsMasker(BaseMasker):
 
         Returns
         -------
-        region_signals : 2D :obj:`numpy.ndarray`
+        region_signals : :obj:`numpy.ndarray`
             Signal for each label.
-            shape: (number of scans, number of labels)
+            shape for 4D images : (number of scans, number of labels)
+            shape for 3D images : (number of labels,)
 
         """
         del y
@@ -737,7 +737,7 @@ class NiftiLabelsMasker(BaseMasker):
 
         Returns
         -------
-        region_signals : 2D numpy.ndarray
+        region_signals : numpy.ndarray
             Signal for each label.
             shape for 4D images : (number of scans, number of labels)
             shape for 3D images : (number of labels,)

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -868,15 +868,13 @@ class NiftiLabelsMasker(BaseMasker):
         signals : 1D/2D :obj:`numpy.ndarray`
             Signal for each region.
             If a 1D array is provided, then the shape should be
-            (number of elements,), and a 3D img will be returned.
+            (number of elements,).
             If a 2D array is provided, then the shape should be
-            (number of scans, number of elements), and a 4D img will be
-            returned.
+            (number of scans, number of elements).
 
         Returns
         -------
-        img : :obj:`nibabel.nifti1.Nifti1Image`
-            Signal for each voxel
+        %(img_inv_transform_nifti)s
 
         """
         from ..regions import signal_extraction

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -703,10 +703,7 @@ class NiftiLabelsMasker(BaseMasker):
 
         Returns
         -------
-        region_signals : :obj:`numpy.ndarray`
-            Signal for each label.
-            shape for 4D images : (number of scans, number of labels)
-            shape for 3D images : (number of labels,)
+        %(signals_transform_nifti)s
 
         """
         del y
@@ -736,10 +733,7 @@ class NiftiLabelsMasker(BaseMasker):
 
         Returns
         -------
-        region_signals : numpy.ndarray
-            Signal for each label.
-            shape for 4D images : (number of scans, number of labels)
-            shape for 3D images : (number of labels,)
+        %(signals_transform_nifti)s
 
         """
         # We handle the resampling of labels separately because the affine of

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -892,7 +892,7 @@ class NiftiLabelsMasker(BaseMasker):
 
         check_is_fitted(self)
 
-        self._check_signal_shape(signals)
+        signals = self._check_array(signals)
 
         logger.log("computing image from signals", verbose=self.verbose)
         return signal_extraction.signals_to_img_labels(

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -727,8 +727,7 @@ class NiftiLabelsMasker(BaseMasker):
         imgs : 3D/4D Niimg-like object
             See :ref:`extracting_data`.
             Images to process.
-            If a 3D niimg is provided, a singleton dimension will be added to
-            the output to represent the single scan in the niimg.
+            If a 3D niimg is provided, a 1D array is returned.
 
         %(confounds)s
 
@@ -740,15 +739,8 @@ class NiftiLabelsMasker(BaseMasker):
         -------
         region_signals : 2D numpy.ndarray
             Signal for each label.
-            shape: (number of scans, number of labels)
-
-        Warns
-        -----
-        DeprecationWarning
-            If a 3D niimg input is provided, the current behavior
-            (adding a singleton dimension to produce a 2D array) is deprecated.
-            Starting in version 0.12, a 1D array will be returned for 3D
-            inputs.
+            shape for 4D images : (number of scans, number of labels)
+            shape for 3D images : (number of labels,)
 
         """
         # We handle the resampling of labels separately because the affine of

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -883,7 +883,6 @@ class NiftiLabelsMasker(BaseMasker):
         -------
         img : :obj:`nibabel.nifti1.Nifti1Image`
             Signal for each voxel
-            shape: (X, Y, Z, number of scans)
 
         """
         from ..regions import signal_extraction

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -672,6 +672,7 @@ class NiftiMapsMasker(BaseMasker):
         )
         return region_signals
 
+    @fill_doc
     def inverse_transform(self, region_signals):
         """Compute :term:`voxel` signals from region signals.
 
@@ -679,12 +680,7 @@ class NiftiMapsMasker(BaseMasker):
 
         Parameters
         ----------
-        region_signals : 1D/2D :class:`numpy.ndarray`
-            Signal for each region.
-            If a 1D array is provided, then the shape should be
-            (number of elements,).
-            If a 2D array is provided, then the shape should be
-            (number of scans, number of elements).
+        %(region_signals_inv_transform)s
 
         Returns
         -------

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -539,7 +539,6 @@ class NiftiMapsMasker(BaseMasker):
         imgs : 3D/4D Niimg-like object
             See :ref:`extracting_data`.
             Images to process.
-            If a 3D niimg is provided, a 1D array is returned.
 
         confounds : CSV file or array-like, default=None
             This parameter is passed to :func:`nilearn.signal.clean`.

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -704,7 +704,7 @@ class NiftiMapsMasker(BaseMasker):
 
         check_is_fitted(self)
 
-        self._check_signal_shape(region_signals)
+        region_signals = self._check_array(region_signals)
 
         logger.log("computing image from signals", verbose=self.verbose)
         return signal_extraction.signals_to_img_maps(

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -680,18 +680,16 @@ class NiftiMapsMasker(BaseMasker):
 
         Parameters
         ----------
-        region_signals : :class:`numpy.ndarray`
+        region_signals : 1D/2D :class:`numpy.ndarray`
             Signal for each region.
             If a 1D array is provided, then the shape should be
-            (number of elements,), and a 3D img will be returned.
+            (number of elements,).
             If a 2D array is provided, then the shape should be
-            (number of scans, number of elements), and a 4D img will be
-            returned.
+            (number of scans, number of elements).
 
         Returns
         -------
-        voxel_signals : nibabel.Nifti1Image
-            Signal for each voxel
+        %(img_inv_transform_nifti)s
 
         """
         from ..regions import signal_extraction

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -686,7 +686,7 @@ class NiftiMapsMasker(BaseMasker):
 
         Parameters
         ----------
-        region_signals : 1D/2D numpy.ndarray
+        region_signals : :class:`numpy.ndarray`
             Signal for each region.
             If a 1D array is provided, then the shape should be
             (number of elements,), and a 3D img will be returned.

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -544,8 +544,7 @@ class NiftiMapsMasker(BaseMasker):
         imgs : 3D/4D Niimg-like object
             See :ref:`extracting_data`.
             Images to process.
-            If a 3D niimg is provided, a singleton dimension will be added to
-            the output to represent the single scan in the niimg.
+            If a 3D niimg is provided, a 1D array is returned.
 
         confounds : CSV file or array-like, default=None
             This parameter is passed to :func:`nilearn.signal.clean`.
@@ -560,15 +559,8 @@ class NiftiMapsMasker(BaseMasker):
         -------
         region_signals : 2D numpy.ndarray
             Signal for each map.
-            shape: (number of scans, number of maps)
-
-        Warns
-        -----
-        DeprecationWarning
-            If a 3D niimg input is provided, the current behavior
-            (adding a singleton dimension to produce a 2D array) is deprecated.
-            Starting in version 0.12, a 1D array will be returned for 3D
-            inputs.
+            shape for 4D images : (number of scans, number of maps)
+            shape for 3D images : (number of maps,)
 
         """
         # We handle the resampling of maps and mask separately because the

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -511,8 +511,7 @@ class NiftiMapsMasker(BaseMasker):
         imgs : 3D/4D Niimg-like object
             See :ref:`extracting_data`.
             Images to process.
-            If a 3D niimg is provided, a singleton dimension will be added to
-            the output to represent the single scan in the niimg.
+            If a 3D niimg is provided, a 1D array is returned.
 
         y : None
             This parameter is unused. It is solely included for scikit-learn
@@ -526,9 +525,10 @@ class NiftiMapsMasker(BaseMasker):
 
         Returns
         -------
-        region_signals : 2D numpy.ndarray
+        region_signals : numpy.ndarray
             Signal for each map.
-            shape: (number of scans, number of maps)
+            shape for 4D images : (number of scans, number of maps)
+            shape for 3D images : (number of maps,)
         """
         del y
         return self.fit(imgs).transform(

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -697,7 +697,7 @@ class NiftiMapsMasker(BaseMasker):
         Returns
         -------
         voxel_signals : nibabel.Nifti1Image
-            Signal for each voxel. shape: that of maps.
+            Signal for each voxel
 
         """
         from ..regions import signal_extraction

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -523,10 +523,7 @@ class NiftiMapsMasker(BaseMasker):
 
         Returns
         -------
-        region_signals : numpy.ndarray
-            Signal for each map.
-            shape for 4D images : (number of scans, number of maps)
-            shape for 3D images : (number of maps,)
+        %(signals_transform_nifti)s
         """
         del y
         return self.fit(imgs).transform(
@@ -555,10 +552,7 @@ class NiftiMapsMasker(BaseMasker):
 
         Returns
         -------
-        region_signals : numpy.ndarray
-            Signal for each map.
-            shape for 4D images : (number of scans, number of maps)
-            shape for 3D images : (number of maps,)
+        %(signals_transform_nifti)s
 
         """
         # We handle the resampling of maps and mask separately because the

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -557,7 +557,7 @@ class NiftiMapsMasker(BaseMasker):
 
         Returns
         -------
-        region_signals : 2D numpy.ndarray
+        region_signals : numpy.ndarray
             Signal for each map.
             shape for 4D images : (number of scans, number of maps)
             shape for 3D images : (number of maps,)

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -571,10 +571,7 @@ class NiftiMasker(BaseMasker):
 
         Returns
         -------
-        region_signals : :obj:`numpy.ndarray`
-            Signal for each :term:`voxel` inside the mask.
-            shape for 4D images : (number of scans, number of voxels)
-            shape for 3D images : (number of voxels,)
+        %(signals_transform_nifti)s
 
         """
         # Ignore the mask-computing params: they are not useful and will

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -108,17 +108,6 @@ def filter_and_mask(
     # coerce 5D data to 4D, which we don't want.
     temp_imgs = _utils.check_niimg(imgs)
 
-    # Raise warning if a 3D niimg is provided.
-    if temp_imgs.ndim == 3:
-        warnings.warn(
-            "Starting in version 0.12, 3D images will be transformed to "
-            "1D arrays. "
-            "Until then, 3D images will be coerced to 2D arrays, with a "
-            "singleton first dimension representing time.",
-            DeprecationWarning,
-            stacklevel=find_stack_level(),
-        )
-
     imgs = _utils.check_niimg(imgs, atleast_4d=True, ensure_ndim=4)
 
     # Check whether resampling is truly necessary. If so, crop mask
@@ -157,6 +146,8 @@ def filter_and_mask(
     # earlier)
     # Optionally: 'doctor_nan', remove voxels with NaNs, other option
     # for later: some form of imputation
+    if temp_imgs.ndim == 3:
+        data = data.squeeze()
     return data
 
 
@@ -571,8 +562,7 @@ class NiftiMasker(BaseMasker):
         imgs : 3D/4D Niimg-like object
             See :ref:`extracting_data`.
             Images to process.
-            If a 3D niimg is provided, a singleton dimension will be added to
-            the output to represent the single scan in the niimg.
+            If a 3D niimg is provided, a 1D array is returned.
 
         %(confounds)s
 
@@ -583,17 +573,10 @@ class NiftiMasker(BaseMasker):
 
         Returns
         -------
-        region_signals : 2D :obj:`numpy.ndarray`
+        region_signals : :obj:`numpy.ndarray`
             Signal for each :term:`voxel` inside the mask.
-            shape: (number of scans, number of voxels)
-
-        Warns
-        -----
-        DeprecationWarning
-            If a 3D niimg input is provided, the current behavior
-            (adding a singleton dimension to produce a 2D array) is deprecated.
-            Starting in version 0.12, a 1D array will be returned for 3D
-            inputs.
+            shape for 4D images : (number of scans, number of voxels)
+            shape for 3D images : (number of voxels,)
 
         """
         # Ignore the mask-computing params: they are not useful and will

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -560,7 +560,6 @@ class NiftiMasker(BaseMasker):
         imgs : 3D/4D Niimg-like object
             See :ref:`extracting_data`.
             Images to process.
-            If a 3D niimg is provided, a 1D array is returned.
 
         %(confounds)s
 

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -715,6 +715,7 @@ class NiftiSpheresMasker(BaseMasker):
         )
         return np.atleast_1d(signals)
 
+    @fill_doc
     def inverse_transform(self, region_signals):
         """Compute :term:`voxel` signals from spheres signals.
 
@@ -723,12 +724,7 @@ class NiftiSpheresMasker(BaseMasker):
 
         Parameters
         ----------
-        region_signals : 1D/2D :obj:`numpy.ndarray`
-            Signal for each region.
-            If a 1D array is provided, then the shape should be
-            (number of elements,).
-            If a 2D array is provided, then the shape should be
-            (number of scans, number of elements).
+        %(region_signals_inv_transform)s
 
         Returns
         -------

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -11,6 +11,7 @@ from joblib import Memory
 from scipy import sparse
 from sklearn import neighbors
 from sklearn.utils.estimator_checks import check_is_fitted
+from sklearn.utils.validation import check_array
 
 from nilearn._utils import logger
 from nilearn._utils.class_inspect import get_params
@@ -691,7 +692,7 @@ class NiftiSpheresMasker(BaseMasker):
 
         Returns
         -------
-        region_signals : 2D :obj:`numpy.ndarray`
+        region_signals : :obj:`numpy.ndarray`
             Signal for each sphere.
             shape: (number of scans, number of spheres)
 
@@ -726,7 +727,7 @@ class NiftiSpheresMasker(BaseMasker):
             # kwargs
             verbose=self.verbose,
         )
-        return signals
+        return np.atleast_1d(signals)
 
     def inverse_transform(self, region_signals):
         """Compute :term:`voxel` signals from spheres signals.
@@ -753,6 +754,8 @@ class NiftiSpheresMasker(BaseMasker):
         """
         check_is_fitted(self)
 
+        region_signals = np.atleast_1d(region_signals)
+        region_signals = check_array(region_signals, ensure_2d=False)
         self._check_signal_shape(region_signals)
 
         logger.log("computing image from signals", verbose=self.verbose)

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -638,8 +638,6 @@ class NiftiSpheresMasker(BaseMasker):
         imgs : 3D/4D Niimg-like object
             See :ref:`extracting_data`.
             Images to process.
-            If a 3D niimg is provided, a singleton dimension will be added to
-            the output to represent the single scan in the niimg.
 
         y : None
             This parameter is unused. It is solely included for scikit-learn
@@ -653,9 +651,7 @@ class NiftiSpheresMasker(BaseMasker):
 
         Returns
         -------
-        region_signals : 2D :obj:`numpy.ndarray`
-            Signal for each sphere.
-            shape: (number of scans, number of spheres)
+        %(signals_transform_nifti)s
 
         """
         del y
@@ -675,8 +671,6 @@ class NiftiSpheresMasker(BaseMasker):
         imgs : 3D/4D Niimg-like object
             See :ref:`extracting_data`.
             Images to process.
-            If a 3D niimg is provided, a singleton dimension will be added to
-            the output to represent the single scan in the niimg.
 
         %(confounds)s
 
@@ -686,9 +680,7 @@ class NiftiSpheresMasker(BaseMasker):
 
         Returns
         -------
-        region_signals : :obj:`numpy.ndarray`
-            Signal for each sphere.
-            shape: (number of scans, number of spheres)
+        %(signals_transform_nifti)s
 
         """
         check_is_fitted(self)

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -11,7 +11,6 @@ from joblib import Memory
 from scipy import sparse
 from sklearn import neighbors
 from sklearn.utils.estimator_checks import check_is_fitted
-from sklearn.utils.validation import check_array
 
 from nilearn._utils import logger
 from nilearn._utils.class_inspect import get_params
@@ -754,9 +753,7 @@ class NiftiSpheresMasker(BaseMasker):
         """
         check_is_fitted(self)
 
-        region_signals = np.atleast_1d(region_signals)
-        region_signals = check_array(region_signals, ensure_2d=False)
-        self._check_signal_shape(region_signals)
+        region_signals = self._check_array(region_signals)
 
         logger.log("computing image from signals", verbose=self.verbose)
 

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -726,16 +726,13 @@ class NiftiSpheresMasker(BaseMasker):
         region_signals : 1D/2D :obj:`numpy.ndarray`
             Signal for each region.
             If a 1D array is provided, then the shape should be
-            (number of elements,), and a 3D img will be returned.
+            (number of elements,).
             If a 2D array is provided, then the shape should be
-            (number of scans, number of elements), and a 4D img will be
-            returned.
+            (number of scans, number of elements).
 
         Returns
         -------
-        voxel_signals : :obj:`nibabel.nifti1.Nifti1Image`
-            Signal for each sphere.
-            shape: (mask_img, number of scans).
+        %(img_inv_transform_nifti)s
 
         """
         check_is_fitted(self)

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -22,6 +22,7 @@ from nilearn._utils.helpers import (
 from nilearn._utils.logger import find_stack_level
 from nilearn._utils.niimg import img_data_dtype
 from nilearn._utils.niimg_conversions import (
+    check_niimg,
     check_niimg_3d,
     check_niimg_4d,
     safe_get_data,
@@ -70,7 +71,7 @@ def apply_mask_and_get_affinity(
 
     Returns
     -------
-    X : 2D numpy.ndarray
+    X : numpy.ndarray
         Signal for each brain voxel in the (masked) niimgs.
         shape: (number of scans, number of voxels)
 
@@ -214,6 +215,8 @@ class _ExtractionFunctor:
 
     def __call__(self, imgs):
         n_seeds = len(self.seeds_)
+        temp_imgs = check_niimg(imgs)
+
         imgs = check_niimg_4d(imgs, dtype=self.dtype)
 
         signals = np.empty(
@@ -229,6 +232,10 @@ class _ExtractionFunctor:
             )
         ):
             signals[:, i] = np.mean(sphere, axis=1)
+
+        if temp_imgs.ndim == 3:
+            signals = signals.squeeze()
+
         return signals, None
 
 
@@ -687,14 +694,6 @@ class NiftiSpheresMasker(BaseMasker):
         region_signals : 2D :obj:`numpy.ndarray`
             Signal for each sphere.
             shape: (number of scans, number of spheres)
-
-        Warns
-        -----
-        DeprecationWarning
-            If a 3D niimg input is provided, the current behavior
-            (adding a singleton dimension to produce a 2D array) is deprecated.
-            Starting in version 0.12, a 1D array will be returned for 3D
-            inputs.
 
         """
         check_is_fitted(self)

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -22,7 +22,6 @@ from nilearn._utils.helpers import (
 from nilearn._utils.logger import find_stack_level
 from nilearn._utils.niimg import img_data_dtype
 from nilearn._utils.niimg_conversions import (
-    check_niimg,
     check_niimg_3d,
     check_niimg_4d,
     safe_get_data,
@@ -215,7 +214,6 @@ class _ExtractionFunctor:
 
     def __call__(self, imgs):
         n_seeds = len(self.seeds_)
-        temp_imgs = check_niimg(imgs)
 
         imgs = check_niimg_4d(imgs, dtype=self.dtype)
 
@@ -232,9 +230,6 @@ class _ExtractionFunctor:
             )
         ):
             signals[:, i] = np.mean(sphere, axis=1)
-
-        if temp_imgs.ndim == 3:
-            signals = signals.squeeze()
 
         return signals, None
 

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -45,6 +45,9 @@ def signals_to_surf_img_labels(
     """Transform signals to surface image labels."""
     labels = labels[labels != background_label]
 
+    if signals.ndim == 1:
+        signals = signals[None, :]
+
     data = {}
     for part_name, labels_part in labels_img.data.parts.items():
         data[part_name] = np.zeros(
@@ -500,7 +503,7 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
         """
         check_is_fitted(self)
 
-        self._check_signal_shape(signals)
+        signals = self._check_array(signals)
 
         return signals_to_surf_img_labels(
             signals,

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -488,11 +488,12 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
         ----------
         signals : :obj:`numpy.ndarray`
             Extracted signal for each region.
-            If a 1D array is provided, then the shape of each hemisphere's data
-            should be (number of elements,) in the returned surface image.
-            If a 2D array is provided, then it would be
-            (number of scans, number of elements).
-
+            If a 1D array is provided,
+            then the shape should be (number of labels,),
+            and a 1D image will be returned.
+            If a 2D array is provided,
+            then the shape should be (number of scans, number of labels),
+            and a 2D image will be returned.
 
         Returns
         -------

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -412,10 +412,7 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
 
         Returns
         -------
-        region_signals : 2D :obj:`numpy.ndarray`
-            Signal for each element.
-            shape for 2D images : (number of scans, number of n_labels)
-            shape for 1D images : (n_labels,)
+        %(signals_transform_surface)s
         """
         check_compatibility_mask_and_images(self.labels_img_, imgs)
         check_polymesh_equal(self.labels_img_.mesh, imgs.mesh)

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -501,14 +501,22 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
         """
         check_is_fitted(self)
 
+        return_1D = signals.ndim < 2
+
         signals = self._check_array(signals)
 
-        return signals_to_surf_img_labels(
+        imgs = signals_to_surf_img_labels(
             signals,
             np.asarray(self.labels_),
             self.labels_img_,
             self.background_label,
         )
+
+        if return_1D:
+            for k, v in imgs.data.parts.items():
+                imgs.data.parts[k] = v.squeeze()
+
+        return imgs
 
     def generate_report(self):
         """Generate a report."""

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -414,7 +414,8 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
         -------
         region_signals : 2D :obj:`numpy.ndarray`
             Signal for each element.
-            shape: (img data shape, total number of vertices)
+            shape for 2D images : (number of scans, number of n_labels)
+            shape for 1D images : (n_labels,)
         """
         check_compatibility_mask_and_images(self.labels_img_, imgs)
         check_polymesh_equal(self.labels_img_.mesh, imgs.mesh)

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -483,19 +483,16 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
 
         Parameters
         ----------
-        signals : :obj:`numpy.ndarray`
+        signals : 1D/2D :obj:`numpy.ndarray`
             Extracted signal for each region.
             If a 1D array is provided,
-            then the shape should be (number of labels,),
-            and a 1D image will be returned.
+            then the shape should be (number of labels,).
             If a 2D array is provided,
-            then the shape should be (number of scans, number of labels),
-            and a 2D image will be returned.
+            then the shape should be (number of scans, number of labels).
 
         Returns
         -------
-        :obj:`~nilearn.surface.SurfaceImage` object
-            Mesh and data for both hemispheres.
+        %(img_inv_transform_surface)s
         """
         check_is_fitted(self)
 

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -478,17 +478,13 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
 
         return region_signals
 
+    @fill_doc
     def inverse_transform(self, signals):
         """Transform extracted signal back to surface image.
 
         Parameters
         ----------
-        signals : 1D/2D :obj:`numpy.ndarray`
-            Extracted signal for each region.
-            If a 1D array is provided,
-            then the shape should be (number of labels,).
-            If a 2D array is provided,
-            then the shape should be (number of scans, number of labels).
+        %(signals_inv_transform)s
 
         Returns
         -------

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -45,9 +45,6 @@ def signals_to_surf_img_labels(
     """Transform signals to surface image labels."""
     labels = labels[labels != background_label]
 
-    if signals.ndim == 1:
-        signals = signals[None, :]
-
     data = {}
     for part_name, labels_part in labels_img.data.parts.items():
         data[part_name] = np.zeros(

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -348,7 +348,10 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
         """
         check_is_fitted(self)
 
-        self._check_signal_shape(region_signals)
+        region_signals = self._check_array(region_signals)
+
+        if region_signals.ndim == 1:
+            region_signals = region_signals[None, :]
 
         # get concatenated hemispheres/parts data from maps_img and mask_img
         maps_data = get_data(self.maps_img)

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -239,8 +239,7 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
         imgs : imgs : :obj:`~nilearn.surface.SurfaceImage` object or \
               iterable of :obj:`~nilearn.surface.SurfaceImage`
             Images to process.
-            Mesh and data for both hemispheres/parts. The data for each \
-            hemisphere is of shape (n_vertices_per_hemisphere, n_timepoints).
+            Mesh and data for both hemispheres/parts.
 
         %(confounds)s
 
@@ -250,7 +249,8 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
         -------
         region_signals: :obj:`numpy.ndarray`
             Signal for each region as provided in the maps (via `maps_img`).
-            shape: (n_timepoints, n_regions)
+            shape for 2D images : (number of scans, number of n_regions)
+            shape for 1D images : (n_regions,)
         """
         check_compatibility_mask_and_images(self.maps_img, imgs)
 

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -25,10 +25,7 @@ from nilearn._utils.masker_validation import (
 from nilearn._utils.param_validation import check_params
 from nilearn.image import index_img, mean_img
 from nilearn.maskers.base_masker import _BaseSurfaceMasker
-from nilearn.surface.surface import (
-    SurfaceImage,
-    get_data,
-)
+from nilearn.surface.surface import SurfaceImage, at_least_2d, get_data
 from nilearn.surface.utils import check_polymesh_equal
 
 
@@ -257,9 +254,9 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
         """
         check_compatibility_mask_and_images(self.maps_img, imgs)
 
-        imgs.data._check_ndims(2, "imgs")
-
         check_polymesh_equal(self.maps_img.mesh, imgs.mesh)
+
+        imgs = at_least_2d(imgs)
 
         img_data = np.concatenate(
             list(imgs.data.parts.values()), axis=0

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -350,9 +350,6 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
 
         region_signals = self._check_array(region_signals)
 
-        if region_signals.ndim == 1:
-            region_signals = region_signals[None, :]
-
         # get concatenated hemispheres/parts data from maps_img and mask_img
         maps_data = get_data(self.maps_img)
         mask_data = (

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -334,14 +334,17 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
         ----------
         region_signals: :obj:`numpy.ndarray`
             Signal for each region as provided in the maps (via `maps_img`).
-            shape: (n_timepoints, n_regions)
+            If a 1D array is provided,
+            then the shape should be (number of maps,),
+            and a 1D image will be returned.
+            If a 2D array is provided,
+            then the shape should be (number of scans, number of maps),
+            and a 2D image will be returned.
 
         Returns
         -------
         vertex_signals: :obj:`~nilearn.surface.SurfaceImage`
             Signal for each vertex projected on the mesh of the `maps_img`.
-            The data for each hemisphere is of shape
-            (n_vertices_per_hemisphere, n_timepoints).
         """
         check_is_fitted(self)
 

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -345,6 +345,8 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
         """
         check_is_fitted(self)
 
+        return_1D = region_signals.ndim < 2
+
         region_signals = self._check_array(region_signals)
 
         # get concatenated hemispheres/parts data from maps_img and mask_img
@@ -389,7 +391,13 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
             ],
         }
 
-        return SurfaceImage(mesh=self.maps_img.mesh, data=vertex_signals)
+        imgs = SurfaceImage(mesh=self.maps_img.mesh, data=vertex_signals)
+
+        if return_1D:
+            for k, v in imgs.data.parts.items():
+                imgs.data.parts[k] = v.squeeze()
+
+        return imgs
 
     def generate_report(self, displayed_maps=10, engine="matplotlib"):
         """Generate an HTML report for the current ``SurfaceMapsMasker``

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -329,19 +329,16 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
 
         Parameters
         ----------
-        region_signals: :obj:`numpy.ndarray`
+        region_signals: 1D/2D :obj:`numpy.ndarray`
             Signal for each region as provided in the maps (via `maps_img`).
             If a 1D array is provided,
-            then the shape should be (number of maps,),
-            and a 1D image will be returned.
+            then the shape should be (number of maps,).
             If a 2D array is provided,
-            then the shape should be (number of scans, number of maps),
-            and a 2D image will be returned.
+            then the shape should be (number of scans, number of maps).
 
         Returns
         -------
-        vertex_signals: :obj:`~nilearn.surface.SurfaceImage`
-            Signal for each vertex projected on the mesh of the `maps_img`.
+        %(img_inv_transform_surface)s
         """
         check_is_fitted(self)
 

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -247,10 +247,7 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
 
         Returns
         -------
-        region_signals: :obj:`numpy.ndarray`
-            Signal for each region as provided in the maps (via `maps_img`).
-            shape for 2D images : (number of scans, number of n_regions)
-            shape for 1D images : (n_regions,)
+        %(signals_transform_surface)s
         """
         check_compatibility_mask_and_images(self.maps_img, imgs)
 

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -324,17 +324,13 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
 
         return region_signals
 
+    @fill_doc
     def inverse_transform(self, region_signals):
         """Compute :term:`vertex` signals from region signals.
 
         Parameters
         ----------
-        region_signals: 1D/2D :obj:`numpy.ndarray`
-            Signal for each region as provided in the maps (via `maps_img`).
-            If a 1D array is provided,
-            then the shape should be (number of maps,).
-            If a 2D array is provided,
-            then the shape should be (number of scans, number of maps).
+        %(region_signals_inv_transform)s
 
         Returns
         -------

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -330,6 +330,8 @@ class SurfaceMasker(_BaseSurfaceMasker):
         """
         check_is_fitted(self)
 
+        return_1D = signals.ndim < 2
+
         # do not run sklearn_check as they may cause some failure
         # with some GLM inputs
         signals = self._check_array(signals, sklearn_check=False)
@@ -342,6 +344,8 @@ class SurfaceMasker(_BaseSurfaceMasker):
             )
             start, stop = self._slices[part_name]
             data[part_name][mask.ravel()] = signals[:, start:stop].T
+            if return_1D:
+                data[part_name] = data[part_name].squeeze()
 
         return SurfaceImage(mesh=self.mask_img_.mesh, data=data)
 

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -317,19 +317,16 @@ class SurfaceMasker(_BaseSurfaceMasker):
 
         Parameters
         ----------
-        signals : :class:`numpy.ndarray`
+        signals : 1D/2D :class:`numpy.ndarray`
             Extracted signal.
             If a 1D array is provided,
-            then the shape should be (number of elements,),
-            and a 1D image will be returned.
+            then the shape should be (number of elements,).
             If a 2D array is provided,
-            then the shape should be (number of scans, number of elements),
-            and a 2D image will be returned.
+            then the shape should be (number of scans, number of elements).
 
         Returns
         -------
-        :obj:`~nilearn.surface.SurfaceImage`
-            Mesh and data for both hemispheres.
+        %(img_inv_transform_surface)s
         """
         check_is_fitted(self)
 

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -263,10 +263,7 @@ class SurfaceMasker(_BaseSurfaceMasker):
 
         Returns
         -------
-        :class:`numpy.ndarray`
-            Signal for each element.
-            shape for 2D images : (number of scans, number of elements)
-            shape for 1D images : (number of elements,)
+        %(signals_transform_surface)s
 
         """
         parameters = get_params(

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -330,7 +330,9 @@ class SurfaceMasker(_BaseSurfaceMasker):
         """
         check_is_fitted(self)
 
-        signals = self._check_array(signals)
+        # do not run sklearn_check as they may cause some failure
+        # with some GLM inputs
+        signals = self._check_array(signals, sklearn_check=False)
 
         data = {}
         for part_name, mask in self.mask_img_.data.parts.items():

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -255,8 +255,7 @@ class SurfaceMasker(_BaseSurfaceMasker):
         imgs : imgs : :obj:`~nilearn.surface.SurfaceImage` object or \
               iterable of :obj:`~nilearn.surface.SurfaceImage`
             Images to process.
-            Mesh and data for both hemispheres/parts. The data for each \
-            hemisphere is of shape (n_vertices_per_hemisphere, n_timepoints).
+            Mesh and data for both hemispheres/parts.
 
         %(confounds)s
 
@@ -264,9 +263,10 @@ class SurfaceMasker(_BaseSurfaceMasker):
 
         Returns
         -------
-        2D :class:`numpy.ndarray`
+        :class:`numpy.ndarray`
             Signal for each element.
-            shape: (n samples, total number of vertices)
+            shape for 2D images : (number of scans, number of elements)
+            shape for 1D images : (number of elements,)
 
         """
         parameters = get_params(

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -312,17 +312,13 @@ class SurfaceMasker(_BaseSurfaceMasker):
 
         return output
 
+    @fill_doc
     def inverse_transform(self, signals):
         """Transform extracted signal back to surface object.
 
         Parameters
         ----------
-        signals : 1D/2D :class:`numpy.ndarray`
-            Extracted signal.
-            If a 1D array is provided,
-            then the shape should be (number of elements,).
-            If a 2D array is provided,
-            then the shape should be (number of scans, number of elements).
+        %(signals_inv_transform)s
 
         Returns
         -------

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -322,6 +322,12 @@ class SurfaceMasker(_BaseSurfaceMasker):
         ----------
         signals : :class:`numpy.ndarray`
             Extracted signal.
+            If a 1D array is provided,
+            then the shape should be (number of elements,),
+            and a 1D image will be returned.
+            If a 2D array is provided,
+            then the shape should be (number of scans, number of elements),
+            and a 2D image will be returned.
 
         Returns
         -------

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -330,10 +330,7 @@ class SurfaceMasker(_BaseSurfaceMasker):
         """
         check_is_fitted(self)
 
-        if signals.ndim == 1:
-            signals = np.array([signals])
-
-        self._check_signal_shape(signals)
+        signals = self._check_array(signals)
 
         data = {}
         for part_name, mask in self.mask_img_.data.parts.items():

--- a/nilearn/maskers/tests/test_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_nifti_labels_masker.py
@@ -152,37 +152,6 @@ def test_nifti_labels_masker_errors(
         masker11.fit()
 
 
-def test_nifti_labels_masker_io_shapes(
-    rng, affine_eye, shape_3d_default, n_regions, img_labels
-):
-    """Ensure that NiftiLabelsMasker inverse_transforms 1D/2D data.
-
-    inverse_transform(2D array) --> 4D image
-    inverse_transform(1D array) --> 3D image
-    """
-    length = 5
-    shape_4d = (*shape_3d_default, length)
-    data_1d = rng.random(n_regions)
-    data_2d = rng.random((length, n_regions))
-
-    _, mask_img = generate_random_img(
-        shape_4d,
-        affine=affine_eye,
-    )
-
-    masker = NiftiLabelsMasker(img_labels, mask_img=mask_img)
-
-    masker.fit()
-
-    test_img = masker.inverse_transform(data_1d)
-
-    assert test_img.shape == shape_3d_default
-
-    test_img = masker.inverse_transform(data_2d)
-
-    assert test_img.shape == shape_4d
-
-
 def test_nifti_labels_masker_with_nans_and_infs(
     affine_eye, shape_3d_default, n_regions, length, img_labels
 ):

--- a/nilearn/maskers/tests/test_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_nifti_labels_masker.py
@@ -5,8 +5,6 @@ not the underlying functions (clean(), img_to_signals_labels(), etc.). See
 test_masking.py and test_signal.py for details.
 """
 
-import warnings
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -157,65 +155,32 @@ def test_nifti_labels_masker_errors(
 def test_nifti_labels_masker_io_shapes(
     rng, affine_eye, shape_3d_default, n_regions, img_labels
 ):
-    """Ensure that NiftiLabelsMasker handles 1D/2D/3D/4D data appropriately.
+    """Ensure that NiftiLabelsMasker inverse_transforms 1D/2D data.
 
-    transform(4D image) --> 2D output, no warning
-    transform(3D image) --> 2D output, DeprecationWarning
-    inverse_transform(2D array) --> 4D image, no warning
-    inverse_transform(1D array) --> 3D image, no warning
+    inverse_transform(2D array) --> 4D image
+    inverse_transform(1D array) --> 3D image
     """
     length = 5
     shape_4d = (*shape_3d_default, length)
     data_1d = rng.random(n_regions)
     data_2d = rng.random((length, n_regions))
 
-    img_4d, mask_img = generate_random_img(
+    _, mask_img = generate_random_img(
         shape_4d,
         affine=affine_eye,
     )
-    img_3d, _ = generate_random_img(shape_3d_default, affine=affine_eye)
 
     masker = NiftiLabelsMasker(img_labels, mask_img=mask_img)
 
     masker.fit()
 
-    # DeprecationWarning *should* be raised for 3D inputs
-    with pytest.deprecated_call(match="Starting in version 0.12"):
-        test_data = masker.transform(img_3d)
-        assert test_data.shape == (1, n_regions)
+    test_img = masker.inverse_transform(data_1d)
 
-    # DeprecationWarning should *not* be raised for 4D inputs
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "error",
-            message="Starting in version 0.12",
-            category=DeprecationWarning,
-        )
-        test_data = masker.transform(img_4d)
+    assert test_img.shape == shape_3d_default
 
-        assert test_data.shape == (length, n_regions)
+    test_img = masker.inverse_transform(data_2d)
 
-    # DeprecationWarning should *not* be raised for 1D inputs
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "error",
-            message="Starting in version 0.12",
-            category=DeprecationWarning,
-        )
-        test_img = masker.inverse_transform(data_1d)
-
-        assert test_img.shape == shape_3d_default
-
-    # DeprecationWarning should *not* be raised for 2D inputs
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "error",
-            message="Starting in version 0.12",
-            category=DeprecationWarning,
-        )
-        test_img = masker.inverse_transform(data_2d)
-
-        assert test_img.shape == shape_4d
+    assert test_img.shape == shape_4d
 
 
 def test_nifti_labels_masker_with_nans_and_infs(
@@ -636,8 +601,8 @@ def test_nifti_labels_masker_with_mask(
     assert np.allclose(signals, masked_signals)
 
     #  masker.region_atlas_ should be the same as the masked_labels
-    # masked_labels is a 4D image with shape (10,10,10,1)
-    masked_labels_data = get_data(masked_labels)[:, :, :, 0]
+    # masked_labels is a 3D image with shape (10,10,10)
+    masked_labels_data = get_data(masked_labels)[:, :, :]
     assert np.allclose(get_data(masker.region_atlas_), masked_labels_data)
 
 
@@ -782,8 +747,10 @@ def check_region_names_after_fit(
     - region_names_ should be the same as the region names
       passed to the masker minus that for "background"
     """
-    assert len(masker.region_names_) == signals.shape[1]
-    assert len(list(masker.region_ids_.items())) == signals.shape[1] + 1
+    n_regions = signals.shape[0] if signals.ndim == 1 else signals.shape[1]
+
+    assert len(masker.region_names_) == n_regions
+    assert len(list(masker.region_ids_.items())) == n_regions + 1
 
     # for coverage
     masker.labels_  # noqa: B018
@@ -990,26 +957,6 @@ def test_more_labels_than_actual_region_in_atlas(
         match="Too many names for the indices. Dropping excess names values.",
     ):
         masker.fit().transform(fmri_img)
-
-
-def test_3d_images(affine_eye, shape_3d_default, n_regions, img_labels):
-    """Test that the NiftiLabelsMasker works with 3D images."""
-    mask_img = Nifti1Image(
-        np.ones(shape_3d_default, dtype=np.int8),
-        affine=affine_eye,
-    )
-
-    masker = NiftiLabelsMasker(img_labels, mask_img=mask_img)
-
-    epi_img1 = Nifti1Image(np.ones(shape_3d_default), affine=affine_eye)
-    epis = masker.fit_transform(epi_img1)
-
-    assert epis.shape == (1, n_regions)
-
-    epi_img2 = Nifti1Image(np.ones(shape_3d_default), affine=affine_eye)
-    epis = masker.fit_transform([epi_img1, epi_img2])
-
-    assert epis.shape == (2, n_regions)
 
 
 @pytest.mark.parametrize("background", [None, "Background"])

--- a/nilearn/maskers/tests/test_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_nifti_labels_masker.py
@@ -72,21 +72,13 @@ def test_nifti_labels_masker(
     # Check attributes defined at fit
     assert masker.n_elements_ == n_regions
 
-    masker.inverse_transform(signals)
-
-    # now with several mask_img
+    # now with mask_img
     masker = NiftiLabelsMasker(
         img_labels, mask_img=mask11_img, resampling_target=None
     )
     signals = masker.fit().transform(fmri_img)
 
     assert signals.shape == (length, n_regions)
-
-    # Call inverse transform (smoke test)
-    fmri_img_r = masker.inverse_transform(signals)
-
-    assert fmri_img_r.shape == fmri_img.shape
-    assert_almost_equal(fmri_img_r.affine, fmri_img.affine)
 
 
 def test_nifti_labels_masker_errors(

--- a/nilearn/maskers/tests/test_nifti_maps_masker.py
+++ b/nilearn/maskers/tests/test_nifti_maps_masker.py
@@ -53,34 +53,6 @@ def test_check_estimator_invalid(estimator, check, name):  # noqa: ARG001
     check(estimator)
 
 
-def test_nifti_maps_masker(
-    length, n_regions, affine_eye, shape_3d_default, img_maps
-):
-    """Check common methods of NiftiMapsMasker."""
-    fmri11_img, mask11_img = generate_fake_fmri(
-        shape_3d_default, affine=affine_eye, length=length
-    )
-
-    masker11 = NiftiMapsMasker(
-        img_maps, mask_img=mask11_img, resampling_target=None
-    )
-
-    signals11 = masker11.fit().transform(fmri11_img)
-
-    assert signals11.shape == (length, n_regions)
-
-    # Call inverse transform (smoke test)
-    fmri11_img_r = masker11.inverse_transform(signals11)
-
-    assert fmri11_img_r.shape == fmri11_img.shape
-    assert_almost_equal(fmri11_img_r.affine, fmri11_img.affine)
-
-    # Now try on a masker that has never seen the call to "transform"
-    masker2 = NiftiMapsMasker(img_maps, resampling_target=None)
-    masker2.fit()
-    masker2.inverse_transform(signals11)
-
-
 def test_nifti_maps_masker_data_atlas_different_shape(
     length, affine_eye, img_maps
 ):

--- a/nilearn/maskers/tests/test_nifti_maps_masker.py
+++ b/nilearn/maskers/tests/test_nifti_maps_masker.py
@@ -199,32 +199,6 @@ def test_nifti_maps_masker_resampling_errors(
         masker.fit()
 
 
-def test_nifti_maps_masker_io_shapes(
-    rng, affine_eye, length, n_regions, shape_3d_default, img_maps
-):
-    """Ensure that NiftiMapsMasker.inverse_transform handles 1D/2D data.
-
-    inverse_transform(2D array) --> 4D image
-    inverse_transform(1D array) --> 3D image
-    """
-    data_1d = rng.random(n_regions)
-    data_2d = rng.random((length, n_regions))
-    _, mask_img = generate_fake_fmri(
-        shape_3d_default, length=length, affine=affine_eye
-    )
-
-    masker = NiftiMapsMasker(img_maps, mask_img=mask_img)
-    masker.fit()
-
-    test_img = masker.inverse_transform(data_1d)
-
-    assert test_img.shape == shape_3d_default
-
-    test_img = masker.inverse_transform(data_2d)
-
-    assert test_img.shape == (*shape_3d_default, length)
-
-
 def test_nifti_maps_masker_with_nans_and_infs(length, n_regions, affine_eye):
     """Apply a NiftiMapsMasker containing NaNs and infs.
 

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -455,31 +455,3 @@ def test_standardization(rng, shape_3d_default, affine_eye):
         trans_signals,
         (signals / signals.mean(1)[:, np.newaxis] * 100 - 100).T,
     )
-
-
-def test_nifti_masker_io_shapes(rng, shape_3d_default, affine_eye):
-    """Ensure that NiftiMasker.inverse_transform 1D/2D data.
-
-    inverse_transform(2D array) --> 4D image
-    inverse_transform(1D array) --> 3D image
-    """
-    n_volumes = 5
-    shape_4d = (*shape_3d_default, n_volumes)
-
-    _, mask_img = data_gen.generate_random_img(
-        shape_4d,
-        affine=affine_eye,
-    )
-
-    n_regions = np.sum(mask_img.get_fdata().astype(bool))
-    data_1d = rng.random(n_regions)
-    data_2d = rng.random((n_volumes, n_regions))
-
-    masker = NiftiMasker(mask_img)
-    masker.fit()
-
-    test_img = masker.inverse_transform(data_1d)
-    assert test_img.shape == shape_3d_default
-
-    test_img = masker.inverse_transform(data_2d)
-    assert test_img.shape == shape_4d

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -458,7 +458,7 @@ def test_standardization(rng, shape_3d_default, affine_eye):
 
 
 def test_nifti_masker_io_shapes(rng, shape_3d_default, affine_eye):
-    """Ensure that NiftiMasker.inverse_transform handles 1D/2D data.
+    """Ensure that NiftiMasker.inverse_transform 1D/2D data.
 
     inverse_transform(2D array) --> 4D image
     inverse_transform(1D array) --> 3D image

--- a/nilearn/maskers/tests/test_nifti_spheres_masker.py
+++ b/nilearn/maskers/tests/test_nifti_spheres_masker.py
@@ -5,7 +5,6 @@ import pytest
 from nibabel import Nifti1Image
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
-from nilearn._utils import data_gen
 from nilearn._utils.estimator_checks import check_estimator
 from nilearn.image import get_data, new_img_like
 from nilearn.maskers import NiftiSpheresMasker
@@ -364,36 +363,3 @@ def test_nifti_spheres_masker_inverse_overlap(rng, affine_eye):
 
     with pytest.raises(ValueError, match="Overlap detected"):
         noverlapping_masker.inverse_transform(inv_data)
-
-
-def test_nifti_spheres_masker_io_shapes(rng, shape_3d_default, affine_eye):
-    """Ensure that NiftiSpheresMasker handles 1D/2D/3D/4D data appropriately.
-
-    transform(4D image) --> 2D output, no warning
-    transform(3D image) --> 2D output, DeprecationWarning
-    inverse_transform(2D array) --> 4D image, no warning
-    inverse_transform(1D array) --> 3D image, no warning
-    """
-    n_regions, n_volumes = 2, 5
-    shape_4d = (*shape_3d_default, n_volumes)
-
-    _, mask_img = data_gen.generate_random_img(
-        shape_4d,
-        affine=affine_eye,
-    )
-
-    masker = NiftiSpheresMasker(
-        [(1, 1, 1), (4, 4, 4)],  # number of tuples equal to n_regions
-        radius=1,
-        mask_img=mask_img,
-    )
-    masker.fit()
-
-    data_1d = rng.random(n_regions)
-    data_2d = rng.random((n_volumes, n_regions))
-
-    test_img = masker.inverse_transform(data_1d)
-    assert test_img.shape == shape_3d_default
-
-    test_img = masker.inverse_transform(data_2d)
-    assert test_img.shape == shape_4d

--- a/nilearn/maskers/tests/test_nifti_spheres_masker.py
+++ b/nilearn/maskers/tests/test_nifti_spheres_masker.py
@@ -1,7 +1,5 @@
 """Test nilearn.maskers.nifti_spheres_masker."""
 
-import warnings
-
 import numpy as np
 import pytest
 from nibabel import Nifti1Image
@@ -379,12 +377,9 @@ def test_nifti_spheres_masker_io_shapes(rng, shape_3d_default, affine_eye):
     n_regions, n_volumes = 2, 5
     shape_4d = (*shape_3d_default, n_volumes)
 
-    img_4d, mask_img = data_gen.generate_random_img(
+    _, mask_img = data_gen.generate_random_img(
         shape_4d,
         affine=affine_eye,
-    )
-    img_3d, _ = data_gen.generate_random_img(
-        shape_3d_default, affine=affine_eye
     )
 
     masker = NiftiSpheresMasker(
@@ -394,39 +389,11 @@ def test_nifti_spheres_masker_io_shapes(rng, shape_3d_default, affine_eye):
     )
     masker.fit()
 
-    # DeprecationWarning *should* be raised for 3D inputs
-    with pytest.deprecated_call(match="Starting in version 0.12"):
-        test_data = masker.transform(img_3d)
-        assert test_data.shape == (1, n_regions)
-
-    # DeprecationWarning should *not* be raised for 4D inputs
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "error",
-            message="Starting in version 0.12",
-            category=DeprecationWarning,
-        )
-        test_data = masker.transform(img_4d)
-        assert test_data.shape == (n_volumes, n_regions)
-
     data_1d = rng.random(n_regions)
     data_2d = rng.random((n_volumes, n_regions))
-    # DeprecationWarning should *not* be raised for 1D inputs
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "error",
-            message="Starting in version 0.12",
-            category=DeprecationWarning,
-        )
-        test_img = masker.inverse_transform(data_1d)
-        assert test_img.shape == shape_3d_default
 
-    # DeprecationWarning should *not* be raised for 2D inputs
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "error",
-            message="Starting in version 0.12",
-            category=DeprecationWarning,
-        )
-        test_img = masker.inverse_transform(data_2d)
-        assert test_img.shape == shape_4d
+    test_img = masker.inverse_transform(data_1d)
+    assert test_img.shape == shape_3d_default
+
+    test_img = masker.inverse_transform(data_2d)
+    assert test_img.shape == shape_4d

--- a/nilearn/maskers/tests/test_surface_labels_masker.py
+++ b/nilearn/maskers/tests/test_surface_labels_masker.py
@@ -315,8 +315,8 @@ def test_surface_label_masker_check_output_1d(
     # expected inverse data is the same as the input data
     # but with the random value replaced by zeros
     expected_inverse_data = {
-        "left": np.asarray([inverse_data_left_1d_with_expected_mean]).T,
-        "right": np.asarray([inverse_data_right_1d_with_expected_mean]).T,
+        "left": np.asarray(inverse_data_left_1d_with_expected_mean).T,
+        "right": np.asarray(inverse_data_right_1d_with_expected_mean).T,
     }
 
     assert_array_equal(img.data.parts["left"], expected_inverse_data["left"])

--- a/nilearn/maskers/tests/test_surface_labels_masker.py
+++ b/nilearn/maskers/tests/test_surface_labels_masker.py
@@ -153,7 +153,7 @@ def test_surface_label_masker_transform(surf_label_img, surf_img_1d, strategy):
     signal = masker.transform(surf_img_1d)
 
     assert isinstance(signal, np.ndarray)
-    assert signal.shape == (1, masker.n_elements_)
+    assert signal.shape == ()
 
 
 def test_surface_label_masker_transform_with_mask(surf_mesh, surf_img_2d):
@@ -307,7 +307,7 @@ def test_surface_label_masker_check_output_1d(
     surf_img_1d = SurfaceImage(surf_mesh, data)
     signal = masker.transform(surf_img_1d)
 
-    assert_array_equal(signal, np.asarray([expected_signal]))
+    assert_array_equal(signal, np.asarray(expected_signal))
 
     # also check the output of inverse_transform
     img = masker.inverse_transform(signal)

--- a/nilearn/maskers/tests/test_surface_labels_masker.py
+++ b/nilearn/maskers/tests/test_surface_labels_masker.py
@@ -431,15 +431,6 @@ def test_surface_label_masker_fit_transform(surf_label_img, surf_img_1d):
     assert signal.shape == (1, masker.n_elements_)
 
 
-def test_surface_label_masker_inverse_transform(surf_label_img, surf_img_1d):
-    """Test transform extract signals."""
-    masker = SurfaceLabelsMasker(labels_img=surf_label_img)
-    masker = masker.fit()
-    signal = masker.transform(surf_img_1d)
-    img = masker.inverse_transform(signal)
-    assert img.shape == (surf_img_1d.shape[0], 1)
-
-
 def test_surface_label_masker_inverse_transform_with_mask(
     surf_mesh, surf_img_2d
 ):

--- a/nilearn/maskers/tests/test_surface_labels_masker.py
+++ b/nilearn/maskers/tests/test_surface_labels_masker.py
@@ -150,7 +150,6 @@ def test_surface_label_masker_transform(surf_label_img, surf_img_1d, strategy):
     masker = SurfaceLabelsMasker(labels_img=surf_label_img, strategy=strategy)
     masker = masker.fit()
 
-    # only one 'timepoint'
     signal = masker.transform(surf_img_1d)
 
     assert isinstance(signal, np.ndarray)

--- a/nilearn/maskers/tests/test_surface_labels_masker.py
+++ b/nilearn/maskers/tests/test_surface_labels_masker.py
@@ -142,9 +142,7 @@ def test_surface_label_masker_fit_no_report(surf_label_img):
         "maximum",
     ),
 )
-def test_surface_label_masker_transform(
-    surf_label_img, surf_img_1d, surf_img_2d, strategy
-):
+def test_surface_label_masker_transform(surf_label_img, surf_img_1d, strategy):
     """Test transform extract signals.
 
     Also a smoke test for different strategies.
@@ -157,13 +155,6 @@ def test_surface_label_masker_transform(
 
     assert isinstance(signal, np.ndarray)
     assert signal.shape == (1, masker.n_elements_)
-
-    # 5 'timepoint'
-    n_timepoints = 5
-    signal = masker.transform(surf_img_2d(n_timepoints))
-
-    assert isinstance(signal, np.ndarray)
-    assert signal.shape == (n_timepoints, masker.n_elements_)
 
 
 def test_surface_label_masker_transform_with_mask(surf_mesh, surf_img_2d):
@@ -424,13 +415,6 @@ def test_surface_label_masker_check_output_2d(
     assert_array_equal(img.data.parts["right"], expected_inverse_data["right"])
 
 
-def test_surface_label_masker_fit_transform(surf_label_img, surf_img_1d):
-    """Smoke test for fit_transform."""
-    masker = SurfaceLabelsMasker(labels_img=surf_label_img)
-    signal = masker.fit_transform(surf_img_1d)
-    assert signal.shape == (1, masker.n_elements_)
-
-
 def test_surface_label_masker_inverse_transform_with_mask(
     surf_mesh, surf_img_2d
 ):
@@ -471,27 +455,6 @@ def test_surface_label_masker_inverse_transform_with_mask(
     # the data for label 2 should be zeros
     assert np.all(img_inverted.data.parts["left"][-1, :] == 0)
     assert np.all(img_inverted.data.parts["right"][2:, :] == 0)
-
-
-def test_surface_label_masker_transform_list_surf_images(
-    surf_label_img, surf_img_1d, surf_img_2d
-):
-    """Test transform on list of surface images."""
-    masker = SurfaceLabelsMasker(surf_label_img).fit()
-    signals = masker.transform([surf_img_1d, surf_img_1d, surf_img_1d])
-    assert signals.shape == (3, masker.n_elements_)
-    signals = masker.transform([surf_img_2d(5), surf_img_2d(4)])
-    assert signals.shape == (9, masker.n_elements_)
-
-
-def test_surface_label_masker_inverse_transform_list_surf_images(
-    surf_label_img, surf_img_2d
-):
-    """Test inverse_transform on list of surface images."""
-    masker = SurfaceLabelsMasker(surf_label_img).fit()
-    signals = masker.transform([surf_img_2d(3), surf_img_2d(4)])
-    img = masker.inverse_transform(signals)
-    assert img.shape == (surf_label_img.mesh.n_vertices, 7)
 
 
 def test_surface_label_masker_labels_img_none():

--- a/nilearn/maskers/tests/test_surface_maps_masker.py
+++ b/nilearn/maskers/tests/test_surface_maps_masker.py
@@ -88,20 +88,6 @@ def test_surface_maps_masker_fit_transform_actual_output(surf_mesh, rng):
     assert np.allclose(region_signals, expected_region_signals)
 
 
-@pytest.mark.parametrize("surf_mask_dim", [1, 2])
-def test_surface_maps_masker_inverse_transform_shape(
-    surf_maps_img, surf_img_2d, surf_mask_1d, surf_mask_2d, surf_mask_dim
-):
-    """Test that inverse_transform returns an image with the same shape as the
-    input.
-    """
-    surf_mask = surf_mask_1d if surf_mask_dim == 1 else surf_mask_2d()
-    masker = SurfaceMapsMasker(surf_maps_img, surf_mask).fit()
-    region_signals = masker.fit_transform(surf_img_2d(50))
-    X_inverse_transformed = masker.inverse_transform(region_signals)
-    assert X_inverse_transformed.shape == surf_img_2d(50).shape
-
-
 def test_surface_maps_masker_inverse_transform_actual_output(surf_mesh, rng):
     """Test that inverse_transform returns the expected output."""
     # create a maps_img with 9 vertices and 2 regions

--- a/nilearn/maskers/tests/test_surface_maps_masker.py
+++ b/nilearn/maskers/tests/test_surface_maps_masker.py
@@ -108,16 +108,6 @@ def test_surface_maps_masker_1d_maps_img(surf_img_1d):
         SurfaceMapsMasker(maps_img=surf_img_1d).fit()
 
 
-def test_surface_maps_masker_1d_img(surf_maps_img, surf_img_1d):
-    """Test that an error is raised when img has 1D data."""
-    with pytest.raises(
-        ValueError,
-        match="should be 2D",
-    ):
-        masker = SurfaceMapsMasker(maps_img=surf_maps_img).fit()
-        masker.transform(surf_img_1d)
-
-
 def test_surface_maps_masker_labels_img_none():
     """Test that an error is raised when maps_img is None."""
     with pytest.raises(

--- a/nilearn/maskers/tests/test_surface_maps_masker.py
+++ b/nilearn/maskers/tests/test_surface_maps_masker.py
@@ -31,23 +31,6 @@ def test_check_estimator_invalid(estimator, check, name):  # noqa: ARG001
     check(estimator)
 
 
-@pytest.mark.parametrize("surf_mask_dim", [1, 2])
-def test_surface_maps_masker_fit_transform_shape(
-    surf_maps_img, surf_img_2d, surf_mask_1d, surf_mask_2d, surf_mask_dim
-):
-    """Test that the fit_transform method returns the expected shape."""
-    surf_mask = surf_mask_1d if surf_mask_dim == 1 else surf_mask_2d()
-    masker = SurfaceMapsMasker(surf_maps_img, surf_mask).fit()
-    region_signals = masker.transform(surf_img_2d(50))
-    # surf_img_2d has shape (n_vertices, n_timepoints) = (9, 50)
-    # surf_maps_img has shape (n_vertices, n_regions) = (9, 6)
-    # region_signals should have shape (n_timepoints, n_regions) = (50, 6)
-    assert region_signals.shape == (
-        surf_img_2d(50).shape[-1],
-        surf_maps_img.shape[-1],
-    )
-
-
 def test_surface_maps_masker_fit_transform_mask_vs_no_mask(
     surf_maps_img, surf_img_2d, surf_mask_1d
 ):

--- a/nilearn/maskers/tests/test_surface_masker.py
+++ b/nilearn/maskers/tests/test_surface_masker.py
@@ -64,7 +64,6 @@ def test_transform_inverse_transform_no_mask(surf_mesh, n_timepoints):
     signals = masker.transform(img)
 
     # make sure none of the data has been removed
-    assert signals.shape == (n_timepoints, img.shape[0])
     assert np.array_equal(signals[0], [1, 2, 3, 4, 10, 20, 30, 40, 50])
     unmasked_img = masker.inverse_transform(signals)
     assert_polydata_equal(img.data, unmasked_img.data)
@@ -94,9 +93,6 @@ def test_transform_inverse_transform_with_mask(surf_mesh, n_timepoints):
 
     masker = SurfaceMasker(mask).fit(img)
     signals = masker.transform(img)
-
-    # check mask shape is as expected
-    assert signals.shape == (n_timepoints, masker.n_elements_)
 
     # check the data for first seven vertices is as expected
     assert np.array_equal(signals.ravel()[:7], [2, 3, 4, 20, 30, 40, 50])

--- a/nilearn/maskers/tests/test_surface_masker.py
+++ b/nilearn/maskers/tests/test_surface_masker.py
@@ -46,35 +46,6 @@ def test_fit_list_surf_images_with_mask(surf_mask_1d, surf_img_2d):
     assert masker.mask_img_.shape == (surf_img_2d(1).shape[0],)
 
 
-@pytest.mark.parametrize("surf_mask_dim", [1, 2])
-def test_transform_list_surf_images(
-    surf_mask_dim,
-    surf_mask_1d,
-    surf_mask_2d,
-    surf_img_1d,
-    surf_img_2d,
-):
-    """Test transform on list of surface images."""
-    surf_mask = surf_mask_1d if surf_mask_dim == 1 else surf_mask_2d()
-    masker = SurfaceMasker(surf_mask).fit()
-    signals = masker.transform([surf_img_1d, surf_img_1d, surf_img_1d])
-    assert signals.shape == (3, masker.n_elements_)
-    signals = masker.transform([surf_img_2d(5), surf_img_2d(4)])
-    assert signals.shape == (9, masker.n_elements_)
-
-
-@pytest.mark.parametrize("surf_mask_dim", [1, 2])
-def test_inverse_transform_list_surf_images(
-    surf_mask_dim, surf_mask_1d, surf_mask_2d, surf_img_2d
-):
-    """Test inverse_transform on list of surface images."""
-    surf_mask = surf_mask_1d if surf_mask_dim == 1 else surf_mask_2d()
-    masker = SurfaceMasker(surf_mask).fit()
-    signals = masker.transform([surf_img_2d(3), surf_img_2d(4)])
-    img = masker.inverse_transform(signals)
-    assert img.shape == (surf_mask.mesh.n_vertices, 7)
-
-
 @pytest.mark.parametrize("n_timepoints", [3])
 def test_transform_inverse_transform_no_mask(surf_mesh, n_timepoints):
     """Check output of inverse transform when not using a mask."""

--- a/nilearn/surface/utils.py
+++ b/nilearn/surface/utils.py
@@ -74,7 +74,7 @@ def assert_surface_mesh_equal(mesh_1, mesh_2):
         raise MeshDimensionError("Meshes do not have the same faces.")
 
 
-def assert_surface_image_equal(img_1, img_2):
+def assert_surface_image_equal(img_1, img_2) -> None:
     """Check that 2 SurfaceImages are equal."""
     assert_polymesh_equal(img_1.mesh, img_2.mesh)
     assert_polydata_equal(img_1.data, img_2.data)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- relates to https://github.com/nilearn/nilearn/issues/5380
- relates to #3322 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

Ensure the following

for nifti maskers
  - transform of 3D images returns 1D arrays
  - transform of 4D images returns 2D arrays
  - inverse_transform of 1D arrays return 3D images
  - inverse_transform of 2D arrays return 4D images
  - check_arrays before inverse transform

for surface maskers
  - transform of 1D images returns 1D arrays
  - transform of 2D images returns 2D arrays
  - inverse_transform of 1D arrays return 1D images
  - inverse_transform of 2D arrays return 2D images
  - check_arrays before inverse transform

Move and refactor tests and integrate them in estimat_check

---

TODO:
- [x] check that transform of 1D surface image return 1D array
- [x] check that inverse transform of 1D array return 1D surface image