### PR TITLE
[DOC] clarify estimator parameter accepts sklearn-compatible objects

### DIFF
--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -221,6 +221,10 @@ docdict["classifier_options"] = f"""
 
         dummy = DummyClassifier(strategy="stratified", random_state=0)
 
+    A custom scikit-learn compatible estimator (i.e., any object with a
+    ``fit`` method) can also be passed directly instead of a string.
+    Use at your own risk; the process may not work as intended.
+
 """
 
 # clean_args
@@ -963,6 +967,10 @@ docdict["regressor_options"] = """
     .. code-block:: python
 
         dummy = DummyRegressor(strategy="mean")
+
+    A custom scikit-learn compatible estimator (i.e., any object with a
+    ``fit`` method) can also be passed directly instead of a string.
+    Use at your own risk; the process may not work as intended.
 
 """
 

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -1241,9 +1241,12 @@ class Decoder(_ClassifierMixin, _BaseDecoder):
 
     Parameters
     ----------
-    estimator : :obj:`str`, default='svc'
+    estimator : :obj:`str` or estimator object, default='svc'
         The estimator to choose among:
         %(classifier_options)s
+
+        Can also pass a custom sklearn-compatible estimator object
+        (use at your own risk).
 
     mask : filename, Nifti1Image, NiftiMasker, MultiNiftiMasker, \
            :obj:`~nilearn.surface.SurfaceImage` \
@@ -1428,9 +1431,12 @@ class DecoderRegressor(MultiOutputMixin, _RegressorMixin, _BaseDecoder):
 
     Parameters
     ----------
-    estimator : :obj:`str`, default="svr"
+    estimator : :obj:`str` or estimator object, default="svr"
         The estimator to choose among:
         %(regressor_options)s
+
+        Can also pass a custom sklearn-compatible estimator object
+        (use at your own risk).
 
     mask : filename, Nifti1Image, NiftiMasker, MultiNiftiMasker, \
             or None, default=None


### PR DESCRIPTION
- closes #6177 

## Summary

The `estimator` parameter in `Decoder` and related classes (e.g., `DecoderRegressor`, `FREMClassifier`) accepts custom scikit-learn compatible estimator objects in addition to named string options, but this was not documented.

The internal `_check_estimator()` function (in `nilearn/decoding/decoder.py`) handles non-string estimators explicitly:
```python
if not isinstance(estimator, str):
    warnings.warn(
        "Use a custom estimator at your own risk "
        "of the process not working as intended.",
        ...
    )
    return estimator
```

This PR adds a note to the `classifier_options` and `regressor_options` docstring macros (in `nilearn/_utils/docs.py`) to document this behavior, improving API discoverability.

## Changes

- `nilearn/_utils/docs.py`: Added a note to `classifier_options` and `regressor_options` macros explaining that a custom sklearn-compatible estimator object can be passed directly instead of a string.