### PR TITLE
FIX: Refactor GLM results for memory efficiency and core API stability (#2381)

### DIFF
--- a/nilearn/glm/_base.py
+++ b/nilearn/glm/_base.py
@@ -10,7 +10,6 @@ from typing import Any, Literal
 import numpy as np
 import pandas as pd
 from nibabel import Nifti1Image
-from nibabel.onetime import auto_attr
 from sklearn.utils import Bunch
 from sklearn.utils.estimator_checks import check_is_fitted
 
@@ -184,10 +183,14 @@ class BaseGLM(CacheMixin, NilearnBaseEstimator):
 
     # @auto_attr store the value as an object attribute after initial call
     # better performance than @property
-    @auto_attr
-    def residuals(self):
+    def residuals(self, Y):
         """Transform voxelwise residuals to the same shape \
         as the input Nifti1Image(s).
+
+        Parameters
+        ----------
+        Y : Niimg-like object
+            The data from which to compute the residuals.
 
         Returns
         -------
@@ -196,10 +199,9 @@ class BaseGLM(CacheMixin, NilearnBaseEstimator):
 
         """
         return self._get_element_wise_model_attribute(
-            "residuals", result_as_time_series=True
+            "residuals", result_as_time_series=True, Y=Y
         )
 
-    @auto_attr
     def predicted(self):
         """Transform voxelwise predicted values to the same shape \
         as the input Nifti1Image(s).
@@ -214,7 +216,6 @@ class BaseGLM(CacheMixin, NilearnBaseEstimator):
             "predicted", result_as_time_series=True
         )
 
-    @auto_attr
     def r_square(self):
         """Transform voxelwise r-squared values to the same shape \
         as the input Nifti1Image(s).

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -213,7 +213,7 @@ def run_glm(
             raise ValueError(err_msg) from e
 
         # compute the AR coefficients
-        ar_coef_ = _yule_walker(ols_result.residuals.T, ar_order)
+        ar_coef_ = _yule_walker(ols_result.residuals(Y).T, ar_order)
         del ols_result
         if len(ar_coef_[0]) == 1:
             ar_coef_ = ar_coef_[:, 0]
@@ -1186,7 +1186,7 @@ class FirstLevelModel(BaseGLM):
         }
 
     def _get_element_wise_model_attribute(
-        self, attribute, result_as_time_series
+        self, attribute, result_as_time_series, Y=None
     ):
         """Transform RegressionResults instances within a dictionary \
         (whose keys represent the autoregressive coefficient under the 'ar1' \
@@ -1204,6 +1204,10 @@ class FirstLevelModel(BaseGLM):
             whether the RegressionResult attribute has a value
             per timepoint of the input nifti image.
 
+        Y : Niimg-like object, default=None
+            The data from which to compute the attribute.
+            Required for 'residuals' and 'normalized_residuals'.
+
         Returns
         -------
         output : :obj:`list`
@@ -1213,10 +1217,10 @@ class FirstLevelModel(BaseGLM):
         # check if valid attribute is being accessed.
         check_is_fitted(self)
 
-        all_attributes = dict(vars(RegressionResults)).keys()
         possible_attributes = [
-            prop for prop in all_attributes if "__" not in prop
+            prop for prop in dict(vars(RegressionResults)) if "__" not in prop
         ]
+        possible_attributes += RegressionResults.__static_attributes__
         check_parameter_in_allowed(attribute, possible_attributes, attribute)
 
         if self.minimize_memory:
@@ -1231,8 +1235,15 @@ class FirstLevelModel(BaseGLM):
 
         output = []
 
-        for design_matrix, labels, results in zip(
-            self.design_matrices_, self.labels_, self.results_, strict=False
+        Y = [Y] if Y is not None and not isinstance(Y, list) else Y
+
+        for i, (design_matrix, labels, results) in enumerate(
+            zip(
+                self.design_matrices_,
+                self.labels_,
+                self.results_,
+                strict=False,
+            )
         ):
             if result_as_time_series:
                 voxelwise_attribute = np.zeros(
@@ -1241,11 +1252,25 @@ class FirstLevelModel(BaseGLM):
             else:
                 voxelwise_attribute = np.zeros((1, len(labels)))
 
+            Y_matrix = self.masker_.transform(Y[i]) if Y is not None else None
+            if Y_matrix is not None and self.signal_scaling is not False:
+                Y_matrix, _ = mean_scaling(Y_matrix, self.signal_scaling)
+
             for label_ in results:
                 label_mask = labels == label_
-                voxelwise_attribute[:, label_mask] = getattr(
-                    results[label_], attribute
-                )
+                attr = getattr(results[label_], attribute)
+                if attribute in ["residuals", "normalized_residuals"]:
+                    if Y_matrix is None:
+                        raise ValueError(
+                            f"Attribute {attribute} requires data Y."
+                        )
+                    val = attr(Y_matrix[:, label_mask])
+                elif attribute == "predicted":
+                    val = attr()
+                else:
+                    val = attr
+
+                voxelwise_attribute[:, label_mask] = val
 
             output.append(self.masker_.inverse_transform(voxelwise_attribute))
 

--- a/nilearn/glm/model.py
+++ b/nilearn/glm/model.py
@@ -1,7 +1,6 @@
 """Implement classes to handle statistical tests on likelihood models."""
 
 import numpy as np
-from nibabel.onetime import auto_attr
 from scipy.linalg import inv
 from scipy.stats import t as t_distribution
 
@@ -23,11 +22,11 @@ class LikelihoodModelResults:
     theta : ndarray
         Parameter estimates from estimated model.
 
-    Y : ndarray
-        Data.
-
     model : ``LikelihoodModel`` instance
         Model used to generate fit.
+
+    n_samples : int
+        Total number of observations (number of rows in the data Y).
 
     cov : None or ndarray, default=None
         Covariance of thetas.
@@ -52,14 +51,13 @@ class LikelihoodModelResults:
     def __init__(
         self,
         theta,
-        Y,
         model,
+        n_samples,
         cov=None,
         dispersion=1.0,
         nuisance=None,
     ):
         self.theta = theta
-        self.Y = Y
         self.model = model
         if cov is None:
             self.cov = self.model.information(
@@ -70,17 +68,25 @@ class LikelihoodModelResults:
         self.dispersion = dispersion
         self.nuisance = nuisance
 
-        self.df_total = Y.shape[0]
+        self.df_total = n_samples
         self.df_model = model.df_model
         # put this as a parameter of LikelihoodModel
         self.df_residuals = self.df_total - self.df_model
 
-    # @auto_attr store the value as an object attribute after initial call
-    # better performance than @property
-    @auto_attr
-    def logL(self):  # noqa: N802
-        """Return the maximized log-likelihood."""
-        return self.model.logL(self.theta, self.Y, nuisance=self.nuisance)
+    def logL(self, Y):  # noqa: N802
+        """Return the maximized log-likelihood.
+
+        Parameters
+        ----------
+        Y : ndarray
+            Data for which to compute the log-likelihood.
+
+        Returns
+        -------
+        float
+            The maximized log-likelihood.
+        """
+        return self.model.logL(self.theta, Y, nuisance=self.nuisance)
 
     def t(self, column=None):
         """

--- a/nilearn/glm/regression.py
+++ b/nilearn/glm/regression.py
@@ -17,9 +17,10 @@ General reference for regression models:
 
 __docformat__ = "restructuredtext en"
 
+from typing import ClassVar
+
 import numpy as np
 import scipy.linalg as spl
-from nibabel.onetime import auto_attr
 from numpy.linalg import matrix_rank
 
 from nilearn.glm._utils import positive_reciprocal
@@ -193,16 +194,26 @@ class OLSModel:
         wY = self.whiten(Y)
         beta = np.dot(self.calc_beta, wY)
         wresid = wY - np.dot(self.whitened_design, beta)
-        dispersion = np.sum(wresid**2, 0) / (
-            self.whitened_design.shape[0] - self.whitened_design.shape[1]
-        )
+        sse = np.sum(wresid**2, 0)
+        n_samples = wY.shape[0]
+        n_features = self.whitened_design.shape[1]
+        df_residuals = n_samples - n_features
+        mse = sse / df_residuals
+
+        # Calculate r_square
+        # r_square = var(predicted) / var(whitened_Y)
+        predicted = np.dot(self.whitened_design, beta)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            r_square = np.var(predicted, 0) / np.var(wY, 0)
+
         lfit = RegressionResults(
             beta,
-            Y,
             self,
-            wY,
-            wresid,
-            dispersion=dispersion,
+            n_samples,
+            sse,
+            r_square,
+            mse,
+            dispersion=mse,
             cov=self.normalized_cov_beta,
         )
         return lfit
@@ -269,44 +280,114 @@ class RegressionResults(LikelihoodModelResults):
 
     It handles the output of contrasts, estimates of covariance, etc.
 
+    Parameters
+    ----------
+    theta : ndarray
+        Parameter estimates from estimated model.
+
+    model : ``LikelihoodModel`` instance
+        Model used to generate fit.
+
+    n_samples : int
+        Total number of observations (number of rows in the data Y).
+
+    SSE : ndarray
+        Sum of squared errors.
+
+    r_square : ndarray
+        R-squared statistic.
+
+    MSE : ndarray
+        Mean squared error.
+
+    cov : None or ndarray, default=None
+        Covariance of thetas.
+
+    dispersion : scalar, default=1
+        Multiplicative factor in front of `cov`.
+
+    nuisance : None of ndarray, default=None
+        Parameter estimates needed to compute logL.
+
     """
+
+    __static_attributes__: ClassVar[list[str]] = ["SSE", "r_square", "MSE"]
 
     def __init__(
         self,
         theta,
-        Y,
         model,
-        whitened_Y,
-        whitened_residuals,
+        n_samples,
+        SSE,
+        r_square,
+        MSE,
         cov=None,
         dispersion=1.0,
         nuisance=None,
     ):
         """See LikelihoodModelResults constructor.
 
-        The only difference is that the whitened Y and residual values
-        are stored for a regression model.
+        The difference is that the summary statistics (SSE, r_square, MSE)
+        are stored for a regression model, and no large arrays (Y, residuals)
+        are kept in memory.
 
         """
         LikelihoodModelResults.__init__(
-            self, theta, Y, model, cov, dispersion, nuisance
+            self,
+            theta,
+            model,
+            n_samples=n_samples,
+            cov=cov,
+            dispersion=dispersion,
+            nuisance=nuisance,
         )
-        self.whitened_Y = whitened_Y
-        self.whitened_residuals = whitened_residuals
+        self.SSE = SSE
+        self.r_square = r_square
+        self.MSE = MSE
         self.whitened_design = model.whitened_design
 
-    # @auto_attr store the value as an object attribute after initial call
-    # better performance than @property
-    @auto_attr
-    def residuals(self):
-        """Residuals from the fit."""
-        return self.Y - self.predicted
+    def predicted(self):
+        """Return linear predictor values from a design matrix.
 
-    @auto_attr
-    def normalized_residuals(self):
+        Returns
+        -------
+        predicted : ndarray
+            Predicted values.
+        """
+        beta = self.theta
+        # the LikelihoodModelResults has parameters named 'theta'
+        X = self.whitened_design
+        return np.dot(X, beta)
+
+    def residuals(self, Y):
+        """Residuals from the fit.
+
+        Parameters
+        ----------
+        Y : ndarray
+            Data for which to compute the residuals.
+
+        Returns
+        -------
+        residuals : ndarray
+            Residuals from the fit.
+        """
+        return Y - self.predicted()
+
+    def normalized_residuals(self, Y):
         """Residuals, normalized to have unit length.
 
         See :footcite:t:`Montgomery2006` and :footcite:t:`Davidson2004`.
+
+        Parameters
+        ----------
+        Y : ndarray
+            Data for which to compute the normalized residuals.
+
+        Returns
+        -------
+        norm_residuals : ndarray
+            Residuals, normalized to have unit length.
 
         Notes
         -----
@@ -323,36 +404,9 @@ class RegressionResults(LikelihoodModelResults):
         .. footbibliography::
 
         """
-        return self.residuals * positive_reciprocal(np.sqrt(self.dispersion))
-
-    @auto_attr
-    def predicted(self):
-        """Return linear predictor values from a design matrix."""
-        beta = self.theta
-        # the LikelihoodModelResults has parameters named 'theta'
-        X = self.whitened_design
-        return np.dot(X, beta)
-
-    @auto_attr
-    def SSE(self):  # noqa: N802
-        """Error sum of squares.
-
-        If not from an OLS model this is "pseudo"-SSE.
-        """
-        return (self.whitened_residuals**2).sum(0)
-
-    @auto_attr
-    def r_square(self):
-        """Proportion of explained variance.
-
-        If not from an OLS model this is "pseudo"-R2.
-        """
-        return np.var(self.predicted, 0) / np.var(self.whitened_Y, 0)
-
-    @auto_attr
-    def MSE(self):  # noqa: N802
-        """Return Mean square (error)."""
-        return self.SSE / self.df_residuals
+        return self.residuals(Y) * positive_reciprocal(
+            np.sqrt(self.dispersion)
+        )
 
 
 class SimpleRegressionResults(LikelihoodModelResults):
@@ -366,20 +420,20 @@ class SimpleRegressionResults(LikelihoodModelResults):
     def __init__(self, results):
         """See LikelihoodModelResults constructor.
 
-        The only difference is that the whitened Y and residual values
-        are stored for a regression model.
+        The difference is that only the necessary information for
+        contrast computation is kept.
         """
         self.theta = results.theta
         self.cov = results.cov
         self.dispersion = results.dispersion
         self.nuisance = results.nuisance
 
-        self.df_total = results.Y.shape[0]
+        self.df_total = results.df_total
         self.df_model = results.model.df_model
         # put this as a parameter of LikelihoodModel
         self.df_residuals = self.df_total - self.df_model
 
-    def logL(self) -> None:  # noqa: N802
+    def logL(self, Y) -> None:  # noqa: N802
         """Return the maximized log-likelihood."""
         raise NotImplementedError(
             "logL not implemented for "
@@ -388,13 +442,40 @@ class SimpleRegressionResults(LikelihoodModelResults):
         )
 
     def residuals(self, Y, X):
-        """Residuals from the fit."""
+        """Residuals from the fit.
+
+        Parameters
+        ----------
+        Y : ndarray
+            Data for which to compute the residuals.
+
+        X : ndarray
+            Design matrix.
+
+        Returns
+        -------
+        residuals : ndarray
+            Residuals from the fit.
+        """
         return Y - self.predicted(X)
 
     def normalized_residuals(self, Y, X):
         """Residuals, normalized to have unit length.
 
         See :footcite:t:`Montgomery2006` and :footcite:t:`Davidson2004`.
+
+        Parameters
+        ----------
+        Y : ndarray
+            Data for which to compute the normalized residuals.
+
+        X : ndarray
+            Design matrix.
+
+        Returns
+        -------
+        norm_residuals : ndarray
+            Residuals, normalized to have unit length.
 
         Notes
         -----
@@ -416,6 +497,17 @@ class SimpleRegressionResults(LikelihoodModelResults):
         )
 
     def predicted(self, X):
