### PR TITLE
[MAINT] mark tests as slow

### DIFF
--- a/nilearn/maskers/tests/test_html_report.py
+++ b/nilearn/maskers/tests/test_html_report.py
@@ -408,6 +408,7 @@ def test_multi_nifti_masker_generate_report_mask(
     masker.fit().generate_report()
 
 
+@pytest.mark.slow
 def test_multi_nifti_masker_generate_report_imgs_and_mask(
     shape_3d_default, affine_eye, img_fmri
 ):

--- a/nilearn/maskers/tests/test_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_nifti_labels_masker.py
@@ -373,6 +373,7 @@ def test_nifti_labels_masker_resampling(
     assert_array_equal(get_data(compressed_img), get_data(compressed_img2))
 
 
+@pytest.mark.slow
 def test_nifti_labels_masker_resampling_to_labels(
     affine_eye, shape_3d_default, n_regions, length
 ):

--- a/nilearn/plotting/tests/test_baseline_comparisons.py
+++ b/nilearn/plotting/tests/test_baseline_comparisons.py
@@ -64,6 +64,7 @@ SURFACE_FUNCS = {
 }
 
 
+@pytest.mark.slow
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("plot_func", PLOTTING_FUNCS_3D)
 def test_plot_functions_black_bg(plot_func, img_3d_mni):
@@ -133,6 +134,7 @@ def test_plot_functions_colorbar_ticks(plot_func, img_3d_mni):
     )
 
 
+@pytest.mark.slow
 @pytest.mark.mpl_image_compare(tolerance=5)
 @pytest.mark.parametrize("plot_func", PLOTTING_FUNCS_3D)
 @pytest.mark.parametrize("vmin", [-1, 1])


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- mark tests that timedout in a previous run as slow: https://github.com/nilearn/nilearn/actions/runs/19961198318/job/57244462879#step:8:13724

