### PR TITLE
[ENH] Refactor to separate backends for plot_surf_stat_map

### DIFF
--- a/nilearn/plotting/_utils.py
+++ b/nilearn/plotting/_utils.py
@@ -13,11 +13,9 @@ DEFAULT_ENGINE = "matplotlib"
 
 def engine_warning(engine):
     message = (
-        (
-            f"'{engine}' is not installed. To be able to use '{engine}' as "
-            "plotting engine for 'nilearn.plotting' package:\n"
-            " pip install 'nilearn[plotting]'"
-        ),
+        f"'{engine}' is not installed. To be able to use '{engine}' as "
+        "plotting engine for 'nilearn.plotting' package:\n"
+        " pip install 'nilearn[plotting]'"
     )
     warn(message, stacklevel=find_stack_level())
 

--- a/nilearn/plotting/surface/_backend.py
+++ b/nilearn/plotting/surface/_backend.py
@@ -21,6 +21,7 @@ from warnings import warn
 
 import numpy as np
 
+from nilearn import DEFAULT_DIVERGING_CMAP
 from nilearn._utils.logger import find_stack_level
 from nilearn._utils.param_validation import check_params
 from nilearn.plotting.surface._utils import (
@@ -191,6 +192,77 @@ class BaseSurfaceBackend:
             output_file=output_file,
             axes=axes,
             figure=figure,
+            **kwargs,
+        )
+
+    def plot_surf_stat_map(
+        self,
+        surf_mesh=None,
+        stat_map=None,
+        bg_map=None,
+        hemi=DEFAULT_HEMI,
+        view=None,
+        cmap=DEFAULT_DIVERGING_CMAP,
+        colorbar=True,
+        avg_method=None,
+        threshold=None,
+        alpha=None,
+        bg_on_data=False,
+        darkness=0.7,
+        vmin=None,
+        vmax=None,
+        symmetric_cbar="auto",
+        cbar_tick_format="auto",
+        title=None,
+        title_font_size=None,
+        output_file=None,
+        axes=None,
+        figure=None,
+        **kwargs,
+    ):
+        check_params(locals())
+
+        stat_map, surf_mesh, bg_map = check_surface_plotting_inputs(
+            stat_map, surf_mesh, hemi, bg_map, map_var_name="stat_map"
+        )
+        check_extensions(stat_map, DATA_EXTENSIONS, FREESURFER_DATA_EXTENSIONS)
+        loaded_stat_map = load_surf_data(stat_map)
+
+        # derive symmetric vmin, vmax and colorbar limits depending on
+        # symmetric_cbar settings
+        cbar_vmin, cbar_vmax, vmin, vmax = (
+            self._adjust_colorbar_and_data_ranges(
+                stat_map,
+                vmin=vmin,
+                vmax=vmax,
+                symmetric_cbar=symmetric_cbar,
+            )
+        )
+
+        return self._plot_surf(
+            surf_mesh,
+            surf_map=stat_map,
+            bg_map=bg_map,
+            hemi=hemi,
+            view=view,
+            avg_method=avg_method,
+            threshold=threshold,
+            cmap=cmap,
+            symmetric_cmap=True,
+            colorbar=colorbar,
+            cbar_tick_format=cbar_tick_format,
+            alpha=alpha,
+            bg_on_data=bg_on_data,
+            darkness=darkness,
+            vmax=vmax,
+            vmin=vmin,
+            title=title,
+            title_font_size=title_font_size,
+            output_file=output_file,
+            axes=axes,
+            figure=figure,
+            cbar_vmin=cbar_vmin,
+            cbar_vmax=cbar_vmax,
             **kwargs,
         )
 

--- a/nilearn/plotting/surface/_matplotlib_backend.py
+++ b/nilearn/plotting/surface/_matplotlib_backend.py
@@ -610,3 +610,13 @@ class MatplotlibSurfaceBackend(BaseSurfaceBackend):
             axes.set_title(title)
 
         return save_figure_if_needed(figure, output_file)
+
+    def _adjust_colorbar_and_data_ranges(
+        self, stat_map, vmin=None, vmax=None, symmetric_cbar=None
+    ):
+        return get_colorbar_and_data_ranges(
+            stat_map,
+            vmin=vmin,
+            vmax=vmax,
+            symmetric_cbar=symmetric_cbar,
+        )

