### PR TITLE
[MAINT] reduce number of FutureWarning thrown when checking estimators

### DIFF
--- a/nilearn/connectome/tests/test_connectivity_matrices.py
+++ b/nilearn/connectome/tests/test_connectivity_matrices.py
@@ -44,9 +44,7 @@ N_SUBJECTS = 5
 
 
 ESTIMATORS_TO_CHECK = [
-    ConnectivityMeasure(
-        cov_estimator=EmpiricalCovariance(), standardize="zscore_sample"
-    )
+    ConnectivityMeasure(cov_estimator=EmpiricalCovariance())
 ]
 
 if SKLEARN_LT_1_6:

--- a/nilearn/decoding/tests/test_decoder.py
+++ b/nilearn/decoding/tests/test_decoder.py
@@ -81,10 +81,10 @@ ESTIMATOR_REGRESSION = ("ridge", "svr")
 
 
 ESTIMATORS_TO_CHECK = [
-    Decoder(standardize="zscore_sample", screening_percentile=100),
-    DecoderRegressor(standardize="zscore_sample", screening_percentile=100),
-    FREMClassifier(standardize="zscore_sample", screening_percentile=100),
-    FREMRegressor(standardize="zscore_sample", screening_percentile=100),
+    Decoder(screening_percentile=100),
+    DecoderRegressor(screening_percentile=100),
+    FREMClassifier(screening_percentile=100),
+    FREMRegressor(screening_percentile=100),
 ]
 
 if SKLEARN_LT_1_6:

--- a/nilearn/decoding/tests/test_space_net.py
+++ b/nilearn/decoding/tests/test_space_net.py
@@ -46,10 +46,7 @@ IS_CLASSIF = [True, False]
 
 PENALTY = ["graph-net", "tv-l1"]
 
-ESTIMATORS_TO_CHECK = [
-    SpaceNetClassifier(standardize="zscore_sample"),
-    SpaceNetRegressor(standardize="zscore_sample"),
-]
+ESTIMATORS_TO_CHECK = [SpaceNetClassifier(), SpaceNetRegressor()]
 
 if SKLEARN_LT_1_6:
 

--- a/nilearn/decomposition/tests/test_decomposition_estimators.py
+++ b/nilearn/decomposition/tests/test_decomposition_estimators.py
@@ -23,10 +23,7 @@ from nilearn.decomposition.tests.conftest import (
 )
 from nilearn.maskers import NiftiMasker, SurfaceMasker
 
-ESTIMATORS_TO_CHECK = [
-    DictLearning(standardize="zscore_sample"),
-    CanICA(standardize="zscore_sample"),
-]
+ESTIMATORS_TO_CHECK = [DictLearning(), CanICA()]
 
 if SKLEARN_LT_1_6:
 

--- a/nilearn/maskers/masker_validation.py
+++ b/nilearn/maskers/masker_validation.py
@@ -80,7 +80,7 @@ def check_embedded_masker(
 
     - If instance contains a mask image in mask parameter,
     we use this image as new masker mask_img, forwarding instance parameters to
-    new masker : smoothing_fwhm, standardize, detrend, low_pass= high_pass,
+    new masker : smoothing_fwhm, standardize, detrend, low_pass, high_pass,
     t_r, target_affine, target_shape, mask_strategy, mask_args...
 
     - If instance contains a masker in mask parameter, we use a copy of

--- a/nilearn/maskers/tests/test_multi_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_labels_masker.py
@@ -20,7 +20,7 @@ from nilearn.conftest import _img_labels
 from nilearn.image import get_data
 from nilearn.maskers import MultiNiftiLabelsMasker
 
-ESTIMATORS_TO_CHECK = [MultiNiftiLabelsMasker(standardize=None)]
+ESTIMATORS_TO_CHECK = [MultiNiftiLabelsMasker()]
 
 if SKLEARN_LT_1_6:
 

--- a/nilearn/maskers/tests/test_multi_nifti_maps_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_maps_masker.py
@@ -17,7 +17,7 @@ from nilearn.conftest import _img_maps
 from nilearn.exceptions import DimensionError
 from nilearn.maskers import MultiNiftiMapsMasker, NiftiMapsMasker
 
-ESTIMATORS_TO_CHECK = [MultiNiftiMapsMasker(standardize=None)]
+ESTIMATORS_TO_CHECK = [MultiNiftiMapsMasker()]
 
 if SKLEARN_LT_1_6:
 

--- a/nilearn/maskers/tests/test_multi_nifti_masker.py
+++ b/nilearn/maskers/tests/test_multi_nifti_masker.py
@@ -17,7 +17,7 @@ from nilearn._utils.versions import SKLEARN_LT_1_6
 from nilearn.image import get_data
 from nilearn.maskers import MultiNiftiMasker
 
-ESTIMATORS_TO_CHECK = [MultiNiftiMasker(standardize=None)]
+ESTIMATORS_TO_CHECK = [MultiNiftiMasker()]
 
 if SKLEARN_LT_1_6:
 

--- a/nilearn/maskers/tests/test_nifti_maps_masker.py
+++ b/nilearn/maskers/tests/test_nifti_maps_masker.py
@@ -30,7 +30,7 @@ from nilearn.conftest import _img_maps, _shape_3d_default
 from nilearn.image import get_data
 from nilearn.maskers import NiftiMapsMasker
 
-ESTIMATORS_TO_CHECK = [NiftiMapsMasker(standardize=None)]
+ESTIMATORS_TO_CHECK = [NiftiMapsMasker()]
 
 if SKLEARN_LT_1_6:
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but relates to #5942

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- force to use the future new default for standardize when checking nilearn estimators to reduce the amount of warnings thrown

