### PR TITLE
[MAINT] Remove pull_request trigger from testing minimal workflow

### DIFF
--- a/.github/workflows/testing_minimum.yml
+++ b/.github/workflows/testing_minimum.yml
@@ -30,7 +30,6 @@ on:
     # This enables manual triggering from GitHub UI
     # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch
     workflow_dispatch:
-    pull_request:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Removed pull_request trigger from the minimal workflow. This was running a bazillion extra jobs for each PR... And I was wondering why CI was slow.

<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

