### PR TITLE
[ENH] Refactor `nilearn.plotting.surface.html_surface` to separate backend

### DIFF
--- a/nilearn/_utils/tests/test_common.py
+++ b/nilearn/_utils/tests/test_common.py
@@ -43,7 +43,7 @@ def test_number_public_functions():
     If this is intentional, then the number should be updated in the test.
     Otherwise it means that the public API of nilearn has changed by mistake.
     """
-    assert len({_[0] for _ in all_functions()}) == 262
+    assert len({_[0] for _ in all_functions()}) == 261
 
 
 @pytest.mark.skipif(

--- a/nilearn/plotting/surface/_matplotlib_backend.py
+++ b/nilearn/plotting/surface/_matplotlib_backend.py
@@ -14,12 +14,14 @@ from nilearn import DEFAULT_DIVERGING_CMAP
 from nilearn._utils import compare_version
 from nilearn._utils.logger import find_stack_level
 from nilearn.image import get_data
+from nilearn.plotting import cm
 from nilearn.plotting._utils import (
     get_cbar_ticks,
     get_colorbar_and_data_ranges,
     save_figure_if_needed,
 )
 from nilearn.plotting.cm import mix_colormaps
+from nilearn.plotting.js_plotting_utils import to_color_strings
 from nilearn.plotting.surface._utils import (
     DEFAULT_HEMI,
     check_engine_params,
@@ -116,6 +118,60 @@ def adjust_plot_roi_params(params):
     cbar_tick_format = params.get("cbar_tick_format", "auto")
     if cbar_tick_format == "auto":
         params["cbar_tick_format"] = "%i"
+
+
+def get_vertexcolor(
+    surf_map,
+    cmap,
+    norm,
+    absolute_threshold=None,
+    bg_map=None,
+    bg_on_data=None,
+    darkness=None,
+):
+    """Get the color of the vertices."""
+    if bg_map is None:
+        bg_data = np.ones(len(surf_map)) * 0.5
+        bg_vmin, bg_vmax = 0, 1
+    else:
+        bg_data = np.copy(load_surf_data(bg_map))
+
+    # scale background map if need be
+    bg_vmin, bg_vmax = np.min(bg_data), np.max(bg_data)
+    if bg_vmin < 0 or bg_vmax > 1:
+        bg_norm = Normalize(vmin=bg_vmin, vmax=bg_vmax)
+        bg_data = bg_norm(bg_data)
+
+    if darkness is not None:
+        bg_data *= darkness
+        warn(
+            (
+                "The `darkness` parameter will be deprecated in release 0.13. "
+                "We recommend setting `darkness` to None"
+            ),
+            DeprecationWarning,
+            stacklevel=find_stack_level(),
+        )
+
+    bg_colors = plt.get_cmap("Greys")(bg_data)
+
+    # select vertices which are filtered out by the threshold
+    if absolute_threshold is None:
+        under_threshold = np.zeros_like(surf_map, dtype=bool)
+    else:
+        under_threshold = np.abs(surf_map) < absolute_threshold
+
+    surf_colors = cmap(norm(surf_map).data)
+    # set transparency of voxels under threshold to 0
+    surf_colors[under_threshold, 3] = 0
+    if bg_on_data:
+        # if need be, set transparency of voxels above threshold to 0.7
+        # so that background map becomes visible
+        surf_colors[~under_threshold, 3] = 0.7
+
+    vertex_colors = cm.mix_colormaps(surf_colors, bg_colors)
+
+    return to_color_strings(vertex_colors)
 
 
 def _colorbar_from_array(

--- a/nilearn/plotting/surface/_matplotlib_backend.py
+++ b/nilearn/plotting/surface/_matplotlib_backend.py
@@ -74,7 +74,7 @@ MATPLOTLIB_VIEWS = {
 }
 
 
-def adjust_colorbar_and_data_ranges(
+def _adjust_colorbar_and_data_ranges(
     stat_map, vmin=None, vmax=None, symmetric_cbar=None
 ):
     """Adjust colorbar and data ranges for 'matplotlib' engine.
@@ -101,7 +101,7 @@ def adjust_colorbar_and_data_ranges(
     )
 
 
