### PR TITLE
[FIX] Align `symmetric_cmap` behavior in plotting package for `plotly` backend with `matplotlib` backend

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -11,6 +11,8 @@ NEW
 Fixes
 -----
 
+- :bdg-dark:`Code` Align ``symmetric_cmap`` behavior for ``plotly`` backend in :func:`~nilearn.plotting.surface.surf_plotting.plot_surf` function with ``matplotlib`` backend (:gh:`5492` by `Hande Gözükan`_).
+
 Enhancements
 ------------
 

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -11,7 +11,7 @@ NEW
 Fixes
 -----
 
-- :bdg-dark:`Code` Align ``symmetric_cmap`` behavior for ``plotly`` backend in :func:`~nilearn.plotting.surface.surf_plotting.plot_surf` function with ``matplotlib`` backend (:gh:`5492` by `Hande Gözükan`_).
+- :bdg-dark:`Code` Align ``symmetric_cmap`` behavior for ``plotly`` backend in :func:`~nilearn.plotting.plot_surf` function with ``matplotlib`` backend (:gh:`5492` by `Hande Gözükan`_).
 
 Enhancements
 ------------

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -239,6 +239,7 @@ def test_permuted_ols_check_h0_noeffect_labelswap_centered(model_intercept):
     check_ktest_p_values_distribution_and_mse(all_kstest_pvals, all_mse)
 
 
+@pytest.mark.timeout(0)
 def test_permuted_ols_check_h0_noeffect_labelswap_uncentered():
     """Check distributions of permutations when tested vars are uncentered."""
     # create dummy design with no effect
@@ -254,6 +255,7 @@ def test_permuted_ols_check_h0_noeffect_labelswap_uncentered():
     check_ktest_p_values_distribution_and_mse(all_kstest_pvals, all_mse)
 
 