-        """Return linear predictor values from a design matrix."""
+        """Return linear predictor values from a design matrix.
+
+        Parameters
+        ----------
+        X : ndarray
+            Design matrix.
+
+        Returns
+        -------
+        predicted : ndarray
+            Predicted values.
+        """
         beta = self.theta
         return np.dot(X, beta)

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -828,7 +828,7 @@ class SecondLevelModel(BaseGLM):
         }
 
     def _get_element_wise_model_attribute(
-        self, attribute, result_as_time_series
+        self, attribute, result_as_time_series, Y=None
     ):
         """Transform RegressionResults instances within a dictionary \
         (whose keys represent the autoregressive coefficient under the 'ar1' \
@@ -846,6 +846,10 @@ class SecondLevelModel(BaseGLM):
             whether the RegressionResult attribute has a value
             per timepoint of the input nifti image.
 
+        Y : Niimg-like object, default=None
+            The data from which to compute the attribute.
+            Required for 'residuals' and 'normalized_residuals'.
+
         Returns
         -------
         output : :obj:`list`
@@ -854,10 +858,10 @@ class SecondLevelModel(BaseGLM):
         """
         check_is_fitted(self)
         # check if valid attribute is being accessed.
-        all_attributes = dict(vars(RegressionResults)).keys()
         possible_attributes = [
-            prop for prop in all_attributes if "__" not in prop
+            prop for prop in dict(vars(RegressionResults)) if "__" not in prop
         ]
