### PR TITLE
[MAINT] Apply ruff rule RUF012

### DIFF
--- a/asv_benchmarks/benchmarks/comparisons/image.py
+++ b/asv_benchmarks/benchmarks/comparisons/image.py
@@ -1,7 +1,5 @@
 """Benchmarks for image operations under nilearn.image module."""
 
-# ruff: noqa: RUF012
-
 from nilearn.image import mean_img
 
 from ..common import Benchmark
@@ -15,8 +13,8 @@ class CompareLoad(Benchmark):
     """
 
     # compare loading images using nibabel and nilearn
-    param_names = ["loader"]
-    params = ["nilearn", "nibabel (ref)"]
+    param_names = ("loader",)
+    params = ("nilearn", "nibabel (ref)")
 
     def time_compare_load(self, loader):
         """Time the loading of images."""
@@ -34,8 +32,8 @@ class CompareMean(Benchmark):
     """
 
     # compare loading images using nibabel and nilearn
-    param_names = ["loader"]
-    params = ["nilearn", "nibabel (ref)"]
+    param_names = ("loader",)
+    params = ("nilearn", "nibabel (ref)")
 
     def time_compare_mean(self, loader):
         """Time the loading followed by taking the mean."""
@@ -55,8 +53,8 @@ class CompareSlice(Benchmark):
     """
 
     # compare loading images using nibabel and nilearn
-    param_names = ["loader"]
-    params = ["nilearn", "nibabel (ref)"]
+    param_names = ("loader",)
+    params = ("nilearn", "nibabel (ref)")
 
     def time_compare_slice(self, loader):
         """Time the loading the image followed by extracting a slice of it."""

--- a/asv_benchmarks/benchmarks/comparisons/maskers.py
+++ b/asv_benchmarks/benchmarks/comparisons/maskers.py
@@ -1,7 +1,5 @@
 """Benchmarks for masker objects under nilearn.maskers module."""
 
-# ruff: noqa: RUF012
-
 from ..common import Benchmark
 from ..utils import apply_mask, load
 
@@ -15,7 +13,7 @@ class CompareMask(Benchmark):
     # here we vary both the implementation and the loader
     # so masking can be done using nilearn or numpy (implementation)
     # and the mask and image can be loaded using nilearn or nibabel (loader)
-    param_names = ["implementation", "loader"]
+    param_names = ("implementation", "loader")
     params = (["nilearn", "numpy (ref)"], ["nilearn", "nibabel (ref)"])
 
     def time_compare_mask(self, implementation, loader):

--- a/asv_benchmarks/benchmarks/tracking/image.py
+++ b/asv_benchmarks/benchmarks/tracking/image.py
@@ -1,7 +1,5 @@
 """Benchmarks for image operations under nilearn.image module."""
 
-# ruff: noqa: RUF012
-
 from nilearn.image import mean_img
 
 from ..common import Benchmark

--- a/asv_benchmarks/benchmarks/tracking/maskers.py
+++ b/asv_benchmarks/benchmarks/tracking/maskers.py
@@ -1,7 +1,5 @@
 """Benchmarks for masker objects under nilearn.maskers module."""
 
-# ruff: noqa: RUF012
-
 from ..common import Benchmark
 from ..utils import apply_mask, load
 
@@ -13,7 +11,7 @@ class NiftiMaskerBenchmark(Benchmark):
     """
 
     # try different combinations of parameters for the NiftiMasker object
-    param_names = ["smoothing_fwhm", "detrend"]
+    param_names = ("smoothing_fwhm", "detrend")
     params = (
         [None, 6],
         [False, True],


### PR DESCRIPTION
RUF012 Mutable class attributes should be annotated with `typing.ClassVar`

Changes proposed in this pull request:
- Use tuples instead of lists to avoid the above ruff error.