### PR TITLE
[FIX] use pytest.warns instead of pytest.deprecated_call()

### DIFF
--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -823,7 +823,7 @@ def test_cluster_level_parameters_warnings(cluster_level_design, masker):
 
     # output_type is "legacy".
     # raise a deprecation warning, but get the standard output.
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning, match="will be removed in version"):
         out = permuted_ols(
             tested_var,
             target_var,
@@ -917,7 +917,7 @@ def test_tfce_smoke_legacy_warnings():
 
     # output_type is "legacy".
     # raise a deprecation warning, but get the standard output.
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning, match="will be removed in version"):
         out = permuted_ols(
             tested_var,
             target_var,


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes none but fixes a couple of failing tests on main

see https://github.com/nilearn/nilearn/actions/runs/23011290182/job/66822277511#step:8:13467

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- use pytest.warns instead of pytest.deprecated_call()