+        possible_attributes += RegressionResults.__static_attributes__
         if attribute not in possible_attributes:
             msg = f"attribute must be one of: {possible_attributes}"
             raise ValueError(msg)
@@ -889,11 +893,22 @@ class SecondLevelModel(BaseGLM):
         else:
             voxelwise_attribute = np.zeros((1, len(self.labels_)))
 
+        Y_matrix = self.masker_.transform(Y) if Y is not None else None
+
         for label_ in self.results_:
             label_mask = self.labels_ == label_
-            voxelwise_attribute[:, label_mask] = getattr(
-                self.results_[label_], attribute
-            )
+            attr = getattr(self.results_[label_], attribute)
+            if attribute in ["residuals", "normalized_residuals"]:
+                if Y_matrix is None:
+                    raise ValueError(f"Attribute {attribute} requires data Y.")
+                val = attr(Y_matrix[:, label_mask])
+            elif attribute == "predicted":
+                val = attr()
+            else:
+                val = attr
+
+            voxelwise_attribute[:, label_mask] = val
+
         return self.masker_.inverse_transform(voxelwise_attribute)
 
 

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -1492,7 +1492,7 @@ def test_first_level_residuals(shape_4d_default):
 
     model.fit(fmri_data, design_matrices=design_matrices)
 
