### PR TITLE
[FIX] deprecate GLM fitted attributes with no trailing underscore

### DIFF
--- a/examples/04_glm_first_level/plot_predictions_residuals.py
+++ b/examples/04_glm_first_level/plot_predictions_residuals.py
@@ -139,7 +139,7 @@ show()
 # Get residuals
 # -------------
 
-resid = masker.fit_transform(fmri_glm.residuals[0])
+resid = masker.fit_transform(fmri_glm.residuals_[0])
 
 
 # %%

--- a/nilearn/glm/_base.py
+++ b/nilearn/glm/_base.py
@@ -187,14 +187,13 @@ class BaseGLM(CacheMixin, NilearnBaseEstimator):
     # @auto_attr store the value as an object attribute after initial call
     # better performance than @property
     @auto_attr
-    def residuals(self):
-        """Transform voxelwise residuals to the same shape \
-        as the input Nifti1Image(s).
+    def residuals_(self):
+        """Transform element-wise residuals to the same shape \
+        as the input image.
 
         Returns
         -------
-        output : list
-            A list of Nifti1Image(s).
+        list[Nifti1Image] or list[SurfaceImage]
 
         """
         return self._get_element_wise_model_attribute(
@@ -202,14 +201,35 @@ class BaseGLM(CacheMixin, NilearnBaseEstimator):
         )
 
     @auto_attr
-    def predicted(self):
-        """Transform voxelwise predicted values to the same shape \
-        as the input Nifti1Image(s).
+    def residuals(self):
+        """Transform element-wise residuals to the same shape \
+        as the input image.
+
+        .. nilearn_deprecated:: 0.14.0dev
+
+        """
+        # TODO (nilearn>=0.16.0) remove the method
+        warnings.warn(
+            stacklevel=find_stack_level(),
+            category=FutureWarning,
+            message=(
+                "residuals' is deprecated.\n "
+                "It will be removed in Nilearn 0.16.0.\n"
+                "Use 'residuals_' instead."
+            ),
+        )
+        return self.residuals_
+
+    # @auto_attr store the value as an object attribute after initial call
+    # better performance than @property
+    @auto_attr
+    def predicted_(self):
+        """Transform element-wise predicted values to the same shape \
+        as the input image.
 
         Returns
         -------
-        output : list
-            A list of Nifti1Image(s).
+        list[Nifti1Image] or list[SurfaceImage]
 
         """
         return self._get_element_wise_model_attribute(
@@ -217,19 +237,60 @@ class BaseGLM(CacheMixin, NilearnBaseEstimator):
         )
 
     @auto_attr
-    def r_square(self):
-        """Transform voxelwise r-squared values to the same shape \
-        as the input Nifti1Image(s).
+    def predicted(self):
+        """Transform element-wise predicted to the same shape \
+        as the input image.
+
+        .. nilearn_deprecated:: 0.14.0dev
+
+        """
+        # TODO (nilearn>=0.16.0) remove the method
+        warnings.warn(
+            stacklevel=find_stack_level(),
+            category=FutureWarning,
+            message=(
+                "residuals' is deprecated.\n "
+                "It will be removed in Nilearn 0.16.0.\n"
+                "Use 'residuals_' instead."
+            ),
+        )
+        return self.predicted_
+
+    # @auto_attr store the value as an object attribute after initial call
+    # better performance than @property
+    @auto_attr
+    def r_square_(self):
+        """Transform element-wise r-squared values to the same shape \
+        as the input image.
 
         Returns
         -------
