### PR TITLE
[DOC] use template doc string for dummy y

### DIFF
--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -1214,6 +1214,13 @@ vmin : :obj:`float`  or obj:`int` or None, optional
     Passed to :func:`matplotlib.pyplot.imshow`.
 """
 
+# y
+docdict["y_dummy"] = """
+y : None
+    This parameter is unused.
+    It is solely included for scikit-learn compatibility.
+"""
+
 
 ##############################################################################
 #

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -479,6 +479,7 @@ class ConnectivityMeasure(TransformerMixin, BaseEstimator):
                 f"You provided {confounds.__class__}"
             )
 
+    @fill_doc
     def fit(self, X, y=None):
         """Fit the covariance estimator to the given time series for each \
         subject.
@@ -489,6 +490,8 @@ class ConnectivityMeasure(TransformerMixin, BaseEstimator):
             shape for each (n_samples, n_features)
             The input subjects time series. The number of samples may differ
             from one subject to another.
+
+        %(y_dummy)s
 
         Returns
         -------
@@ -595,6 +598,7 @@ class ConnectivityMeasure(TransformerMixin, BaseEstimator):
 
         return connectivities
 
+    @fill_doc
     def fit_transform(self, X, y=None, confounds=None):
         """Fit the covariance estimator to the given time series \
         for each subject. \
@@ -605,7 +609,8 @@ class ConnectivityMeasure(TransformerMixin, BaseEstimator):
         X : :obj:`list` of n_subjects numpy.ndarray with shapes \
             (n_samples, n_features)
             The input subjects time series. The number of samples may differ
-            from one subject to another.
+
+        %(y_dummy)s
 
         confounds : np.ndarray with shape (n_samples) or \
                     (n_samples, n_confounds), or pandas DataFrame, default=None

--- a/nilearn/connectome/group_sparse_cov.py
+++ b/nilearn/connectome/group_sparse_cov.py
@@ -601,6 +601,7 @@ class GroupSparseCovariance(CacheMixin, BaseEstimator):
         self.memory_level = memory_level
         self.verbose = verbose
 
+    @fill_doc
     def fit(self, subjects, y=None):
         """Fits the group sparse precision model according \
         to the given training data and parameters.
@@ -612,6 +613,8 @@ class GroupSparseCovariance(CacheMixin, BaseEstimator):
             input subjects. Each subject is a 2D array, whose columns contain
             signals. Sample number can vary from subject to subject, but all
             subjects must have the same number of features (i.e. of columns).
+
+        %(y_dummy)s
 
         Returns
         -------
@@ -1077,6 +1080,7 @@ class GroupSparseCovarianceCV(CacheMixin, BaseEstimator):
         self.debug = debug
         self.early_stopping = early_stopping
 
+    @fill_doc
     def fit(self, subjects, y=None):
         """Compute cross-validated group-sparse precisions.
 
@@ -1087,6 +1091,8 @@ class GroupSparseCovarianceCV(CacheMixin, BaseEstimator):
             input subjects. Each subject is a 2D array, whose columns contain
             signals. Sample number can vary from subject to subject, but all
             subjects must have the same number of features (i.e. of columns.)
+
+        %(y_dummy)s
 
         Returns
         -------

--- a/nilearn/decomposition/_base.py
+++ b/nilearn/decomposition/_base.py
@@ -425,17 +425,20 @@ class _BaseDecomposition(CacheMixin, TransformerMixin, BaseEstimator):
         tags.input_tags = InputTags()
         return tags
 
+    @fill_doc
     def fit(self, imgs, y=None, confounds=None):
         """Compute the mask and the components across subjects.
 
         Parameters
         ----------
-        imgs : list of Niimg-like objects or
-        list of :obj:`~nilearn.surface.SurfaceImage`
+        imgs : list of Niimg-like objects or \
+               list of :obj:`~nilearn.surface.SurfaceImage`
             See :ref:`extracting_data`.
             Data on which the mask is calculated. If this is a list,
             the affine (for Niimg-like objects) and mesh (for SurfaceImages)
             is considered the same for all
+
+        %(y_dummy)s
 
         confounds : list of CSV file paths, numpy.ndarrays
             or pandas DataFrames, optional.