-    residuals = model.residuals[0]
+    residuals = model.residuals(fmri_data)[0]
     mean_residuals = model.masker_.transform(residuals).mean(0)
 
     assert_array_almost_equal(mean_residuals, 0)
@@ -1516,7 +1516,7 @@ def test_first_level_residuals_errors(shape_4d_default):
     model.fit(fmri_data, design_matrices=design_matrices)
 
     with pytest.raises(ValueError, match="To access voxelwise attributes"):
-        model.residuals[0]
+        model.residuals(fmri_data)[0]
 
     # Check that trying to access residuals without fitting
     # raises an error
@@ -1556,7 +1556,7 @@ def test_get_element_wise_attributes_should_return_as_many_as_design_matrices(
     model.fit(fmri_data, design_matrices=design_matrices)
 
     assert len(
-        model._get_element_wise_model_attribute("residuals", True)
+        model._get_element_wise_model_attribute("residuals", True, Y=fmri_data)
     ) == len(shapes)
 
 
@@ -1578,9 +1578,9 @@ def test_first_level_predictions_r_square(shape_4d_default):
     )
     model.fit(fmri_data, design_matrices=design_matrices)
 
-    pred = model.predicted[0]
+    pred = model.predicted()[0]
     data = fmri_data[0]
-    r_square_3d = model.r_square[0]
+    r_square_3d = model.r_square()[0]
 
     y_predicted = model.masker_.transform(pred)
     y_measured = model.masker_.transform(data)
