### PR TITLE
[MAINT] add test for using target_affine as list

### DIFF
--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -1162,9 +1162,12 @@ t_r : :obj:`float` or :obj:`int` or None, default=None
 
 # target_affine
 docdict["target_affine"] = """
-target_affine : :class:`numpy.ndarray` or None, default=None
+target_affine : :class:`numpy.ndarray`, :obj:`list` of numeric, or None, \
+       default=None
     If specified, the image is resampled corresponding to this new affine.
-    `target_affine` can be a 3x3 or a 4x4 matrix.
+    `target_affine` can be a 3x3 or a 4x4 array.
+    If a list of numeric values is passed,
+    it must equivalent to a 3x3 or a 4x4 array.
 """
 
 # target_shape

--- a/nilearn/image/tests/test_resampling.py
+++ b/nilearn/image/tests/test_resampling.py
@@ -96,6 +96,23 @@ def test_identity_resample(data, force_resample, shape, affine_eye):
     )
 
 
+@pytest.mark.parametrize(
+    "target_affine",
+    [
+        [1, 2, 3],
+        [[1, 2, 3]],
+    ],
+)
+def test_target_affine_error(data, target_affine, affine_eye):
+    """Check errors when passing affine as list with wrong dimensions."""
+    with pytest.raises(np.linalg.LinAlgError):
+        resample_img(
+            Nifti1Image(data, affine_eye),
+            target_affine=target_affine,
+            interpolation="nearest",
+        )
+
+
 @pytest.mark.parametrize("force_resample", [False, True])
 @pytest.mark.parametrize("endian_type", [">f8", "<f8"])
 @pytest.mark.parametrize("interpolation", ["nearest", "linear", "continuous"])

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -100,12 +100,33 @@ def test_fit_transform_warning(img_3d_rand_eye, mask_img_1):
         assert np.any(X != 0)
 
 
-def test_resample(img_3d_rand_eye, mask_img_1):
-    """Check that target_affine triggers the right resampling."""
-    masker = NiftiMasker(mask_img=mask_img_1, target_affine=2 * np.eye(3))
+@pytest.mark.parametrize(
+    "target_affine", [2 * np.eye(3), (2 * np.eye(3)).tolist()]
+)
+def test_resample(img_3d_rand_eye, mask_img_1, target_affine):
+    """Check that target_affine triggers the right resampling.
+
+    Also check that target affine can be passed as a list.
+    """
+    masker = NiftiMasker(mask_img=mask_img_1, target_affine=target_affine)
     # Smoke test the fit
     X = masker.fit_transform(img_3d_rand_eye)
     assert np.any(X != 0)
+
+
+@pytest.mark.parametrize(
+    "target_affine",
+    [
+        [1, 2, 3],
+        [[1, 2, 3]],
+    ],
+)
+def test_target_affine_error(img_3d_rand_eye, target_affine):
+    """Check errors when passing affine as list with wrong dimensions."""
+    masker = NiftiMasker(target_affine=target_affine)
+
+    with pytest.raises(np.linalg.LinAlgError):
+        masker.fit_transform(img_3d_rand_eye)
 
 
 def test_resample_to_mask_warning(img_3d_rand_eye, affine_eye):


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #5691

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- update doc to mention that target affine can be a list of numeric
- update tests to make sure  target affine as a list of numeric can be used and that the proper errors are thrown when the list has the wrong dimensions
-
