### PR TITLE
[FIX] Update deprecation warning for `nilearn.datasets.fetch_neurovault_motor_task`

### DIFF
--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -2891,9 +2891,7 @@ def fetch_neurovault_motor_task(
 
     .. deprecated:: 0.12.0
 
-        This fetcher function will be removed in version>0.13.1
-        as it returns the same data
-        as :func:`nilearn.datasets.load_sample_motor_activation_image`.
+        This fetcher function will be removed in version>0.13.1.
 
         Please use
         :func:`nilearn.datasets.load_sample_motor_activation_image`
@@ -2934,8 +2932,7 @@ def fetch_neurovault_motor_task(
     warnings.warn(
         (
             "The 'fetch_neurovault_motor_task' function will be removed "
-            "in version>0.13.1 as it returns the same data "
-            "as 'load_sample_motor_activation_image'.\n"
+            "in version>0.13.1. \n"
             "Please use 'load_sample_motor_activation_image' instead.'"
         ),
         DeprecationWarning,


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #5522

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Update deprecation warning for `nilearn.datasets.fetch_neurovault_motor_task` as the data type returned is different from `load_sample_motor_activation_image`.
