### PR TITLE
[FIX] ensure transform / inverse_transform can be used on decomposition estimators

### DIFF
--- a/nilearn/decomposition/tests/test_decomposition_estimators.py
+++ b/nilearn/decomposition/tests/test_decomposition_estimators.py
@@ -69,7 +69,7 @@ def test_check_estimator_nilearn(estimator, check, name):  # noqa: ARG001
 @pytest.mark.parametrize("estimator", [CanICA, _MultiPCA, DictLearning])
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 def test_fit_errors(data_type, decomposition_images, estimator):
-    """Fit and transform fail without the proper arguments."""
+    """Fit fail without the proper arguments."""
     est = estimator(
         smoothing_fwhm=None,
     )
@@ -134,6 +134,11 @@ def test_masker_attributes_with_fit(
 
     check_decomposition_estimator(canica, data_type)
 
+    # smoke test transforn and inverse transform
+    signals = canica.transform(canica_data)
+
+    canica.inverse_transform(signals)
+
 
 @pytest.mark.parametrize("estimator", [CanICA, _MultiPCA, DictLearning])
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
@@ -166,6 +171,11 @@ def test_pass_masker_arg_to_estimator(
         est.fit(decomposition_img)
 
     check_decomposition_estimator(est, data_type)
+
+    # smoke test transforn and inverse transform
+    signals = est.transform(decomposition_img)
+
+    est.inverse_transform(signals)
 
 
 @pytest.mark.timeout(0)
@@ -219,6 +229,18 @@ def test_with_confounds(
     assert_raises(
         AssertionError, assert_array_equal, components, components_clean
     )
+
+    signals = est.transform(decomposition_images)
+    signals_confounds = est.transform(
+        decomposition_images, confounds=confounds
+    )
+
+    assert_raises(
+        AssertionError, assert_array_equal, signals, signals_confounds
+    )
+
+    # smoke test
+    est.inverse_transform(signals)
 
 
 @pytest.mark.parametrize("estimator", [CanICA, _MultiPCA, DictLearning])
@@ -284,6 +306,11 @@ def test_single_subject_file(
 
     check_decomposition_estimator(est, data_type)
 
+    # smoke test transforn and inverse transform
+    signals = est.transform(tmp_file)
+
+    est.inverse_transform(signals)
+
 
 @pytest.mark.timeout(0)
 @pytest.mark.parametrize("estimator", [CanICA, _MultiPCA, DictLearning])
@@ -311,3 +338,8 @@ def test_with_globbing_patterns(
     est.fit(img)
 
     check_decomposition_estimator(est, data_type)
+
+    # smoke test transforn and inverse transform
+    signals = est.transform(img)
+
+    est.inverse_transform(signals)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none
- Discovered this was an issue when working on another PR

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- add failing tests to demonstrate the issue
-