--- a/nilearn/plotting/surface/_plotly_backend.py
+++ b/nilearn/plotting/surface/_plotly_backend.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from nilearn import DEFAULT_DIVERGING_CMAP
 from nilearn._utils.helpers import is_kaleido_installed
+from nilearn.plotting._utils import get_colorbar_and_data_ranges
 from nilearn.plotting.displays import PlotlySurfaceFigure
 from nilearn.plotting.js_plotting_utils import colorscale
 from nilearn.plotting.surface._backend import (
@@ -365,3 +366,15 @@ class PlotlySurfaceBackend(BaseSurfaceBackend):
         **kwargs,
     ):
         raise NotImplementedError()
+
+    def _adjust_colorbar_and_data_ranges(
+        self, stat_map, vmin=None, vmax=None, symmetric_cbar=None
+    ):
+        _, _, vmin, vmax = get_colorbar_and_data_ranges(
+            stat_map,
+            vmin=vmin,
+            vmax=vmax,
+            symmetric_cbar=symmetric_cbar,
+        )
+
+        return None, None, vmin, vmax

--- a/nilearn/plotting/surface/surf_plotting.py
+++ b/nilearn/plotting/surface/surf_plotting.py
@@ -396,22 +396,22 @@ def plot_surf_stat_map(
     hemi=DEFAULT_HEMI,
     view=None,
     engine=DEFAULT_ENGINE,
-    threshold=None,
-    alpha=None,
-    vmin=None,
-    vmax=None,
     cmap=DEFAULT_DIVERGING_CMAP,
     colorbar=True,
-    symmetric_cbar="auto",
-    cbar_tick_format="auto",
+    avg_method=None,
+    threshold=None,
+    alpha=None,
     bg_on_data=False,
     darkness=0.7,
+    vmin=None,
+    vmax=None,
+    symmetric_cbar="auto",
+    cbar_tick_format="auto",
     title=None,
-    title_font_size=18,
+    title_font_size=None,
     output_file=None,
     axes=None,
     figure=None,
-    avg_method=None,
     **kwargs,
 ):
     """Plot a stats map on a surface :term:`mesh` with optional background.
@@ -463,22 +463,8 @@ def plot_surf_stat_map(
             Please report bugs that you may encounter.
 
 
-    threshold : a number or None, default=None
-        If None is given, the image is not thresholded.
-        If a number is given, it is used to threshold the image,
-        values below the threshold (in absolute value) are plotted
-        as transparent.
-
     %(cmap)s
         default="RdBu_r"
-
-    %(cbar_tick_format)s
-        Default="auto" which will select:
-
-            - '%%.2g' (scientific notation) with ``matplotlib`` engine.
-            - '.1f' (rounded floats) with ``plotly`` engine.
-
-        .. versionadded:: 0.7.1
 
     %(colorbar)s
 
@@ -486,6 +472,23 @@ def plot_surf_stat_map(
             This function uses a symmetric colorbar for the statistical map.
 
         Default=True.
+
+    %(avg_method)s
+
+        .. note::
+            This option is currently only implemented for the
+            ``matplotlib`` engine.
+
+        When using matplotlib as engine,
+        `avg_method` will default to ``"mean"`` if ``None`` is passed.
+
+        .. versionadded:: 0.10.3dev
+
+    threshold : a number or None, default=None
+        If None is given, the image is not thresholded.
+        If a number is given, it is used to threshold the image,
+        values below the threshold (in absolute value) are plotted
+        as transparent.
 
     alpha : :obj:`float` or 'auto' or None, default=None
         Alpha level of the :term:`mesh` (not the stat_map).
@@ -497,12 +500,6 @@ def plot_surf_stat_map(
             This option is currently only implemented for the
             ``matplotlib`` engine.
 
-    %(vmin)s
-
-    %(vmax)s
-
-    %(symmetric_cbar)s
-
     %(bg_on_data)s
 
     %(darkness)s
@@ -512,9 +509,23 @@ def plot_surf_stat_map(
             This option is currently only implemented for the
             ``matplotlib`` engine.
 
+    %(vmin)s
+
+    %(vmax)s
+
+    %(symmetric_cbar)s
+
+    %(cbar_tick_format)s
+        Default="auto" which will select:
+
+            - '%%.2g' (scientific notation) with ``matplotlib`` engine.
+            - '.1f' (rounded floats) with ``plotly`` engine.
+
+        .. versionadded:: 0.7.1
+
     %(title)s
 
-    title_font_size : :obj:`int`, default=18
+    title_font_size : :obj:`int`, default=None
         Size of the title font (only implemented for the plotly engine).
 
         .. versionadded:: 0.9.0
@@ -537,17 +548,6 @@ def plot_surf_stat_map(
             This option is currently only implemented for the
             ``matplotlib`` engine.
 
-    %(avg_method)s
-
-        .. note::
-            This option is currently only implemented for the
-            ``matplotlib`` engine.
-
-        When using matplotlib as engine,
-        `avg_method` will default to ``"mean"`` if ``None`` is passed.
-
-        .. versionadded:: 0.10.3dev
-
     kwargs : :obj:`dict`, optional
         Keyword arguments passed to :func:`nilearn.plotting.plot_surf`.
 
@@ -560,59 +560,31 @@ def plot_surf_stat_map(
 
     nilearn.surface.vol_to_surf : For info on the generation of surfaces.
     """
