### PR TITLE
[FIX] forbid  bool as dtype for estimators

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -75,7 +75,7 @@ Fixes
 
 - :bdg-dark:`Code` Do not copy mask image's header in ``masking.unmask`` (:gh:`6157` by `Taylor Salo`_).
 
-- :bdg-dark:`Code` Make sure that area data of Freesurfer can loaded as :class:`~surface.SurfaceImage` by :func:`~nilearn.datasets.load_fsaverage_data` (:gh:`6230` by `Rémi Gau`_).
+- :bdg-dark:`Code` Make sure that area data of Freesurfer can be loaded as :class:`~surface.SurfaceImage` by :func:`~nilearn.datasets.load_fsaverage_data` (:gh:`6230` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Fix order of vertices and data for ``fsaverage3`` and ``fsaverage4`` datasets and warn user (:gh:`6127` by `Rémi Gau`_ and `Hande Gözükan`_).
 

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -63,6 +63,10 @@ Fixes
 
 - :bdg-info:`Plotting` Fix ``nilearn.plotting.view_img`` resampling of non-isotropic images when no background image is used (:gh:`6031` by `Michelle Wang`_).
 
+- :bdg-dark:`Code` Disallow boolean dtype for estimators. (:gh:`6271` by `Rémi Gau`_).
+
+- :bdg-dark:`Code` Better checks of dtype for :class:`~surface.SurfaceImage` and :class:`~nilearn.surface.PolyData`. (:gh:`6271` by `Rémi Gau`_).
+
 - :bdg-dark:`Code` Ensure that estimators that accept images can work will several datatypes as input and that their methods can output arrays or images of the requested datatype (:gh:`5511` by `Rémi Gau`_).
 
 - :bdg-info:`Plotting` Fix bug introduced in ``0.13.0`` while plotting single valued data with :func:`~nilearn.plotting.plot_roi`.  (:gh:`6122` by `Hande Gözükan`_).
@@ -71,7 +75,7 @@ Fixes
 
 - :bdg-dark:`Code` Do not copy mask image's header in ``masking.unmask`` (:gh:`6157` by `Taylor Salo`_).
 
-- :bdg-dark:`Code` Make sure that area data of Freesurfer can loaded as SurfaceImage by :func:`~nilearn.datasets.load_fsaverage_data` (:gh:`6230` by `Rémi Gau`_).
+- :bdg-dark:`Code` Make sure that area data of Freesurfer can loaded as :class:`~surface.SurfaceImage` by :func:`~nilearn.datasets.load_fsaverage_data` (:gh:`6230` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Fix order of vertices and data for ``fsaverage3`` and ``fsaverage4`` datasets and warn user (:gh:`6127` by `Rémi Gau`_ and `Hande Gözükan`_).
 

--- a/examples/02_decoding/plot_oasis_vbm.py
+++ b/examples/02_decoding/plot_oasis_vbm.py
@@ -83,20 +83,21 @@ print(
 # %%
 # Preprocess data
 # ---------------
+# The features with too low between-subject variance are removed using
+# :class:`sklearn.feature_selection.VarianceThreshold`.
+# Then we convert the data back to the mask image in order to use it for
+# decoding process
+#
 nifti_masker = NiftiMasker(
     standardize=False, smoothing_fwhm=2, memory="nilearn_cache", verbose=1
 )  # cache options
 gm_maps_masked = nifti_masker.fit_transform(gm_imgs_train)
 
-# The features with too low between-subject variance are removed using
-# :class:`sklearn.feature_selection.VarianceThreshold`.
 from sklearn.feature_selection import VarianceThreshold
 
 variance_threshold = VarianceThreshold(threshold=0.01)
 variance_threshold.fit_transform(gm_maps_masked)
 
-# Then we convert the data back to the mask image in order to use it for
-# decoding process
 mask = nifti_masker.inverse_transform(variance_threshold.get_support())
 
 # %%

--- a/examples/07_advanced/plot_surface_image_and_maskers.py
+++ b/examples/07_advanced/plot_surface_image_and_maskers.py
@@ -15,8 +15,10 @@ This shows:
 
 -   how to use run some decoding directly on surface data.
 
-See the :ref:`dataset description <nki_dataset>`
-for more information on the data used in this example.
+.. seealso::
+
+    See the :ref:`dataset description <nki_dataset>`
+    for more information on the data used in this example.
 """
 
 from nilearn._utils.helpers import check_matplotlib

--- a/examples/07_advanced/plot_surface_image_and_maskers.py
+++ b/examples/07_advanced/plot_surface_image_and_maskers.py
@@ -47,7 +47,7 @@ from nilearn.plotting import plot_matrix, plot_surf, show
 surf_img_nki = load_nki()[0]
 print(f"NKI image: {surf_img_nki}")
 
-masker = SurfaceMasker(verbose=1, smoothing_fwhm=3)
+masker = SurfaceMasker(verbose=1, smoothing_fwhm=3, standardize=None)
 masked_data = masker.fit_transform(surf_img_nki)
 print(f"Masked data shape: {masked_data.shape}")
 
@@ -139,7 +139,7 @@ labels_img = SurfaceImage(
 )
 
 labels_masker = SurfaceLabelsMasker(
-    labels_img=labels_img, lut=destrieux.lut, verbose=1
+    labels_img=labels_img, lut=destrieux.lut, verbose=1, standardize=None
 ).fit()
 
 masked_data = labels_masker.transform(surf_img_nki)
@@ -205,6 +205,7 @@ decoder = Decoder(
     param_grid={"C": [0.01, 0.1]},
     cv=3,
     screening_percentile=1,
+    standardize=None,
 )
 decoder.fit(surf_img_nki, y)
 print("CV scores:", decoder.cv_scores_)
@@ -225,7 +226,7 @@ show()
 from sklearn import feature_selection, linear_model, pipeline, preprocessing
 
 decoder = pipeline.make_pipeline(
-    SurfaceMasker(verbose=1),
+    SurfaceMasker(verbose=1, standardize=None),
     preprocessing.StandardScaler(),
     feature_selection.SelectKBest(
         score_func=feature_selection.f_regression, k=500

--- a/maint_tools/check_docstrings.py
+++ b/maint_tools/check_docstrings.py
@@ -294,7 +294,8 @@ def check_returns_yields_and_annotation(
 
     np_docstring = NumpyDocString(docstring)
 
-    # function returns / yields a value to must have Returns / Yields section
+    # if the function returns (or yields) a value
+    # then its docstring must have Returns (or Yields) section
     if has_return_value or has_yield:
         if has_yield and bool(np_docstring["Yields"]):
             print(
@@ -309,7 +310,8 @@ def check_returns_yields_and_annotation(
                 "- [red]missing Return section in docstring"
             )
 
-    # no return & no yield to must be annotated as -> None
+    # if the function does not return or yield anything
+    # then its return type annotation must be None
     elif not has_none_return_annotation(ast_node):
         print(
             f"{filename}:{ast_node.lineno} "

--- a/maint_tools/check_docstrings.py
+++ b/maint_tools/check_docstrings.py
@@ -294,7 +294,7 @@ def check_returns_yields_and_annotation(
 
     np_docstring = NumpyDocString(docstring)
 
-    # function returns / yields a value → must have Returns / Yields section
+    # function returns / yields a value to must have Returns / Yields section
     if has_return_value or has_yield:
         if has_yield and bool(np_docstring["Yields"]):
             print(
@@ -309,7 +309,7 @@ def check_returns_yields_and_annotation(
                 "- [red]missing Return section in docstring"
             )
 
-    # no return & no yield → must be annotated as -> None
+    # no return & no yield to must be annotated as -> None
     elif not has_none_return_annotation(ast_node):
         print(
             f"{filename}:{ast_node.lineno} "

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -479,9 +479,11 @@ draw_cross : :obj:`bool`, default=True
 docdict["dtype"] = """
 dtype : dtype like, "auto" or None, default=None
     Data type toward which the data should be converted.
-    If "auto", the data will be converted to int32
-    if dtype is discrete and float32 if it is continuous.
+    If "auto", the data will be converted
+    to int32 if dtype is discrete
+    and to float32 if it is continuous.
     If None, data will not be converted to a new data type.
+    ``dtype=bool`` will raise an Exception.
 """
 
 # estimator_args

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -579,6 +579,7 @@ def nilearn_check_generator(estimator: NilearnBaseEstimator):
     if accept_niimg_input(estimator) or accept_surf_img_input(estimator):
         yield (clone(estimator), check_fit_returns_self)
         yield (clone(estimator), check_img_estimator_dtypes)
+        yield (clone(estimator), check_img_estimator_dtypes_transform)
         yield (clone(estimator), check_img_estimator_dtype_bool)
         yield (clone(estimator), check_img_estimator_dict_unchanged)
         yield (clone(estimator), check_img_estimator_dont_overwrite_parameters)
@@ -1802,6 +1803,107 @@ def check_img_estimator_dtype_bool(estimator_orig):
         estimator.inverse_transform(signal)
 
 
+def check_img_estimator_dtypes_transform(estimator_orig):
+    """Check estimator can fit and run for transform \
+       with inputs of varying dtypes.
+
+    Replacement for sklearn check_estimators_dtypes
+    and check_transformer_preserve_dtypes
+
+    Check that transform() are OK dealing with input of varying dtype.
+    and check the dtype of the output.
+
+    input_dtype np.int64 not tested: see no_int64_nifti in nilearn/conftest.py
+    """
+    if not hasattr(estimator_orig, "transform"):
+        return
+
+    dtype_list = [None]
+    if hasattr(estimator_orig, "dtype"):
+        dtype_list = [
+            np.float32,
+            "float64",
+            np.int32,
+            np.int64,
+            "i4",
+            "auto",
+            None,
+        ]
+
+    memory_list = [None]
+    if hasattr(estimator_orig, "memory"):
+        memory = [None, Path(mkdtemp())]
+
+    for input_dtype in [np.float32, "float64", np.int32, "i4"]:
+        for dtype in dtype_list:
+            for memory in memory_list:
+                estimator = clone(estimator_orig)
+
+                if hasattr(estimator, "dtype"):
+                    estimator.dtype = dtype
+
+                if hasattr(estimator, "memory"):
+                    estimator.memory = memory
+
+                input_dtype = np.dtype(input_dtype)
+
+                X, y = generate_data_to_fit(estimator)
+                if (
+                    isinstance(estimator, NiftiMasker)
+                    and input_dtype == np.int32
+                ):
+                    # Needed for NiftiMasker because the default strategy
+                    # returns an empty mask
+                    estimator.mask_strategy = "epi"
+
+                if isinstance(X, Nifti1Image):
+                    data = get_data(X)
+                    X = Nifti1Image(
+                        data.astype(input_dtype),
+                        affine=_affine_eye(),
+                        dtype=input_dtype,
+                    )
+                else:
+                    X.data._set_dtype(input_dtype)
+
+                estimator = fit_estimator(estimator, X, y)
+
+                if isinstance(estimator, SearchLight):
+                    # skip SearchLight.transform()
+                    # as it behaves differently from others
+                    continue
+
+                result = estimator.transform(X)
+
+                if not isinstance(result, list):
+                    result = [result]
+
+                target_dtype = get_target_dtype(input_dtype, dtype)
+                if target_dtype is None:
+                    target_dtype = input_dtype
+
+                for s in result:
+                    output_dtype = s.dtype
+                    try:
+                        assert output_dtype == target_dtype
+                    except AssertionError as e:
+                        raise TypeError(
+                            "'transform' should have returned "
+                            f"an array of type '{target_dtype}'. "
+                            f"Got '{output_dtype}' instead."
+                        ) from e
+
+                # when caching
+                # check transform results are the same
+                if memory is not None:
+                    result_2 = estimator.transform(X)
+                    if not isinstance(result_2, list):
+                        result_2 = [result_2]
+                    for s1, s2 in zip(result, result_2, strict=False):
+                        assert s1.dtype == s2.dtype
+                        assert_array_equal(s1, s2)
+
+
 def check_img_estimator_dtypes(estimator_orig):
     """Check estimator can fit and run several methods \
        with inputs of varying dtypes.
@@ -1809,9 +1911,8 @@ def check_img_estimator_dtypes(estimator_orig):
     Replacement for sklearn check_estimators_dtypes
     and check_transformer_preserve_dtypes
 
-    Check that several methods are OK dealing with input of varying dtype.
-
-    For transform, check the dtype of the output.
+    Only smoke tests:
+    check several methods are OK dealing with input of varying dtype.
 
     input_dtype np.int64 not tested: see no_int64_nifti in nilearn/conftest.py
     """
@@ -1866,7 +1967,6 @@ def check_img_estimator_dtypes(estimator_orig):
                 estimator = fit_estimator(estimator, X, y)
 
                 for method in [
-                    "transform",
                     "predict",
                     "score",
                     "decision_function",
@@ -1874,50 +1974,11 @@ def check_img_estimator_dtypes(estimator_orig):
                     if not hasattr(estimator, method):
                         continue
 
-                    if method == "transform" and isinstance(
-                        estimator, SearchLight
-                    ):
-                        # skip SearchLight.transform()
-                        # as it behaves differently from others
-                        continue
-
+                    # for now we only check the output dtype for transform
                     if method == "score":
-                        result = getattr(estimator, method)(X, y)
+                        getattr(estimator, method)(X, y)
                     else:
-                        result = getattr(estimator, method)(X)
-
-                    if method != "transform":
-                        # TODO
-                        # for now we only check the output dtype for transform
-                        continue
-
-                    if not isinstance(result, list):
-                        result = [result]
-
-                    target_dtype = get_target_dtype(input_dtype, dtype)
-                    if target_dtype is None:
-                        target_dtype = input_dtype
-
-                    for s in result:
-                        output_dtype = s.dtype
-                        try:
-                            assert output_dtype == target_dtype
-                        except AssertionError as e:
-                            raise TypeError(
-                                "'transform' should have returned "
-                                f"an array of type '{target_dtype}'. "
-                                f"Got '{output_dtype}' instead."
-                            ) from e
-
-                    # when caching
-                    # check transform results are the same
-                    if memory is not None:
-                        result_2 = getattr(estimator, method)(X)
-                        if not isinstance(result_2, list):
-                            result_2 = [result_2]
-                        for s1, s2 in zip(result, result_2, strict=False):
-                            assert s1.dtype == s2.dtype
-                            assert_array_equal(s1, s2)
+                        getattr(estimator, method)(X)
 
 
 def check_img_estimator_dtypes_inverse_transform(estimator_orig):

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1799,7 +1799,7 @@ def check_img_estimator_dtype_bool(estimator_orig):
     else:
         signal = signal.astype(bool)
 
-    with pytest.warns(UserWarning, match="Casting boolean input to int32"):
+    with pytest.warns(UserWarning, match="Casting boolean input to"):
         estimator.inverse_transform(signal)
 
 

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -579,6 +579,7 @@ def nilearn_check_generator(estimator: NilearnBaseEstimator):
     if accept_niimg_input(estimator) or accept_surf_img_input(estimator):
         yield (clone(estimator), check_fit_returns_self)
         yield (clone(estimator), check_img_estimator_dtypes)
+        yield (clone(estimator), check_img_estimator_dtype_bool)
         yield (clone(estimator), check_img_estimator_dict_unchanged)
         yield (clone(estimator), check_img_estimator_dont_overwrite_parameters)
         yield (clone(estimator), check_img_estimator_fit_check_is_fitted)
@@ -1767,6 +1768,40 @@ def check_img_estimator_pipeline_consistency(estimator_orig) -> None:
             assert_allclose_dense_sparse(result, result_pipe)
 
 
+def check_img_estimator_dtype_bool(estimator_orig):
+    """Raise error for dtype bool or
+    cast bool input to int for inverse_transform.
+    """
+    estimator = clone(estimator_orig)
+    if hasattr(estimator_orig, "dtype"):
+        estimator.dtype = bool
+        with pytest.raises(TypeError, match="'dtype' cannot be bool"):
+            estimator = fit_estimator(estimator)
+
+    if not hasattr(estimator, "inverse_transform"):
+        return None
+
+    estimator = clone(estimator_orig)
+
+    X, _ = generate_data_to_fit(estimator)
+
+    if isinstance(estimator, NiftiSpheresMasker):
+        # NiftiSpheresMasker needs mask_img to run inverse_transform
+        mask_img = new_img_like(X, np.ones(X.shape[:3]))
+        estimator.mask_img = mask_img
+
+    estimator = fit_estimator(estimator)
+
+    signal = estimator.transform(X)
+    if isinstance(signal, list):
+        signal = [x.astype(bool) for x in signal]
+    else:
+        signal = signal.astype(bool)
+
+    with pytest.warns(UserWarning, match="Casting boolean input to int32"):
+        estimator.inverse_transform(signal)
+
+
 def check_img_estimator_dtypes(estimator_orig):
     """Check estimator can fit and run several methods \
        with inputs of varying dtypes.
@@ -1780,8 +1815,9 @@ def check_img_estimator_dtypes(estimator_orig):
 
     input_dtype np.int64 not tested: see no_int64_nifti in nilearn/conftest.py
     """
-    for input_dtype in [np.float32, "float64", np.int32, "i4"]:
-        for dtype in [
+    dtype_list = [None]
+    if hasattr(estimator_orig, "dtype"):
+        dtype_list = [
             np.float32,
             "float64",
             np.int32,
@@ -1789,14 +1825,22 @@ def check_img_estimator_dtypes(estimator_orig):
             "i4",
             "auto",
             None,
-        ]:
-            for memory in [None, Path(mkdtemp())]:
+        ]
+
+    memory_list = [None]
+    if hasattr(estimator_orig, "memory"):
+        memory = [None, Path(mkdtemp())]
+
+    for input_dtype in [np.float32, "float64", np.int32, "i4"]:
+        for dtype in dtype_list:
+            for memory in memory_list:
                 estimator = clone(estimator_orig)
 
                 if hasattr(estimator, "dtype"):
                     estimator.dtype = dtype
 
-                estimator.memory = memory
+                if hasattr(estimator, "memory"):
+                    estimator.memory = memory
 
                 input_dtype = np.dtype(input_dtype)
 
@@ -1885,8 +1929,9 @@ def check_img_estimator_dtypes_inverse_transform(estimator_orig):
     we must handle deal with the fact that nibabel won't create
     images with np.int64
     """
-    for input_dtype in [np.float32, "float64", np.int64, np.int32, "i4"]:
-        for dtype in [
+    dtype_list = [None]
+    if hasattr(estimator_orig, "dtype"):
+        dtype_list = [
             np.float32,
             "float64",
             np.int32,
@@ -1894,7 +1939,10 @@ def check_img_estimator_dtypes_inverse_transform(estimator_orig):
             "i4",
             "auto",
             None,
-        ]:
+        ]
+
+    for input_dtype in [np.float32, "float64", np.int64, np.int32, "i4"]:
+        for dtype in dtype_list:
             estimator = clone(estimator_orig)
 
             if hasattr(estimator, "dtype"):

--- a/nilearn/decomposition/tests/test_decomposition_estimators.py
+++ b/nilearn/decomposition/tests/test_decomposition_estimators.py
@@ -56,7 +56,7 @@ else:
 
 
 @pytest.mark.slow
-@pytest.mark.flaky(reruns=5, reruns_delay=2)
+@pytest.mark.flaky(reruns=2, reruns_delay=2)
 @pytest.mark.parametrize(
     "estimator, check, name",
     nilearn_check_estimator(estimators=ESTIMATORS_TO_CHECK),

--- a/nilearn/decomposition/tests/test_decomposition_estimators.py
+++ b/nilearn/decomposition/tests/test_decomposition_estimators.py
@@ -56,7 +56,7 @@ else:
 
 
 @pytest.mark.slow
-@pytest.mark.flaky(reruns=2, reruns_delay=2)
+@pytest.mark.flaky(reruns=5, reruns_delay=1)
 @pytest.mark.parametrize(
     "estimator, check, name",
     nilearn_check_estimator(estimators=ESTIMATORS_TO_CHECK),

--- a/nilearn/decomposition/tests/test_decomposition_estimators.py
+++ b/nilearn/decomposition/tests/test_decomposition_estimators.py
@@ -56,7 +56,7 @@ else:
 
 
 @pytest.mark.slow
-@pytest.mark.flaky(reruns=5, reruns_delay=1)
+@pytest.mark.flaky(reruns=10, reruns_delay=1)
 @pytest.mark.parametrize(
     "estimator, check, name",
     nilearn_check_estimator(estimators=ESTIMATORS_TO_CHECK),

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -2169,7 +2169,6 @@ def test_check_niimg(img_3d_zeros_eye, img_4d_zeros_eye):
     )
 
 
-@pytest.mark.thread_unsafe
 def test_check_niimg_bool_error(img_3d_zeros_eye):
     """Check data dtype equal with dtype='auto'."""
     with pytest.raises(HeaderDataError, match=r"bool.*not supported"):

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -12,6 +12,7 @@ import pandas as pd
 import pytest
 from nibabel import AnalyzeImage, Nifti1Image, Nifti2Image, load, spatialimages
 from nibabel.freesurfer import MGHImage
+from nibabel.spatialimages import HeaderDataError
 from numpy.testing import (
     assert_allclose,
     assert_almost_equal,
@@ -2166,6 +2167,13 @@ def test_check_niimg(img_3d_zeros_eye, img_4d_zeros_eye):
         get_data(img_4d_zeros_eye).dtype.kind
         == get_data(img_4d_check).dtype.kind
     )
+
+
+@pytest.mark.thread_unsafe
+def test_check_niimg_bool_error(img_3d_zeros_eye):
+    """Check data dtype equal with dtype='auto'."""
+    with pytest.raises(HeaderDataError, match=r"bool.*not supported"):
+        check_niimg(img_3d_zeros_eye, dtype=bool)
 
 
 @pytest.mark.thread_unsafe

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -315,6 +315,10 @@ class _BaseMasker(
         """
         raise NotImplementedError()
 
+    def _check_dtype(self):
+        if self.dtype == bool:
+            raise TypeError("'dtype' cannot be bool")
+
 
 @fill_doc
 class BaseMasker(_BaseMasker):
@@ -337,6 +341,7 @@ class BaseMasker(_BaseMasker):
         """
         del y
         check_params(self.__dict__)
+        self._check_dtype()
 
         if imgs is not None:
             self._check_imgs(imgs)
@@ -644,6 +649,12 @@ class BaseMasker(_BaseMasker):
                 f"Got {signals.shape}."
             )
 
+        if signals.dtype == bool:
+            warnings.warn(
+                "Casting boolean input to int32", stacklevel=find_stack_level()
+            )
+            signals = signals.astype(np.int32)
+
         return signals
 
     def _get_summary_html(self, summary):
@@ -946,6 +957,12 @@ class _BaseSurfaceMasker(_BaseMasker):
                 f"Last dimension should be {self.n_elements_}.\n"
                 f"Got {signals.shape[-1]}."
             )
+
+        if signals.dtype == bool:
+            warnings.warn(
+                "Casting boolean input to int32", stacklevel=find_stack_level()
+            )
+            signals = signals.astype(np.int32)
 
         return signals
 

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -613,7 +613,7 @@ class BaseMasker(_BaseMasker):
         with contextlib.suppress(Exception):
             img._header._structarr = np.array(img._header._structarr).copy()
 
-        img = self._set_inverse_transform_output_dtype(X, img)
+        img = self._post_process_inverse_transform(X, img)
 
         return img
 
@@ -650,10 +650,12 @@ class BaseMasker(_BaseMasker):
             )
 
         if signals.dtype == bool:
+            target_dtype = self.dtype if self.dtype is not None else np.int32
             warnings.warn(
-                "Casting boolean input to int32", stacklevel=find_stack_level()
+                f"Casting boolean input to {target_dtype}",
+                stacklevel=find_stack_level(),
             )
-            signals = signals.astype(np.int32)
+            signals = signals.astype(target_dtype)
 
         return signals
 
@@ -695,7 +697,7 @@ class BaseMasker(_BaseMasker):
         self._reporting_data["stat_map_base64"] = json_view["stat_map_base64"]
         self._reporting_data["params"] = json.dumps(json_view["params"])
 
-    def _set_inverse_transform_output_dtype(
+    def _post_process_inverse_transform(
         self, input: np.ndarray, output: Nifti1Image
     ) -> Nifti1Image:
         """Set dtype for data to return for inverse_transform."""
@@ -959,10 +961,12 @@ class _BaseSurfaceMasker(_BaseMasker):
             )
 
         if signals.dtype == bool:
+            target_dtype = self.dtype if self.dtype is not None else np.int32
             warnings.warn(
-                "Casting boolean input to int32", stacklevel=find_stack_level()
+                f"Casting boolean input to {target_dtype}",
+                stacklevel=find_stack_level(),
             )
-            signals = signals.astype(np.int32)
+            signals = signals.astype(target_dtype)
 
         return signals
 

--- a/nilearn/maskers/multi_surface_labels_masker.py
+++ b/nilearn/maskers/multi_surface_labels_masker.py
@@ -193,6 +193,7 @@ class MultiSurfaceLabelsMasker(_MultiMixin, SurfaceLabelsMasker):
         """
         del y
         check_params(self.__dict__)
+        self._check_dtype()
 
         # Reset report
         # in case where the masker was previously fitted

--- a/nilearn/maskers/multi_surface_maps_masker.py
+++ b/nilearn/maskers/multi_surface_maps_masker.py
@@ -160,6 +160,7 @@ class MultiSurfaceMapsMasker(_MultiMixin, SurfaceMapsMasker):
         """
         del y
         check_params(self.__dict__)
+        self._check_dtype()
 
         # Reset report
         # in case where the masker was previously fitted

--- a/nilearn/maskers/multi_surface_masker.py
+++ b/nilearn/maskers/multi_surface_masker.py
@@ -150,6 +150,7 @@ class MultiSurfaceMasker(_MultiMixin, SurfaceMasker):
         """
         del y
         check_params(self.__dict__)
+        self._check_dtype()
 
         # Reset report
         # in case where the masker was previously fitted

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -875,6 +875,6 @@ class NiftiLabelsMasker(_LabelMaskerMixin, BaseMasker):
             background_label=self.background_label,
         )
 
-        img = self._set_inverse_transform_output_dtype(signals, img)
+        img = self._post_process_inverse_transform(signals, img)
 
         return img

--- a/nilearn/maskers/nifti_maps_masker.py
+++ b/nilearn/maskers/nifti_maps_masker.py
@@ -716,6 +716,6 @@ class NiftiMapsMasker(ClassNamePrefixFeaturesOutMixin, BaseMasker):
             mask_img=self.mask_img_,
         )
 
-        img = self._set_inverse_transform_output_dtype(region_signals, img)
+        img = self._post_process_inverse_transform(region_signals, img)
 
         return img

--- a/nilearn/maskers/nifti_spheres_masker.py
+++ b/nilearn/maskers/nifti_spheres_masker.py
@@ -695,6 +695,6 @@ class NiftiSpheresMasker(ClassNamePrefixFeaturesOutMixin, BaseMasker):
 
         img = unmask(img, self.mask_img_)
 
-        img = self._set_inverse_transform_output_dtype(region_signals, img)
+        img = self._post_process_inverse_transform(region_signals, img)
 
         return img

--- a/nilearn/maskers/surface_labels_masker.py
+++ b/nilearn/maskers/surface_labels_masker.py
@@ -238,6 +238,7 @@ class SurfaceLabelsMasker(_LabelMaskerMixin, _BaseSurfaceMasker):
         """
         del y
         check_params(self.__dict__)
+        self._check_dtype()
 
         # Reset report
         # in case where the masker was previously fitted

--- a/nilearn/maskers/surface_maps_masker.py
+++ b/nilearn/maskers/surface_maps_masker.py
@@ -202,6 +202,7 @@ class SurfaceMapsMasker(ClassNamePrefixFeaturesOutMixin, _BaseSurfaceMasker):
         """
         del y
         check_params(self.__dict__)
+        self._check_dtype()
 
         # Reset report
         # in case where the masker was previously fitted

--- a/nilearn/maskers/surface_masker.py
+++ b/nilearn/maskers/surface_masker.py
@@ -219,6 +219,7 @@ class SurfaceMasker(ClassNamePrefixFeaturesOutMixin, _BaseSurfaceMasker):
         """
         del y
         check_params(self.__dict__)
+        self._check_dtype()
 
         # Reset report
         # in case where the masker was previously fitted

--- a/nilearn/regions/parcellations.py
+++ b/nilearn/regions/parcellations.py
@@ -799,4 +799,10 @@ class Parcellations(_MultiPCA):
                     f"Got {signals.shape}."
                 )
 
+        if signals.dtype == bool:
+            warnings.warn(
+                "Casting boolean input to int32", stacklevel=find_stack_level()
+            )
+            signals = signals.astype(np.int32)
+
         return signals

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -1320,7 +1320,7 @@ class PolyData:
 
     dtype : DTypeLike object, default=None
         dtype to enforce on the data.
-        If ``None`` the original dtype if used.
+        If ``None`` the original dtype is used.
 
         .. nilearn_versionadded:: 0.12.1
 

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -1318,6 +1318,12 @@ class PolyData:
     right : 1/2D :obj:`numpy.ndarray` or :obj:`str` or :obj:`pathlib.Path` \
             or None, default = None
 
+    dtype : DTypeLike object, default=None
+        dtype to enforce on the data.
+        If ``None`` the original dtype if used.
+
+        .. nilearn_versionadded:: 0.12.1
+
     Attributes
     ----------
     parts : :obj:`dict` of 2D :obj:`numpy.ndarray` (n_vertices, n_timepoints)
@@ -1326,12 +1332,6 @@ class PolyData:
             The first dimension corresponds to the vertices:
             the typical shape of the
             data for a hemisphere is ``(n_vertices, n_time_points)``.
-
-    dtype : DTypeLike object, default=None
-        dtype to enforce on the data.
-        If ``None`` the original dtype if used.
-
-        .. nilearn_versionadded:: 0.12.1
 
     Examples
     --------
@@ -1859,7 +1859,7 @@ def data_to_gifti(data, gifti_file=None) -> gifti.GiftiImage:
     gifti_file : :obj:`str` or :obj:`pathlib.Path` or None, default=None
         name for the output gifti file.
     """
-    if data.dtype in [np.uint16, np.uint32, np.uint64]:
+    if data.dtype in [np.uint16, np.uint32, np.uint64, bool]:
         data = data.astype(np.uint8)
     elif data.dtype in [np.int8, np.int16, np.int64]:
         data = data.astype(np.int32)

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -879,9 +879,13 @@ def _gifti_img_to_data(gifti_img):
     if len(gifti_img.darrays) == 1:
         return np.asarray([gifti_img.darrays[0].data]).T.squeeze()
 
-    return np.asarray(
-        [arr.data for arr in gifti_img.darrays], dtype=object
-    ).T.squeeze()
+    try:
+        return np.asarray([arr.data for arr in gifti_img.darrays]).T.squeeze()
+    except ValueError:
+        # Ragged arrays (darrays with different shapes): fall back to object.
+        return np.asarray(
+            [arr.data for arr in gifti_img.darrays], dtype=object
+        ).T.squeeze()
 
 
 FREESURFER_MESH_EXTENSIONS = ("orig", "pial", "sphere", "white", "inflated")
@@ -1361,6 +1365,14 @@ class PolyData:
             if param is not None:
                 if not isinstance(param, np.ndarray):
                     param = load_surf_data(param)
+                if param.dtype == object:
+                    warnings.warn(
+                        "Object dtype is not supported for surface data. "
+                        f"Part '{hemi}' will be cast to np.float32.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                    param = param.astype(np.float32)
                 parts[hemi] = param
         self.parts = parts
         self._set_dtype(dtype)
@@ -1512,6 +1524,14 @@ class PolyData:
     def _set_dtype(self, dtype) -> None:
         """Set dtype for all parts."""
         if dtype is not None:
+            if np.dtype(dtype) == np.dtype(object):
+                warnings.warn(
+                    "Object dtype is not supported for surface data. "
+                    "Data will be cast to np.float32 instead.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                dtype = np.float32
             for h, v in self.parts.items():
                 self.parts[h] = v.astype(dtype)
 

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -22,6 +22,7 @@ from nilearn.surface.surface import (
     PolyMesh,
     SurfaceImage,
     _choose_kind,
+    _gifti_img_to_data,
     _gifti_img_to_mesh,
     _interpolation_sampling,
     _load_surf_files_gifti_gzip,
@@ -117,6 +118,68 @@ def test_load_surf_data_numpy_gt_1pt23():
     """
     fsaverage = datasets.fetch_surf_fsaverage()
     load_surf_data(fsaverage["pial_left"])
+
+
+@pytest.mark.ai_generated
+def test_gifti_img_to_data_preserves_numeric_dtype():
+    """Multi-darray GIFTI with uniform dtype must not return object array.
+
+    Regression test: _gifti_img_to_data previously forced dtype=object for
+    any multi-darray GIFTI, causing downstream failures (e.g. np.isfinite)
+    when the dtype was preserved through the masker pipeline.
+    """
+    n_vertices = 20
+    n_timepoints = 5
+    darrays = [
+        gifti.GiftiDataArray(
+            data=np.ones(n_vertices, dtype=np.float32),
+            datatype="NIFTI_TYPE_FLOAT32",
+        )
+        for _ in range(n_timepoints)
+    ]
+    gii = gifti.GiftiImage(darrays=darrays)
+
+    data = _gifti_img_to_data(gii)
+
+    assert data.dtype != object, (
+        "Expected a numeric dtype, got object. "
+        "Downstream np.isfinite calls will fail on object arrays."
+    )
+    assert data.dtype == np.float32
+    assert data.shape == (n_vertices, n_timepoints)
+
+
+@pytest.mark.ai_generated
+def test_polydata_casts_object_dtype_with_warning():
+    """PolyData must warn and cast to float32 when given object-dtype data.
+
+    Regression test: object dtype propagated silently through the masker
+    pipeline (fit_transform → inverse_transform) and caused np.isfinite to
+    fail inside threshold_img.
+    """
+    data = np.ones((10, 3), dtype=object)
+
+    with pytest.warns(UserWarning, match="Object dtype is not supported"):
+        pd = PolyData(left=data)
+    assert pd.parts["left"].dtype == np.float32
+
+    with pytest.warns(UserWarning, match="Object dtype is not supported"):
+        pd = PolyData(left=np.ones((10, 3), dtype=np.float32), dtype=object)
+    assert pd.parts["left"].dtype == np.float32
+
+
+@pytest.mark.ai_generated
+def test_surface_image_casts_object_dtype_with_warning(surf_mesh):
+    """SurfaceImage warns and casts to float32 when data has object dtype."""
+    data = {
+        hemi: np.ones((part.n_vertices, 3), dtype=object)
+        for hemi, part in surf_mesh.parts.items()
+    }
+
+    with pytest.warns(UserWarning, match="Object dtype is not supported"):
+        img = SurfaceImage(mesh=surf_mesh, data=data)
+    for part in img.data.parts.values():
+        assert part.dtype == np.float32
 
 
 def test_load_surf_data_array():

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -120,11 +120,13 @@ def test_load_surf_data_numpy_gt_1pt23():
     load_surf_data(fsaverage["pial_left"])
 
 
-@pytest.mark.ai_generated
 def test_gifti_img_to_data_preserves_numeric_dtype():
     """Multi-darray GIFTI with uniform dtype must not return object array.
 
-    Regression test: _gifti_img_to_data previously forced dtype=object for
+    Regression test for
+    https://github.com/nilearn/nilearn/issues/5525#issuecomment-4646130161
+
+    _gifti_img_to_data previously forced dtype=object for
     any multi-darray GIFTI, causing downstream failures (e.g. np.isfinite)
     when the dtype was preserved through the masker pipeline.
     """
@@ -149,11 +151,13 @@ def test_gifti_img_to_data_preserves_numeric_dtype():
     assert data.shape == (n_vertices, n_timepoints)
 
 
-@pytest.mark.ai_generated
 def test_polydata_casts_object_dtype_with_warning():
     """PolyData must warn and cast to float32 when given object-dtype data.
 
-    Regression test: object dtype propagated silently through the masker
+    Regression test for
+    https://github.com/nilearn/nilearn/issues/5525#issuecomment-4646130161
+
+    Object dtype propagated silently through the masker
     pipeline (fit_transform to inverse_transform) and caused np.isfinite to
     fail inside threshold_img.
     """
@@ -168,7 +172,6 @@ def test_polydata_casts_object_dtype_with_warning():
     assert pd.parts["left"].dtype == np.float32
 
 
-@pytest.mark.ai_generated
 def test_surface_image_casts_object_dtype_with_warning(surf_mesh):
     """SurfaceImage warns and casts to float32 when data has object dtype."""
     data = {
@@ -180,6 +183,23 @@ def test_surface_image_casts_object_dtype_with_warning(surf_mesh):
         img = SurfaceImage(mesh=surf_mesh, data=data)
     for part in img.data.parts.values():
         assert part.dtype == np.float32
+
+
+@pytest.mark.parametrize("dtype", [1, 1.5, "foo"])
+def test_dtype_error(surf_mesh, dtype):
+    """Check dtype errors.
+
+    Note the errors are raised by numpy.
+    """
+    with pytest.raises(TypeError, match=r"understood|data type"):
+        PolyData(left=np.ones((10, 3)), dtype=dtype)
+
+    data = {
+        hemi: np.ones((part.n_vertices, 3))
+        for hemi, part in surf_mesh.parts.items()
+    }
+    with pytest.raises(TypeError, match=r"understood|data type"):
+        SurfaceImage(mesh=surf_mesh, data=data, dtype=dtype)
 
 
 def test_load_surf_data_array():

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -154,7 +154,7 @@ def test_polydata_casts_object_dtype_with_warning():
     """PolyData must warn and cast to float32 when given object-dtype data.
 
     Regression test: object dtype propagated silently through the masker
-    pipeline (fit_transform → inverse_transform) and caused np.isfinite to
+    pipeline (fit_transform to inverse_transform) and caused np.isfinite to
     fail inside threshold_img.
     """
     data = np.ones((10, 3), dtype=object)

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -1206,6 +1206,7 @@ def test_load_save_data_1d(rng, tmp_path, surf_mesh):
         np.int64,
         np.float32,
         np.float64,
+        bool,
     ],
 )
 def test_save_dtype(surf_img_1d, tmp_path, dtype):

--- a/nilearn/surface/tests/test_surface.py
+++ b/nilearn/surface/tests/test_surface.py
@@ -1246,12 +1246,17 @@ def test_check_surf_img(surf_img_1d, surf_img_2d):
 
 
 def test_check_surf_img_dtype(surf_img_1d):
-    """Check dtype of SurfaceImage can be set at init."""
+    """Check dtype of SurfaceImage can be set at init.
+
+    Check private attribute _dtype of PolyData is set.
+    """
     data = {
         "left": np.ones(surf_img_1d.data.parts["left"].shape, dtype="float32"),
         "right": np.ones(surf_img_1d.data.parts["right"].shape, dtype="int32"),
     }
     new_img = SurfaceImage(surf_img_1d.mesh, data, dtype=np.int32)
+
+    assert new_img.data._dtype == np.int32
 
     for k in surf_img_1d.data.parts:
         assert new_img.data.parts[k].dtype != surf_img_1d.data.parts[k].dtype

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -502,7 +502,7 @@ convention = "numpy"
 # https://docs.astral.sh/ruff/settings/#lint_pylint_max-args
 max-args = 27
 # https://docs.astral.sh/ruff/settings/#lint_pylint_max-branches
-max-branches = 25
+max-branches = 22
 # https://docs.astral.sh/ruff/settings/#lint_pylint_max-returns
 max-returns = 8
 # https://docs.astral.sh/ruff/settings/#lint_pylint_max-statements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -502,8 +502,8 @@ convention = "numpy"
 # https://docs.astral.sh/ruff/settings/#lint_pylint_max-args
 max-args = 27
 # https://docs.astral.sh/ruff/settings/#lint_pylint_max-branches
-max-branches = 22
+max-branches = 25
 # https://docs.astral.sh/ruff/settings/#lint_pylint_max-returns
 max-returns = 8
 # https://docs.astral.sh/ruff/settings/#lint_pylint_max-statements
-max-statements = 96
+max-statements = 100


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this pull request.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the pull request closes multiple issues, includes "closes" before each one is listed.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->
- Relates to https://github.com/nilearn/nilearn/issues/5525#issuecomment-4646130161

<!-- Please indicate whether LLM tools were used for this pull request
by adding a 'x' in one of the following check box.
Work made with LLM tools has a very different set of typical failure modes
than work done entirely by humans,
it helps others to better trace eventual issues when reviewing the code.
-->
Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

<!-- Please give a brief overview of what has changed in the pull request.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- avoid dtype = bool for estimators and cast bool input to inverse_transform to int32 (with a warning)
- _gifti_img_to_data: try numeric array first; fall back to object
  only for genuinely ragged darrays (different shapes).
- PolyData.__init__ / _set_dtype: detect object dtype, emit a
  UserWarning, and cast to np.float32 automatically.

