### PR TITLE
[ENH] enforce dtype for all parts of SurfaceImage and Polydata

### DIFF
--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -1232,3 +1232,27 @@ def test_check_surf_img(surf_img_1d, surf_img_2d):
     imgs = SurfaceImage(surf_img_1d.mesh, data)
     with pytest.raises(ValueError, match="empty"):
         check_surf_img(imgs)
+
+
+def test_check_surf_img_dtype(surf_img_1d):
+    """Check dtype of SurfaceImage can be set at init."""
+    data = {
+        "left": np.ones(surf_img_1d.data.parts["left"].shape, dtype="float32"),
+        "right": np.ones(surf_img_1d.data.parts["right"].shape, dtype="int32"),
+    }
+    new_img = SurfaceImage(surf_img_1d.mesh, data, dtype=np.int32)
+
+    for k in surf_img_1d.data.parts:
+        assert new_img.data.parts[k].dtype != surf_img_1d.data.parts[k].dtype
+        assert new_img.data.parts[k].dtype == np.int32
+
+
+def test_check_surf_img_dtype_error(surf_img_1d):
+    """Check that both hemispheres must have same dtype."""
+    data = {
+        "left": np.ones(surf_img_1d.data.parts["left"].shape, dtype="float32"),
+        "right": np.ones(surf_img_1d.data.parts["right"].shape, dtype="int32"),
+    }
+
+    with pytest.raises(TypeError, match="All parts should have same dtype."):
+        SurfaceImage(surf_img_1d.mesh, data)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #5524 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- add errors and test for instantiation of SurfaceImage and Polydata with specific dtype

