### PR TITLE
[MAINT] add 'needs triage' label to new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -8,7 +8,7 @@ description: Fill in this template to report a bug
 
 title: '[BUG] '
 
-labels: ['Priority: high', 'Needs Triage']
+labels: ['Priority: high', Needs Triage]
 
 type: bug
 

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -8,7 +8,9 @@ description: Fill in this template to report a bug
 
 title: '[BUG] '
 
-labels: [Bug]
+labels: ['Priority: high', Needs Triage]
+
+type: bug
 
 body:
 

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -8,7 +8,7 @@ description: Fill in this template to report a bug
 
 title: '[BUG] '
 
-labels: ['Priority: high', Needs Triage]
+labels: ['Priority: high', 'Needs Triage']
 
 type: bug
 

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -8,7 +8,7 @@ description: Request an improvement to the existing documentation.
 
 title: '[DOC] '
 
-labels: [Documentation]
+labels: [Documentation, Needs Triage]
 
 body:
 

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -8,7 +8,7 @@ description: Request an improvement to the existing documentation.
 
 title: '[DOC] '
 
-labels: [Documentation, 'Needs Triage']
+labels: [Documentation, Needs Triage]
 
 body:
 

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -8,7 +8,7 @@ description: Request an improvement to the existing documentation.
 
 title: '[DOC] '
 
-labels: [Documentation, Needs Triage]
+labels: [Documentation, 'Needs Triage']
 
 body:
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ description: Got an idea for a new feature, or changing an existing one? This is
 
 title: '[ENH] '
 
-labels: ['Needs Triage']
+labels: [Needs Triage]
 
 type: Enhancement
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,9 @@ description: Got an idea for a new feature, or changing an existing one? This is
 
 title: '[ENH] '
 
-labels: [Enhancement]
+labels: [Needs Triage]
+
+type: Enhancement
 
 body:
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ description: Got an idea for a new feature, or changing an existing one? This is
 
 title: '[ENH] '
 
-labels: [Needs Triage]
+labels: ['Needs Triage']
 
 type: Enhancement
 

--- a/.github/workflows/label_blank_issue.yml
+++ b/.github/workflows/label_blank_issue.yml
@@ -16,5 +16,5 @@ jobs:
         steps:
         -   uses: andymckay/labeler@1.0.4
             with:
-                add-labels: Needs Triage
+                add-labels: 'Needs Triage'
                 ignore-if-labeled: true

--- a/.github/workflows/label_blank_issue.yml
+++ b/.github/workflows/label_blank_issue.yml
@@ -1,0 +1,20 @@
+---
+# Gives 'Needs Triage' label to new issues.
+#
+###
+name: Labels Blank issues
+permissions:
+    issues: write
+
+on:
+    issues:
+        types: [opened]
+
+jobs:
+    label-blank-issues:
+        runs-on: ubuntu-latest
+        steps:
+        -   uses: andymckay/labeler@1.0.4
+            with:
+                add-labels: Needs Triage
+                ignore-if-labeled: true

--- a/.github/workflows/label_blank_issue.yml
+++ b/.github/workflows/label_blank_issue.yml
@@ -16,5 +16,5 @@ jobs:
         steps:
         -   uses: andymckay/labeler@1.0.4
             with:
-                add-labels: 'Needs Triage'
+                add-labels: Needs Triage
                 ignore-if-labeled: true

--- a/doc/maintenance.rst
+++ b/doc/maintenance.rst
@@ -27,16 +27,14 @@ and easily find what you are looking for in the issue tracker.
 When :nilearn-gh:`creating an issue <issues/new/choose>`, the user
 is responsible for a very basic labeling categorizing the issue:
 
-- |Bug| for bug reports.
-- |Documentation| for documentation related questions or requests.
-- |Enhancement| for feature requests.
+- |Bug| issue type for bug reports
+- |Enhancement| issue type for feature requests
+- |Documentation| issue label for documentation related questions or requests.
 
-First of all, the user might have mislabeled the issue, in which case a member
-of the :ref:`core_devs` team needs to correct the labels.
+New issues get the ``Needs Triage`` label and must be reviewed by a member of the :ref:`core_devs`
+who should remove the ``Needs Triage`` label and give the issue an effort, impact and priority label.
 
-In addition to these basic labels, we have many more labels which describes
-in more detail a given issue. First, we try to describe the **estimated amount
-of work** required to solve each issue:
+First, we try to describe the **estimated amount of work** required to solve each issue:
 
 - |Effort: high| The issue is likely to require a serious amount of work (more than a couple of days).
 - |Effort: medium| The issue is likely to require a decent amount of work (in between a few hours and a couple days).
@@ -59,48 +57,9 @@ new contributors. We label these issues with the |Good first issue| label
 which can be seen as an equivalent to a "very low effort" label. Because of
 this, good first issues do not require a separate effort label.
 
