### PR TITLE
[FIX] revert short option for pytest markers

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,8 +56,8 @@ description = Run tests on latest version of all dependencies (plotting not incl
 passenv = {[global_var]passenv}
 extras = test
 commands =
-    pytest --markers "not slow and not flaky and not single_process" --timeout=45 --cov=nilearn --cov-report=xml --cov-report=html --cov-append --report=report.html --numprocesses auto --csv results/pytest_output/pytest_output.csv  {posargs:}
-    pytest --markers "slow and not flaky and not single_process" --cov=nilearn --cov-report=xml --cov-report=html --cov-append --report=report_slow.html --numprocesses auto --csv results/pytest_output/pytest_output_slow_tests.csv  {posargs:}
+    pytest -m "not slow and not flaky and not single_process" --timeout=45 --cov=nilearn --cov-report=xml --cov-report=html --cov-append --report=report.html --numprocesses auto --csv results/pytest_output/pytest_output.csv  {posargs:}
+    pytest -m "slow and not flaky and not single_process" --cov=nilearn --cov-report=xml --cov-report=html --cov-append --report=report_slow.html --numprocesses auto --csv results/pytest_output/pytest_output_slow_tests.csv  {posargs:}
 
 
 [testenv:flaky]
@@ -68,7 +68,7 @@ extras =
     plotting
 commands =
     coverage erase
-    pytest --markers "flaky or single_process" {posargs:}
+    pytest -m "flaky or single_process" {posargs:}
 
 
 [testenv:plotting]


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- reverts one change from https://github.com/nilearn/nilearn/pull/5935 that only lists the test markers instead of only selecting the tests with some markers



