### PR TITLE
add_kwargs_fastica

### DIFF
--- a/nilearn/decomposition/canica.py
+++ b/nilearn/decomposition/canica.py
@@ -115,6 +115,9 @@ class CanICA(_MultiPCA):
         The amount of variance explained
         by each of the selected components.
 
+    fastica_kwargs : :obj:`dict` or None, default=None
+        Arguments passed to :func:`sklearn.decomposition.fastica`.
+        
     References
     ----------
     .. footbibliography::
@@ -144,6 +147,7 @@ class CanICA(_MultiPCA):
         memory_level=0,
         n_jobs=1,
         verbose=0,
+        fastica_args=None
     ):
         super().__init__(
             n_components=n_components,
@@ -169,6 +173,7 @@ class CanICA(_MultiPCA):
 
         self.threshold = threshold
         self.n_init = n_init
+        self.fastica_kwargs = fastica_args
 
     def _unmix_components(self, components) -> None:
         """Core function of CanICA than rotate components_ to maximize \
@@ -184,6 +189,7 @@ class CanICA(_MultiPCA):
                 whiten="arbitrary-variance",
                 fun="cube",
                 random_state=seed,
+                **self.fastica_kwargs
             )
             for seed in seeds
         )


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.
https://help.github.com/articles/closing-issues-using-keywords -->
- Closes # Allow passing additional kwargs to the underlying fastICA implementation

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- decomposition.CanICA takes fastica_args (as dict) to pass arguments to sklearn.decomposition.fastica
-