+@pytest.mark.timeout(0)
 def test_permuted_ols_check_h0_noeffect_signswap():
     """Check that h0 is close to the theoretical distribution \
     for permuted OLS with sign swap.

--- a/nilearn/plotting/js_plotting_utils.py
+++ b/nilearn/plotting/js_plotting_utils.py
@@ -77,11 +77,11 @@ def colorscale(
     if not symmetric_cmap and (values.min() < 0):
         warnings.warn(
             "you have specified symmetric_cmap=False "
-            "but the map contains negative values; "
-            "setting symmetric_cmap to True",
+            "but the map contains negative values; ",
+            #           "setting symmetric_cmap to True",
             stacklevel=find_stack_level(),
         )
-        symmetric_cmap = True
+    #        symmetric_cmap = True
     if symmetric_cmap and vmin is not None:
         warnings.warn(
             "vmin cannot be chosen when cmap is symmetric",

--- a/nilearn/plotting/js_plotting_utils.py
+++ b/nilearn/plotting/js_plotting_utils.py
@@ -7,9 +7,13 @@ import warnings
 from pathlib import Path
 from string import Template
 
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.colors import (
+    LinearSegmentedColormap,
+    ListedColormap,
+    Normalize,
+)
 
 from nilearn._utils.extmath import fast_abs_percentile
 from nilearn._utils.html_document import (  # noqa: F401
@@ -97,7 +101,7 @@ def colorscale(
     if symmetric_cmap:
         vmax = max(abs(vmin), abs(vmax))
         vmin = -vmax
-    norm = mpl.colors.Normalize(vmin=vmin, vmax=vmax)
+    norm = Normalize(vmin=vmin, vmax=vmax)
     cmaplist = [cmap(i) for i in range(cmap.N)]
     abs_threshold = None
     if threshold is not None:
@@ -106,7 +110,7 @@ def colorscale(
         istop = int(norm(abs_threshold, clip=True) * (cmap.N - 1))
         for i in range(istart, istop):
             cmaplist[i] = (0.5, 0.5, 0.5, 1.0)  # just an average gray color
-    our_cmap = mpl.colors.LinearSegmentedColormap.from_list(
+    our_cmap = LinearSegmentedColormap.from_list(
         "Custom cmap", cmaplist, cmap.N
     )
     x = np.linspace(0, 1, 100)
@@ -159,7 +163,7 @@ def mesh_to_plotly(mesh):
 
 def to_color_strings(colors):
     """Return a list of colors as hex strings."""
-    cmap = mpl.colors.ListedColormap(colors)
+    cmap = ListedColormap(colors)
     colors = cmap(np.arange(cmap.N))[:, :3]
     colors = np.asarray(colors * 255, dtype="uint8")
     colors = [

--- a/nilearn/plotting/js_plotting_utils.py
+++ b/nilearn/plotting/js_plotting_utils.py
@@ -74,14 +74,7 @@ def colorscale(
     """Normalize a cmap, put it in plotly format, get threshold and range."""
     cmap = plt.get_cmap(cmap)
     abs_values = np.abs(values)
-    if not symmetric_cmap and (values.min() < 0):
-        warnings.warn(
-            "you have specified symmetric_cmap=False "
-            "but the map contains negative values; ",
-            #           "setting symmetric_cmap to True",
-            stacklevel=find_stack_level(),
-        )
-    #        symmetric_cmap = True
+
     if symmetric_cmap and vmin is not None:
         warnings.warn(
             "vmin cannot be chosen when cmap is symmetric",

--- a/nilearn/plotting/js_plotting_utils.py
+++ b/nilearn/plotting/js_plotting_utils.py
@@ -75,20 +75,28 @@ def colorscale(
     cmap = plt.get_cmap(cmap)
     abs_values = np.abs(values)
 
-    if symmetric_cmap and vmin is not None:
+    if (
+        symmetric_cmap
+        and vmin is not None
+        and vmax is not None
+        and vmin != -vmax
+    ):
         warnings.warn(
-            "vmin cannot be chosen when cmap is symmetric",
+            f"Specified {vmin=} and {vmax=} values do not create a symmetric"
+            " colorbar. The values will be modified to be symmetric.",
             stacklevel=find_stack_level(),
         )
-        vmin = None
     if vmax is None:
         vmax = abs_values.max()
-    # cast to float to avoid TypeError if vmax is a numpy boolean
-    vmax = float(vmax)
-    if symmetric_cmap:
-        vmin = -vmax
     if vmin is None:
         vmin = values.min()
+    # cast to float to avoid TypeError if vmax/vmin is a numpy boolean
+    vmax = float(vmax)
+    vmin = float(vmin)
+
+    if symmetric_cmap:
+        vmax = max(abs(vmin), abs(vmax))
+        vmin = -vmax
     norm = mpl.colors.Normalize(vmin=vmin, vmax=vmax)
     cmaplist = [cmap(i) for i in range(cmap.N)]
     abs_threshold = None

--- a/nilearn/plotting/js_plotting_utils.py
+++ b/nilearn/plotting/js_plotting_utils.py
@@ -123,7 +123,6 @@ def colorscale(
         "cmap": our_cmap,
         "norm": norm,
         "abs_threshold": abs_threshold,
-        "symmetric_cmap": symmetric_cmap,
     }
 
 

--- a/nilearn/plotting/tests/test_js_plotting_utils.py
+++ b/nilearn/plotting/tests/test_js_plotting_utils.py
@@ -105,7 +105,6 @@ def test_colorscale_threshold(threshold, expected_abs_threshold):
     assert colors["cmap"].N == 256
     assert (colors["norm"].vmax, colors["norm"].vmin) == (13, -13)
     assert np.allclose(colors["abs_threshold"], expected_abs_threshold, 2)
-    assert colors["symmetric_cmap"]
 
 
 @pytest.mark.parametrize("vmin,vmax", [(None, 7), (-5, 7)])
@@ -115,7 +114,6 @@ def test_colorscale_symmetric_cmap(vmin, vmax):
     assert (colors["vmin"], colors["vmax"]) == (-7, 7)
     assert colors["cmap"].N == 256
     assert (colors["norm"].vmax, colors["norm"].vmin) == (7, -7)
-    assert colors["symmetric_cmap"]
 
 
 @pytest.fixture
@@ -152,7 +150,6 @@ def test_colorscale_asymmetric_cmap(
         threshold=threshold,
         symmetric_cmap=False,
     )
-    assert (min(values) < 0) | (not colors["symmetric_cmap"])
     assert colors["cmap"].N == 256
     assert (int(colors["vmin"]), int(colors["vmax"])) == expected_vmin_vmax
     assert (colors["norm"].vmax, colors["norm"].vmin) == expected_vmin_vmax[

--- a/nilearn/plotting/tests/test_js_plotting_utils.py
+++ b/nilearn/plotting/tests/test_js_plotting_utils.py
@@ -123,8 +123,6 @@ def expected_vmin_vmax(values, vmax, vmin):
     """Return expected vmin and vmax."""
     if vmax is None:
         return (min(values), max(values))
-    if min(values) < 0:
-        return (-vmax, vmax)
     return (min(values), vmax) if vmin is None else (vmin, vmax)
 
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #4296 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Do not change value of `symmetric_cmap`  inside `nilearn.plotting.js_plotting_utils.colorscale` function depending on the values of the specified data.
- Let user set `vmin` even if `symmetric_cmap` is specified to be `True`.
- Remove `symmetric_cmap` from the dictionary returned from `nilearn.plotting.js_plotting_utils.colorscale`.