-def adjust_plot_roi_params(params):
+def _adjust_plot_roi_params(params):
     """Adjust avg_method and cbar_tick_format values for 'matplotlib' engine.
 
     Sets the values in params dict.
@@ -120,7 +120,7 @@ def adjust_plot_roi_params(params):
         params["cbar_tick_format"] = "%i"
 
 
-def get_vertexcolor(
+def _get_vertexcolor(
     surf_map,
     cmap,
     norm,
@@ -796,7 +796,7 @@ def _plot_img_on_surf(
 
         # derive symmetric vmin, vmax and colorbar limits depending on
         # symmetric_cbar settings
-        cbar_vmin, cbar_vmax, vmin, vmax = adjust_colorbar_and_data_ranges(
+        cbar_vmin, cbar_vmax, vmin, vmax = _adjust_colorbar_and_data_ranges(
             loaded_stat_map,
             vmin=vmin,
             vmax=vmax,

--- a/nilearn/plotting/surface/_plotly_backend.py
+++ b/nilearn/plotting/surface/_plotly_backend.py
@@ -15,13 +15,14 @@ from nilearn.plotting._utils import get_colorbar_and_data_ranges
 from nilearn.plotting.displays import PlotlySurfaceFigure
 from nilearn.plotting.js_plotting_utils import colorscale
 from nilearn.plotting.surface._utils import (
+    DEFAULT_ENGINE,
     DEFAULT_HEMI,
     VALID_HEMISPHERES,
     check_engine_params,
     check_surf_map,
+    get_surface_backend,
     sanitize_hemi_view,
 )
-from nilearn.plotting.surface.html_surface import get_vertexcolor
 from nilearn.surface import load_surf_data, load_surf_mesh
 
 try:
@@ -328,6 +329,7 @@ def _plot_surf(
                 "of vertices as the mesh."
             )
 
+    backend = get_surface_backend(DEFAULT_ENGINE)
     if surf_map is not None:
         check_surf_map(surf_map, coords.shape[0])
         colors = colorscale(
@@ -338,7 +340,7 @@ def _plot_surf(
             vmin=vmin,
             symmetric_cmap=symmetric_cmap,
         )
-        vertexcolor = get_vertexcolor(
+        vertexcolor = backend.get_vertexcolor(
             surf_map,
             colors["cmap"],
             colors["norm"],
@@ -351,7 +353,7 @@ def _plot_surf(
         if bg_data is None:
             bg_data = np.zeros(coords.shape[0])
         colors = colorscale("Greys", bg_data, symmetric_cmap=False)
-        vertexcolor = get_vertexcolor(
+        vertexcolor = backend.get_vertexcolor(
             bg_data,
             colors["cmap"],
             colors["norm"],

--- a/nilearn/plotting/surface/_plotly_backend.py
+++ b/nilearn/plotting/surface/_plotly_backend.py
@@ -90,7 +90,7 @@ LAYOUT = {
 }
 
 
-def adjust_colorbar_and_data_ranges(
+def _adjust_colorbar_and_data_ranges(
     stat_map, vmin=None, vmax=None, symmetric_cbar=None
 ):
     """Adjust colorbar and data ranges for 'plotly' engine.
