### PR TITLE
[MAINT] avoid extra warning when computing fixed effects

### DIFF
--- a/examples/04_glm_first_level/plot_two_runs_model.py
+++ b/examples/04_glm_first_level/plot_two_runs_model.py
@@ -150,10 +150,8 @@ variance_imgs = [
     summary_statistics_run_2["effect_variance"],
 ]
 
-fixed_fx_contrast, fixed_fx_variance, fixed_fx_stat = compute_fixed_effects(
-    contrast_imgs,
-    variance_imgs,
-    data["mask"],
+fixed_fx_contrast, fixed_fx_variance, fixed_fx_stat, _ = compute_fixed_effects(
+    contrast_imgs, variance_imgs, data["mask"], return_z_score=True
 )
 plot_stat_map(
     fixed_fx_stat,

--- a/nilearn/glm/contrasts.py
+++ b/nilearn/glm/contrasts.py
@@ -569,8 +569,8 @@ def compute_fixed_effects(
     warn(
         category=DeprecationWarning,
         message="The behavior of this function will be "
-        "changed in release 0.13 to have an additional"
-        "return value 'fixed_fx_z_score_img'  by default. "
+        "changed in release 0.13 to have an additional "
+        "return value 'fixed_fx_z_score_img' by default. "
         "Please set return_z_score to True.",
         stacklevel=find_stack_level(),
     )

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -161,11 +161,9 @@ def test_explicit_fixed_effects(shape_3d_default):
     contrasts = [dic1["effect_size"], dic2["effect_size"]]
     variance = [dic1["effect_variance"], dic2["effect_variance"]]
 
-    (
-        fixed_fx_contrast,
-        fixed_fx_variance,
-        fixed_fx_stat,
-    ) = compute_fixed_effects(contrasts, variance, mask)
+    (fixed_fx_contrast, fixed_fx_variance, fixed_fx_stat, _) = (
+        compute_fixed_effects(contrasts, variance, mask, return_z_score=True)
+    )
 
     assert_almost_equal(
         get_data(fixed_fx_contrast), get_data(fixed_fx_dic["effect_size"])
@@ -186,13 +184,17 @@ def test_explicit_fixed_effects(shape_3d_default):
             "from the number of variance images"
         ),
     ):
-        compute_fixed_effects(contrasts * 2, variance, mask)
+        compute_fixed_effects(
+            contrasts * 2, variance, mask, return_z_score=True
+        )
 
     # ensure that not providing the right number of dofs
     with pytest.raises(
         ValueError, match="degrees of freedom .* differs .* contrast images"
     ):
-        compute_fixed_effects(contrasts, variance, mask, dofs=[100])
+        compute_fixed_effects(
+            contrasts, variance, mask, dofs=[100], return_z_score=True
+        )
 
 
 def test_explicit_fixed_effects_without_mask(shape_3d_default):
@@ -2455,9 +2457,12 @@ def test_fixed_effect_contrast_surface(surface_glm_data):
     surf_mask_ = masker.mask_img_
     for mask in [SurfaceMasker(mask_img=masker.mask_img_), surf_mask_, None]:
         outputs = compute_fixed_effects(
-            [effect, effect], [variance, variance], mask=mask
+            [effect, effect],
+            [variance, variance],
+            mask=mask,
+            return_z_score=True,
         )
-        assert len(outputs) == 3
+        assert len(outputs) == 4
         for output in outputs:
             assert isinstance(output, SurfaceImage)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- return z score image when computing fixed effects as this will be the new default in 0.13

