### PR TITLE
[MAINT] use difumo instead of msdl for masker report embeddded in doc

### DIFF
--- a/doc/get_data_examples.py
+++ b/doc/get_data_examples.py
@@ -19,7 +19,6 @@ def main(args=sys.argv) -> None:
     datasets.fetch_icbm152_2009()
 
     datasets.fetch_atlas_difumo(dimension=64, resolution_mm=2)
-    datasets.fetch_atlas_msdl()
     datasets.fetch_atlas_schaefer_2018()
     datasets.fetch_atlas_yeo_2011()
 

--- a/doc/visual_testing/reporter_visual_inspection_suite.py
+++ b/doc/visual_testing/reporter_visual_inspection_suite.py
@@ -17,7 +17,6 @@ import pandas as pd
 from nilearn.datasets import (
     fetch_adhd,
     fetch_atlas_difumo,
-    fetch_atlas_msdl,
     fetch_atlas_schaefer_2018,
     fetch_atlas_surf_destrieux,
     fetch_atlas_yeo_2011,
@@ -396,7 +395,7 @@ def report_nifti_maps_masker(build_type):
         _generate_dummy_html(filenames=["nifti_maps_masker.html"])
         return None
 
-    atlas = fetch_atlas_msdl()
+    atlas = fetch_atlas_difumo(dimension=64, resolution_mm=2)
     atlas_filename = atlas["maps"]
 
     data = fetch_development_fmri(n_subjects=1)
@@ -720,7 +719,7 @@ def report_surface_maps_masker(build_type):
         return None, None
 
     # Fetch a volumetric probabilistic atlas
-    atlas = fetch_atlas_msdl()
+    atlas = fetch_atlas_difumo(dimension=64, resolution_mm=2)
     # Fetch the fsaverage5 mesh
     fsaverage5_mesh = load_fsaverage("fsaverage5")["pial"]
     # project atlas to the surface


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- getting a lot of doc build error trying to fetch the msdl atlas because it needed to build the masker reports (even when not running any examples: see https://nilearn.github.io/dev/modules/generated_reports/masker_reports_examples.html#nifti-maps-masker and https://nilearn.github.io/dev/modules/generated_reports/masker_reports_examples.html#surface-maps-masker), switching to difumo instead

