### PR TITLE
[FIX] adapt mask_args depending on masking strategy for (Multi)NiftiMasker.

### DIFF
--- a/nilearn/maskers/multi_nifti_masker.py
+++ b/nilearn/maskers/multi_nifti_masker.py
@@ -3,6 +3,7 @@ on multi subject MRI data.
 """
 
 import collections.abc
+import inspect
 import itertools
 import warnings
 
@@ -322,16 +323,36 @@ class MultiNiftiMasker(NiftiMasker):
             ):
                 imgs = [imgs]
 
-            mask_args = self.mask_args if self.mask_args is not None else {}
             compute_mask = _get_mask_strategy(self.mask_strategy)
-            self.mask_img_ = self._cache(
-                compute_mask,
-                ignore=["n_jobs", "verbose", "memory"],
-            )(
+
+            # add extra argument to pass
+            # to the mask computing function
+            # depending if they are supported.
+            sig = dict(**inspect.signature(compute_mask).parameters)
+            mask_args = {}
+            for arg in ["n_jobs", "target_shape", "target_affine"]:
+                if arg in sig and getattr(self, arg) is not None:
+                    mask_args[arg] = getattr(self, arg)
+            if self.mask_args:
+                skipped_args = []
+                for arg in self.mask_args:
+                    if arg in sig:
+                        mask_args[arg] = self.mask_args.get(arg)
+                    else:
+                        skipped_args.append(arg)
+                if skipped_args:
+                    warnings.warn(
+                        (
+                            "The following arguments are not supported by"
+                            f"the masking strategy '{self.mask_strategy}': "
+                            f"{skipped_args}"
+                        ),
+                        UserWarning,
+                        stacklevel=find_stack_level(),
+                    )
+
+            self.mask_img_ = self._cache(compute_mask, ignore=["verbose"])(
                 imgs,
-                target_affine=self.target_affine,
-                target_shape=self.target_shape,
-                n_jobs=self.n_jobs,
                 memory=self.memory_,
                 verbose=max(0, self.verbose - 1),
                 **mask_args,

--- a/nilearn/maskers/nifti_masker.py
+++ b/nilearn/maskers/nifti_masker.py
@@ -1,5 +1,6 @@
 """Transformer used to apply basic transformations on MRI data."""
 
+import inspect
 import warnings
 from copy import copy as copy_object
 
@@ -93,7 +94,6 @@ def _make_brain_mask_func(mask_type: str, multi: bool = False):
         opening=2,
         memory=None,
         verbose=0,
-        **kwargs,
     ):
         if multi:
             return compute_multi_brain_mask(
@@ -104,7 +104,6 @@ def _make_brain_mask_func(mask_type: str, multi: bool = False):
                 memory,
                 verbose,
                 mask_type=mask_type,
-                **kwargs,
             )
 
         return compute_brain_mask(
@@ -508,11 +507,34 @@ class NiftiMasker(BaseMasker):
                     f"{self.__class__.__name__}.fit() "
                     "if no mask is passed to mask_img."
                 )
-            mask_args = self.mask_args if self.mask_args is not None else {}
 
             mask_logger("compute_mask", verbose=self.verbose)
 
             compute_mask = _get_mask_strategy(self.mask_strategy)
+
+            # add extra argument to pass
+            # to the mask computing function
+            # depending if they are supported.
+            sig = dict(**inspect.signature(compute_mask).parameters)
+            mask_args = {}
+            if self.mask_args:
+                skipped_args = []
+                for arg in self.mask_args:
+                    if arg in sig:
+                        mask_args[arg] = self.mask_args.get(arg)
+                    else:
+                        skipped_args.append(arg)
+                if skipped_args:
+                    warnings.warn(
+                        (
+                            "The following arguments are not supported by"
+                            f"the masking strategy '{self.mask_strategy}': "
+                            f"{skipped_args}"
+                        ),
+                        UserWarning,
+                        stacklevel=find_stack_level(),
+                    )
+
             self.mask_img_ = self._cache(compute_mask, ignore=["verbose"])(
                 imgs, verbose=max(0, self.verbose - 1), **mask_args
             )

--- a/nilearn/maskers/tests/test_multi_nifti_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_masker.py
@@ -199,6 +199,25 @@ def test_compute_mask_strategy(strategy, shape_3d_default, list_random_imgs):
 
 
 @pytest.mark.parametrize(
+    "strategy",
+    ["background", *[f"{p}-template" for p in ["whole-brain", "gm", "wm"]]],
+)
+def test_invalid_mask_arg_for_strategy(strategy, list_random_imgs):
+    """Pass mask_args specific to epi strategy should not fail.
+
+    But a warning should be thrown.
+    """
+    masker = MultiNiftiMasker(
+        mask_strategy=strategy,
+        mask_args={"lower_cutoff": 0.1, "ensure_finite": False},
+    )
+    with pytest.warns(
+        UserWarning, match="The following arguments are not supported by"
+    ):
+        masker.fit(list_random_imgs)
+
+
+@pytest.mark.parametrize(
     "strategy", [f"{p}-template" for p in ["whole-brain", "gm", "wm"]]
 )
 def test_no_warning_partial_joblib(strategy, list_random_imgs):

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -362,6 +362,23 @@ def test_compute_brain_mask(strategy, expected_mask, mask_args):
     np.testing.assert_array_equal(get_data(masker.mask_img_), expected_mask)
 
 
+def test_invalid_mask_arg_for_strategy():
+    """Pass mask_args specific to epi strategy should not fail.
+
+    But a warning should be thrown.
+    """
+    masker = NiftiMasker(
+        mask_strategy="background",
+        mask_args={"lower_cutoff": 0.1, "ensure_finite": False},
+    )
+    img, _ = data_gen.generate_random_img((9, 9, 5))
+
+    with pytest.warns(
+        UserWarning, match="The following arguments are not supported by"
+    ):
+        masker.fit(img)
+
+
 @pytest.mark.parametrize(
     "strategy", [f"{p}-template" for p in ["whole-brain", "gm", "wm"]]
 )

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -733,7 +733,6 @@ def compute_multi_brain_mask(
     memory=None,
     verbose=0,
     mask_type="whole-brain",
-    **kwargs,
 ):
     """Compute the whole-brain, grey-matter or white-matter mask \
     for a list of images.
@@ -769,14 +768,6 @@ def compute_multi_brain_mask(
     %(memory)s
 
     %(verbose0)s
-
-    .. note::
-        Argument not used but kept to fit the API
-
-    **kwargs : optional arguments
-        Arguments such as 'target_affine' are used in the call of other
-        masking strategies, which then would raise an error for this function
-        which does not need such arguments.
 
     Returns
     -------


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- fixes a bug that would crash a (Multi)NiftiMasker.fit if the wrong extra arguments were passed to a masking strategy

