### PR TITLE
[FIX] check all decoders can work with surfaces

### DIFF
--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1372,7 +1372,7 @@ def check_decoders_with_surface_data(estimator_orig):
             else:
                 getattr(estimator, method)(X)
 
-                
+
 @ignore_warnings
 def check_img_regressors_no_decision_function(regressor_orig):
     """Check that regressors don't have a decision_function.
@@ -1387,7 +1387,6 @@ def check_img_regressors_no_decision_function(regressor_orig):
     funcs = ["decision_function"]
     for func_name in funcs:
         assert not hasattr(regressor, func_name)
-
 
 
 # ------------------ MASKER CHECKS ------------------

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1460,6 +1460,15 @@ def check_decoder_compatibility_mask_image(estimator_orig):
 
     # fitting volume data when the mask is a surface should fail
     estimator.mask = _make_surface_mask()
+
+    if isinstance(estimator, BaseSpaceNet):
+        # TODO: remove when BaseSpaceNet support surface data
+        with pytest.raises(
+            TypeError, match=("input should be a NiftiLike object")
+        ):
+            fit_estimator(estimator)
+        return
+
     with pytest.raises(
         TypeError, match=("Mask and input images must be of compatible types")
     ):
@@ -1506,6 +1515,12 @@ def check_decoders_with_surface_data(estimator_orig):
             # for FREM decoders include all elements
             # to avoid getting 0 clusters to work with
             estimator.clustering_percentile = 100
+
+        if isinstance(estimator, BaseSpaceNet):
+            # TODO: remove when BaseSpaceNet support surface data
+            with pytest.raises(NotImplementedError):
+                estimator.fit(X, y)
+            continue
 
         estimator.fit(X, y)
 

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1244,7 +1244,7 @@ def check_decoder_compatibility_mask_image(estimator_orig):
 
 @ignore_warnings()
 def check_decoders_with_surface_data(estimator_orig):
-    """Test fit for surface image."""
+    """Test fit and other methods with surface image."""
     if isinstance(estimator_orig, SearchLight):
         # note searchlight does not fit Surface data
         return

--- a/nilearn/_utils/masker_validation.py
+++ b/nilearn/_utils/masker_validation.py
@@ -165,7 +165,7 @@ def check_compatibility_mask_and_images(mask_img, run_imgs):
         run_imgs = [run_imgs]
 
     msg = (
-        "Mask and images to fit must be of compatible types.\n"
+        "Mask and input images must be of compatible types.\n"
         f"Got mask of type: {type(mask_img)}, "
         f"and images of type: {[type(x) for x in run_imgs]}"
     )

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -903,7 +903,8 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
             class would be predicted.
         """
         check_is_fitted(self)
