### PR TITLE
[FIX] set default butterworth padtype to constant 

### DIFF
--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -310,7 +310,7 @@ def butterworth(
     low_pass=None,
     high_pass=None,
     order=5,
-    padtype="odd",
+    padtype="constant",
     padlen=None,
     copy=False,
 ):
@@ -340,14 +340,14 @@ def butterworth(
         Increasing the order sharpens this decay. Be aware that very high
         orders can lead to numerical instability.
 
-    padtype : {"odd", "even", "constant", None}, default="odd"
+    padtype : {"odd", "even", "constant", None}, default="constant"
         Type of padding to use for the Butterworth filter.
-        For more information about this, see :func:`scipy.signal.filtfilt`.
+        For more information about this, see :func:`scipy.signal.sosfiltfilt`.
 
     padlen : :obj:`int` or None, default=None
         The size of the padding to add to the beginning and end of ``signals``.
-        If None, the default value from :func:`scipy.signal.filtfilt` will be
-        used.
+        If None, the default value from :func:`scipy.signal.sosfiltfilt` will
+        be used.
 
     copy : :obj:`bool`, default=False
         If False, `signals` is modified inplace, and memory consumption is


### PR DESCRIPTION

<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes #5415 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- set default butterworth padtype to constant  to avoid border effect with extrapolation
