### PR TITLE
[FIX] turn _sanitize_cleaning_parameters into a private method

### DIFF
--- a/nilearn/maskers/_utils.py
+++ b/nilearn/maskers/_utils.py
@@ -35,8 +35,6 @@ def sanitize_cleaning_parameters(masker):
     else:
         masker.clean_args_ = masker.clean_args
 
-    return masker
-
 
 def _check_dims(imgs):
     # check dims of one image if given a list

--- a/nilearn/maskers/_utils.py
+++ b/nilearn/maskers/_utils.py
@@ -30,10 +30,7 @@ def sanitize_cleaning_parameters(masker):
             for k, v in masker.clean_kwargs.items()
             if k.startswith("clean__")
         }
-    if masker.clean_args is None:
-        masker.clean_args_ = {}
-    else:
-        masker.clean_args_ = masker.clean_args
+
 
 
 def _check_dims(imgs):

--- a/nilearn/maskers/_utils.py
+++ b/nilearn/maskers/_utils.py
@@ -1,36 +1,4 @@
-import warnings
-
 from nilearn import image
-from nilearn._utils.logger import find_stack_level
-
-
-def sanitize_cleaning_parameters(masker):
-    """Make sure that clarning parameters are passed via clean_args.
-
-    TODO simplify after nilearn 0.13.2
-    """
-    if hasattr(masker, "clean_kwargs"):
-        if masker.clean_kwargs:
-            tmp = [", ".join(list(masker.clean_kwargs))]
-            warnings.warn(
-                f"You passed some kwargs to {masker.__class__.__name__}: "
-                f"{tmp}. "
-                "This behavior is deprecated "
-                "and will be removed in version 0.13.2.",
-                DeprecationWarning,
-                stacklevel=find_stack_level(),
-            )
-            if masker.clean_args:
-                raise ValueError(
-                    "Passing arguments via 'kwargs' "
-                    "is mutually exclusive with using 'clean_args'"
-                )
-        masker.clean_kwargs_ = {
-            k[7:]: v
-            for k, v in masker.clean_kwargs.items()
-            if k.startswith("clean__")
-        }
-
 
 
 def _check_dims(imgs):

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -478,6 +478,33 @@ class BaseMasker(TransformerMixin, CacheMixin, BaseEstimator):
         """
         raise NotImplementedError()
 
+    def _sanitize_cleaning_parameters(self):
+        """Make sure that clarning parameters are passed via clean_args.
+
+        TODO remove when bumping to nilearn >0.13
+        """
+        if hasattr(self, "clean_kwargs"):
+            if self.clean_kwargs:
+                tmp = [", ".join(list(self.clean_kwargs))]
+                warnings.warn(
+                    f"You passed some kwargs to {self.__class__.__name__}: "
+                    f"{tmp}. "
+                    "This behavior is deprecated "
+                    "and will be removed in version >0.13.",
+                    DeprecationWarning,
+                    stacklevel=find_stack_level(),
+                )
+                if self.clean_args:
+                    raise ValueError(
+                        "Passing arguments via 'kwargs' "
+                        "is mutually exclusive with using 'clean_args'"
+                    )
+            self.clean_kwargs_ = {
+                k[7:]: v
+                for k, v in self.clean_kwargs.items()
+                if k.startswith("clean__")
+            }
+
 
 class _BaseSurfaceMasker(TransformerMixin, CacheMixin, BaseEstimator):
     """Class from which all surface maskers should inherit."""

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -284,7 +284,7 @@ class MultiNiftiMasker(NiftiMasker):
             "hover over the displayed image."
         )
 
-        self = sanitize_cleaning_parameters(self)
+        sanitize_cleaning_parameters(self)
 
         self.mask_img_ = self._load_mask(imgs)
 

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -27,10 +27,7 @@ from nilearn._utils.tags import SKLEARN_LT_1_6
 from nilearn.image import (
     resample_img,
 )
-from nilearn.maskers._utils import (
-    compute_middle_image,
-    sanitize_cleaning_parameters,
-)
+from nilearn.maskers._utils import compute_middle_image
 from nilearn.maskers.base_masker import prepare_confounds_multimaskers
 from nilearn.maskers.nifti_masker import NiftiMasker, filter_and_mask
 from nilearn.masking import (
@@ -197,7 +194,7 @@ class MultiNiftiMasker(NiftiMasker):
         verbose=0,
         cmap="CMRmap_r",
         clean_args=None,
-        **kwargs,
+        **kwargs,  # TODO remove when bumping to nilearn >0.13
     ):
         super().__init__(
             # Mask is provided or computed
@@ -220,6 +217,7 @@ class MultiNiftiMasker(NiftiMasker):
             verbose=verbose,
             cmap=cmap,
             clean_args=clean_args,
+            # TODO remove when bumping to nilearn >0.13
             **kwargs,
         )
         self.n_jobs = n_jobs
@@ -284,8 +282,8 @@ class MultiNiftiMasker(NiftiMasker):
             "hover over the displayed image."
         )
 
-        sanitize_cleaning_parameters(self)
-        self.clean_args_ = {}  if self.clean_args is None else  self.clean_args
+        self.sanitize_cleaning_parameters()
+        self.clean_args_ = {} if self.clean_args is None else self.clean_args
 
         self.mask_img_ = self._load_mask(imgs)
 

--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -285,6 +285,7 @@ class MultiNiftiMasker(NiftiMasker):
         )
 
         sanitize_cleaning_parameters(self)
+        self.clean_args_ = {}  if self.clean_args is None else  self.clean_args
 
         self.mask_img_ = self._load_mask(imgs)
 

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -517,6 +517,7 @@ class NiftiLabelsMasker(BaseMasker):
             )
 
         sanitize_cleaning_parameters(self)
+        self.clean_args_ = {}  if self.clean_args is None else  self.clean_args
 
         self._report_content = {
             "description": (

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -516,7 +516,7 @@ class NiftiLabelsMasker(BaseMasker):
                 f"parameter: {self.resampling_target}"
             )
 
-        self = sanitize_cleaning_parameters(self)
+        sanitize_cleaning_parameters(self)
 
         self._report_content = {
             "description": (

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -29,10 +29,7 @@ from nilearn._utils.param_validation import (
     check_reduction_strategy,
 )
 from nilearn.image import get_data, load_img, resample_img
-from nilearn.maskers._utils import (
-    compute_middle_image,
-    sanitize_cleaning_parameters,
-)
+from nilearn.maskers._utils import compute_middle_image
 from nilearn.maskers.base_masker import BaseMasker, filter_and_extract
 from nilearn.masking import load_mask_img
 
@@ -215,7 +212,7 @@ class NiftiLabelsMasker(BaseMasker):
         reports=True,
         cmap="CMRmap_r",
         clean_args=None,
-        **kwargs,
+        **kwargs,  # TODO remove when bumping to nilearn >0.13
     ):
         self.labels_img = labels_img
         self.background_label = background_label
@@ -239,6 +236,8 @@ class NiftiLabelsMasker(BaseMasker):
         self.t_r = t_r
         self.dtype = dtype
         self.clean_args = clean_args
+
+        # TODO remove when bumping to nilearn >0.13
         self.clean_kwargs = kwargs
 
         # Parameters for resampling
@@ -516,8 +515,8 @@ class NiftiLabelsMasker(BaseMasker):
                 f"parameter: {self.resampling_target}"
             )
 
-        sanitize_cleaning_parameters(self)
-        self.clean_args_ = {}  if self.clean_args is None else  self.clean_args
+        self.sanitize_cleaning_parameters()
+        self.clean_args_ = {} if self.clean_args is None else self.clean_args
 
         self._report_content = {
             "description": (

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -14,10 +14,7 @@ from nilearn._utils.logger import find_stack_level, log
 from nilearn._utils.niimg_conversions import check_niimg, check_same_fov
 from nilearn._utils.param_validation import check_params
 from nilearn.image import clean_img, get_data, index_img, resample_img
-from nilearn.maskers._utils import (
-    compute_middle_image,
-    sanitize_cleaning_parameters,
-)
+from nilearn.maskers._utils import compute_middle_image
 from nilearn.maskers.base_masker import BaseMasker, filter_and_extract
 from nilearn.masking import load_mask_img
 
@@ -173,7 +170,7 @@ class NiftiMapsMasker(BaseMasker):
         reports=True,
         cmap="CMRmap_r",
         clean_args=None,
-        **kwargs,
+        **kwargs,  # TODO remove when bumping to nilearn >0.13
     ):
         self.maps_img = maps_img
         self.mask_img = mask_img
@@ -194,6 +191,8 @@ class NiftiMapsMasker(BaseMasker):
         self.t_r = t_r
         self.dtype = dtype
         self.clean_args = clean_args
+
+        # TODO remove when bumping to nilearn >0.13
         self.clean_kwargs = kwargs
 
         # Parameters for resampling
@@ -404,8 +403,8 @@ class NiftiMapsMasker(BaseMasker):
                 "Set resampling_target to something else or provide a mask."
             )
 
-        sanitize_cleaning_parameters(self)
-        self.clean_args_ = {}  if self.clean_args is None else  self.clean_args
+        self.sanitize_cleaning_parameters()
+        self.clean_args_ = {} if self.clean_args is None else self.clean_args
 
         self._report_content = {
             "description": (

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -405,6 +405,7 @@ class NiftiMapsMasker(BaseMasker):
             )
 
         sanitize_cleaning_parameters(self)
+        self.clean_args_ = {}  if self.clean_args is None else  self.clean_args
 
         self._report_content = {
             "description": (

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -404,7 +404,7 @@ class NiftiMapsMasker(BaseMasker):
                 "Set resampling_target to something else or provide a mask."
             )
 
-        self = sanitize_cleaning_parameters(self)
+        sanitize_cleaning_parameters(self)
 
         self._report_content = {
             "description": (

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -445,6 +445,7 @@ class NiftiMasker(BaseMasker):
             self._shelving = False
 
         sanitize_cleaning_parameters(self)
+        self.clean_args_ = {}  if self.clean_args is None else  self.clean_args
 
         # Load data (if filenames are given, load them)
         logger.log(

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -444,7 +444,7 @@ class NiftiMasker(BaseMasker):
         if getattr(self, "_shelving", None) is None:
             self._shelving = False
 
-        self = sanitize_cleaning_parameters(self)
+        sanitize_cleaning_parameters(self)
 
         # Load data (if filenames are given, load them)
         logger.log(

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -14,10 +14,7 @@ from nilearn._utils.docs import fill_doc
 from nilearn._utils.logger import find_stack_level
 from nilearn._utils.param_validation import check_params
 from nilearn.image import crop_img, resample_img
-from nilearn.maskers._utils import (
-    compute_middle_image,
-    sanitize_cleaning_parameters,
-)
+from nilearn.maskers._utils import compute_middle_image
 from nilearn.maskers.base_masker import BaseMasker, filter_and_extract
 from nilearn.masking import (
     apply_mask,
@@ -296,7 +293,7 @@ class NiftiMasker(BaseMasker):
         reports=True,
         cmap="gray",
         clean_args=None,
-        **kwargs,
+        **kwargs,  # TODO remove when bumping to nilearn >0.13
     ):
         # Mask is provided or computed
         self.mask_img = mask_img
@@ -320,6 +317,8 @@ class NiftiMasker(BaseMasker):
         self.reports = reports
         self.cmap = cmap
         self.clean_args = clean_args
+
+        # TODO remove when bumping to nilearn >0.13
         self.clean_kwargs = kwargs
 
     def generate_report(self):
@@ -444,8 +443,8 @@ class NiftiMasker(BaseMasker):
         if getattr(self, "_shelving", None) is None:
             self._shelving = False
 
-        sanitize_cleaning_parameters(self)
-        self.clean_args_ = {}  if self.clean_args is None else  self.clean_args
+        self.sanitize_cleaning_parameters()
+        self.clean_args_ = {} if self.clean_args is None else self.clean_args
 
         # Load data (if filenames are given, load them)
         logger.log(

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -29,10 +29,7 @@ from nilearn._utils.niimg_conversions import (
 from nilearn.datasets import load_mni152_template
 from nilearn.image import resample_img
 from nilearn.image.resampling import coord_transform
-from nilearn.maskers._utils import (
-    compute_middle_image,
-    sanitize_cleaning_parameters,
-)
+from nilearn.maskers._utils import compute_middle_image
 from nilearn.maskers.base_masker import BaseMasker, filter_and_extract
 from nilearn.masking import apply_mask_fmri, load_mask_img, unmask
 
@@ -559,8 +556,8 @@ class NiftiSpheresMasker(BaseMasker):
             "warning_message": None,
         }
 
-        sanitize_cleaning_parameters(self)
-        self.clean_args_ = {}  if self.clean_args is None else  self.clean_args
+        self.sanitize_cleaning_parameters()
+        self.clean_args_ = {} if self.clean_args is None else self.clean_args
 
         error = (
             "Seeds must be a list of triplets of coordinates in "

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -559,7 +559,7 @@ class NiftiSpheresMasker(BaseMasker):
             "warning_message": None,
         }
 
-        self = sanitize_cleaning_parameters(self)
+        sanitize_cleaning_parameters(self)
 
         error = (
             "Seeds must be a list of triplets of coordinates in "

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -560,6 +560,7 @@ class NiftiSpheresMasker(BaseMasker):
         }
 
         sanitize_cleaning_parameters(self)
+        self.clean_args_ = {}  if self.clean_args is None else  self.clean_args
 
         error = (
             "Seeds must be a list of triplets of coordinates in "


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Supersedes #5434

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- split parts of sanitize_cleaning_parameters that will have to be deprecated from those that will be kept after nilearn > 0.13
- turn the function into a private method specific to BaseMasker