-        check_compatibility_mask_and_images(self.mask_img_, X)
+        if not isinstance(X, np.ndarray):
+            check_compatibility_mask_and_images(self.mask_img_, X)
 
         # Prediction for dummy estimator is different from others as there is
         # no fitted coefficient

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -842,13 +842,15 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
             Predicted class label per sample.
         """
         check_is_fitted(self)
-        check_compatibility_mask_and_images(self.mask_img_, X)
 
         # for backwards compatibility - apply masker transform if X is
         # niimg-like or a list of strings or surface image
         if not isinstance(X, np.ndarray) or len(np.shape(X)) == 1:
+            check_compatibility_mask_and_images(self.mask_img_, X)
             X = self.masker_.transform(X)
+
         n_features = self.coef_.shape[1]
+
         if X.shape[1] != n_features:
             raise ValueError(
                 f"X has {X.shape[1]} features per sample;"
@@ -886,7 +888,7 @@ class _BaseDecoder(CacheMixin, BaseEstimator):
         # Prediction for dummy estimator is different from others as there is
         # no fitted coefficient
         if isinstance(self.estimator_, (DummyClassifier, DummyRegressor)):
-            if isinstance(SurfaceImage):
+            if isinstance(X, SurfaceImage):
                 n_samples = X.data.shape[1] if len(X.data.shape) == 2 else 1
             else:
                 X = check_niimg(X)

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -18,9 +18,6 @@ from sklearn.utils import check_array
 from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn._utils import check_niimg_3d, check_niimg_4d, fill_doc, logger
-from nilearn._utils.masker_validation import (
-    check_compatibility_mask_and_images,
-)
 from nilearn._utils.param_validation import check_params
 from nilearn._utils.tags import SKLEARN_LT_1_6
 from nilearn.image import new_img_like
@@ -413,12 +410,12 @@ class SearchLight(TransformerMixin, BaseEstimator):
         # Get the seeds
         self.mask_img_ = deepcopy(self.mask_img)
         if self.mask_img_ is not None:
-            check_compatibility_mask_and_images(self.mask_img_, imgs)
             self.mask_img_ = check_niimg_3d(self.mask_img_)
 
-        process_mask_img = self.process_mask_img or self.mask_img_
+        if self.process_mask_img is not None:
+            check_niimg_3d(self.process_mask_img)
 
-        check_compatibility_mask_and_images(process_mask_img, imgs)
+        process_mask_img = self.process_mask_img or self.mask_img_
 
         # Compute world coordinates of the seeds
         process_mask, process_mask_affine = masking.load_mask_img(

--- a/nilearn/decoding/searchlight.py
+++ b/nilearn/decoding/searchlight.py
@@ -18,6 +18,9 @@ from sklearn.utils import check_array
 from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn._utils import check_niimg_3d, check_niimg_4d, fill_doc, logger
+from nilearn._utils.masker_validation import (
+    check_compatibility_mask_and_images,
+)
 from nilearn._utils.param_validation import check_params
 from nilearn._utils.tags import SKLEARN_LT_1_6
 from nilearn.image import new_img_like
@@ -357,7 +360,7 @@ class SearchLight(TransformerMixin, BaseEstimator):
         from nilearn._utils.tags import InputTags
 
         tags = super().__sklearn_tags__()
-        tags.input_tags = InputTags(surf_img=True)
+        tags.input_tags = InputTags(surf_img=False)
 
         if self.estimator == "svr":
             if SKLEARN_LT_1_6:
@@ -410,8 +413,12 @@ class SearchLight(TransformerMixin, BaseEstimator):
         # Get the seeds
         self.mask_img_ = deepcopy(self.mask_img)
         if self.mask_img_ is not None:
+            check_compatibility_mask_and_images(self.mask_img_, imgs)
             self.mask_img_ = check_niimg_3d(self.mask_img_)
+
         process_mask_img = self.process_mask_img or self.mask_img_
+
+        check_compatibility_mask_and_images(process_mask_img, imgs)
 
         # Compute world coordinates of the seeds
         process_mask, process_mask_affine = masking.load_mask_img(

--- a/nilearn/decoding/space_net.py
+++ b/nilearn/decoding/space_net.py
@@ -785,7 +785,7 @@ class BaseSpaceNet(CacheMixin, LinearRegression):
 
         tags = super().__sklearn_tags__()
         tags.target_tags.required = True
-        tags.input_tags = InputTags(niimg_like=True, surf_img=True)
+        tags.input_tags = InputTags(niimg_like=True, surf_img=False)
         return tags
 
     def _check_params(self):

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -1260,14 +1260,14 @@ def test_decoder_error_incompatible_surface_mask_and_volume_data(
     model = decoder(mask=surf_mask_1d)
 
     with pytest.raises(
-        TypeError, match="Mask and images to fit must be of compatible types."
+        TypeError, match="Mask and input images must be of compatible types."
     ):
         model.fit(data_volume, y)
 
     model = decoder(mask=SurfaceMasker())
 
     with pytest.raises(
-        TypeError, match="Mask and images to fit must be of compatible types."
+        TypeError, match="Mask and input images must be of compatible types."
     ):
         model.fit(data_volume, y)
 
@@ -1282,7 +1282,7 @@ def test_decoder_error_incompatible_surface_data_and_volume_mask(
     model = decoder(mask=mask)
 
     with pytest.raises(
-        TypeError, match="Mask and images to fit must be of compatible types."
+        TypeError, match="Mask and input images must be of compatible types."
     ):
         model.fit(data_surface, y)
 

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -1163,7 +1163,7 @@ def test_decoder_screening_percentile_surface(perc, _make_surface_class_data):
 
 
 @pytest.mark.parametrize("surf_mask_dim", [1, 2])
-def test_decoder_adjust_screening_lessthan_mask_surface(
+def test_decoder_adjust_screening_less_than_mask_surface(
     surf_mask_dim,
     surf_mask_1d,
     surf_mask_2d,
@@ -1193,7 +1193,7 @@ def test_decoder_adjust_screening_lessthan_mask_surface(
 
 
 @pytest.mark.parametrize("surf_mask_dim", [1, 2])
-def test_decoder_adjust_screening_greaterthan_mask_surface(
+def test_decoder_adjust_screening_greater_than_mask_surface(
     surf_mask_dim,
     surf_mask_1d,
     surf_mask_2d,
@@ -1218,73 +1218,6 @@ def test_decoder_adjust_screening_greaterthan_mask_surface(
     decoder.fit(img, y)
     adjusted = decoder.screening_percentile_
     assert adjusted == 100
-
-
-@pytest.mark.parametrize("mask", [None, SurfaceMasker()])
-@pytest.mark.parametrize("decoder", [_BaseDecoder, Decoder, DecoderRegressor])
-def test_decoder_fit_surface(decoder, _make_surface_class_data, mask):
-    """Test fit for surface image."""
-    warnings.simplefilter("ignore", ConvergenceWarning)
-    X, y = _make_surface_class_data
-    model = decoder(mask=mask)
-    model.fit(X, y)
-
-    assert model.coef_ is not None
-
-
-@pytest.mark.parametrize("surf_mask_dim", [1, 2])
-@pytest.mark.parametrize("decoder", [_BaseDecoder, Decoder, DecoderRegressor])
-def test_decoder_fit_surface_with_mask_image(
-    _make_surface_class_data,
-    decoder,
-    surf_mask_dim,
-    surf_mask_1d,
-    surf_mask_2d,
-):
-    """Test fit for surface image."""
-    warnings.simplefilter("ignore", ConvergenceWarning)
-    X, y = _make_surface_class_data
-    surf_mask = surf_mask_1d if surf_mask_dim == 1 else surf_mask_2d()
-    model = decoder(mask=surf_mask)
-    model.fit(X, y)
-
-    assert model.coef_ is not None
-
-
-@pytest.mark.parametrize("decoder", [_BaseDecoder, Decoder, DecoderRegressor])
-def test_decoder_error_incompatible_surface_mask_and_volume_data(
-    decoder, surf_mask_1d, tiny_binary_classification_data
-):
-    """Test error when fitting volume data with a surface mask."""
-    data_volume, y, _ = tiny_binary_classification_data
-    model = decoder(mask=surf_mask_1d)
-
-    with pytest.raises(
-        TypeError, match="Mask and input images must be of compatible types."
-    ):
-        model.fit(data_volume, y)
-
-    model = decoder(mask=SurfaceMasker())
-
-    with pytest.raises(
-        TypeError, match="Mask and input images must be of compatible types."
-    ):
-        model.fit(data_volume, y)
-
-
-@pytest.mark.parametrize("decoder", [_BaseDecoder, Decoder, DecoderRegressor])
-def test_decoder_error_incompatible_surface_data_and_volume_mask(
-    _make_surface_class_data, decoder, tiny_binary_classification_data
-):
-    """Test error when fiting for surface data with a volume mask."""
-    data_surface, y = _make_surface_class_data
-    _, _, mask = tiny_binary_classification_data
-    model = decoder(mask=mask)
-
-    with pytest.raises(
-        TypeError, match="Mask and input images must be of compatible types."
-    ):
-        model.fit(data_surface, y)
 
 
 def test_decoder_predict_score_surface(_make_surface_class_data):

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -2376,14 +2376,14 @@ def test_error_flm_surface_mask_volume_image(
     img, des = surface_glm_data(5)
     model = FirstLevelModel(mask_img=surf_mask_1d)
     with pytest.raises(
-        TypeError, match="Mask and images to fit must be of compatible types."
+        TypeError, match="Mask and input images must be of compatible types."
     ):
         model.fit(img_4d_rand_eye, design_matrices=des)
 
     masker = SurfaceMasker().fit(img)
     model = FirstLevelModel(mask_img=masker)
     with pytest.raises(
-        TypeError, match="Mask and images to fit must be of compatible types."
+        TypeError, match="Mask and input images must be of compatible types."
     ):
         model.fit(img_4d_rand_eye, design_matrices=des)
 
@@ -2396,14 +2396,14 @@ def test_error_flm_volume_mask_surface_image(surface_glm_data):
     img, des = surface_glm_data(5)
     model = FirstLevelModel(mask_img=mask)
     with pytest.raises(
-        TypeError, match="Mask and images to fit must be of compatible types."
+        TypeError, match="Mask and input images must be of compatible types."
     ):
         model.fit(img, design_matrices=des)
 
     masker = NiftiMasker().fit(mask)
     model = FirstLevelModel(mask_img=masker)
     with pytest.raises(
-        TypeError, match="Mask and images to fit must be of compatible types."
+        TypeError, match="Mask and input images must be of compatible types."
     ):
         model.fit(img, design_matrices=des)
 

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -1497,7 +1497,7 @@ def test_second_level_input_with_wrong_mask(
     model = SecondLevelModel(mask_img=img_mask_mni)
 
     with pytest.raises(
-        TypeError, match="Mask and images to fit must be of compatible types."
+        TypeError, match="Mask and input images must be of compatible types."
     ):
         model = model.fit(second_level_input, design_matrix=design_matrix)
 
@@ -1507,7 +1507,7 @@ def test_second_level_input_with_wrong_mask(
     model = SecondLevelModel(mask_img=surf_mask_1d)
 
     with pytest.raises(
-        TypeError, match="Mask and images to fit must be of compatible types."
+        TypeError, match="Mask and input images must be of compatible types."
     ):
         model = model.fit(second_level_input, design_matrix=design_matrix)
 

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -932,12 +932,12 @@ def test_input_in_threshold_img_errors(
     # incompatible inputs raise errors
     with pytest.raises(
         TypeError,
-        match="Mask and images to fit must be of compatible types.",
+        match="Mask and input images must be of compatible types.",
     ):
         threshold_img(vol_img, threshold=1, mask_img=surf_mask_1d)
     with pytest.raises(
         TypeError,
-        match="Mask and images to fit must be of compatible types.",
+        match="Mask and input images must be of compatible types.",
     ):
         threshold_img(surf_img_1d, threshold=1, mask_img=vol_mask)
 

--- a/nilearn/plotting/tests/test_img_comparisons.py
+++ b/nilearn/plotting/tests/test_img_comparisons.py
@@ -250,7 +250,7 @@ def test_plot_bland_altman_incompatible_errors(
     surf_img_1d, surf_mask_1d, img_3d_rand_eye, img_3d_ones_eye
 ):
     """Check error for bland altman plots incompatible mask and images."""
-    error_msg = "Mask and images to fit must be of compatible types."
+    error_msg = "Mask and input images must be of compatible types."
     with pytest.raises(TypeError, match=error_msg):
         plot_bland_altman(
             img_3d_rand_eye, img_3d_rand_eye, masker=SurfaceMasker()


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- make sure all decoders are tested on surface images
- check that decoders that can work both with volume and surface data check compatibility of input images with their mask (for example to also avoid trying to get score from surface data when the model was fitted on volume)