-Some other labels can be used to describe further the topic of the issue:
-
--   |API| This issue is related to the Nilearn's API.
--   |Code quality| This issue tackles code quality (code refactoring, PEP8...).
--   |Datasets| This issue is related to datasets or the :mod:`nilearn.datasets` module.
--   |Discussion| This issue is used to hold a general discussion on a specific topic
-    where community feedback is desired (no need to specify effort, priority, or impact here).
--   |GLM| This issue is related to the :mod:`nilearn.glm` module.
--   |Infrastructure| This issue describes a problem with the project's infrastructure (CI/CD...).
--   |Installation| The issue describes a problem with the installation of Nilearn.
--   |Maintenance| This issue is related to maintenance work.
--   |Plotting| The issue is related to plotting functionalities.
--   |Testing| The issue is related to testing.
--   |Usage| This issue is a usage question and should have been posted on :neurostars:`neurostars <>`.
-
+We have many more labels which describes in more detail a given issue.
 For a complete list of all issue labels that can be used to describe and their description,
 see `this page <https://github.com/nilearn/nilearn/labels>`_
-
-.. |API| image:: https://img.shields.io/badge/-API-fef2c0.svg
-.. |Bug| image:: https://img.shields.io/badge/-Bug-fc2929.svg
-.. |Code quality| image:: https://img.shields.io/badge/-code%20quality-09ef5a.svg
-.. |Datasets| image:: https://img.shields.io/badge/-Datasets-fad8c7.svg
-.. |Discussion| image:: https://img.shields.io/badge/-Discussion-bfe5bf.svg
-.. |Documentation| image:: https://img.shields.io/badge/-Documentation-5319e7.svg
-.. |Effort: high| image:: https://img.shields.io/badge/-effort:%20high-e26051.svg
-.. |Effort: medium| image:: https://img.shields.io/badge/-effort:%20medium-ddad1a.svg
-.. |Effort: low| image:: https://img.shields.io/badge/-effort:%20low-77c940.svg
-.. |Enhancement| image:: https://img.shields.io/badge/-Enhancement-fbca04.svg
-.. |GLM| image:: https://img.shields.io/badge/-GLM-fce1c4.svg
-.. |Good first issue| image:: https://img.shields.io/badge/-Good%20first%20issue-c7def8.svg
-.. |Impact: high| image:: https://img.shields.io/badge/-impact:%20high-1f1dc1.svg
-.. |Impact: medium| image:: https://img.shields.io/badge/-impact:%20medium-bac1fc.svg
-.. |Impact: low| image:: https://img.shields.io/badge/-impact:%20low-75eae6.svg
-.. |Infrastructure| image:: https://img.shields.io/badge/-Infrastructure-0052cc.svg
-.. |Installation| image:: https://img.shields.io/badge/-Installation-ba7030.svg
-.. |Maintenance| image:: https://img.shields.io/badge/-Maintenance-fc918f.svg
-.. |Plotting| image:: https://img.shields.io/badge/-Plotting-5319e7.svg
-.. |Priority: high| image:: https://img.shields.io/badge/-priority:%20high-9e2409.svg
-.. |Priority: medium| image:: https://img.shields.io/badge/-priority:%20medium-FBCA04.svg
-.. |Priority: low| image:: https://img.shields.io/badge/-priority:%20low-c5def5.svg
-.. |Testing| image:: https://img.shields.io/badge/-Testing-50bac4.svg
-.. |Usage| image:: https://img.shields.io/badge/-Usage-e99695.svg
 
 .. _closing_policy:
 

--- a/doc/maintenance.rst
+++ b/doc/maintenance.rst
@@ -34,7 +34,12 @@ is responsible for a very basic labeling categorizing the issue:
 New issues get the ``Needs Triage`` label and must be reviewed by a member of the :ref:`core_devs`
 who should remove the ``Needs Triage`` label and give the issue an effort, impact and priority label.
 
-First, we try to describe the **estimated amount of work** required to solve each issue:
+The reviewer should also:
+
+- ensure that bugs can be reproduced
+- feature requests are within the scope of the project
+
+We try to describe the **estimated amount of work** required to solve each issue:
 
 - |Effort: high| The issue is likely to require a serious amount of work (more than a couple of days).
 - |Effort: medium| The issue is likely to require a decent amount of work (in between a few hours and a couple days).


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this pull request.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the pull request closes multiple issues, includes "closes" before each one is listed.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->
- Closes #2779 

<!-- Please indicate whether LLM tools were used for this pull request
by adding a 'x' in one of the following check box.
Work made with LLM tools has a very different set of typical failure modes
than work done entirely by humans,
it helps others to better trace eventual issues when reviewing the code.
-->
- [ ] LLM tools were used to generate at least part of the content of this pull-request.
- [x] No LLM tools were used to generate at least part of the content of this pull-request.

<!-- Please give a brief overview of what has changed in the pull request.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- new issues get a 'needs triage' label
- bug issues get the 'bug' issue type and high priority label
- feature request get the "enhancement" issue type
