### PR TITLE
DOC: add notes about non-redownload behavior to fetch_* datasets

### DIFF
--- a/nilearn/datasets/func.py
+++ b/nilearn/datasets/func.py
@@ -60,6 +60,17 @@ def fetch_haxby(
 ):
     """Download and loads complete haxby dataset.
 
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
+
     See :footcite:t:`Haxby2001`.
 
     Parameters
@@ -275,7 +286,20 @@ def adhd_ids():
 def fetch_adhd(n_subjects=30, data_dir=None, url=None, resume=True, verbose=1):
     """Download and load the ADHD :term:`resting-state` dataset.
 
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
+
     See :footcite:t:`ADHDdataset`.
+
+
 
     Parameters
     ----------
@@ -430,6 +454,17 @@ def miyawaki2008_file_mask():
 @fill_doc
 def fetch_miyawaki2008(data_dir=None, url=None, resume=True, verbose=1):
     """Download and loads Miyawaki et al. 2008 dataset (153MB).
+
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
 
     See :footcite:t:`Miyawaki2008`.
 
@@ -611,11 +646,24 @@ def fetch_localizer_contrasts(
     Functional Localizer page."
     (see https://osf.io/vhtf6/)
 
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
+
     You may cite :footcite:t:`Papadopoulos-Orfanos2017`
     when using this dataset.
 
     Scientific results obtained using this dataset are described
     in :footcite:t:`Pinel2007`.
+
+
 
     Parameters
     ----------
@@ -942,6 +990,17 @@ def _is_valid_path(path, index, verbose):
 def fetch_localizer_calculation_task(n_subjects=1, data_dir=None, verbose=1):
     """Fetch calculation task contrast maps from the localizer.
 
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
+
     Parameters
     ----------
     n_subjects : :obj:`int`, default=1
@@ -989,6 +1048,17 @@ def fetch_localizer_calculation_task(n_subjects=1, data_dir=None, verbose=1):
 def fetch_localizer_button_task(data_dir=None, verbose=1):
     """Fetch left vs right button press :term:`contrast` maps \
        from the localizer.
+
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
 
     Parameters
     ----------
@@ -1054,6 +1124,17 @@ def fetch_abide_pcp(
     that can be passed as parameter. Note that this is the preprocessed
     version of ABIDE provided by the preprocess connectome projects (PCP).
     See :footcite:t:`Nielsen2013`.
+
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
 
     Parameters
     ----------
@@ -1380,6 +1461,17 @@ def fetch_mixed_gambles(
     See the :ref:`dataset description <mixed_gamble_maps>`
     for more information.
 
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
+
     Parameters
     ----------
     n_subjects : :obj:`int`, default=1
@@ -1484,6 +1576,17 @@ def fetch_megatrawls_netmats(
         This is open access data. You must agree to Terms and conditions
         of using this data before using it, available at:
         http://humanconnectome.org/data/data-use-terms/open-access.html
+
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
 
     Parameters
     ----------
@@ -1706,6 +1809,17 @@ def fetch_surf_nki_enhanced(
     preprocessed and projected to the fsaverage5 space surface.
 
     .. versionadded:: 0.3
+
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
 
     Parameters
     ----------
@@ -2084,6 +2198,17 @@ def fetch_development_fmri(
 
     .. versionadded:: 0.5.2
 
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
+
     Parameters
     ----------
     n_subjects : :obj:`int`, default=None
@@ -2283,6 +2408,17 @@ def _reduce_confounds(regressors, keep_confounds):
 def fetch_language_localizer_demo_dataset(data_dir=None, verbose=1):
     """Download language localizer demo dataset.
 
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
+
     Parameters
     ----------
     %(data_dir)s
@@ -2341,6 +2477,17 @@ def fetch_ds000030_urls(data_dir=None, verbose=1):
     Downloading the index allows users to explore the dataset directories
     to select specific files to download.
     The index is a sorted list of urls.
+
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
 
     Parameters
     ----------
@@ -2507,6 +2654,17 @@ def fetch_openneuro_dataset(
     it is up to the user to ensure that the URLs are correct,
     and that they are associated with an OpenNeuro dataset.
 
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
+
     Parameters
     ----------
     urls : :obj:`list` of :obj:`str`, default=None
@@ -2633,6 +2791,17 @@ def fetch_openneuro_dataset(
 def fetch_localizer_first_level(data_dir=None, verbose=1):
     """Download a first-level localizer :term:`fMRI` dataset.
 
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
+
     Parameters
     ----------
     %(data_dir)s
@@ -2705,6 +2874,17 @@ def fetch_spm_auditory(
     """Fetch :term:`SPM` auditory single-subject data.
 
     See :footcite:t:`spm_auditory`.
+
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
 
     Parameters
     ----------
@@ -2916,6 +3096,17 @@ def fetch_spm_multimodal_fmri(
     For more information,
     see the :ref:`dataset description <spm_multimodal_dataset>`.
 
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
+
     Parameters
     ----------
     %(data_dir)s
@@ -2980,6 +3171,17 @@ def fetch_spm_multimodal_fmri(
 @fill_doc
 def fetch_fiac_first_level(data_dir=None, verbose=1):
     """Download a first-level fiac :term:`fMRI` dataset (2 runs).
+
+    Notes
+    -----
+    If the dataset files are already present in the user's Nilearn data
+    directory, this fetcher will **not** re-download them. To force a fresh
+    download, you can remove the existing dataset folder from your local
+    Nilearn data directory.
+
+
+    For more details on how Nilearn stores datasets, see:
+    https://nilearn.github.io/dev/manipulating_images/input_output.html#datasets
 
     Parameters
     ----------


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #2040 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Added a Notes section to all fetch_* functions in nilearn.datasets.
- Notes clarify that datasets already present in the user's data directory are not re-downloaded.
- Provided a link to the Nilearn dataset storage documentation for more details.
- This PR is purely documentation and does not change any functionality
