### PR TITLE
[FIX] ensure fit and transform takes a y parameter

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -11,6 +11,9 @@ NEW
 Fixes
 -----
 
+- :bdg-success:`API` Add a dummy ``y`` parameter to :meth:`~nilearn.decomposition.CanICA.score` and :meth:`~nilearn.decomposition.DictLearning.score` for compatibility with scikit-learn API (:gh:`5565` by `Rémi Gau`_).
+
+
 - :bdg-dark:`Code` Fix several issues in :class:`~nilearn.maskers.NiftiLabelsMasker` and :class:`~nilearn.maskers.SurfaceLabelsMasker` that lead to invalid ``region_names_``, ``region_ids_`` or look-up-table content (:gh:`5492` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Align ``symmetric_cmap`` behavior for ``plotly`` backend in :func:`~nilearn.plotting.plot_surf` function with ``matplotlib`` backend (:gh:`5492` by `Hande Gözükan`_).

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1228,7 +1228,7 @@ def check_img_estimator_requires_y_none(estimator) -> None:
         estimator.fit(input_img, None)
     except ValueError as ve:
         if all(msg not in str(ve) for msg in expected_err_msgs):
-            raise ve@ignore_warnings()
+            raise ve
 
             
 @ignore_warnings()

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1314,7 +1314,7 @@ def check_img_estimator_requires_y_none(estimator) -> None:
         if all(msg not in str(ve) for msg in expected_err_msgs):
             raise ve
 
-            
+
 @ignore_warnings()
 def check_img_estimator_fit_score_takes_y(estimator):
     """Replace sklearn check_fit_score_takes_y for maskers.
@@ -1361,8 +1361,8 @@ def check_img_estimator_fit_score_takes_y(estimator):
                 )
             assert tmp["y"] is None
 
-            
-@ignore_warnings()         
+
+@ignore_warnings()
 def check_img_estimator_n_elements(estimator):
     """Check n_elements is set during fitting and used after that.
 

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -422,6 +422,9 @@ def expected_failed_checks_decoders(estimator) -> dict[str, str]:
         "check_fit_check_is_fitted": (
             "replaced by check_img_estimator_fit_check_is_fitted"
         ),
+        "check_fit_score_takes_y": (
+            "replaced by check_img_estimator_fit_score_takes_y"
+        ),
         "check_requires_y_none": (
             "replaced by check_img_estimator_requires_y_none"
         ),

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -431,6 +431,7 @@ def expected_failed_checks_decoders(estimator) -> dict[str, str]:
         ),
         "check_fit_score_takes_y": (
             "replaced by check_img_estimator_fit_score_takes_y"
+        ),
         "check_pipeline_consistency": (
             "replaced by check_img_estimator_pipeline_consistency"
         ),

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -474,7 +474,18 @@ class SearchLight(TransformerMixin, BaseEstimator):
         return new_img_like(self.mask_img_, self.scores_)
 
     def transform(self, imgs):
-        """Apply the fitted searchlight on new images."""
+        """Apply the fitted searchlight on new images.
+
+        Parameters
+        ----------
+        imgs : Niimg-like object
+            See :ref:`extracting_data`.
+            4D image.
+
+        Returns
+        -------
+        result : np.ndarray
+        """
         check_is_fitted(self)
 
         imgs = check_niimg_4d(imgs)
@@ -509,6 +520,29 @@ class SearchLight(TransformerMixin, BaseEstimator):
         reshaped_result = np.abs(reshaped_result)
 
         return reshaped_result
+
+    def fit_transform(self, imgs, y, groups=None):
+        """Fit the searchlight and applies to the input image.
+
+        Parameters
+        ----------
+        imgs : Niimg-like object
+            See :ref:`extracting_data`.
+            4D image.
+
+        y : 1D array-like
+            Target variable to predict. Must have exactly as many elements as
+            3D images in img.
+
+        groups : array-like, default=None
+            group label for each sample for cross validation. Must have
+            exactly as many elements as 3D images in img.
+
+        Returns
+        -------
+        result : np.ndarray
+        """
+        return self.fit(imgs, y, groups=groups).transform(imgs)
 
     def set_output(self, *, transform=None):
         """Set the output container when ``"transform"`` is called.

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -532,11 +532,11 @@ class SearchLight(TransformerMixin, BaseEstimator):
 
         y : 1D array-like
             Target variable to predict. Must have exactly as many elements as
-            3D images in img.
+            3D images in imgs.
 
         groups : array-like, default=None
             group label for each sample for cross validation. Must have
-            exactly as many elements as 3D images in img.
+            exactly as many elements as 3D images in imgs.
 
         Returns
         -------

--- a/nilearn/decomposition/_base.py
+++ b/nilearn/decomposition/_base.py
@@ -666,7 +666,7 @@ class _BaseDecomposition(CacheMixin, TransformerMixin, BaseEstimator):
             data, self.components_, per_component=per_component
         )
 
-    def score(self, imgs, confounds=None, per_component=False):
+    def score(self, imgs, y=None, confounds=None, per_component=False):
         """Score function based on explained variance on imgs.
 
         Should only be used by DecompositionEstimator derived classes
@@ -677,6 +677,8 @@ class _BaseDecomposition(CacheMixin, TransformerMixin, BaseEstimator):
                :obj:`list` of :obj:`~nilearn.surface.SurfaceImage`
             See :ref:`extracting_data`.
             Data to be scored
+
+        %(y_dummy)s
 
         confounds : CSV file path or numpy.ndarray
             or pandas DataFrame, optional
@@ -695,6 +697,7 @@ class _BaseDecomposition(CacheMixin, TransformerMixin, BaseEstimator):
             is squeezed if the number of subjects is one
 
         """
+        del y
         check_is_fitted(self)
 
         data = _mask_and_reduce(

--- a/nilearn/decomposition/tests/test_decomposition_estimators.py
+++ b/nilearn/decomposition/tests/test_decomposition_estimators.py
@@ -23,7 +23,6 @@ from nilearn.decomposition.tests.conftest import (
 )
 
 ESTIMATORS_TO_CHECK = [
-    _MultiPCA(verbose=0),
     DictLearning(verbose=0),
     CanICA(verbose=0),
 ]


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Relatest to https://github.com/nilearn/nilearn/issues/5444

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- make sure all image estimators take a y for methods: transform, fit_transform, score
- [x] update changelog