-    # set default view to dorsal if hemi is both and view is not set
-    check_params(locals())
-    if view is None:
-        view = "dorsal" if hemi == "both" else "lateral"
-
-    stat_map, surf_mesh, bg_map = check_surface_plotting_inputs(
-        stat_map, surf_mesh, hemi, bg_map, map_var_name="stat_map"
-    )
-
-    check_extensions(stat_map, DATA_EXTENSIONS, FREESURFER_DATA_EXTENSIONS)
-    loaded_stat_map = load_surf_data(stat_map)
-
-    # Call get_colorbar_and_data_ranges to derive symmetric vmin, vmax
-    # And colorbar limits depending on symmetric_cbar settings
-    cbar_vmin, cbar_vmax, vmin, vmax = get_colorbar_and_data_ranges(
-        loaded_stat_map,
-        vmin=vmin,
-        vmax=vmax,
-        symmetric_cbar=symmetric_cbar,
-    )
-    # Set to None the values that are not used by plotly
-    # to avoid warnings thrown by plot_surf
-    if engine == "plotly":
-        cbar_vmin = None
-        cbar_vmax = None
-
-    display = plot_surf(
-        surf_mesh,
-        surf_map=loaded_stat_map,
+    display = get_surface_backend(engine).plot_surf_stat_map(
+        surf_mesh=surf_mesh,
+        stat_map=stat_map,
         bg_map=bg_map,
         hemi=hemi,
         view=view,
-        engine=engine,
+        cmap=cmap,
+        colorbar=colorbar,
         avg_method=avg_method,
         threshold=threshold,
-        cmap=cmap,
-        symmetric_cmap=True,
-        colorbar=colorbar,
-        cbar_tick_format=cbar_tick_format,
         alpha=alpha,
         bg_on_data=bg_on_data,
         darkness=darkness,
-        vmax=vmax,
         vmin=vmin,
+        vmax=vmax,
+        symmetric_cbar=symmetric_cbar,
+        cbar_tick_format=cbar_tick_format,
         title=title,
         title_font_size=title_font_size,
         output_file=output_file,
         axes=axes,
         figure=figure,
-        cbar_vmin=cbar_vmin,
-        cbar_vmax=cbar_vmax,
         **kwargs,
     )
+
     return display
 
 

--- a/nilearn/plotting/surface/tests/test_backend.py
+++ b/nilearn/plotting/surface/tests/test_backend.py
@@ -1,11 +1,29 @@
 """Test nilearn.plotting.surface._backend functions."""
 
+# ruff: noqa: ARG001
+
 import pytest
 
 from nilearn.plotting.surface._backend import (
     _check_hemisphere_is_valid,
     _check_view_is_valid,
 )
+
+
+@pytest.fixture
+def backend(engine):
+    if engine == "matplotlib":
+        from nilearn.plotting.surface._matplotlib_backend import (
+            MatplotlibSurfaceBackend,
+        )
+
+        return MatplotlibSurfaceBackend()
+    elif engine == "plotly":
+        from nilearn.plotting.surface._plotly_backend import (
+            PlotlySurfaceBackend,
+        )
+
+        return PlotlySurfaceBackend()
 
 
 @pytest.mark.parametrize(
@@ -36,3 +54,56 @@ def test_check_view_is_valid(view, is_valid):
 )
 def test_check_hemisphere_is_valid(hemi, is_valid):
     assert _check_hemisphere_is_valid(hemi) is is_valid
+
+
+def test_plot_surf(plt, engine, backend, tmp_path, in_memory_mesh, bg_map):
+    """Test
+    nilearn.plotting.surface._backend.MatplotlibBackend.plot_surf and
+    nilearn.plotting.surface._backend.PlotlyBackend.plot_surf functions
+    with available engine backends.
+    """
+    # to avoid extra warnings
+    alpha = None
+    cbar_vmin = None
+    cbar_vmax = None
+    if engine == "matplotlib":
+        alpha = 0.5
+        cbar_vmin = 0
+        cbar_vmax = 150
+
+    # Plot mesh only
+    backend.plot_surf(in_memory_mesh)
+
+    # Plot mesh with background
+    backend.plot_surf(in_memory_mesh, bg_map=bg_map)
+    backend.plot_surf(in_memory_mesh, bg_map=bg_map, darkness=0.5)
+    backend.plot_surf(
+        in_memory_mesh,
+        bg_map=bg_map,
+        alpha=alpha,
+        output_file=tmp_path / "tmp.png",
+    )
+
+    # Plot with colorbar
+    backend.plot_surf(in_memory_mesh, bg_map=bg_map, colorbar=True)
+    backend.plot_surf(
+        in_memory_mesh,
+        bg_map=bg_map,
+        colorbar=True,
+        cbar_vmin=cbar_vmin,
+        cbar_vmax=cbar_vmax,
+        cbar_tick_format="%i",
+    )
+
+
+def test_plot_surf_stat_map(plt, engine, backend, in_memory_mesh, bg_map):
+    """Smoke test when stat_map is specified to
+    nilearn.plotting.surface._backend.MatplotlibBackend.plot_surf_stat_map
+    and
+    nilearn.plotting.surface._backend.PlotlyBackend.plot_surf_stat_map
+    functions together with mesh.
+    """
+    alpha = 1 if engine == "matplotlib" else None
+
+    backend.plot_surf_stat_map(in_memory_mesh, stat_map=bg_map)
+    backend.plot_surf_stat_map(in_memory_mesh, stat_map=bg_map, alpha=alpha)

--- a/nilearn/plotting/surface/tests/test_matplotlib_backend.py
+++ b/nilearn/plotting/surface/tests/test_matplotlib_backend.py
@@ -230,3 +230,23 @@ def test_compute_facecolors_deprecation():
             0.5,
             alpha,
         )
