### PR TITLE
[MAINT] Update pre-commit ruff legacy alias

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,7 @@ repos:
     rev: v0.12.2
     hooks:
     # Run the linter.
-    -   id: ruff
+    -   id: ruff-check
         # args: [--statistics]
         args: [--fix, --show-fixes]
     # Run the formatter.


### PR DESCRIPTION
Changes proposed in this pull request:

Changes:
```
ruff (legacy alias)......................................................Passed
```
into:
```
ruff check...............................................................Passed
```