### PR TITLE
[DOC] Fix typos and grammar in the fMRI decoding tutorial

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -139,6 +139,7 @@ Some other past or present contributors are:
 * `Koen Helwegen`_: Dutch Connectome Lab, VU, Amsterdam, The Netherlands
 * `Konrad Wagstyl`_
 * `Konstantin Shmelkov`_
+* `Kosei Tanno`_
 * `Kshitij Chawla`_: Duke University Health System, USA
 * `Kun CHEN`_: University of Macau, Macau, China
 * `Laura Piñero Roig`_: University of Barcelona, Barcelona, Spain

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -455,6 +455,9 @@ authors:
   - given-names: Konstantin
     family-names: Shmelkov
     website: https://github.com/kshmelkov
+  - given-names: Kosei
+    family-names: Tanno
+    website: https://github.com/KoseiTanno
   - given-names: Kshitij
     family-names: Chawla
     website: https://github.com/kchawla-pi

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -85,7 +85,7 @@ Fixes
 
 - :bdg-info:`Plotting` Fix colors while plotting ROI contours with ``nilearn.plotting.plot_roi`` (:gh:`6245` by `Hande Gözükan`_).
 
-- :bdg-primary:`Doc` Fix several typos and grammatical errors in the :ref:`introduction tutorial to fMRI decoding <sphx_glr_auto_examples_00_tutorials_plot_decoding_tutorial.py>` (:gh:`XXXX` by `Kosei Tanno`_).
+- :bdg-primary:`Doc` Fix several typos and grammatical errors in the :ref:`introduction tutorial to fMRI decoding <sphx_glr_auto_examples_00_tutorials_plot_decoding_tutorial.py>` (:gh:`6269` by `Kosei Tanno`_).
 
 Enhancements
 ------------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -85,6 +85,8 @@ Fixes
 
 - :bdg-info:`Plotting` Fix colors while plotting ROI contours with ``nilearn.plotting.plot_roi`` (:gh:`6245` by `Hande Gözükan`_).
 
+- :bdg-primary:`Doc` Fix several typos and grammatical errors in the :ref:`introduction tutorial to fMRI decoding <sphx_glr_auto_examples_00_tutorials_plot_decoding_tutorial.py>` (:gh:`XXXX` by `Kosei Tanno`_).
+
 Enhancements
 ------------
 

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -185,6 +185,8 @@
 
 .. _Konstantin Shmelkov: https://github.com/kshmelkov
 
+.. _Kosei Tanno: https://github.com/KoseiTanno
+
 .. _Kshitij Chawla: https://github.com/kchawla-pi
 
 .. _Kun CHEN: https://chenkun.me

--- a/examples/00_tutorials/plot_decoding_tutorial.py
+++ b/examples/00_tutorials/plot_decoding_tutorial.py
@@ -368,9 +368,10 @@ view_img(
 # by comparing to a score at chance.
 
 # %%
-# Let's define an object with Dummy estimator replacing 'svc' for
-# classification setting. This object initializes estimator with default
-# dummy strategy.
+# Let's define an object with a Dummy estimator
+# replacing 'svc' for classification setting.
+# This object initializes estimator
+# with a default dummy strategy.
 dummy_decoder = Decoder(
     estimator="dummy_classifier",
     mask=mask_filename,

--- a/examples/00_tutorials/plot_decoding_tutorial.py
+++ b/examples/00_tutorials/plot_decoding_tutorial.py
@@ -1,6 +1,6 @@
 """
-A introduction tutorial to fMRI decoding
-========================================
+An introduction tutorial to fMRI decoding
+=========================================
 
 Here is a simple tutorial on decoding with nilearn.
 It reproduces the :footcite:t:`Haxby2001` study
@@ -141,7 +141,7 @@ print(f"{conditions.shape=}")
 # ------------------------------------
 #
 # As a decoder, we use a Support Vector Classifier with a linear kernel. We
-# first create it using by using :class:`~nilearn.decoding.Decoder`.
+# first create it by using :class:`~nilearn.decoding.Decoder`.
 from nilearn.decoding import Decoder
 
 decoder = Decoder(
@@ -167,7 +167,7 @@ decoder
 #
 #   After fitting,
 #   the HTML representation of the estimator looks different
-#   than before before fitting.
+#   than before fitting.
 #
 decoder.fit(fmri_niimgs, conditions)
 
@@ -215,13 +215,13 @@ decoder.fit(fmri_niimgs_train, conditions_train)
 prediction = decoder.predict(fmri_niimgs_test)
 
 # The prediction accuracy is calculated on the test data: this is the accuracy
-# of our model on examples it hasn't seen to examine how well the model perform
-# in general.
+# of our model on examples it hasn't seen to examine how well the model
+# performs in general.
 
-predicton_accuracy = (prediction == conditions_test).sum() / float(
+prediction_accuracy = (prediction == conditions_test).sum() / float(
     len(conditions_test)
 )
-print(f"Prediction Accuracy: {predicton_accuracy:.3f}")
+print(f"Prediction Accuracy: {prediction_accuracy:.3f}")
 
 # %%
 # Implementing a KFold loop
@@ -242,11 +242,11 @@ for fold, (train, test) in enumerate(cv.split(conditions), start=1):
     )
     decoder.fit(index_img(fmri_niimgs, train), conditions[train])
     prediction = decoder.predict(index_img(fmri_niimgs, test))
-    predicton_accuracy = (prediction == conditions[test]).sum() / float(
+    prediction_accuracy = (prediction == conditions[test]).sum() / float(
         len(conditions[test])
     )
     print(
-        f"CV Fold {fold:01d} | Prediction Accuracy: {predicton_accuracy:.3f}"
+        f"CV Fold {fold:01d} | Prediction Accuracy: {prediction_accuracy:.3f}"
     )
 
 # %%
@@ -329,7 +329,7 @@ print(f"{coef_=}")
 print(f"{coef_.shape=}")
 
 # %%
-# To get the Nifti image of these coefficients, we only need retrieve the
+# To get the Nifti image of these coefficients, we only need to retrieve the
 # `coef_img_` in the decoder and select the class
 
 coef_img = decoder.coef_img_["face"]
@@ -368,8 +368,9 @@ view_img(
 # by comparing to a score at chance.
 
 # %%
-# Let's define a object with Dummy estimator replacing 'svc' for classification
-# setting. This object initializes estimator with default dummy strategy.
+# Let's define an object with Dummy estimator replacing 'svc' for
+# classification setting. This object initializes estimator with default
+# dummy strategy.
 dummy_decoder = Decoder(
     estimator="dummy_classifier",
     mask=mask_filename,


### PR DESCRIPTION
## Changes

Read-through of `examples/00_tutorials/plot_decoding_tutorial.py` (part of #6265), fixing several typos and grammatical errors. No behavioral changes — comment/docstring text plus one local variable name.

- Title: "A introduction" → "An introduction" (and extend the RST title underline to match)
- "we first create it using by using" → "by using"
- "looks different than before before fitting" → "before fitting"
- "examine how well the model perform" → "performs"
- "we only need retrieve the" → "need to retrieve"
- "Let's define a object" → "an object"
- Fix the misspelled local variable `predicton_accuracy` → `prediction_accuracy`

I also added a changelog entry and added myself to `CITATION.cff` (with the generated updates to `AUTHORS.rst` and `doc/changes/names.rst`).

Addresses part of #6265.

## AI disclosure

Per the contributing guidelines, I used an AI assistant to help spot these typos during the read-through. I reviewed and verified every change myself and can explain each one.
