### PR TITLE
[DOC] add Examples sections for 5 GLM utility functions

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -57,6 +57,8 @@ Fixes
 
 - :bdg-success:`API` Fix bug when ``confounds_strategy=None`` in :func:`~glm.first_level.first_level_from_bids` (:gh:`6247` by `Pierre-Louis Barbarant`_).
 
+- :bdg-primary:`Doc` Add ``Examples`` docstring sections for :func:`~nilearn.glm.fdr_threshold`, :func:`~nilearn.glm.first_level.mean_scaling`, :func:`~nilearn.glm.first_level.glover_hrf`, :func:`~nilearn.glm.first_level.glover_time_derivative` and :func:`~nilearn.glm.first_level.glover_dispersion_derivative` (:gh:`6262` by `Laura Piñero Roig`_).
+
 - :bdg-secondary:`Maint` Allow local installation with ``uv sync`` (:gh:`6024` by `Mathieu Dugré`_)
 
 - :bdg-primary:`Doc` Rewrite :class:`~nilearn.decoding.Decoder` :ref:`example <sphx_glr_auto_examples_02_decoding_plot_haxby_grid_search.py>` with incorrect nested cross-validation implementation (:gh:`6059` by `Michelle Wang`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -57,13 +57,9 @@ Fixes
 
 - :bdg-success:`API` Fix bug when ``confounds_strategy=None`` in :func:`~glm.first_level.first_level_from_bids` (:gh:`6247` by `Pierre-Louis Barbarant`_).
 
-- :bdg-primary:`Doc` Add ``Examples`` docstring sections for :func:`~nilearn.glm.fdr_threshold`, :func:`~nilearn.glm.first_level.mean_scaling`, :func:`~nilearn.glm.first_level.glover_hrf`, :func:`~nilearn.glm.first_level.glover_time_derivative` and :func:`~nilearn.glm.first_level.glover_dispersion_derivative` (:gh:`6262` by `Laura Piñero Roig`_).
-
 - :bdg-secondary:`Maint` Allow local installation with ``uv sync`` (:gh:`6024` by `Mathieu Dugré`_)
 
 - :bdg-primary:`Doc` Rewrite :class:`~nilearn.decoding.Decoder` :ref:`example <sphx_glr_auto_examples_02_decoding_plot_haxby_grid_search.py>` with incorrect nested cross-validation implementation (:gh:`6059` by `Michelle Wang`_).
-
-- :bdg-primary:`Doc` Add ``Examples`` docstring sections for :func:`~nilearn.connectome.cov_to_corr`, :func:`~nilearn.connectome.prec_to_partial`, :func:`~nilearn.glm.expression_to_contrast_vector` and :func:`~nilearn.interfaces.bids.parse_bids_filename` (:gh:`5824` by `Laura Piñero Roig`_).
 
 - :bdg-info:`Plotting` Fix ``nilearn.plotting.view_img`` resampling of non-isotropic images when no background image is used (:gh:`6031` by `Michelle Wang`_).
 
@@ -127,6 +123,8 @@ Enhancements
 - :bdg-primary:`Doc` Unify estimator documentation to explicitly accept scikit-learn compatible objects and add cross-links to the developer guide (:gh:`6181` by `Xichun Xu`_).
 
 - :bdg-primary:`Doc` Add API documentation for :class:`~nilearn.connectome.ConnectivityMeasure` to elaborate the requirement for customized ``cov_estimator`` and extra test to ensure the user input is a valid sklearn estimator (:gh:`6074` by `Hao-Ting Wang`_).
+
+- :bdg-primary:`Doc` Add ``Examples`` docstring sections for nine utility functions in the public API: :func:`~nilearn.connectome.cov_to_corr`, :func:`~nilearn.connectome.prec_to_partial`, :func:`~nilearn.glm.expression_to_contrast_vector`, :func:`~nilearn.glm.fdr_threshold`, :func:`~nilearn.glm.first_level.glover_dispersion_derivative`, :func:`~nilearn.glm.first_level.glover_hrf`, :func:`~nilearn.glm.first_level.glover_time_derivative`, :func:`~nilearn.glm.first_level.mean_scaling` and :func:`~nilearn.interfaces.bids.parse_bids_filename` (:gh:`6259` and :gh:`6262` by `Laura Piñero Roig`_).
 
 Changes
 -------

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -81,6 +81,19 @@ def mean_scaling(Y, axis=0):
     mean : array of shape (n_voxels,)
         The data mean.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from nilearn.glm.first_level import mean_scaling
+    >>> Y = np.array([[1.0, 2.0, 3.0], [2.0, 4.0, 6.0]])
+    >>> Y_scaled, mean = mean_scaling(Y)
+    >>> Y_scaled.shape
+    (2, 3)
+    >>> mean
+    array([1.5, 3. , 4.5])
+    >>> bool(np.allclose(Y_scaled.mean(axis=0), 0))
+    True
+
     """
     mean = Y.mean(axis=axis)
     if (mean == 0).any():

--- a/nilearn/glm/first_level/hemodynamic_models.py
+++ b/nilearn/glm/first_level/hemodynamic_models.py
@@ -274,7 +274,9 @@ def glover_time_derivative(t_r, oversampling=50, time_length=32.0, onset=0.0):
     --------
     >>> import numpy as np
     >>> from nilearn.glm.first_level import glover_time_derivative
-    >>> dhrf = glover_time_derivative(t_r=2.0, oversampling=1, time_length=20.0)
+    >>> dhrf = glover_time_derivative(
+    ...     t_r=2.0, oversampling=1, time_length=20.0
+    ... )
     >>> np.round(dhrf, 3).tolist()
     [0.0, 0.0, 0.267, 0.076, -0.215, -0.168, -0.039, 0.027, 0.033, 0.019]
 

--- a/nilearn/glm/first_level/hemodynamic_models.py
+++ b/nilearn/glm/first_level/hemodynamic_models.py
@@ -145,6 +145,17 @@ def glover_hrf(t_r, oversampling=50, time_length=32.0, onset=0.0):
     hrf : array of shape(length / t_r * oversampling, dtype=float)
          :term:`HRF` sampling on the oversampled time grid.
 
+    Examples
+    --------
+    >>> from nilearn.glm.first_level import glover_hrf
+    >>> hrf = glover_hrf(t_r=2.0, oversampling=1, time_length=20.0)
+    >>> hrf.shape
+    (10,)
+    >>> bool(hrf.max() > 0)
+    True
+    >>> bool(hrf.min() < 0)
+    True
+
     """
     return _gamma_difference_hrf(
         t_r,
@@ -261,6 +272,13 @@ def glover_time_derivative(t_r, oversampling=50, time_length=32.0, onset=0.0):
     -------
     dhrf : array of shape(length / t_r), dtype=float
           dhrf sampling on the provided grid
+
+    Examples
+    --------
+    >>> from nilearn.glm.first_level import glover_time_derivative
+    >>> dhrf = glover_time_derivative(t_r=2.0, oversampling=1, time_length=20.0)
+    >>> dhrf.shape
+    (10,)
 
     """
     return _generic_time_derivative(
@@ -379,6 +397,15 @@ def glover_dispersion_derivative(
     -------
     dhrf : array of shape(length / t_r * oversampling), dtype=float
           dhrf sampling on the oversampled time grid
+
+    Examples
+    --------
+    >>> from nilearn.glm.first_level import glover_dispersion_derivative
+    >>> ddhrf = glover_dispersion_derivative(
+    ...     t_r=2.0, oversampling=1, time_length=20.0
+    ... )
+    >>> ddhrf.shape
+    (10,)
 
     """
     return _generic_dispersion_derivative(

--- a/nilearn/glm/first_level/hemodynamic_models.py
+++ b/nilearn/glm/first_level/hemodynamic_models.py
@@ -147,14 +147,11 @@ def glover_hrf(t_r, oversampling=50, time_length=32.0, onset=0.0):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from nilearn.glm.first_level import glover_hrf
     >>> hrf = glover_hrf(t_r=2.0, oversampling=1, time_length=20.0)
-    >>> hrf.shape
-    (10,)
-    >>> bool(hrf.max() > 0)
-    True
-    >>> bool(hrf.min() < 0)
-    True
+    >>> np.round(hrf, 3).tolist()
+    [0.0, 0.0, 0.226, 0.741, 0.5, 0.037, -0.181, -0.176, -0.103, -0.045]
 
     """
     return _gamma_difference_hrf(
@@ -275,10 +272,11 @@ def glover_time_derivative(t_r, oversampling=50, time_length=32.0, onset=0.0):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from nilearn.glm.first_level import glover_time_derivative
     >>> dhrf = glover_time_derivative(t_r=2.0, oversampling=1, time_length=20.0)
-    >>> dhrf.shape
-    (10,)
+    >>> np.round(dhrf, 3).tolist()
+    [0.0, 0.0, 0.267, 0.076, -0.215, -0.168, -0.039, 0.027, 0.033, 0.019]
 
     """
     return _generic_time_derivative(
@@ -400,12 +398,13 @@ def glover_dispersion_derivative(
 
     Examples
     --------
+    >>> import numpy as np
     >>> from nilearn.glm.first_level import glover_dispersion_derivative
     >>> ddhrf = glover_dispersion_derivative(
     ...     t_r=2.0, oversampling=1, time_length=20.0
     ... )
-    >>> ddhrf.shape
-    (10,)
+    >>> np.round(ddhrf, 3).tolist()
+    [0.0, -0.0, -0.373, 0.282, 0.295, -0.04, -0.094, -0.048, -0.017, -0.005]
 
     """
     return _generic_dispersion_derivative(

--- a/nilearn/glm/thresholding.py
+++ b/nilearn/glm/thresholding.py
@@ -111,6 +111,14 @@ def fdr_threshold(z_vals, alpha):
     threshold : :obj:`float`
         FDR-controling threshold from the Benjamini-Hochberg procedure.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from nilearn.glm import fdr_threshold
+    >>> z_vals = np.array([4.0, 3.5, 2.8, 2.5, 1.9, 1.2])
+    >>> float(np.round(fdr_threshold(z_vals, alpha=0.05), 2))
+    1.9
+
     """
     if alpha < 0 or alpha > 1:
         raise ValueError(


### PR DESCRIPTION
- Refs #5824

Use of AI tools:
- [ ] LLM tools were used to generate at least part of the content of this pull-request.
- [x] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- adds doctested ``Examples`` sections to five more user-API utility functions flagged in #5824, all in the ``nilearn.glm`` namespace: `fdr_threshold`, `mean_scaling`, `glover_hrf`, `glover_time_derivative`, `glover_dispersion_derivative`
- examples use only small numpy arrays and short parameter values (``oversampling=1``, ``time_length=20``) so no dataset download or fixture is needed and doctests run in milliseconds
- for `fdr_threshold` and `mean_scaling` the example shows concrete output values; for the three `glover_*` HRF functions the example asserts ``.shape`` and, for `glover_hrf`, the canonical positive peak and post-stimulus undershoot — avoiding fragile numeric comparisons against the HRF kernel
- adds ``Laura Piñero Roig`` to ``CITATION.cff`` and ``doc/changes/names.rst`` (only needed because the previous PR adding this entry, #6259, is not yet merged; will be a trivial conflict to resolve if it merges first)
- changelog entry to be added after PR number is assigned

All five examples were run locally with ``python -m doctest`` and pass.