### PR TITLE
[DOC] add example to docstring for check_design_matrix

### DIFF
--- a/nilearn/glm/first_level/design_matrix.py
+++ b/nilearn/glm/first_level/design_matrix.py
@@ -425,23 +425,22 @@ def check_design_matrix(design_matrix):
     --------
     >>> import pandas as pd
     >>> from nilearn.glm.first_level import check_design_matrix
-
-    Create a mock design matrix
+    >>>
+    >>> # Create a mock design matrix.
     >>> design_matrix = pd.DataFrame(
     ...     data={"col1": [1, 2], "col2": [3, 4]},
     ...     index=[3, 4],
     ... )
-
-    check the design matrix
+    >>>
+    >>> # Check the design matrix.
     >>> frame_times, matrix, names = check_design_matrix(design_matrix)
-    >>> print(f"Frame times: {frame_times}")
-    Frame times: Index([3, 4], dtype='int64')
-    >>> print(f"Matrix:\n{matrix}")
-    Matrix:
-    [[1 3]
-    [2 4]]
-    >>> print(f"Key names: {names}")
-    Key names: ['col1', 'col2']
+    >>> frame_times
+    Index([3, 4], dtype='int64')
+    >>> matrix
+    array([[1, 3],
+           [2, 4]])
+    >>> names
+    ['col1', 'col2']
 
     """
     if len(design_matrix.columns) == 0:

--- a/nilearn/glm/first_level/design_matrix.py
+++ b/nilearn/glm/first_level/design_matrix.py
@@ -421,6 +421,28 @@ def check_design_matrix(design_matrix):
     names : array of shape (n_events,), dtype='f'
         Per-event onset time (in seconds)
 
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from nilearn.glm.first_level import check_design_matrix
+
+    Create a mock design matrix
+    >>> design_matrix = pd.DataFrame(
+    ...     data={"col1": [1, 2], "col2": [3, 4]},
+    ...     index=[3, 4],
+    ... )
+
+    check the design matrix
+    >>> frame_times, matrix, names = check_design_matrix(design_matrix)
+    >>> print(f"Frame times: {frame_times}")
+    Frame times: Index([3, 4], dtype='int64')
+    >>> print(f"Matrix:\n{matrix}")
+    Matrix:
+    [[1 3]
+    [2 4]]
+    >>> print(f"Key names: {names}")
+    Key names: ['col1', 'col2']
+
     """
     if len(design_matrix.columns) == 0:
         raise ValueError("The design_matrix dataframe cannot be empty.")


### PR DESCRIPTION
Adding a minimal example for the `check_design_matrix` function. This addresses one of the tasks from #5824.

Use of AI tools:
- [ ] LLM tools were used to generate at least part of the content of this pull-request.
- [x] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:
- add a minimal example to the doc string showing how the iteration works