@@ -1643,7 +1643,7 @@ def test_glm_sample_mask(shape_4d_default):
     )
 
     assert model.design_matrices_[0].shape[0] == shape_4d_default[3] - 3
-    assert model.predicted[0].shape[-1] == shape_4d_default[3] - 3
+    assert model.predicted()[0].shape[-1] == shape_4d_default[3] - 3
 
 
 def _inputs_for_new_bids_dataset():
@@ -2621,12 +2621,12 @@ def test_flm_get_element_wise_model_attribute_with_surface_data(
     events = basic_paradigm()
     model.fit([img, img], events=[events, events])
 
-    assert len(model.residuals) == 2
-    assert model.residuals[0].shape == img.shape
-    assert len(model.predicted) == 2
-    assert model.predicted[0].shape == img.shape
-    assert len(model.r_square) == 2
-    assert model.r_square[0].shape == (img.mesh.n_vertices, 1)
+    assert len(model.residuals([img, img])) == 2
+    assert model.residuals([img, img])[0].shape == img.shape
+    assert len(model.predicted()) == 2
+    assert model.predicted()[0].shape == img.shape
+    assert len(model.r_square()) == 2
+    assert model.r_square()[0].shape == (img.mesh.n_vertices, 1)
 
 
 # -----------------------bids tests----------------------- #

--- a/nilearn/glm/tests/test_model.py
+++ b/nilearn/glm/tests/test_model.py
@@ -54,7 +54,7 @@ def test_model():
     # Check we get the same as R
     assert_array_almost_equal(RESULTS.theta, [1.773, 2.5], 3)
     percentile = np.percentile
-    pcts = percentile(RESULTS.residuals, [0, 25, 50, 75, 100])
+    pcts = percentile(RESULTS.residuals(Y), [0, 25, 50, 75, 100])
     assert_array_almost_equal(pcts, [-1.6970, -0.6667, 0, 0.6667, 1.6970], 4)
 
 

--- a/nilearn/glm/tests/test_regression.py
+++ b/nilearn/glm/tests/test_regression.py
@@ -24,16 +24,16 @@ def test_ols(X, Y):
     model = OLSModel(design=X)
     results = model.fit(Y)
     assert results.df_residuals == 30
-    assert results.residuals.shape[0] == 40
-    assert results.predicted.shape[0] == 40
+    assert results.residuals(Y).shape[0] == 40
+    assert results.predicted().shape[0] == 40
 
 
 def test_ar(X, Y):
     model = ARModel(design=X, rho=0.4)
     results = model.fit(Y)
     assert results.df_residuals == 30
-    assert results.residuals.shape[0] == 40
-    assert results.predicted.shape[0] == 40
+    assert results.residuals(Y).shape[0] == 40
+    assert results.predicted().shape[0] == 40
 
 
 def test_residuals(X, Y):
@@ -43,8 +43,8 @@ def test_residuals(X, Y):
     X[:, 0] = 1
     model = OLSModel(design=X)
     results = model.fit(Y)
-    assert_almost_equal(results.residuals.mean(), 0)
-    assert len(results.whitened_residuals) == 40
+    assert_almost_equal(results.residuals(Y).mean(), 0)
+    assert len(results.residuals(Y)) == 40
 
 
 def test_predicted_r_square(X, Y):
@@ -56,8 +56,8 @@ def test_predicted_r_square(X, Y):
     # rounding errors)
     model = OLSModel(design=Xshort)
     results = model.fit(Yshort)
-    assert_almost_equal(results.residuals.sum(), 0)
-    assert_array_almost_equal(results.predicted, Yshort)
+    assert_almost_equal(results.residuals(Yshort).sum(), 0)
+    assert_array_almost_equal(results.predicted(), Yshort)
     assert_almost_equal(results.r_square, 1.0)
 
 
@@ -80,8 +80,9 @@ def test_simple_results(X, Y):
     results = model.fit(Y)
 
     simple_results = SimpleRegressionResults(results)
-    assert_array_equal(results.predicted, simple_results.predicted(X))
-    assert_array_equal(results.residuals, simple_results.residuals(Y, X))
+    assert_array_equal(results.predicted(), simple_results.predicted(X))
+    assert_array_equal(results.residuals(Y), simple_results.residuals(Y, X))
     assert_array_equal(
-        results.normalized_residuals, simple_results.normalized_residuals(Y, X)
+        results.normalized_residuals(Y),
+        simple_results.normalized_residuals(Y, X),
     )

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -1038,7 +1038,14 @@ def test_second_level_voxelwise_attribute_errors(attribute, n_subjects):
     model.fit(Y, design_matrix=X)
 
     with pytest.raises(ValueError, match=r"The model has no results."):
-        getattr(model, attribute)
+        if attribute == "residuals":
+            model.residuals(Y=None)
+        elif attribute == "predicted":
+            model.predicted()
+        elif attribute == "r_square":
+            model.r_square()
+        else:
+            getattr(model, attribute)
     with pytest.raises(ValueError, match="attribute must be one of"):
         model._get_element_wise_model_attribute("foo", True)
 
@@ -1063,7 +1070,14 @@ def test_second_level_voxelwise_attribute_errors_minimize_memory(
     model.compute_contrast()
 
     with pytest.raises(ValueError, match="To access voxelwise attributes"):
-        getattr(model, attribute)
+        if attribute == "residuals":
+            model.residuals(Y=None)
+        elif attribute == "predicted":
+            model.predicted()
+        elif attribute == "r_square":
+            model.r_square()
+        else:
+            getattr(model, attribute)
 
 
 @pytest.mark.slow
@@ -1076,7 +1090,14 @@ def test_second_level_voxelwise_attribute(attribute, n_subjects):
     X = pd.DataFrame([[1]] * n_subjects, columns=["intercept"])
     model.fit(Y, design_matrix=X)
     model.compute_contrast()
-    getattr(model, attribute)
+    if attribute == "residuals":
+        model.residuals(Y)
+    elif attribute == "predicted":
+        model.predicted()
+    elif attribute == "r_square":
+        model.r_square()
+    else:
+        getattr(model, attribute)
 
 
 @pytest.mark.slow
@@ -1089,9 +1110,9 @@ def test_second_level_residuals(n_subjects):
     model.fit(Y, design_matrix=X)
     model.compute_contrast()
 
-    assert isinstance(model.residuals, Nifti1Image)
-    assert model.residuals.shape == (*SHAPE[:3], n_subjects)
-    mean_residuals = model.masker_.transform(model.residuals).mean(0)
+    assert isinstance(model.residuals(Y), Nifti1Image)
+    assert model.residuals(Y).shape == (*SHAPE[:3], n_subjects)
+    mean_residuals = model.masker_.transform(model.residuals(Y)).mean(0)
     assert_array_almost_equal(mean_residuals, 0)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,7 +327,9 @@ log_cli_level = "INFO"
 markers = [
     "slow",  # for tests that exceed the timeout allowed for each test
     "single_process",  # for test that require testing n_jobs>1 or that are flaky when used xdist testing parallelization
-    "thread_unsafe"
+    "thread_unsafe",
+    "flaky",
+    "mpl_image_compare"
 ]
 minversion = "6.0"
 xfail_strict = true


### PR DESCRIPTION
Refactors GLM results to improve memory efficiency by eliminating redundant storage of large data arrays (input images, whitened data, and residuals) within the `RegressionResults` objects.

### Key Changes
- **Memory Optimization**: `RegressionResults` no longer stores `Y`, `whitened_Y`, or `residuals` by default. These are now computed or retrieved via methods only when explicitly requested.
- **Summary Statistics**: Common statistics like `SSE`, `r_square` and `MSE` are now computed once during `fit()` and stored as pre-calculated static attributes, maintaining fast performance for most use cases (like maps and summaries).

### API Evolution
Most voxel-wise attributes have transitioned from attributes/properties to methods.

#### Residuals and Predictions
- **Before**: 
  ```python
  res = model.residuals    # Attribute (High memory)
  pred = model.predicted   # Attribute
  ```
- **After**: 
  ```python
  res = model.residuals(Y)  # Method requiring input data 'Y'
  pred = model.predicted()  # Method call
  ```

#### Summary Statistics (R-squared)
- **Before**: 
  ```python
  r2 = model.r_square      # Property
  ```
- **After**: 
  ```python
  r2 = model.r_square()    # Method call (returns pre-calculated map)
  ```

#### Normalized Residuals
- **Before**: 
  ```python
  norm_res = model.normalized_residuals  # Attribute
  ```
- **After**: 
  ```python
  norm_res = model.normalized_residuals(Y)  # Method requiring input data 'Y'
  ```

### Verification Results
- **Code Quality**: Full cleanup with `ruff` and `pre-commit` validation across all modified files.
- **Test Suite**: 304 non-BIDS GLM tests passing (Regression, Model, First/Second Level, Reporter).

### Next Step Before Merging
- **Phase 2**: Merge and eventually deprecate `SimpleRegressionResults`. The new `RegressionResults` is now efficient enough to serve both standard and memory-minimized use cases.
- **Phase 3**: Audit and update `io.py` and BIDS saving functions. 

> [!NOTE]
> Currently, tests for `io.py` and some edge cases with `minimize_memory=True` (specifically for late-stage statistical map saving) are expected to fail. I will work on resolving these while addressing Phases 2 and 3.

### Linked Issues
- Fixes #2381 / Potentially also #5588
- Might help with #2421
