### PR TITLE
[DOC] add Examples sections for 4 utility functions

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -467,6 +467,11 @@ authors:
     affiliation: University of Macau, Macau, China
     email: yc17307@um.edu.mo
     orcid: https://orcid.org/0000-0002-9138-3195
+  - given-names: Laura
+    family-names: Piñero Roig
+    website: https://github.com/laurapiro17
+    affiliation: University of Barcelona, Barcelona, Spain
+    orcid: https://orcid.org/0009-0008-3390-4029
   - given-names: Lee
     family-names: Newberg
     website: https://github.com/Leengit

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -61,7 +61,7 @@ Fixes
 
 - :bdg-primary:`Doc` Rewrite :class:`~nilearn.decoding.Decoder` :ref:`example <sphx_glr_auto_examples_02_decoding_plot_haxby_grid_search.py>` with incorrect nested cross-validation implementation (:gh:`6059` by `Michelle Wang`_).
 
-- :bdg-primary:`Doc` Add ``Examples`` docstring sections for :func:`~nilearn.connectome.cov_to_corr`, :func:`~nilearn.connectome.prec_to_partial`, :func:`~nilearn.glm.contrasts.expression_to_contrast_vector` and :func:`~nilearn.interfaces.bids.parse_bids_filename` (:gh:`5824` by `Laura Piñero Roig`_).
+- :bdg-primary:`Doc` Add ``Examples`` docstring sections for :func:`~nilearn.connectome.cov_to_corr`, :func:`~nilearn.connectome.prec_to_partial`, :func:`~nilearn.glm.expression_to_contrast_vector` and :func:`~nilearn.interfaces.bids.parse_bids_filename` (:gh:`5824` by `Laura Piñero Roig`_).
 
 - :bdg-info:`Plotting` Fix ``nilearn.plotting.view_img`` resampling of non-isotropic images when no background image is used (:gh:`6031` by `Michelle Wang`_).
 

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -61,6 +61,8 @@ Fixes
 
 - :bdg-primary:`Doc` Rewrite :class:`~nilearn.decoding.Decoder` :ref:`example <sphx_glr_auto_examples_02_decoding_plot_haxby_grid_search.py>` with incorrect nested cross-validation implementation (:gh:`6059` by `Michelle Wang`_).
 
+- :bdg-primary:`Doc` Add ``Examples`` docstring sections for :func:`~nilearn.connectome.cov_to_corr`, :func:`~nilearn.connectome.prec_to_partial`, :func:`~nilearn.glm.contrasts.expression_to_contrast_vector` and :func:`~nilearn.interfaces.bids.parse_bids_filename` (:gh:`5824` by `Laura Piñero Roig`_).
+
 - :bdg-info:`Plotting` Fix ``nilearn.plotting.view_img`` resampling of non-isotropic images when no background image is used (:gh:`6031` by `Michelle Wang`_).
 
 - :bdg-info:`Plotting` Fix bug introduced in ``0.13.0`` while plotting single valued data with :func:`~nilearn.plotting.plot_roi`.  (:gh:`6122` by `Hande Gözükan`_).

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -189,6 +189,8 @@
 
 .. _Kun CHEN: https://chenkun.me
 
+.. _Laura Piñero Roig: https://github.com/laurapiro17
+
 .. _Lee Newberg: https://github.com/Leengit
 
 .. _Leonard Sasse: https://github.com/LeSasse

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -349,6 +349,15 @@ def cov_to_corr(covariance: np.ndarray) -> np.ndarray:
     correlation : 2D numpy.ndarray
         The output correlation matrix.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from nilearn.connectome import cov_to_corr
+    >>> cov = np.array([[4.0, 2.0], [2.0, 9.0]])
+    >>> cov_to_corr(cov)
+    array([[1.        , 0.33333333],
+           [0.33333333, 1.        ]])
+
     """
     diagonal = np.atleast_2d(1.0 / np.sqrt(np.diag(covariance)))
     correlation = covariance * diagonal * diagonal.T
@@ -370,6 +379,15 @@ def prec_to_partial(precision: np.ndarray) -> np.ndarray:
     -------
     partial_correlation : 2D numpy.ndarray
         The 2D output partial correlation matrix.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from nilearn.connectome import prec_to_partial
+    >>> precision = np.array([[2.0, -1.0], [-1.0, 2.0]])
+    >>> prec_to_partial(precision)
+    array([[1. , 0.5],
+           [0.5, 1. ]])
 
     """
     partial_correlation = -cov_to_corr(precision)

--- a/nilearn/glm/contrasts.py
+++ b/nilearn/glm/contrasts.py
@@ -31,6 +31,19 @@ def expression_to_contrast_vector(expression, design_columns):
     design_columns : :obj:`list` or array of :obj:`str`
         The column names of the design matrix.
 
+    Returns
+    -------
+    contrast_vector : numpy.ndarray
+        1D array with one entry per design column.
+
+    Examples
+    --------
+    >>> from nilearn.glm.contrasts import expression_to_contrast_vector
+    >>> expression_to_contrast_vector("task", ["task", "rest"])
+    array([1., 0.])
+    >>> expression_to_contrast_vector("task - rest", ["task", "rest"])
+    array([ 1., -1.])
+
     """
     if expression in design_columns:
         contrast_vector = np.zeros(len(design_columns))

--- a/nilearn/interfaces/bids/query.py
+++ b/nilearn/interfaces/bids/query.py
@@ -300,6 +300,17 @@ def parse_bids_filename(img_path):
         `typical bids filename <https://bids.neuroimaging.io/getting_started/folders_and_files/files.html#filename-template>`_
         for more information.
 
+    Examples
+    --------
+    >>> from nilearn.interfaces.bids import parse_bids_filename
+    >>> ref = parse_bids_filename("sub-01_task-rest_bold.nii.gz")
+    >>> ref["suffix"]
+    'bold'
+    >>> ref["extension"]
+    'nii.gz'
+    >>> ref["entities"] == {"sub": "01", "task": "rest"}
+    True
+
     """
     reference = {
         "file_path": img_path,


### PR DESCRIPTION
- Relates to #5824

Use of AI tools:
- [ ] LLM tools were used to generate at least part of the content of this pull-request.
- [x] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- adds doctested ``Examples`` sections to four user-API utility functions flagged in #5824: `cov_to_corr`, `prec_to_partial`, `expression_to_contrast_vector`, `parse_bids_filename`
- examples use only numpy arrays or short BIDS-style strings so no dataset download or fixture is needed
- also adds a missing `Returns` block to `expression_to_contrast_vector`
- changelog entry under `NEW > Fixes` in `doc/changes/latest.rst`
- adds `Laura Piñero Roig` to `CITATION.cff` (regenerated `names.rst` accordingly)

all four examples were run locally with `python -m doctest` and pass.