+
+
+def test_plot_surf_contours(
+    matplotlib_backend,
+    matplotlib_pyplot,
+    in_memory_mesh,
+    parcellation,
+    surf_mask_1d,
+):
+    """Test
+    nilearn.plotting.surface._backend.MatplotlibBackend.plot_surf_contours
+    for valid input values.
+    """
+    matplotlib_backend.plot_surf_contours(in_memory_mesh, parcellation)
+    matplotlib_backend.plot_surf_contours(
+        in_memory_mesh, parcellation, levels=[1, 2]
+    )
+    matplotlib_backend.plot_surf_contours(
+        in_memory_mesh, parcellation, levels=[1, 2], cmap="gist_ncar"
+    )

--- a/nilearn/plotting/surface/tests/test_surf_plotting.py
+++ b/nilearn/plotting/surface/tests/test_surf_plotting.py
@@ -537,8 +537,12 @@ def test_plot_surf_contours_errors_with_plotly_figure(plotly, in_memory_mesh):
 
 
 def test_plot_surf_stat_map(plt, engine, in_memory_mesh, bg_map):
+    """Smoke test when stat_map is specified to
+    nilearn.plotting.surface.surf_plotting.plot_surf_stat_map together with
+    mesh.
+    """
     alpha = 1 if engine == "matplotlib" else None
