### PR TITLE
[FIX] no missing img warning with nifti masker in fit_transform

### DIFF
--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -385,8 +385,7 @@ class BaseMasker(
         imgs : Niimg-like object
             See :ref:`extracting_data`.
 
-        y : numpy array of shape [n_samples], default=None
-            Target values.
+        %(y_dummy)s
 
         %(confounds)s
 
@@ -399,34 +398,7 @@ class BaseMasker(
         %(signals_transform_nifti)s
 
         """
-        # non-optimized default implementation; override when a better
-        # method is possible for a given clustering algorithm
-        if y is None:
-            # fit method of arity 1 (unsupervised transformation)
-            if self.mask_img is None:
-                return self.fit(imgs, **fit_params).transform(
-                    imgs, confounds=confounds, sample_mask=sample_mask
-                )
-
-            return self.fit(**fit_params).transform(
-                imgs, confounds=confounds, sample_mask=sample_mask
-            )
-
-        # fit method of arity 2 (supervised transformation)
-        if self.mask_img is None:
-            return self.fit(imgs, y, **fit_params).transform(
-                imgs, confounds=confounds, sample_mask=sample_mask
-            )
-
-        warnings.warn(
-            f"[{self.__class__.__name__}.fit] "
-            "Generation of a mask has been"
-            " requested (y != None) while a mask was"
-            " given at masker creation. Given mask"
-            " will be used.",
-            stacklevel=find_stack_level(),
-        )
-        return self.fit(**fit_params).transform(
+        return self.fit(imgs, y, **fit_params).transform(
             imgs, confounds=confounds, sample_mask=sample_mask
         )
 

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -156,7 +156,7 @@ class SurfaceMasker(ClassNamePrefixFeaturesOutMixin, _BaseSurfaceMasker):
                 warn(
                     f"[{self.__class__.__name__}.fit] "
                     "Generation of a mask has been"
-                    " requested (y != None) while a mask was"
+                    " requested (img != None) while a mask was"
                     " given at masker creation. Given mask"
                     " will be used.",
                     stacklevel=find_stack_level(),

--- a/nilearn/reporting/tests/test_html_report.py
+++ b/nilearn/reporting/tests/test_html_report.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import Counter
 
 import numpy as np
@@ -8,7 +9,7 @@ from numpy.testing import assert_almost_equal
 from nilearn._utils.data_gen import generate_random_img
 from nilearn._utils.helpers import is_matplotlib_installed, is_plotly_installed
 from nilearn._utils.html_document import WIDTH_DEFAULT, HTMLDocument
-from nilearn.conftest import _img_maps
+from nilearn.conftest import _img_maps, _img_mask_eye
 from nilearn.image import get_data
 from nilearn.maskers import (
     MultiNiftiLabelsMasker,
@@ -414,6 +415,25 @@ def test_overlaid_report(img_fmri):
     html = masker.generate_report()
 
     assert '<div class="overlay">' in str(html)
+
+
+@pytest.mark.parametrize("mask_img", [None, _img_mask_eye()])
+def test_nifti_label_masker_no_warning_in_report_after_fit_transform(
+    mask_img, img_fmri
+):
+    """Check no warning about fitted image in report generation \
+        after fit_transform on image.
+
+    Regression test for https://github.com/nilearn/nilearn/issues/5121.
+    """
+    masker = NiftiMasker(mask_img=mask_img)
+    masker.fit_transform(img_fmri)
+    with warnings.catch_warnings(record=True) as warning_list:
+        masker.generate_report()
+    if warning_list:
+        assert not any(
+            "No image provided to fit" in str(x) for x in warning_list
+        )
 
 
 def test_multi_nifti_masker_generate_report_imgs(img_fmri):


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #5121

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- make sure nifti masker does not throw warning about no missing img passed to fit when using fit_transform on an image

