### PR TITLE
[FIX] Do not copy mask img's header in masking.unmask

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -61,6 +61,8 @@ Fixes
 
 - :bdg-info:`Thresholding` Keep values equal to threshold while thresholding image with :func:`~nilearn.image.threshold_img`.  (:gh:`6130` by `Hande Gözükan`_).
 
+- :bdg-dark:`Code` Do not copy mask image's header in ``masking.unmask`` (:gh:`6157` by `Taylor Salo`_).
+
 Enhancements
 ------------
 

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -1058,7 +1058,7 @@ def unmask(X, mask_img, order="F"):
             f"Masked data X must be 2D or 1D array; got shape: {X.shape!s}"
         )
 
-    return new_img_like(mask_img, unmasked, affine)
+    return new_img_like(mask_img, unmasked, affine, copy_header=False)
 
 
 def unmask_from_to_3d_array(w, mask):

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -561,6 +561,10 @@ def test_unmask_3d_with_files(
     assert t[0].flags["F_CONTIGUOUS"]
     assert_array_equal(t[0], unmasked3D)
 
+    # Check that the unmasked image retains the datatype of the data array
+    t = unmask([masked3D], filename, order="F")
+    assert t[0].get_data_dtype() == data3D.dtype
+
 
 def test_unmask_errors(rng, affine_eye, shape_3d_default):
     """Test unmask errors."""

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -561,11 +561,20 @@ def test_unmask_3d_with_files(
     assert t[0].flags["F_CONTIGUOUS"]
     assert_array_equal(t[0], unmasked3D)
 
-    # Check that the unmasked image retains the datatype of the data array
-    #
-    # see https://github.com/nilearn/nilearn/issues/6150
-    #
-    t = unmask([masked3D], filename, order="F")
+
+def test_unmask_retain_datatype(rng, affine_eye, shape_3d_default):
+    """Check that the unmasked image retains the datatype of the data array.
+
+    see https://github.com/nilearn/nilearn/issues/6150
+    """
+    data3D = rng.uniform(size=shape_3d_default)
+    mask = rng.integers(2, size=shape_3d_default, dtype="int32")
+    mask_img = Nifti1Image(mask, affine_eye)
+
+    mask = mask.astype(bool)
+    masked3D = data3D[mask]
+
+    t = unmask([masked3D], mask_img, order="F")
     assert t[0].get_data_dtype() == data3D.dtype
 
 

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -562,6 +562,9 @@ def test_unmask_3d_with_files(
     assert_array_equal(t[0], unmasked3D)
 
     # Check that the unmasked image retains the datatype of the data array
+    #
+    # see https://github.com/nilearn/nilearn/issues/6150
+    #
     t = unmask([masked3D], filename, order="F")
     assert t[0].get_data_dtype() == data3D.dtype
 


### PR DESCRIPTION
- Closes #6150.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Update `test_unmask_3d_with_files` to check that the datatype of the unmasked image created by `masking.unmask` is the same as the datatype of the array to be unmasked (not the datatype of the mask image). I have verified that this test fails with the code from before my fix.
- Include `copy_header=False` in the `new_img_like` call within `masking.unmask`.
