### PR TITLE
[MAINT] check all image estimators are unchanged by transform

### DIFF
--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -932,7 +932,7 @@ def check_img_estimator_overwrite_params(estimator) -> None:
 def check_img_estimator_dict_unchanged(estimator):
     """Replace check_dict_unchanged from sklearn.
 
-    transform() should not changed the dict of the object.
+    transform() should not change the dict of the object.
     """
     estimator = fit_estimator(estimator)
 

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -253,7 +253,9 @@ def return_expected_failed_checks(
     expected_failed_checks = {
         # the following are skipped
         # because there is nilearn specific replacement
-        "check_dict_unchanged": "replaced by check_masker_dict_unchanged",
+        "check_dict_unchanged": (
+            "replaced by check_img_estimator_dict_unchanged"
+        ),
         "check_dont_overwrite_parameters": (
             "replaced by check_img_estimator_dont_overwrite_parameters"
         ),
@@ -320,6 +322,7 @@ def return_expected_failed_checks(
 
         expected_failed_checks |= {
             # have nilearn replacements
+            "check_dict_unchanged": "does not apply - no transform method",
             "check_estimators_dtypes": ("replaced by check_glm_dtypes"),
             "check_estimators_empty_data_messages": (
                 "not implemented for nifti data for performance reasons"
@@ -340,7 +343,6 @@ def return_expected_failed_checks(
                 "replaced by check_masker_transformer"
             ),
             # nilearn replacements required
-            "check_dict_unchanged": "TODO",
             "check_fit_score_takes_y": "TODO",
         }
 
@@ -440,7 +442,9 @@ def expected_failed_checks_decoders(estimator) -> dict[str, str]:
         # that errors with maskers,
         # or because a suitable nilearn replacement
         # has not yet been created.
-        "check_dict_unchanged": "TODO",
+        "check_dict_unchanged": (
+            "replaced by check_img_estimator_dict_unchanged"
+        ),
         "check_estimators_dtypes": "TODO",
         "check_estimators_pickle": "TODO",
         "check_estimators_nan_inf": "TODO",
@@ -530,6 +534,9 @@ def nilearn_check_generator(estimator: BaseEstimator):
         yield (clone(estimator), check_fit_returns_self)
         yield (clone(estimator), check_img_estimator_fit_check_is_fitted)
 
+        if hasattr(estimator, "transform"):
+            yield (clone(estimator), check_img_estimator_dict_unchanged)
+
         if requires_y:
             yield (clone(estimator), check_img_estimator_requires_y_none)
 
@@ -552,7 +559,6 @@ def nilearn_check_generator(estimator: BaseEstimator):
     if is_masker(estimator):
         yield (clone(estimator), check_masker_clean_kwargs)
         yield (clone(estimator), check_masker_compatibility_mask_image)
-        yield (clone(estimator), check_masker_dict_unchanged)
         yield (clone(estimator), check_masker_dtypes)
         yield (clone(estimator), check_masker_empty_data_messages)
         yield (clone(estimator), check_masker_fit_score_takes_y)
@@ -933,6 +939,76 @@ def check_img_estimator_overwrite_params(estimator) -> None:
 
 
 @ignore_warnings()
+def check_img_estimator_dict_unchanged(estimator):
+    """Replace check_dict_unchanged from sklearn.
+
+    transform() should not changed the dict of the object.
+    """
+    estimator = fit_estimator(estimator)
+
+    dict_before = estimator.__dict__.copy()
+
+    input_img, _ = generate_data_to_fit(estimator)
+
+    if isinstance(estimator, _BaseDecomposition):
+        estimator.transform([input_img])
+    else:
+        estimator.transform(input_img)
+
+    dict_after = estimator.__dict__
+
+    # TODO NiftiLabelsMasker is modified at transform time
+    # see issue https://github.com/nilearn/nilearn/issues/2720
+    if isinstance(estimator, (NiftiLabelsMasker)):
+        with pytest.raises(AssertionError):
+            assert dict_after == dict_before
+    else:
+        # The following try / except is mostly
+        # to give more informative error messages when this check fails.
+        try:
+            assert dict_after == dict_before
+        except AssertionError as e:
+            unmatched_keys = set(dict_after.keys()) ^ set(dict_before.keys())
+            if len(unmatched_keys) > 0:
+                raise ValueError(
+                    "Estimator changes '__dict__' keys during transform.\n"
+                    f"{unmatched_keys} \n"
+                )
+
+            difference = {}
+            for x in dict_before:
+                if type(dict_before[x]) is not type(dict_after[x]):
+                    difference[x] = {
+                        "before": dict_before[x],
+                        "after": dict_after[x],
+                    }
+                    continue
+                if (
+                    isinstance(dict_before[x], np.ndarray)
+                    and not np.array_equal(dict_before[x], dict_after[x])
+                    and not check_imgs_equal(dict_before[x], dict_after[x])
+                ) or (
+                    not isinstance(dict_before[x], (np.ndarray, Nifti1Image))
+                    and dict_before[x] != dict_after[x]
+                ):
+                    difference[x] = {
+                        "before": dict_before[x],
+                        "after": dict_after[x],
+                    }
+                    continue
+            if difference:
+                raise ValueError(
+                    "Estimator changes the following '__dict__' keys \n"
+                    "during transform.\n"
+                    f"{difference}"
+                )
+            else:
+                raise e
+        except Exception as e:
+            raise e
+
+
+@ignore_warnings()
 def check_img_estimator_pickle(estimator_orig):
     """Test that we can pickle all estimators.
 
@@ -1083,79 +1159,6 @@ def check_decoder_empty_data_messages(estimator):
 
 
 # ------------------ MASKER CHECKS ------------------
-
-
-@ignore_warnings()
-def check_masker_dict_unchanged(estimator):
-    """Replace check_dict_unchanged from sklearn.
-
-    transform() should not changed the dict of the object.
-    """
-    if accept_niimg_input(estimator):
-        # We use a different shape here to force some maskers
-        # to perform a resampling.
-        shape = (30, 31, 32)
-        input_img = Nifti1Image(_rng().random(shape), _affine_eye())
-    else:
-        input_img = _make_surface_img(10)
-
-    estimator = estimator.fit(input_img)
-
-    dict_before = estimator.__dict__.copy()
-
-    estimator.transform(input_img)
-
-    dict_after = estimator.__dict__
-
-    # TODO NiftiLabelsMasker is modified at transform time
-    # see issue https://github.com/nilearn/nilearn/issues/2720
-    if isinstance(estimator, (NiftiLabelsMasker)):
-        with pytest.raises(AssertionError):
-            assert dict_after == dict_before
-    else:
-        # The following try / except is mostly
-        # to give more informative error messages when this check fails.
-        try:
-            assert dict_after == dict_before
-        except AssertionError as e:
-            unmatched_keys = set(dict_after.keys()) ^ set(dict_before.keys())
-            if len(unmatched_keys) > 0:
-                raise ValueError(
-                    "Estimator changes '__dict__' keys during transform.\n"
-                    f"{unmatched_keys} \n"
-                )
-
-            difference = {}
-            for x in dict_before:
-                if type(dict_before[x]) is not type(dict_after[x]):
-                    difference[x] = {
-                        "before": dict_before[x],
-                        "after": dict_after[x],
-                    }
-                    continue
-                if (
-                    isinstance(dict_before[x], np.ndarray)
-                    and not np.array_equal(dict_before[x], dict_after[x])
-                    and not check_imgs_equal(dict_before[x], dict_after[x])
-                ) or (
-                    not isinstance(dict_before[x], (np.ndarray, Nifti1Image))
-                    and dict_before[x] != dict_after[x]
-                ):
-                    difference[x] = {
-                        "before": dict_before[x],
-                        "after": dict_after[x],
-                    }
-                    continue
-            if difference:
-                raise ValueError(
-                    "Estimator changes the following '__dict__' keys \n"
-                    "during transform.\n"
-                    f"{difference}"
-                )
-            else:
-                raise e
-        except Exception as e:
-            raise e
 
 
 @ignore_warnings()

--- a/nilearn/_utils/tests/test_estimator_checks.py
+++ b/nilearn/_utils/tests/test_estimator_checks.py
@@ -9,8 +9,8 @@ ignores modules whose name starts with an underscore.
 import pytest
 
 from nilearn._utils.estimator_checks import (
+    check_img_estimator_dict_unchanged,
     check_img_estimator_fit_check_is_fitted,
-    check_masker_dict_unchanged,
 )
 from nilearn.maskers.base_masker import BaseMasker
 
@@ -62,7 +62,7 @@ def test_check_masker_dict_unchanged():
     with pytest.raises(
         ValueError, match="Estimator changes '__dict__' keys during transform."
     ):
-        check_masker_dict_unchanged(estimator)
+        check_img_estimator_dict_unchanged(estimator)
 
     class DummyEstimator(BaseMasker):
         """Estimator with a transform method that modifies an attribute."""
@@ -83,4 +83,4 @@ def test_check_masker_dict_unchanged():
     with pytest.raises(
         ValueError, match="Estimator changes the following '__dict__' keys"
     ):
-        check_masker_dict_unchanged(estimator)
+        check_img_estimator_dict_unchanged(estimator)

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -5,6 +5,7 @@ import numbers
 from copy import deepcopy
 
 import numpy as np
+from joblib import Memory
 from scipy.ndimage import label
 from scipy.stats import scoreatpercentile
 
@@ -507,6 +508,9 @@ class RegionExtractor(NiftiMapsMasker):
             self.smoothing_fwhm,
             mask_img=self.mask_img_,
         )
+
+        if self.memory is None:
+            self.memory = Memory(location=None)
 
         self._maps_img = self.regions_img_
         super().fit(imgs)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Relates to #5444, #5446, #5445

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- run check_img_estimator_dict_unchanged on all image estimators with a transform methods

