### PR TITLE
[DOC] avoid showing matplotlib non-interactive warning in sphinx gallery

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,10 +17,9 @@ import sys
 import warnings
 from pathlib import Path
 
+from nilearn._version import __version__  # noqa : I001, RUF100
 from sphinx.domains import changeset
 from sphinx.locale import _
-
-from nilearn._version import __version__  # noqa : I001, RUF100
 
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- should prevent 'non-interactive backend' warnings to show in the sphinx gallery

see https://nilearn.github.io/stable/auto_examples/00_tutorials/plot_decoding_tutorial.html#visualizing-the-fmri-volume

<img width="858" height="218" alt="image" src="https://github.com/user-attachments/assets/5bf104c2-3176-497e-a1fb-b1dff5022287" />