@@ -122,7 +122,7 @@ def adjust_colorbar_and_data_ranges(
     return None, None, vmin, vmax
 
 
-def adjust_plot_roi_params(params):
+def _adjust_plot_roi_params(params):
     """Adjust cbar_tick_format value for 'plotly' engine.
 
     Sets the values in params dict.
@@ -340,7 +340,7 @@ def _plot_surf(
             vmin=vmin,
             symmetric_cmap=symmetric_cmap,
         )
-        vertexcolor = backend.get_vertexcolor(
+        vertexcolor = backend._get_vertexcolor(
             surf_map,
             colors["cmap"],
             colors["norm"],
@@ -353,7 +353,7 @@ def _plot_surf(
         if bg_data is None:
             bg_data = np.zeros(coords.shape[0])
         colors = colorscale("Greys", bg_data, symmetric_cmap=False)
-        vertexcolor = backend.get_vertexcolor(
+        vertexcolor = backend._get_vertexcolor(
             bg_data,
             colors["cmap"],
             colors["norm"],

--- a/nilearn/plotting/surface/_utils.py
+++ b/nilearn/plotting/surface/_utils.py
@@ -6,7 +6,9 @@ from warnings import warn
 import numpy as np
 
 from nilearn._utils import fill_doc
+from nilearn._utils.helpers import is_matplotlib_installed, is_plotly_installed
 from nilearn._utils.logger import find_stack_level
+from nilearn.plotting._utils import DEFAULT_ENGINE
 from nilearn.surface import (
     PolyMesh,
     SurfaceImage,
@@ -29,6 +31,45 @@ VALID_VIEWS = (
 )
 
 VALID_HEMISPHERES = "left", "right", "both"
+
+
+def get_surface_backend(engine=DEFAULT_ENGINE):
+    """Instantiate and return the required backend engine.
+
+    Parameters
+    ----------
+    engine: :obj:`str`, default='matplotlib'
+        Name of the required backend engine. Can be ``matplotlib`` or
+    ``plotly``.
+
+    Returns
+    -------
+    backend : :class:`~nilearn.plotting.surface._matplotlib_backend` or
+    :class:`~nilearn.plotting.surface._plotly_backend`.
+        The backend module for the specified engine.
+    """
+    if engine == "matplotlib":
+        if is_matplotlib_installed():
+            import nilearn.plotting.surface._matplotlib_backend as backend
+        else:
+            raise ImportError(
+                "Using engine='matplotlib' requires that ``matplotlib`` is "
+                "installed."
+            )
+    elif engine == "plotly":
+        if is_plotly_installed():
+            import nilearn.plotting.surface._plotly_backend as backend
+        else:
+            raise ImportError(
+                "Using engine='plotly' requires that ``plotly`` is installed."
+            )
+    else:
+        raise ValueError(
+            f"Unknown plotting engine {engine}. "
+            "Please use either 'matplotlib' or "
+            "'plotly'."
+        )
+    return backend
 
 
 def check_engine_params(params, engine):

--- a/nilearn/plotting/surface/html_surface.py
+++ b/nilearn/plotting/surface/html_surface.py
@@ -71,7 +71,7 @@ def _one_mesh_info(
     )
     info = {"inflated_both": mesh_to_plotly(surf_mesh)}
     backend = get_surface_backend(DEFAULT_ENGINE)
-    info["vertexcolor_both"] = backend.get_vertexcolor(
+    info["vertexcolor_both"] = backend._get_vertexcolor(
         surf_map,
         colors["cmap"],
         colors["norm"],
@@ -191,7 +191,7 @@ def _full_brain_info(
         info[f"inflated_{hemi}"] = mesh_to_plotly(mesh[f"infl_{hemi}"])
 
         backend = get_surface_backend(DEFAULT_ENGINE)
-        info[f"vertexcolor_{hemi}"] = backend.get_vertexcolor(
+        info[f"vertexcolor_{hemi}"] = backend._get_vertexcolor(
             surf_map,
             colors["cmap"],
             colors["norm"],
@@ -222,7 +222,7 @@ def _full_brain_info(
                 )
             )
     backend = get_surface_backend(DEFAULT_ENGINE)
-    info["vertexcolor_both"] = backend.get_vertexcolor(
+    info["vertexcolor_both"] = backend._get_vertexcolor(
         get_data(surface_maps),
         colors["cmap"],
         colors["norm"],

--- a/nilearn/plotting/surface/surf_plotting.py
+++ b/nilearn/plotting/surface/surf_plotting.py
@@ -7,7 +7,6 @@ import pandas as pd
 
 from nilearn import DEFAULT_DIVERGING_CMAP
 from nilearn._utils import fill_doc
-from nilearn._utils.helpers import is_matplotlib_installed, is_plotly_installed
 from nilearn._utils.logger import find_stack_level
 from nilearn._utils.niimg_conversions import check_niimg_3d
 from nilearn._utils.param_validation import check_params
@@ -21,6 +20,7 @@ from nilearn.plotting.surface._utils import (
     check_hemispheres,
     check_surface_plotting_inputs,
     check_views,
+    get_surface_backend,
 )
 from nilearn.surface import load_surf_data, load_surf_mesh, vol_to_surf
 from nilearn.surface.surface import (
@@ -35,45 +35,6 @@ DATA_EXTENSIONS = (
     "gii.gz",
     "mgz",
 )
-
-
-def _get_surface_backend(engine=DEFAULT_ENGINE):
-    """Instantiate and return the required backend engine.
-
-    Parameters
-    ----------
-    engine: :obj:`str`, default='matplotlib'
-        Name of the required backend engine. Can be ``matplotlib`` or
-    ``plotly``.
-
-    Returns
-    -------
-    backend : :class:`~nilearn.plotting.surface._matplotlib_backend` or
-    :class:`~nilearn.plotting.surface._plotly_backend`.
-        The backend module for the specified engine.
-    """
-    if engine == "matplotlib":
-        if is_matplotlib_installed():
-            import nilearn.plotting.surface._matplotlib_backend as backend
-        else:
-            raise ImportError(
-                "Using engine='matplotlib' requires that ``matplotlib`` is "
-                "installed."
-            )
-    elif engine == "plotly":
-        if is_plotly_installed():
-            import nilearn.plotting.surface._plotly_backend as backend
-        else:
-            raise ImportError(
-                "Using engine='plotly' requires that ``plotly`` is installed."
-            )
-    else:
-        raise ValueError(
-            f"Unknown plotting engine {engine}. "
-            "Please use either 'matplotlib' or "
-            "'plotly'."
-        )
-    return backend
 
 
 @fill_doc
@@ -290,7 +251,7 @@ def plot_surf(
     )
     check_extensions(surf_map, DATA_EXTENSIONS, FREESURFER_DATA_EXTENSIONS)
 
-    backend = _get_surface_backend(engine)
+    backend = get_surface_backend(engine)
     fig = backend._plot_surf(
         surf_mesh,
         surf_map=surf_map,
@@ -414,7 +375,7 @@ def plot_surf_contours(
     )
     check_extensions(roi_map, DATA_EXTENSIONS, FREESURFER_DATA_EXTENSIONS)
 
-    backend = _get_surface_backend(DEFAULT_ENGINE)
+    backend = get_surface_backend(DEFAULT_ENGINE)
     fig = backend._plot_surf_contours(
         surf_mesh=surf_mesh,
         roi_map=roi_map,
@@ -613,7 +574,7 @@ def plot_surf_stat_map(
     check_extensions(stat_map, DATA_EXTENSIONS, FREESURFER_DATA_EXTENSIONS)
     loaded_stat_map = load_surf_data(stat_map)
 
-    backend = _get_surface_backend(engine)
+    backend = get_surface_backend(engine)
     # derive symmetric vmin, vmax and colorbar limits depending on
     # symmetric_cbar settings
     cbar_vmin, cbar_vmax, vmin, vmax = backend.adjust_colorbar_and_data_ranges(
@@ -795,7 +756,7 @@ def plot_img_on_surf(
         ),
     }
 
-    backend = _get_surface_backend(DEFAULT_ENGINE)
+    backend = get_surface_backend(DEFAULT_ENGINE)
     # get vmin and vmax for entire data (all hemis)
     _, _, vmin, vmax = backend.adjust_colorbar_and_data_ranges(
         get_data(stat_map),
@@ -1053,7 +1014,7 @@ def plot_surf_roi(
         "cbar_tick_format": cbar_tick_format,
     }
 
-    backend = _get_surface_backend(engine)
+    backend = get_surface_backend(engine)
     backend.adjust_plot_roi_params(params)
 
     fig = backend._plot_surf(

--- a/nilearn/plotting/surface/surf_plotting.py
+++ b/nilearn/plotting/surface/surf_plotting.py
@@ -575,11 +575,13 @@ def plot_surf_stat_map(
     backend = get_surface_backend(engine)
     # derive symmetric vmin, vmax and colorbar limits depending on
     # symmetric_cbar settings
-    cbar_vmin, cbar_vmax, vmin, vmax = backend.adjust_colorbar_and_data_ranges(
-        loaded_stat_map,
-        vmin=vmin,
-        vmax=vmax,
-        symmetric_cbar=symmetric_cbar,
+    cbar_vmin, cbar_vmax, vmin, vmax = (
+        backend._adjust_colorbar_and_data_ranges(
+            loaded_stat_map,
+            vmin=vmin,
+            vmax=vmax,
+            symmetric_cbar=symmetric_cbar,
+        )
     )
 
     fig = backend._plot_surf(
@@ -758,7 +760,7 @@ def plot_img_on_surf(
 
     backend = get_surface_backend(DEFAULT_ENGINE)
     # get vmin and vmax for entire data (all hemis)
-    _, _, vmin, vmax = backend.adjust_colorbar_and_data_ranges(
+    _, _, vmin, vmax = backend._adjust_colorbar_and_data_ranges(
         get_data(stat_map),
         vmin=vmin,
         vmax=vmax,
@@ -1020,7 +1022,7 @@ def plot_surf_roi(
     }
 
     backend = get_surface_backend(engine)
-    backend.adjust_plot_roi_params(params)
+    backend._adjust_plot_roi_params(params)
 
     fig = backend._plot_surf(
         mesh,

--- a/nilearn/plotting/surface/tests/test_html_surface.py
+++ b/nilearn/plotting/surface/tests/test_html_surface.py
@@ -14,9 +14,7 @@ from nilearn.plotting.surface.html_surface import (
     _fill_html_template,
     _full_brain_info,
     _one_mesh_info,
-    colorscale,
     full_brain_info,
-    get_vertexcolor,
     one_mesh_info,
     view_img_on_surf,
     view_surf,
@@ -35,111 +33,6 @@ from nilearn.surface.surface import (
 @pytest.fixture(scope="session")
 def mni152_template_res_2():
     return datasets.load_mni152_template(resolution=2)
-
-
-def test_get_vertexcolor():
-    """Test get_vertexcolor."""
-    fsaverage = fetch_surf_fsaverage()
-    mesh = load_surf_mesh(fsaverage["pial_left"])
-    surf_map = np.arange(len(mesh.coordinates))
-    colors = colorscale("jet", surf_map, 10)
-
-    vertexcolors = get_vertexcolor(
-        surf_map,
-        colors["cmap"],
-        colors["norm"],
-        absolute_threshold=colors["abs_threshold"],
-        bg_map=fsaverage["sulc_left"],
-    )
-
-    assert len(vertexcolors) == len(mesh.coordinates)
-
-    vertexcolors = get_vertexcolor(
-        surf_map,
-        colors["cmap"],
-        colors["norm"],
-        absolute_threshold=colors["abs_threshold"],
-    )
-
-    assert len(vertexcolors) == len(mesh.coordinates)
-
-
-def test_get_vertexcolor_bg_map():
-    """Test get_vertexcolor with background map."""
-    fsaverage = fetch_surf_fsaverage()
-    mesh = load_surf_mesh(fsaverage["pial_left"])
-    surf_map = np.arange(len(mesh.coordinates))
-    colors = colorscale("jet", surf_map, 10)
-
-    # Surface map whose value in each vertex is
-    # 1 if this vertex's curv > 0
-    # 0 if this vertex's curv is 0
-    # -1 if this vertex's curv < 0
-    bg_map = np.sign(load_surf_data(fsaverage["curv_left"]))
-    bg_min, bg_max = np.min(bg_map), np.max(bg_map)
-    assert bg_min < 0 or bg_max > 1
-
-    vertexcolors_auto_normalized = get_vertexcolor(
-        surf_map,
-        colors["cmap"],
-        colors["norm"],
-        absolute_threshold=colors["abs_threshold"],
-        bg_map=bg_map,
-    )
-
-    assert len(vertexcolors_auto_normalized) == len(mesh.coordinates)
-
-    # Manually set values of background map between 0 and 1
-    bg_map_normalized = (bg_map - bg_min) / (bg_max - bg_min)
-    assert np.min(bg_map_normalized) == 0 and np.max(bg_map_normalized) == 1
-
-    vertexcolors_manually_normalized = get_vertexcolor(
-        surf_map,
-        colors["cmap"],
-        colors["norm"],
-        absolute_threshold=colors["abs_threshold"],
-        bg_map=bg_map_normalized,
-    )
-
-    assert len(vertexcolors_manually_normalized) == len(mesh.coordinates)
-    assert vertexcolors_manually_normalized == vertexcolors_auto_normalized
-
-    # Scale background map between 0.25 and 0.75
-    bg_map_scaled = bg_map_normalized / 2 + 0.25
-    assert np.min(bg_map_scaled) == 0.25 and np.max(bg_map_scaled) == 0.75
-
-    vertexcolors_manually_rescaled = get_vertexcolor(
-        surf_map,
-        colors["cmap"],
-        colors["norm"],
-        absolute_threshold=colors["abs_threshold"],
-        bg_map=bg_map_scaled,
-    )
-
-    assert len(vertexcolors_manually_rescaled) == len(mesh.coordinates)
-    assert vertexcolors_manually_rescaled != vertexcolors_auto_normalized
-
-
-def test_get_vertexcolor_deprecation():
-    """Check deprecation warning."""
-    fsaverage = fetch_surf_fsaverage()
-    mesh = load_surf_mesh(fsaverage["pial_left"])
-    surf_map = np.arange(len(mesh.coordinates))
-    colors = colorscale("jet", surf_map, 10)
-
-    with pytest.warns(
-        DeprecationWarning,
-        match=(
-            "The `darkness` parameter will be deprecated in release 0.13. "
-            "We recommend setting `darkness` to None"
-        ),
-    ):
-        get_vertexcolor(
-            surf_map,
-            colors["cmap"],
-            colors["norm"],
-            darkness=0.5,
-        )
 
 
 def test_check_mesh():

--- a/nilearn/plotting/surface/tests/test_matplotlib_backend.py
+++ b/nilearn/plotting/surface/tests/test_matplotlib_backend.py
@@ -6,12 +6,14 @@ import numpy as np
 import pytest
 
 from nilearn.datasets import fetch_surf_fsaverage
+from nilearn.plotting.js_plotting_utils import colorscale
 from nilearn.plotting.surface._matplotlib_backend import (
     MATPLOTLIB_VIEWS,
     _compute_facecolors,
     _get_bounds,
     _get_ticks,
     _get_view_plot_surf,
+    get_vertexcolor,
 )
 from nilearn.surface import (
     load_surf_data,
@@ -223,4 +225,109 @@ def test_compute_facecolors_deprecation():
             len(mesh.coordinates),
             0.5,
             alpha,
+        )
+
+
+def test_get_vertexcolor():
+    """Test get_vertexcolor."""
+    fsaverage = fetch_surf_fsaverage()
+    mesh = load_surf_mesh(fsaverage["pial_left"])
+    surf_map = np.arange(len(mesh.coordinates))
+    colors = colorscale("jet", surf_map, 10)
+
+    vertexcolors = get_vertexcolor(
+        surf_map,
+        colors["cmap"],
+        colors["norm"],
+        absolute_threshold=colors["abs_threshold"],
+        bg_map=fsaverage["sulc_left"],
+    )
+
+    assert len(vertexcolors) == len(mesh.coordinates)
+
+    vertexcolors = get_vertexcolor(
+        surf_map,
+        colors["cmap"],
+        colors["norm"],
+        absolute_threshold=colors["abs_threshold"],
+    )
+
+    assert len(vertexcolors) == len(mesh.coordinates)
+
+
+def test_get_vertexcolor_bg_map():
+    """Test get_vertexcolor with background map."""
+    fsaverage = fetch_surf_fsaverage()
+    mesh = load_surf_mesh(fsaverage["pial_left"])
+    surf_map = np.arange(len(mesh.coordinates))
+    colors = colorscale("jet", surf_map, 10)
+
+    # Surface map whose value in each vertex is
+    # 1 if this vertex's curv > 0
+    # 0 if this vertex's curv is 0
+    # -1 if this vertex's curv < 0
+    bg_map = np.sign(load_surf_data(fsaverage["curv_left"]))
+    bg_min, bg_max = np.min(bg_map), np.max(bg_map)
+    assert bg_min < 0 or bg_max > 1
+
+    vertexcolors_auto_normalized = get_vertexcolor(
+        surf_map,
+        colors["cmap"],
+        colors["norm"],
+        absolute_threshold=colors["abs_threshold"],
+        bg_map=bg_map,
+    )
+
+    assert len(vertexcolors_auto_normalized) == len(mesh.coordinates)
+
+    # Manually set values of background map between 0 and 1
+    bg_map_normalized = (bg_map - bg_min) / (bg_max - bg_min)
+    assert np.min(bg_map_normalized) == 0 and np.max(bg_map_normalized) == 1
+
+    vertexcolors_manually_normalized = get_vertexcolor(
+        surf_map,
+        colors["cmap"],
+        colors["norm"],
+        absolute_threshold=colors["abs_threshold"],
+        bg_map=bg_map_normalized,
+    )
+
+    assert len(vertexcolors_manually_normalized) == len(mesh.coordinates)
+    assert vertexcolors_manually_normalized == vertexcolors_auto_normalized
+
+    # Scale background map between 0.25 and 0.75
+    bg_map_scaled = bg_map_normalized / 2 + 0.25
+    assert np.min(bg_map_scaled) == 0.25 and np.max(bg_map_scaled) == 0.75
+
+    vertexcolors_manually_rescaled = get_vertexcolor(
+        surf_map,
+        colors["cmap"],
+        colors["norm"],
+        absolute_threshold=colors["abs_threshold"],
+        bg_map=bg_map_scaled,
+    )
+
+    assert len(vertexcolors_manually_rescaled) == len(mesh.coordinates)
+    assert vertexcolors_manually_rescaled != vertexcolors_auto_normalized
+
+
+def test_get_vertexcolor_deprecation():
+    """Check deprecation warning."""
+    fsaverage = fetch_surf_fsaverage()
+    mesh = load_surf_mesh(fsaverage["pial_left"])
+    surf_map = np.arange(len(mesh.coordinates))
+    colors = colorscale("jet", surf_map, 10)
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=(
+            "The `darkness` parameter will be deprecated in release 0.13. "
+            "We recommend setting `darkness` to None"
+        ),
+    ):
+        get_vertexcolor(
+            surf_map,
+            colors["cmap"],
+            colors["norm"],
+            darkness=0.5,
         )

--- a/nilearn/plotting/surface/tests/test_matplotlib_backend.py
+++ b/nilearn/plotting/surface/tests/test_matplotlib_backend.py
@@ -12,8 +12,8 @@ from nilearn.plotting.surface._matplotlib_backend import (
     _compute_facecolors,
     _get_bounds,
     _get_ticks,
+    _get_vertexcolor,
     _get_view_plot_surf,
-    get_vertexcolor,
 )
 from nilearn.surface import (
     load_surf_data,
@@ -235,7 +235,7 @@ def test_get_vertexcolor():
     surf_map = np.arange(len(mesh.coordinates))
     colors = colorscale("jet", surf_map, 10)
 
-    vertexcolors = get_vertexcolor(
+    vertexcolors = _get_vertexcolor(
         surf_map,
         colors["cmap"],
         colors["norm"],
@@ -245,7 +245,7 @@ def test_get_vertexcolor():
 
     assert len(vertexcolors) == len(mesh.coordinates)
 
-    vertexcolors = get_vertexcolor(
+    vertexcolors = _get_vertexcolor(
         surf_map,
         colors["cmap"],
         colors["norm"],
@@ -270,7 +270,7 @@ def test_get_vertexcolor_bg_map():
     bg_min, bg_max = np.min(bg_map), np.max(bg_map)
     assert bg_min < 0 or bg_max > 1
 
-    vertexcolors_auto_normalized = get_vertexcolor(
+    vertexcolors_auto_normalized = _get_vertexcolor(
         surf_map,
         colors["cmap"],
         colors["norm"],
@@ -284,7 +284,7 @@ def test_get_vertexcolor_bg_map():
     bg_map_normalized = (bg_map - bg_min) / (bg_max - bg_min)
     assert np.min(bg_map_normalized) == 0 and np.max(bg_map_normalized) == 1
 
-    vertexcolors_manually_normalized = get_vertexcolor(
+    vertexcolors_manually_normalized = _get_vertexcolor(
         surf_map,
         colors["cmap"],
         colors["norm"],
@@ -299,7 +299,7 @@ def test_get_vertexcolor_bg_map():
     bg_map_scaled = bg_map_normalized / 2 + 0.25
     assert np.min(bg_map_scaled) == 0.25 and np.max(bg_map_scaled) == 0.75
 
-    vertexcolors_manually_rescaled = get_vertexcolor(
+    vertexcolors_manually_rescaled = _get_vertexcolor(
         surf_map,
         colors["cmap"],
         colors["norm"],
@@ -325,7 +325,7 @@ def test_get_vertexcolor_deprecation():
             "We recommend setting `darkness` to None"
         ),
     ):
-        get_vertexcolor(
+        _get_vertexcolor(
             surf_map,
             colors["cmap"],
             colors["norm"],

--- a/nilearn/plotting/surface/tests/test_surf_plotting.py
+++ b/nilearn/plotting/surface/tests/test_surf_plotting.py
@@ -13,7 +13,6 @@ from numpy.testing import assert_array_equal
 from nilearn._utils.exceptions import MeshDimensionError
 from nilearn._utils.helpers import (
     is_kaleido_installed,
-    is_matplotlib_installed,
     is_plotly_installed,
 )
 from nilearn.datasets import fetch_surf_fsaverage
@@ -24,7 +23,6 @@ from nilearn.plotting import (
     plot_surf_roi,
     plot_surf_stat_map,
 )
-from nilearn.plotting.surface.surf_plotting import _get_surface_backend
 
 
 @pytest.fixture
@@ -33,38 +31,6 @@ def surf_roi_data(rng, in_memory_mesh):
     roi_idx = rng.integers(0, in_memory_mesh.n_vertices, size=10)
     roi_map[roi_idx] = 1
     return roi_map
-
-
-@pytest.mark.skipif(
-    is_matplotlib_installed(),
-    reason="This test is run only if matplotlib is not installed.",
-)
-def test_get_surface_backend_matplotlib_not_installed():
-    """Tests to see if get_surface_backend raises error when matplotlib is not
-    installed.
-    """
-    with pytest.raises(ImportError, match="Using engine"):
-        _get_surface_backend("matplotlib")
-
-
-@pytest.mark.skipif(
-    is_plotly_installed(),
-    reason="This test is run only if plotly is not installed.",
-)
-def test_get_surface_backend_plotly_not_installed():
-    """Tests to see if get_surface_backend raises error when plotly is not
-    installed.
-    """
-    with pytest.raises(ImportError, match="Using engine"):
-        _get_surface_backend("plotly")
-
-
-def test_get_surface_backend_unknown_error():
-    """Tests to see if get_surface_backend raises error when the specified
-    backend is not implemented.
-    """
-    with pytest.raises(ValueError, match="Unknown plotting engine"):
-        _get_surface_backend("unknown")
 
 
 @pytest.mark.parametrize(

--- a/nilearn/plotting/surface/tests/test_utils.py
+++ b/nilearn/plotting/surface/tests/test_utils.py
@@ -6,11 +6,16 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
+from nilearn._utils.helpers import (
+    is_matplotlib_installed,
+    is_plotly_installed,
+)
 from nilearn.plotting.surface._utils import (
     _check_hemisphere_is_valid,
     _check_view_is_valid,
     check_surface_plotting_inputs,
     get_faces_on_edge,
+    get_surface_backend,
 )
 from nilearn.surface import InMemoryMesh, load_surf_mesh
 from nilearn.surface.utils import assert_surface_mesh_equal
@@ -209,3 +214,35 @@ def test_get_faces_on_edge_matplotlib(in_memory_mesh):
         ValueError, match=("Vertices in parcellation do not form region.")
     ):
         get_faces_on_edge(faces, [91])
+
+
+@pytest.mark.skipif(
+    is_matplotlib_installed(),
+    reason="This test is run only if matplotlib is not installed.",
+)
+def test_get_surface_backend_matplotlib_not_installed():
+    """Tests to see if get_surface_backend raises error when matplotlib is not
+    installed.
+    """
+    with pytest.raises(ImportError, match="Using engine"):
+        get_surface_backend("matplotlib")
+
+
+@pytest.mark.skipif(
+    is_plotly_installed(),
+    reason="This test is run only if plotly is not installed.",
+)
+def test_get_surface_backend_plotly_not_installed():
+    """Tests to see if get_surface_backend raises error when plotly is not
+    installed.
+    """
+    with pytest.raises(ImportError, match="Using engine"):
+        get_surface_backend("plotly")
+
+
+def test_get_surface_backend_unknown_error():
+    """Tests to see if get_surface_backend raises error when the specified
+    backend is not implemented.
+    """
+    with pytest.raises(ValueError, match="Unknown plotting engine"):
+        get_surface_backend("unknown")


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes None, but relates to:
  - #5234 
  - #5253 
  - #5276
  - #5282 
  - #5322
  - #5349
  - #5389
  - #5391
  - #5401 
  - #5407 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-  Refactor `plotting.surface.html_surface` to extract `get_vertexcolor` function that uses matplotlib and move it to `_matplotlib_backend`
- Move tests accordingly

This is the final PR that refactors `nilearn.plotting.surface` package to separate `matplotlib` and `plotly` code to backend modules.