### PR TITLE
[MAINT] Consistency between ruff and pre-commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,11 +175,10 @@ minversion = "6.0"
 xfail_strict = true
 
 [tool.ruff]
-extend-exclude = [
+exclude = [
     "nilearn/externals/*",
-    "doc/auto_examples/*"
+    "nilearn/_version.py"
 ]
-include = ["pyproject.toml", "nilearn/**/*.py", "examples/**/*.py", "maint_tools/**/*.py", "doc/**/*.py"]
 indent-width = 4
 line-length = 79
 


### PR DESCRIPTION
Make sure the same set of files is processed by ruff, whether run directly from the command line or through pre-commit.

Changes proposed in this pull request:
- Change the set of files processed by ruff when run from the command line, to match the set of files processed by pre-commit.