-        output : list
-            A list of Nifti1Image(s).
+        list[Nifti1Image] or list[SurfaceImage]
 
         """
         return self._get_element_wise_model_attribute(
             "r_square", result_as_time_series=False
         )
+
+    @auto_attr
+    def r_square(self):
+        """Transform element-wise r-squared to the same shape \
+        as the input image.
+
+        .. nilearn_deprecated:: 0.14.0dev
+
+        """
+        # TODO (nilearn>=0.16.0) remove the method
+        warnings.warn(
+            stacklevel=find_stack_level(),
+            category=FutureWarning,
+            message=(
+                "residuals' is deprecated.\n "
+                "It will be removed in Nilearn 0.16.0.\n"
+                "Use 'residuals_' instead."
+            ),
+        )
+        return self.r_square_
 
     def _generate_filenames_output(
         self, prefix, contrasts, contrast_types, out_dir, entities_to_drop=None

--- a/nilearn/glm/io.py
+++ b/nilearn/glm/io.py
@@ -517,7 +517,7 @@ def _write_model_level_statistical_maps(model, out_dir):
         "model_level_mapping"
     ].items():
         for attr, map_name in model_level_mapping.items():
-            img = getattr(model, attr)
+            img = getattr(model, f"{attr}_")
             stat_map_to_save = img[i_run] if isinstance(img, Iterable) else img
             if model._is_volume_glm():
                 stat_map_to_save.to_filename(out_dir / map_name)

--- a/nilearn/glm/tests/test_first_level.py
+++ b/nilearn/glm/tests/test_first_level.py
@@ -1247,7 +1247,7 @@ def test_first_level_residuals(shape_4d_default):
 
     model.fit(fmri_data, design_matrices=design_matrices)
 
-    residuals = model.residuals[0]
+    residuals = model.residuals_[0]
     mean_residuals = model.masker_.transform(residuals).mean(0)
 
     assert_array_almost_equal(mean_residuals, 0)
@@ -1271,7 +1271,7 @@ def test_first_level_residuals_errors(shape_4d_default):
     model.fit(fmri_data, design_matrices=design_matrices)
 
     with pytest.raises(AttributeError, match="To access voxelwise attributes"):
-        model.residuals[0]
+        model.residuals_[0]
 
     # Check that trying to access residuals without fitting
     # raises an error
@@ -1332,9 +1332,9 @@ def test_first_level_predictions_r_square(shape_4d_default):
     )
     model.fit(fmri_data, design_matrices=design_matrices)
 
-    pred = model.predicted[0]
+    pred = model.predicted_[0]
     data = fmri_data[0]
-    r_square_3d = model.r_square[0]
+    r_square_3d = model.r_square_[0]
 
     y_predicted = model.masker_.transform(pred)
     y_measured = model.masker_.transform(data)
@@ -1397,7 +1397,7 @@ def test_glm_sample_mask(shape_4d_default):
     )
 
     assert model.design_matrices_[0].shape[0] == shape_4d_default[3] - 3
-    assert model.predicted[0].shape[-1] == shape_4d_default[3] - 3
+    assert model.predicted_[0].shape[-1] == shape_4d_default[3] - 3
 
 
 def test_check_trial_type_warning(tmp_path):
@@ -1601,12 +1601,12 @@ def test_flm_get_element_wise_model_attribute_with_surface_data(
     events = basic_paradigm()
     model.fit([img, img], events=[events, events])
 
-    assert len(model.residuals) == 2
-    assert model.residuals[0].shape == img.shape
-    assert len(model.predicted) == 2
-    assert model.predicted[0].shape == img.shape
-    assert len(model.r_square) == 2
-    assert model.r_square[0].shape == (img.mesh.n_vertices, 1)
+    assert len(model.residuals_) == 2
+    assert model.residuals_[0].shape == img.shape
+    assert len(model.predicted_) == 2
+    assert model.predicted_[0].shape == img.shape
+    assert len(model.r_square_) == 2
+    assert model.r_square_[0].shape == (img.mesh.n_vertices, 1)
 
 
 # -----------------------bids tests----------------------- #

--- a/nilearn/glm/tests/test_second_level.py
+++ b/nilearn/glm/tests/test_second_level.py
@@ -796,7 +796,9 @@ def test_second_level_glm_computation(n_subjects):
     assert len(results1) == len(results2)
 
 
-@pytest.mark.parametrize("attribute", ["residuals", "predicted", "r_square"])
+@pytest.mark.parametrize(
+    "attribute", ["residuals_", "predicted_", "r_square_"]
+)
 def test_second_level_voxelwise_attribute_errors(attribute, n_subjects):
     """Tests that an error is raised when trying to access \
        voxelwise attributes before fitting the model, \
@@ -817,7 +819,9 @@ def test_second_level_voxelwise_attribute_errors(attribute, n_subjects):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("attribute", ["residuals", "predicted", "r_square"])
+@pytest.mark.parametrize(
+    "attribute", ["residuals_", "predicted_", "r_square_"]
+)
 def test_second_level_voxelwise_attribute_errors_minimize_memory(
     attribute, n_subjects
 ):
@@ -840,7 +844,9 @@ def test_second_level_voxelwise_attribute_errors_minimize_memory(
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("attribute", ["residuals", "predicted", "r_square"])
+@pytest.mark.parametrize(
+    "attribute", ["residuals_", "predicted_", "r_square_"]
+)
 def test_second_level_voxelwise_attribute(attribute, n_subjects):
     """Smoke test for voxelwise attributes for SecondLevelModel."""
     mask, fmri_data, _ = generate_fake_fmri_data_and_design((SHAPE,))
@@ -862,9 +868,9 @@ def test_second_level_residuals(n_subjects):
     model.fit(Y, design_matrix=X)
     model.compute_contrast()
 
-    assert isinstance(model.residuals, Nifti1Image)
-    assert model.residuals.shape == (*SHAPE[:3], n_subjects)
-    mean_residuals = model.masker_.transform(model.residuals).mean(0)
+    assert isinstance(model.residuals_, Nifti1Image)
+    assert model.residuals_.shape == (*SHAPE[:3], n_subjects)
+    mean_residuals = model.masker_.transform(model.residuals_).mean(0)
     assert_array_almost_equal(mean_residuals, 0)
 
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this pull request.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the pull request closes multiple issues, includes "closes" before each one is listed.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->
- Closes #6231 

<!-- Please indicate whether LLM tools were used for this pull request
by adding a 'x' in one of the following check box.
Work made with LLM tools has a very different set of typical failure modes
than work done entirely by humans,
it helps others to better trace eventual issues when reviewing the code.
-->
Use of AI tools:
- [ ] LLM tools were used to generate at least part of the content of this pull-request.
- [x] No LLM tools were used to generate any part of the content of this pull-request.

<!-- Please give a brief overview of what has changed in the pull request.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- start deprecation cycle fitted attributes residuals, predicted, r_square of glm and replace them with equivalent ones with a trailing underscore

