### PR TITLE
[FIX] skip stack frame in warning

### DIFF
--- a/nilearn/_utils/logger.py
+++ b/nilearn/_utils/logger.py
@@ -152,7 +152,10 @@ def find_stack_level() -> int:
     pkg_dir = Path(nil.__file__).parent
 
     # list of stack frames to skip
-    skip_list = [Path("sklearn") / "utils" / "_set_output.py"]
+    skip_list = [
+        Path("sklearn") / "utils" / "_set_output.py",
+        Path("joblib") / "memory.py",
+    ]
 
     # https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow
     frame = inspect.currentframe()


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #5699 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- skip sklearn _set_output when reporting stacklevel for nilearn warnings