-    # Plot mesh with stat map
+
     plot_surf_stat_map(in_memory_mesh, stat_map=bg_map, engine=engine)
     plot_surf_stat_map(
         in_memory_mesh, stat_map=bg_map, alpha=alpha, engine=engine
@@ -548,7 +552,9 @@ def test_plot_surf_stat_map(plt, engine, in_memory_mesh, bg_map):
 def test_plot_surf_stat_map_with_background(
     plt, engine, in_memory_mesh, bg_map
 ):
-    """Plot mesh with background and stat map."""
+    """Smoke test when background map is specified also as stat_map to
+    nilearn.plotting.surface.surf_plotting.plot_surf_stat_map.
+    """
     plot_surf_stat_map(
         in_memory_mesh, stat_map=bg_map, bg_map=bg_map, engine=engine
     )
@@ -563,7 +569,9 @@ def test_plot_surf_stat_map_with_background(
 
 
 def test_plot_surf_stat_map_with_title(plt, engine, in_memory_mesh, bg_map):
-    """Check title is added."""
+    """Test if nilearn.plotting.surface.surf_plotting.plot_surf_stat_map adds
+    title when specified.
+    """
     display = plot_surf_stat_map(
         in_memory_mesh, stat_map=bg_map, title="Stat map title"
     )
@@ -573,7 +581,9 @@ def test_plot_surf_stat_map_with_title(plt, engine, in_memory_mesh, bg_map):
 def test_plot_surf_stat_map_with_threshold(
     plt, engine, in_memory_mesh, bg_map
 ):
-    """Check title is added."""
+    """Smoke test when threshold is specified to
+    nilearn.plotting.surface.surf_plotting.plot_surf_stat_map.
+    """
     plot_surf_stat_map(
         in_memory_mesh,
         stat_map=bg_map,
@@ -583,18 +593,25 @@ def test_plot_surf_stat_map_with_threshold(
 
 
 def test_plot_surf_stat_map_vmax(plt, engine, in_memory_mesh, bg_map):
-    """Change vmax."""
+    """Smoke test when vmax is specified to
+    nilearn.plotting.surface.surf_plotting.plot_surf_stat_map.
+    """
     plot_surf_stat_map(in_memory_mesh, stat_map=bg_map, vmax=5, engine=engine)
 
 
 def test_plot_surf_stat_map_colormap(plt, engine, in_memory_mesh, bg_map):
-    """Change colormap."""
+    """Smoke test when colormap is specified to
+    nilearn.plotting.surface.surf_plotting.plot_surf_stat_map.
+    """
     plot_surf_stat_map(
         in_memory_mesh, stat_map=bg_map, cmap="cubehelix", engine=engine
     )
 
 
 def test_plot_surf_stat_map_error(in_memory_mesh, bg_map):
+    """Test if nilearn.plotting.surface.surf_plotting.plot_surf_stat_map
+    raises error with wrong size of stat map data.
+    """
     # Wrong size of stat map data
     with pytest.raises(
         ValueError, match="surf_map does not have the same number of vertices"
@@ -612,7 +629,9 @@ def test_plot_surf_stat_map_error(in_memory_mesh, bg_map):
 
 
 def test_plot_surf_stat_map_colorbar_tick(plotly, in_memory_mesh, bg_map):
-    """Change colorbar tick format."""
+    """Smoke test when colorbar tick format with plotly engine is specified to
+    nilearn.plotting.surface.surf_plotting.plot_surf_stat_map.
+    """
     plot_surf_stat_map(
         in_memory_mesh,
         stat_map=bg_map,
@@ -624,6 +643,9 @@ def test_plot_surf_stat_map_colorbar_tick(plotly, in_memory_mesh, bg_map):
 def test_plot_surf_stat_map_matplotlib_specific(
     matplotlib_pyplot, in_memory_mesh, bg_map
 ):
+    """Test nilearn.plotting.surface.surf_plotting.plot_surf_stat_map for
+    matplotlib engine specific parameters.
+    """
     # Plot to axes
     axes = matplotlib_pyplot.subplots(
         ncols=2, subplot_kw={"projection": "3d"}


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes None, but relates to:
  - #5234 
  - #5253 
  - #5276
  - #5282 
  - #5322
  - #5349

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-  Refactor `plotting.surface.surf_plotting.plot_surf_stat_maps` to separate matplotlib code to `_matplotlib_backend` and plotly code to `_plotly_backend` and common parts to `backend`
- Add/update missing docstrings for tests in `test_surf_plotting` for `plot_surf_stat_maps`