### PR TITLE
[ENH] Refactor `nilearn.plotting.surface.plot_img_on_surf` to separate backends

### DIFF
--- a/nilearn/plotting/_utils.py
+++ b/nilearn/plotting/_utils.py
@@ -20,7 +20,7 @@ def engine_warning(engine):
     warn(message, stacklevel=find_stack_level())
 
 
-def save_figure_if_needed(fig, output_file):
+def save_figure_if_needed(fig, output_file, bbox_inches=None):
     """Save figure if an output file value is given.
 
     Create output path if required.
@@ -47,7 +47,7 @@ def save_figure_if_needed(fig, output_file):
     if not isinstance(fig, (plt.Figure, BaseSlicer)):
         fig = fig.figure
 
-    fig.savefig(output_file)
+    fig.savefig(output_file, bbox_inches=bbox_inches)
     if isinstance(fig, plt.Figure):
         plt.close(fig)
     else:

--- a/nilearn/plotting/surface/_matplotlib_backend.py
+++ b/nilearn/plotting/surface/_matplotlib_backend.py
@@ -722,10 +722,7 @@ class MatplotlibSurfaceBackend(BaseSurfaceBackend):
                 title, y=1.0 - title_h / sum(height_ratios), va="bottom"
             )
 
-        if output_file is None:
-            return fig, axes
-        fig.savefig(output_file, bbox_inches="tight")
-        plt.close(fig)
+        return save_figure_if_needed(fig, output_file, bbox_inches="tight")
 
     def _adjust_colorbar_and_data_ranges(
         self, stat_map, vmin=None, vmax=None, symmetric_cbar=None

--- a/nilearn/plotting/surface/_plotly_backend.py
+++ b/nilearn/plotting/surface/_plotly_backend.py
@@ -367,6 +367,29 @@ class PlotlySurfaceBackend(BaseSurfaceBackend):
     ):
         raise NotImplementedError()
 
+    def _plot_img_on_surf(
+        self,
+        surf,
+        surf_mesh,
+        stat_map,
+        texture,
+        hemis,
+        modes,
+        bg_on_data=False,
+        inflate=False,
+        output_file=None,
+        title=None,
+        colorbar=True,
+        vmin=None,
+        vmax=None,
+        threshold=None,
+        symmetric_cbar=None,
+        cmap=DEFAULT_DIVERGING_CMAP,
+        cbar_tick_format=None,
+        **kwargs,
+    ):
+        raise NotImplementedError()
+
     def _adjust_colorbar_and_data_ranges(
         self, stat_map, vmin=None, vmax=None, symmetric_cbar=None
     ):

--- a/nilearn/plotting/surface/tests/test_surf_plotting.py
+++ b/nilearn/plotting/surface/tests/test_surf_plotting.py
@@ -957,11 +957,17 @@ def test_plot_surf_roi_colorbar_vmin_equal_across_engines(
 def test_plot_img_on_surf_hemispheres_and_orientations(
     matplotlib_pyplot, img_3d_mni, hemispheres, views
 ):
+    """Smoke test for nilearn.plotting.surface.plot_img_on_surf for
+    combinations of 1D or 2D hemis and orientations.
+    """
     # Check that all combinations of 1D or 2D hemis and orientations work.
     plot_img_on_surf(img_3d_mni, hemispheres=hemispheres, views=views)
 
 
 def test_plot_img_on_surf_colorbar(matplotlib_pyplot, img_3d_mni):
+    """Smoke test for nilearn.plotting.surface.plot_img_on_surf colorbar
+    parameter.
+    """
     plot_img_on_surf(
         img_3d_mni,
         hemispheres=["right"],
@@ -1002,6 +1008,9 @@ def test_plot_img_on_surf_colorbar(matplotlib_pyplot, img_3d_mni):
 
 
 def test_plot_img_on_surf_inflate(matplotlib_pyplot, img_3d_mni):
+    """Smoke test for nilearn.plotting.surface.plot_img_on_surf inflate
+    parameter.
+    """
     plot_img_on_surf(
         img_3d_mni, hemispheres=["right"], views=["lateral"], inflate=True
     )
@@ -1009,6 +1018,9 @@ def test_plot_img_on_surf_inflate(matplotlib_pyplot, img_3d_mni):
 
 @pytest.mark.parametrize("surf_mesh", ["fsaverage5", fetch_surf_fsaverage()])
 def test_plot_img_on_surf_surf_mesh(matplotlib_pyplot, img_3d_mni, surf_mesh):
+    """Smoke test for nilearn.plotting.surface.plot_img_on_surf for surf_mesh
+    parameter.
+    """
     plot_img_on_surf(
         img_3d_mni,
         hemispheres=["right", "left"],
@@ -1026,6 +1038,9 @@ def test_plot_img_on_surf_surf_mesh_low_alpha(matplotlib_pyplot, img_3d_mni):
 
 
 def test_plot_img_on_surf_with_invalid_orientation(img_3d_mni):
+    """Test if nilearn.plotting.surface.plot_img_on_surf raises error when
+    invalid views parameter is specified.
+    """
     kwargs = {"hemisphere": ["right"], "inflate": True}
     with pytest.raises(ValueError):
         plot_img_on_surf(img_3d_mni, views=["latral"], **kwargs)
@@ -1038,6 +1053,9 @@ def test_plot_img_on_surf_with_invalid_orientation(img_3d_mni):
 
 
 def test_plot_img_on_surf_with_invalid_hemisphere(img_3d_mni):
+    """Test if nilearn.plotting.surface.plot_img_on_surf raises error when
+    invalid hemispheres parameter is specified.
+    """
     with pytest.raises(ValueError):
         plot_img_on_surf(
             img_3d_mni, views=["lateral"], inflate=True, hemispheres=["lft]"]
@@ -1056,6 +1074,9 @@ def test_plot_img_on_surf_with_invalid_hemisphere(img_3d_mni):
 
 
 def test_plot_img_on_surf_with_figure_kwarg(img_3d_mni):
+    """Test if nilearn.plotting.surface.plot_img_on_surf raises error when
+    figure parameter is specified.
+    """
     with pytest.raises(ValueError):
         plot_img_on_surf(
             img_3d_mni,
@@ -1066,6 +1087,9 @@ def test_plot_img_on_surf_with_figure_kwarg(img_3d_mni):
 
 
 def test_plot_img_on_surf_with_axes_kwarg(img_3d_mni):
+    """Test if nilearn.plotting.surface.plot_img_on_surf raises error when axes
+    parameter is specified.
+    """
     with pytest.raises(ValueError):
         plot_img_on_surf(
             img_3d_mni,
@@ -1077,6 +1101,9 @@ def test_plot_img_on_surf_with_axes_kwarg(img_3d_mni):
 
 
 def test_plot_img_on_surf_with_engine_kwarg(img_3d_mni):
+    """Test if nilearn.plotting.surface.plot_img_on_surf raises error when
+    engine parameter is specified.
+    """
     with pytest.raises(ValueError):
         plot_img_on_surf(
             img_3d_mni,
@@ -1088,6 +1115,10 @@ def test_plot_img_on_surf_with_engine_kwarg(img_3d_mni):
 
 
 def test_plot_img_on_surf_title(matplotlib_pyplot, img_3d_mni):
+    """Test nilearn.plotting.surface.plot_img_on_surf with and without title
+    specified.
+    .
+    """
     title = "Title"
     fig = plot_img_on_surf(
         img_3d_mni, hemispheres=["right"], views=["lateral"]
@@ -1101,6 +1132,7 @@ def test_plot_img_on_surf_title(matplotlib_pyplot, img_3d_mni):
 
 
 def test_plot_img_on_surf_output_file(matplotlib_pyplot, tmp_path, img_3d_mni):
+    """Test nilearn.plotting.surface.plot_img_on_surf for output_file."""
     fname = tmp_path / "tmp.png"
     return_value = plot_img_on_surf(
         img_3d_mni,

--- a/nilearn/plotting/surface/tests/test_surf_plotting.py
+++ b/nilearn/plotting/surface/tests/test_surf_plotting.py
@@ -1089,11 +1089,11 @@ def test_plot_img_on_surf_with_engine_kwarg(img_3d_mni):
 
 def test_plot_img_on_surf_title(matplotlib_pyplot, img_3d_mni):
     title = "Title"
-    fig, _ = plot_img_on_surf(
+    fig = plot_img_on_surf(
         img_3d_mni, hemispheres=["right"], views=["lateral"]
     )
     assert fig._suptitle is None, "Created title without title kwarg."
-    fig, _ = plot_img_on_surf(
+    fig = plot_img_on_surf(
         img_3d_mni, hemispheres=["right"], views=["lateral"], title=title
     )
     assert fig._suptitle is not None, "Title not created."


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes None, but relates to:
  - #5234 
  - #5253 
  - #5276
  - #5282 
  - #5322
  - #5349
  - #5389
  - #5391 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-  Refactor `plotting.surface.surf_plotting.plot_img_on_surf` to separate matplotlib code to `_matplotlib_backend` and plotly code to `_plotly_backend` and common parts to `backend`
- Add/update missing docstrings for tests in `test_surf_plotting` for `plot_img_on_surf`