--- a/nilearn/interfaces/bids/glm.py
+++ b/nilearn/interfaces/bids/glm.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from nilearn import __version__
 from nilearn._utils import logger
+from nilearn._utils.docs import fill_doc
 from nilearn._utils.glm import coerce_to_dict, make_stat_maps
 from nilearn._utils.helpers import is_matplotlib_installed
 from nilearn._utils.logger import find_stack_level
@@ -78,6 +79,7 @@ def _generate_dataset_description(out_file, model_level):
         json.dump(dataset_description, f_obj, indent=4, sort_keys=True)
 
 
+@fill_doc
 def save_glm_to_bids(
     model,
     contrasts,

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -240,6 +240,7 @@ class MultiNiftiMasker(NiftiMasker):
         tags.input_tags = InputTags(masker=True, multi_masker=True)
         return tags
 
+    @fill_doc
     def fit(
         self,
         imgs=None,
@@ -255,9 +256,7 @@ class MultiNiftiMasker(NiftiMasker):
             Data on which the mask must be calculated. If this is a list,
             the affine is considered the same for all.
 
-        y : None
-            This parameter is unused. It is solely included for scikit-learn
-            compatibility.
+        %(y_dummy)s
 
         """
         del y

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -492,6 +492,7 @@ class NiftiLabelsMasker(BaseMasker):
 
         return [display]
 
+    @fill_doc
     def fit(self, imgs=None, y=None):
         """Prepare signal extraction from regions.
 
@@ -501,9 +502,7 @@ class NiftiLabelsMasker(BaseMasker):
             See :ref:`extracting_data`.
             Image data passed to the reporter.
 
-        y : None
-            This parameter is unused. It is solely included for scikit-learn
-            compatibility.
+        %(y_dummy)s
         """
         del y
         check_params(self.__dict__)

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -502,6 +502,7 @@ class NiftiMapsMasker(BaseMasker):
     def __sklearn_is_fitted__(self):
         return hasattr(self, "maps_img_") and hasattr(self, "n_elements_")
 
+    @fill_doc
     def fit_transform(self, imgs, y=None, confounds=None, sample_mask=None):
         """Prepare and perform signal extraction.
 
@@ -513,9 +514,7 @@ class NiftiMapsMasker(BaseMasker):
             If a 3D niimg is provided, a singleton dimension will be added to
             the output to represent the single scan in the niimg.
 
-        y : None
-            This parameter is unused. It is solely included for scikit-learn
-            compatibility.
+        %(y_dummy)s
 
         %(confounds)s
 

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -378,6 +378,7 @@ class NiftiMapsMasker(BaseMasker):
             display.close()
         return embeded_images
 
+    @fill_doc
     def fit(self, imgs=None, y=None):
         """Prepare signal extraction from regions.
 
@@ -387,9 +388,7 @@ class NiftiMapsMasker(BaseMasker):
             See :ref:`extracting_data`.
             Image data passed to the reporter.
 
-        y : None
-            This parameter is unused. It is solely included for scikit-learn
-            compatibility.
+        %(y_dummy)s
         """
         del y
         check_params(self.__dict__)

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -417,6 +417,7 @@ class NiftiMasker(BaseMasker):
     def __sklearn_is_fitted__(self):
         return hasattr(self, "mask_img_")
 
+    @fill_doc
     def fit(self, imgs=None, y=None):
         """Compute the mask corresponding to the data.
 
@@ -427,10 +428,7 @@ class NiftiMasker(BaseMasker):
             Data on which the mask must be calculated. If this is a list,
             the affine is considered the same for all.
 
-        y : None
-            This parameter is unused. It is solely included for scikit-learn
-            compatibility.
-
+        %(y_dummy)s
         """
         del y
         check_params(self.__dict__)

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -245,6 +245,7 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
         lut = self.lut_
         return lut["index"].to_dict()
 
+    @fill_doc
     @rename_parameters(
         replacement_params={"img": "imgs"}, end_version="0.13.2"
     )
@@ -256,9 +257,7 @@ class SurfaceLabelsMasker(_BaseSurfaceMasker):
         imgs : :obj:`~nilearn.surface.SurfaceImage` object or None, \
                default=None
 
-        y : None
-            This parameter is unused.
-            It is solely included for scikit-learn compatibility.
+        %(y_dummy)s
 
         Returns
         -------

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -153,6 +153,7 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
         self.cmap = cmap
         self.clean_args = clean_args
 
+    @fill_doc
     @rename_parameters(
         replacement_params={"img": "imgs"}, end_version="0.13.2"
     )

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -164,9 +164,7 @@ class SurfaceMapsMasker(_BaseSurfaceMasker):
         imgs : :obj:`~nilearn.surface.SurfaceImage` object or None, \
                default=None
 
-        y : None
-            This parameter is unused.
-            It is solely included for scikit-learn compatibility.
+        %(y_dummy)s
 
         Returns
         -------

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -203,9 +203,7 @@ class SurfaceMasker(_BaseSurfaceMasker):
               default = None
             Mesh and data for both hemispheres.
 
-        y : None
-            This parameter is unused.
-            It is solely included for scikit-learn compatibility.
+        %(y_dummy)s
 
         Returns
         -------

--- a/nilearn/regions/hierarchical_kmeans_clustering.py
+++ b/nilearn/regions/hierarchical_kmeans_clustering.py
@@ -255,6 +255,7 @@ class HierarchicalKMeans(ClusterMixin, TransformerMixin, BaseEstimator):
         tags.input_tags = InputTags()
         return tags
 
+    @fill_doc
     def fit(self, X, y=None):
         """Compute clustering of the data.
 
@@ -262,7 +263,8 @@ class HierarchicalKMeans(ClusterMixin, TransformerMixin, BaseEstimator):
         ----------
         X : ndarray, shape = [n_samples, n_features]
             Training data.
-        y : Ignored
+
+        %(y_dummy)s
 
         Returns
         -------
@@ -313,6 +315,7 @@ class HierarchicalKMeans(ClusterMixin, TransformerMixin, BaseEstimator):
     def __sklearn_is_fitted__(self):
         return hasattr(self, "labels_")
 
+    @fill_doc
     def transform(
         self,
         X,
@@ -324,6 +327,8 @@ class HierarchicalKMeans(ClusterMixin, TransformerMixin, BaseEstimator):
         ----------
         X : ndarray, shape = [n_samples, n_features]
             Data to transform with the fitted clustering.
+
+        %(y_dummy)s
 
         Returns
         -------

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -443,9 +443,19 @@ class RegionExtractor(NiftiMapsMasker):
         self.extractor = extractor
         self.smoothing_fwhm = smoothing_fwhm
 
+    @fill_doc
     @rename_parameters(replacement_params={"X": "imgs"}, end_version="0.13.2")
     def fit(self, imgs=None, y=None):
-        """Prepare the data and setup for the region extraction."""
+        """Prepare signal extraction from regions.
+
+        Parameters
+        ----------
+        imgs : :obj:`list` of Niimg-like objects or None, default=None
+            See :ref:`extracting_data`.
+            Image data passed to the reporter.
+
+        %(y_dummy)s
+        """
         del y
         check_params(self.__dict__)
         maps_img = check_niimg_4d(self.maps_img)

--- a/nilearn/regions/rena_clustering.py
+++ b/nilearn/regions/rena_clustering.py
@@ -685,6 +685,7 @@ class ReNA(ClusterMixin, TransformerMixin, BaseEstimator):
         tags.input_tags = InputTags()
         return tags
 
+    @fill_doc
     def fit(self, X, y=None):
         """Compute clustering of the data.
 
@@ -693,7 +694,7 @@ class ReNA(ClusterMixin, TransformerMixin, BaseEstimator):
         X : :class:`numpy.ndarray`, shape = [n_samples, n_features]
             Training data.
 
-        y : Ignored
+        %(y_dummy)s
 
         Returns
         -------
@@ -770,6 +771,7 @@ class ReNA(ClusterMixin, TransformerMixin, BaseEstimator):
     def __sklearn_is_fitted__(self):
         return hasattr(self, "labels_")
 
+    @fill_doc
     def transform(
         self,
         X,
@@ -781,6 +783,8 @@ class ReNA(ClusterMixin, TransformerMixin, BaseEstimator):
         ----------
         X : :class:`numpy.ndarray`, shape = [n_samples, n_features]
             Data to transform with the fitted clustering.
+
+        %(y_dummy)s
 
         Returns
         -------


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- use a template doc strings for estimator methods that do not use their y parameter

