### PR TITLE
[FIX] avoid joblib warnings regarding using partial functions

### DIFF
--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -56,7 +56,7 @@ def _get_mask_strategy(strategy):
     elif strategy == "whole-brain-template":
         return partial(compute_brain_mask, mask_type="whole-brain")
     elif strategy == "gm-template":
-        return partial(compute_brain_mask, mask_type="gm")
+        return _partial_compute_brain_mask_gm
     elif strategy == "wm-template":
         return partial(compute_brain_mask, mask_type="wm")
     else:
@@ -67,6 +67,20 @@ def _get_mask_strategy(strategy):
             "'gm-template', and "
             "'wm-template'."
         )
+    
+def _partial_compute_brain_mask_gm(target_img,
+    threshold,
+    connected,
+    opening,
+    memory,
+    verbose):
+    return compute_brain_mask_gm(target_img,
+    threshold,
+    connected,
+    opening,
+    memory,
+    verbose,
+    mask_type="gm")
 
 
 def filter_and_mask(

--- a/nilearn/maskers/tests/test_multi_nifti_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_masker.py
@@ -1,5 +1,5 @@
 """Test the multi_nifti_masker module."""
-
+import warnings
 import numpy as np
 import pytest
 from nibabel import Nifti1Image
@@ -194,6 +194,20 @@ def test_compute_mask_strategy(strategy, shape_3d_default, list_random_imgs):
 
     np.testing.assert_array_equal(get_data(masker.mask_img_), mask_ref)
     np.testing.assert_array_equal(get_data(masker2.mask_img_), mask_ref)
+
+@pytest.mark.parametrize(
+    "strategy", [f"{p}-template" for p in ["whole-brain", "gm", "wm"]]
+)
+def test_no_warning_partial_joblib(strategy, list_random_imgs):
+    """Check different strategies to compute masks."""
+    masker = MultiNiftiMasker(mask_strategy=strategy, mask_args={"opening": 1})
+    with warnings.catch_warnings(record=True) as warning_list:
+        masker.fit(list_random_imgs)
+
+    assert not any(
+        "Cannot inspect object functools.partial" in str(x)
+        for x in warning_list
+    )
 
 
 def test_standardization(rng, shape_3d_default, affine_eye):

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -335,10 +335,9 @@ def expected_mask(mask_args):
 @pytest.mark.parametrize(
     "strategy", [f"{p}-template" for p in ["whole-brain", "gm", "wm"]]
 )
-@pytest.mark.parametrize("mask_args", [{}])
-def test_compute_brain_mask_empty_mask_error(strategy, mask_args):
+def test_compute_brain_mask_empty_mask_error(strategy):
     """Check masker raise error when estimated mask is empty."""
-    masker = NiftiMasker(mask_strategy=strategy, mask_args=mask_args)
+    masker = NiftiMasker(mask_strategy=strategy, mask_args={})
 
     img, _ = data_gen.generate_random_img((9, 9, 5))
 
@@ -350,10 +349,9 @@ def test_compute_brain_mask_empty_mask_error(strategy, mask_args):
 @pytest.mark.parametrize(
     "strategy", [f"{p}-template" for p in ["whole-brain", "gm", "wm"]]
 )
-@pytest.mark.parametrize("mask_args", [{"threshold": 0.0}])
-def test_compute_brain_mask(strategy, expected_mask, mask_args):
+def test_compute_brain_mask(strategy, expected_mask):
     """Check masker for template masking strategy."""
-    masker = NiftiMasker(mask_strategy=strategy, mask_args=mask_args)
+    masker = NiftiMasker(mask_strategy=strategy, mask_args={"threshold": 0.0})
     img, _ = data_gen.generate_random_img((9, 9, 5))
 
     masker.fit(img)
@@ -364,8 +362,7 @@ def test_compute_brain_mask(strategy, expected_mask, mask_args):
 @pytest.mark.parametrize(
     "strategy", [f"{p}-template" for p in ["whole-brain", "gm", "wm"]]
 )
-@pytest.mark.parametrize("mask_args", [{"threshold": 0.0}])
-def test_no_warning_partial_joblib(strategy, mask_args):
+def test_no_warning_partial_joblib(strategy):
     """Check no warning thrown by joblib regarding masking strategy.
 
     Regression test for:
@@ -373,7 +370,7 @@ def test_no_warning_partial_joblib(strategy, mask_args):
     """
     masker = NiftiMasker(
         mask_strategy=strategy,
-        mask_args=mask_args,
+        mask_args={"threshold": 0.0},
         memory="nilearn_cache",
         memory_level=1,
     )

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -5,6 +5,8 @@ not the underlying functions used (e.g. clean()). See test_masking.py and
 test_signal.py for this.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 from nibabel import Nifti1Image
@@ -357,6 +359,32 @@ def test_compute_brain_mask(strategy, expected_mask, mask_args):
     masker.fit(img)
 
     np.testing.assert_array_equal(get_data(masker.mask_img_), expected_mask)
+
+
+@pytest.mark.parametrize(
+    "strategy", [f"{p}-template" for p in ["whole-brain", "gm", "wm"]]
+)
+@pytest.mark.parametrize("mask_args", [{"threshold": 0.0}])
+def test_no_warning_partial_joblib(strategy, mask_args):
+    """Check no warning thrown by joblib regarding masking strategy.
+
+    Regression test for:
+    https://github.com/nilearn/nilearn/issues/5527
+    """
+    masker = NiftiMasker(
+        mask_strategy=strategy,
+        mask_args=mask_args,
+        memory="nilearn_cache",
+        memory_level=1,
+    )
+    img, _ = data_gen.generate_random_img((9, 9, 5))
+    with warnings.catch_warnings(record=True) as warning_list:
+        masker.fit(img)
+
+    assert not any(
+        "Cannot inspect object functools.partial" in str(x)
+        for x in warning_list
+    )
 
 
 def test_filter_and_mask_error(affine_eye):


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #5527 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- avoid using partial functions for (multi) nifti masker strategies

