### PR TITLE
[FIX] throw warning when NiftiLabelMasker resamples images at transform time

### DIFF
--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -3430,7 +3430,7 @@ def check_masker_transform_resampling(estimator_orig) -> None:
             actual_shape = new_imgs.shape
             assert actual_shape == expected_shape
 
-            if resampling_target == "maps":
+            if resampling_target in ["maps", "labels"]:
                 with pytest.warns(UserWarning, match="at transform time"):
                     estimator.transform(imgs)
             else:
@@ -3451,16 +3451,8 @@ def check_masker_transform_resampling(estimator_orig) -> None:
             # than the one used at fit time,
             # but there should be a resampling warning
             # we are resampling to data
-            if resampling_target in ["data", "maps"]:
-                with pytest.warns(UserWarning, match="at transform time"):
-                    estimator.transform(imgs_with_different_fov)
-            else:
-                with warnings.catch_warnings(record=True) as warning_list:
-                    estimator.transform(imgs_with_different_fov)
-                assert all(
-                    "at transform time" not in str(x.message)
-                    for x in warning_list
-                )
+            with pytest.warns(UserWarning, match="at transform time"):
+                estimator.transform(imgs_with_different_fov)
 
 
 def check_masker_shelving(estimator_orig) -> None:

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -3482,7 +3482,9 @@ def check_masker_transform_resampling(estimator_orig) -> None:
             assert actual_shape == expected_shape
 
             if resampling_target in ["maps", "labels"]:
-                with pytest.warns(UserWarning, match="at transform time"):
+                with pytest.warns(
+                    UserWarning, match="images at transform time"
+                ):
                     estimator.transform(imgs)
             else:
                 # no resampling warning when using same imgs as for fit()
@@ -3501,9 +3503,17 @@ def check_masker_transform_resampling(estimator_orig) -> None:
             # no error transforming an image with different fov
             # than the one used at fit time,
             # but there should be a resampling warning
-            # we are resampling to data
-            with pytest.warns(UserWarning, match="Resampling images at transform time"):
-                estimator.transform(imgs_with_different_fov)
+            # we are resampling
+            if resampling_target == "data":
+                with pytest.warns(
+                    UserWarning, match="[maps|labels] at transform time"
+                ):
+                    estimator.transform(imgs_with_different_fov)
+            elif resampling_target in ["maps", "labels"]:
+                with pytest.warns(
+                    UserWarning, match="images at transform time"
+                ):
+                    estimator.transform(imgs_with_different_fov)
 
 
 def check_masker_shelving(estimator_orig) -> None:

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -3502,7 +3502,7 @@ def check_masker_transform_resampling(estimator_orig) -> None:
             # than the one used at fit time,
             # but there should be a resampling warning
             # we are resampling to data
-            with pytest.warns(UserWarning, match="at transform time"):
+            with pytest.warns(UserWarning, match="Resampling images at transform time"):
                 estimator.transform(imgs_with_different_fov)
 
 

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -743,6 +743,17 @@ class NiftiLabelsMasker(_LabelMaskerMixin, BaseMasker):
         target_shape = None
         target_affine = None
         if self.resampling_target == "labels":
+            if not check_same_fov(labels_img_, imgs):
+                warnings.warn(
+                    (
+                        "Resampling images at transform time...\n"
+                        "To avoid this warning, make sure to resample the "
+                        "images you want to transform to the shape of the "
+                        "maps or set resampling_target to 'data'."
+                    ),
+                    stacklevel=find_stack_level(),
+                )
+
             target_shape = labels_img_.shape[:3]
             target_affine = labels_img_.affine
 

--- a/nilearn/maskers/tests/test_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_nifti_labels_masker.py
@@ -464,8 +464,12 @@ def test_nifti_labels_masker_resampling(
             "labels were removed",
         ):
             signals = masker.fit_transform(fmri_img)
-    else:
-        signals = masker.fit_transform(fmri_img)
+    elif resampling_target == "labels":
+        with pytest.warns(
+            UserWarning,
+            match="Resampling images at transform time",
+        ):
+            signals = masker.fit_transform(fmri_img)
 
     resampled_labels_img = masker.labels_img_
     n_resampled_labels = len(np.unique(get_data(resampled_labels_img)))

--- a/nilearn/maskers/tests/test_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_nifti_labels_masker.py
@@ -464,12 +464,8 @@ def test_nifti_labels_masker_resampling(
             "labels were removed",
         ):
             signals = masker.fit_transform(fmri_img)
-    elif resampling_target == "labels":
-        with pytest.warns(
-            UserWarning,
-            match="Resampling images at transform time",
-        ):
-            signals = masker.fit_transform(fmri_img)
+    else:
+        signals = masker.fit_transform(fmri_img)
 
     resampled_labels_img = masker.labels_img_
     n_resampled_labels = len(np.unique(get_data(resampled_labels_img)))

--- a/nilearn/maskers/tests/test_nifti_maps_masker.py
+++ b/nilearn/maskers/tests/test_nifti_maps_masker.py
@@ -534,28 +534,3 @@ def test_nifti_maps_masker_overlap(maps_img_fn, allow_overlap, img_fmri):
             masker.fit_transform(img_fmri)
     else:
         masker.fit_transform(img_fmri)
-
-
-def test_nifti_maps_masker_transform_resample_warning(img_fmri):
-    """Test warnings when images are resampled at transform."""
-    maps_img, _ = generate_maps((13, 11, 12), 2)
-    masker = NiftiMapsMasker(
-        maps_img, resampling_target="data", standardize=None
-    )
-
-    # Images have different fov between fit and transform
-    masker.fit(maps_img)
-    with pytest.warns(
-        UserWarning, match="Resampling maps at transform time..."
-    ):
-        masker.transform(img_fmri)
-
-    # Same fov between fit and transform, but resampling_target="maps"
-    masker = NiftiMapsMasker(
-        maps_img, resampling_target="maps", standardize=None
-    )
-
-    with pytest.warns(
-        UserWarning, match="Resampling images at transform time..."
-    ):
-        masker.fit_transform(img_fmri)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this pull request.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the pull request closes multiple issues, includes "closes" before each one is listed.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->
- Closes #6040

<!-- Please indicate whether LLM tools were used for this pull request
by adding a 'x' in one of the following check box.
Work made with LLM tools has a very different set of typical failure modes
than work done entirely by humans,
it helps others to better trace eventual issues when reviewing the code.
-->
Use of AI tools:
- [ ] LLM tools were used to generate at least part of the content of this pull-request.
- [x] No LLM tools were used to generate any part of the content of this pull-request.

<!-- Please give a brief overview of what has changed in the pull request.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- throw warning when NiftiLabelMasker resamples images at transform time

