### PR TITLE
[MAINT] Add return type annotations to public functions in nilearn.image

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -165,7 +165,7 @@ Enhancements
 Changes
 -------
 
-- :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.image` (:gh:`XXXX` by `Rémi Gau`_).
+- :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.image` (:gh:`6338` by `Rémi Gau`_).
 
 - :bdg-danger:`Deprecation` The function ``nilearn.datasets.utils.load_sample_motor_activation_image`` and ``nilearn.datasets.fetch_neurovault_motor_task`` were removed. Use :func:`~datasets.load_sample_motor_activation_image` instead (:gh:`5995` by `Rémi Gau`_).
 

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -165,6 +165,8 @@ Enhancements
 Changes
 -------
 
+- :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.image` (:gh:`XXXX` by `Rémi Gau`_).
+
 - :bdg-danger:`Deprecation` The function ``nilearn.datasets.utils.load_sample_motor_activation_image`` and ``nilearn.datasets.fetch_neurovault_motor_task`` were removed. Use :func:`~datasets.load_sample_motor_activation_image` instead (:gh:`5995` by `Rémi Gau`_).
 
 - :bdg-danger:`Deprecation` The private functions ``nilearn._utils.niimg_conversions.check_niimg*`` have been removed, please use their public equivalent :func:`~image.check_niimg`, :func:`~image.check_niimg_3d` and :func:`~image.check_niimg_4d` (:gh:`5995` by `Rémi Gau`_).

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1350,6 +1350,7 @@ def check_nilearn_methods_sample_order_invariance(estimator_orig) -> None:
     n_samples = 30
     idx = _rng().permutation(n_samples)
 
+    new_X: Nifti1Image | SurfaceImage
     if isinstance(X, SurfaceImage):
         data = {
             x: _rng().random((v.shape[0], n_samples))

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -1,5 +1,8 @@
+from typing import cast
+
 import numpy as np
 import pytest
+from nibabel import Nifti1Image
 
 from nilearn.decomposition.dict_learning import DictLearning
 from nilearn.decomposition.tests.conftest import (
@@ -8,6 +11,7 @@ from nilearn.decomposition.tests.conftest import (
 )
 from nilearn.image import get_data, iter_img
 from nilearn.maskers import NiftiMasker, SurfaceMasker
+from nilearn.surface import SurfaceImage
 from nilearn.surface.surface import get_data as get_surface_data
 
 
@@ -105,6 +109,7 @@ def test_dict_learning(
         assert recovered_maps >= 2
 
 
+@pytest.mark.ai_generated
 @pytest.mark.slow
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 def test_component_sign(
@@ -130,5 +135,9 @@ def test_component_sign(
     check_decomposition_estimator(dict_learning, data_type)
 
     for mp in iter_img(dict_learning.components_img_):
-        mp = get_data(mp) if data_type == "nifti" else get_surface_data(mp)
-        assert np.sum(mp[mp <= 0]) <= np.sum(mp[mp > 0])
+        data = (
+            get_data(cast(Nifti1Image, mp))
+            if data_type == "nifti"
+            else get_surface_data(cast(SurfaceImage, mp))
+        )
+        assert np.sum(data[data <= 0]) <= np.sum(data[data > 0])

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -108,7 +108,6 @@ def test_dict_learning(
         assert recovered_maps >= 2
 
 
-@pytest.mark.ai_generated
 @pytest.mark.slow
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 def test_component_sign(

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -11,7 +11,6 @@ from nilearn.decomposition.tests.conftest import (
 )
 from nilearn.image import get_data, iter_img
 from nilearn.maskers import NiftiMasker, SurfaceMasker
-from nilearn.surface import SurfaceImage
 from nilearn.surface.surface import get_data as get_surface_data
 
 
@@ -138,6 +137,6 @@ def test_component_sign(
         data = (
             get_data(cast(Nifti1Image, mp))
             if data_type == "nifti"
-            else get_surface_data(cast(SurfaceImage, mp))
+            else get_surface_data(mp)
         )
         assert np.sum(data[data <= 0]) <= np.sum(data[data > 0])

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -455,8 +455,11 @@ def smooth_img(
 
     Returns
     -------
-    Niimg-like object, :obj:~nilearn.surface.SurfaceImage.
-    Smoothed input image or surface.
+    :obj:`~nibabel.nifti1.Nifti1Image`, :obj:`~nilearn.surface.SurfaceImage`, \
+        :obj:`list` of :obj:`~nibabel.nifti1.Nifti1Image`, or :obj:`list` \
+        of :obj:`~nilearn.surface.SurfaceImage`
+        Smoothed input image(s) or surface(s).
+        A :obj:`list` is returned if ``imgs`` was passed as an iterable.
 
     Examples
     --------
@@ -2536,7 +2539,8 @@ def largest_connected_component_img(
 
     Returns
     -------
-    3D Niimg-like object or list of
+    :obj:`~nibabel.nifti1.Nifti1Image` or :obj:`list` of \
+        :obj:`~nibabel.nifti1.Nifti1Image`
         Image or list of images containing the largest connected component.
 
     Notes
@@ -2609,7 +2613,7 @@ def copy_img(img) -> Nifti1Image:
 
     Returns
     -------
-    img_copy : image
+    img_copy : :obj:`~nibabel.nifti1.Nifti1Image`
         copy of input (data, affine and header)
 
     Examples

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -427,21 +427,17 @@ def smooth_img(imgs: NiimgLike, fwhm) -> Nifti1Image: ...
 
 
 @overload
-def smooth_img(
-    imgs: list[SurfaceImage] | tuple[SurfaceImage, ...], fwhm
-) -> list[SurfaceImage]: ...
+def smooth_img(imgs: Iterable[SurfaceImage], fwhm) -> list[SurfaceImage]: ...
 
 
 @overload
-def smooth_img(
-    imgs: list[NiimgLike] | tuple[NiimgLike, ...], fwhm
-) -> list[Nifti1Image]: ...
+def smooth_img(imgs: Iterable[NiimgLike], fwhm) -> list[Nifti1Image]: ...
 
 
 @fill_doc
 def smooth_img(
     imgs, fwhm
-) -> Nifti1Image | SurfaceImage | list[Nifti1Image] | list[SurfaceImage]:
+) -> NiimgLike | SurfaceImage | list[NiimgLike] | list[SurfaceImage]:
     """Smooth images by applying a Gaussian filter.
 
     Apply a Gaussian filter along the three first dimensions of `arr`.
@@ -1135,7 +1131,7 @@ def iter_img(imgs) -> Iterator[Nifti1Image | SurfaceImage]:
             index_img(imgs, i) for i in range(at_least_2d(imgs).shape[1])
         )
         return output
-    return iter(check_niimg_4d(imgs, return_iterator=True))
+    return check_niimg_4d(imgs, return_iterator=True)
 
 
 def _downcast_from_int64_if_possible(data):
@@ -2304,7 +2300,7 @@ def load_img(
 
 @overload
 def concat_imgs(
-    niimgs: list[SurfaceImage] | tuple[SurfaceImage, ...],
+    niimgs: SurfaceImage | Iterable[SurfaceImage],
     dtype=...,
     ensure_ndim=...,
     memory=...,
@@ -2911,7 +2907,7 @@ def check_niimg(
     dtype=...,
     return_iterator: Literal[True] = ...,
     wildcards=...,
-) -> Iterable[Nifti1Image]: ...
+) -> Iterator[Nifti1Image]: ...
 
 
 @fill_doc
@@ -3170,7 +3166,7 @@ def check_niimg_4d(
     niimg: Any,
     return_iterator: Literal[True] = ...,
     dtype: Any = ...,
-) -> Iterable[Nifti1Image]: ...
+) -> Iterator[Nifti1Image]: ...
 
 
 @fill_doc
@@ -3178,7 +3174,7 @@ def check_niimg_4d(
     niimg: Any,
     return_iterator: Literal[False, True] = False,
     dtype: Any = None,
-) -> Nifti1Image | Iterable[Nifti1Image]:
+) -> Nifti1Image | Iterator[Nifti1Image]:
     """Check that niimg is a proper 4D niimg-like object and load it.
 
     Parameters

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -964,7 +964,7 @@ def swap_img_hemispheres(img):
     return out_img
 
 
-def index_img(imgs, index):
+def index_img(imgs, index) -> Nifti1Image | SurfaceImage:
     """Indexes into a image in the last dimension.
 
     Common use cases include extracting an image out of `img` or

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -2487,7 +2487,7 @@ def largest_connected_component_img(imgs):
     return ret[0] if single_img else ret
 
 
-def copy_img(img):
+def copy_img(img) -> Nifti1Image:
     """Copy an image to a nibabel.Nifti1Image.
 
     Parameters

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -9,7 +9,7 @@ import glob
 import itertools
 import math
 import warnings
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeGuard, get_args, overload
@@ -1049,7 +1049,7 @@ def _index_img(img: Nifti1Image, index):
     return new_img_like(img, data, img.affine)
 
 
-def iter_img(imgs):
+def iter_img(imgs) -> Iterator[Nifti1Image | SurfaceImage]:
     """Iterate over images.
 
     Could be along the the 4th dimension for 4D Niimg-like object
@@ -1075,7 +1075,7 @@ def iter_img(imgs):
             index_img(imgs, i) for i in range(at_least_2d(imgs).shape[1])
         )
         return output
-    return check_niimg_4d(imgs, return_iterator=True)
+    return iter(check_niimg_4d(imgs, return_iterator=True))
 
 
 def _downcast_from_int64_if_possible(data):

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -2495,6 +2495,16 @@ def concat_imgs(
     return new_img_like(first_niimg, data, first_niimg.affine)
 
 
+@overload
+def largest_connected_component_img(imgs: NiimgLike) -> Nifti1Image: ...
+
+
+@overload
+def largest_connected_component_img(
+    imgs: list[NiimgLike] | tuple[NiimgLike, ...],
+) -> list[Nifti1Image]: ...
+
+
 def largest_connected_component_img(
     imgs,
 ) -> Nifti1Image | list[Nifti1Image]:

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -2282,6 +2282,30 @@ def load_img(
     return check_niimg(img, wildcards=wildcards, dtype=dtype)
 
 
+@overload
+def concat_imgs(
+    niimgs: list[SurfaceImage] | tuple[SurfaceImage, ...],
+    dtype=...,
+    ensure_ndim=...,
+    memory=...,
+    memory_level=...,
+    auto_resample=...,
+    verbose=...,
+) -> SurfaceImage: ...
+
+
+@overload
+def concat_imgs(
+    niimgs: NiimgLike | Iterable[NiimgLike],
+    dtype=...,
+    ensure_ndim=...,
+    memory=...,
+    memory_level=...,
+    auto_resample=...,
+    verbose=...,
+) -> Nifti1Image: ...
+
+
 @fill_doc
 def concat_imgs(
     niimgs,

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -419,7 +419,9 @@ def smooth_array(arr, affine, fwhm=None, ensure_finite=True, copy=True):
 
 
 @fill_doc
-def smooth_img(imgs, fwhm):
+def smooth_img(
+    imgs, fwhm
+) -> Nifti1Image | SurfaceImage | list[Nifti1Image] | list[SurfaceImage]:
     """Smooth images by applying a Gaussian filter.
 
     Apply a Gaussian filter along the three first dimensions of `arr`.

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -810,7 +810,7 @@ def mean_img(
     verbose=0,
     n_jobs=1,
     copy_header=True,
-):
+) -> Nifti1Image | SurfaceImage:
     """Compute the mean over images.
 
     This can be a mean over time or the 4th dimension for a volume,

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1059,6 +1059,14 @@ def _index_img(img: Nifti1Image, index):
     return new_img_like(img, data, img.affine)
 
 
+@overload
+def iter_img(imgs: SurfaceImage) -> Iterator[SurfaceImage]: ...
+
+
+@overload
+def iter_img(imgs: NiimgLike) -> Iterator[Nifti1Image]: ...
+
+
 def iter_img(imgs) -> Iterator[Nifti1Image | SurfaceImage]:
     """Iterate over images.
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1112,6 +1112,24 @@ def _downcast_from_int64_if_possible(data):
     return data
 
 
+@overload
+def new_img_like(
+    ref_niimg: SurfaceImage,
+    data,
+    affine=...,
+    copy_header: bool = ...,
+) -> SurfaceImage: ...
+
+
+@overload
+def new_img_like(
+    ref_niimg: NiimgLike | Iterable[NiimgLike],
+    data,
+    affine=...,
+    copy_header: bool = ...,
+) -> Nifti1Image: ...
+
+
 @fill_doc
 def new_img_like(
     ref_niimg, data, affine=None, copy_header=True

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -1111,7 +1111,9 @@ def _downcast_from_int64_if_possible(data):
 
 
 @fill_doc
-def new_img_like(ref_niimg, data, affine=None, copy_header=True):
+def new_img_like(
+    ref_niimg, data, affine=None, copy_header=True
+) -> Nifti1Image | SurfaceImage:
     """Create a new image of the same class as the reference image.
 
     Parameters

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -3053,7 +3053,7 @@ def check_niimg_4d(
     niimg: Any,
     return_iterator: Literal[False, True] = False,
     dtype: Any = None,
-):
+) -> Nifti1Image | Iterable[Nifti1Image]:
     """Check that niimg is a proper 4D niimg-like object and load it.
 
     Parameters

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -2411,7 +2411,9 @@ def concat_imgs(
     return new_img_like(first_niimg, data, first_niimg.affine)
 
 
-def largest_connected_component_img(imgs):
+def largest_connected_component_img(
+    imgs,
+) -> Nifti1Image | list[Nifti1Image]:
     """Return the largest connected component of an image or list of images.
 
     .. nilearn_versionadded:: 0.3.1

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -804,6 +804,28 @@ def _compute_surface_mean(imgs: SurfaceImage) -> SurfaceImage:
     return new_img_like(imgs, data=data)
 
 
+@overload
+def mean_img(
+    imgs: SurfaceImage | Iterable[SurfaceImage],
+    target_affine=...,
+    target_shape=...,
+    verbose=...,
+    n_jobs=...,
+    copy_header: bool = ...,
+) -> SurfaceImage: ...
+
+
+@overload
+def mean_img(
+    imgs: NiimgLike | Iterable[NiimgLike],
+    target_affine=...,
+    target_shape=...,
+    verbose=...,
+    n_jobs=...,
+    copy_header: bool = ...,
+) -> Nifti1Image: ...
+
+
 @fill_doc
 def mean_img(
     imgs,

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -418,6 +418,26 @@ def smooth_array(arr, affine, fwhm=None, ensure_finite=True, copy=True):
     return arr
 
 
+@overload
+def smooth_img(imgs: SurfaceImage, fwhm) -> SurfaceImage: ...
+
+
+@overload
+def smooth_img(imgs: NiimgLike, fwhm) -> Nifti1Image: ...
+
+
+@overload
+def smooth_img(
+    imgs: list[SurfaceImage] | tuple[SurfaceImage, ...], fwhm
+) -> list[SurfaceImage]: ...
+
+
+@overload
+def smooth_img(
+    imgs: list[NiimgLike] | tuple[NiimgLike, ...], fwhm
+) -> list[Nifti1Image]: ...
+
+
 @fill_doc
 def smooth_img(
     imgs, fwhm

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -966,6 +966,14 @@ def swap_img_hemispheres(img) -> Nifti1Image:
     return out_img
 
 
+@overload
+def index_img(imgs: SurfaceImage, index) -> SurfaceImage: ...
+
+
+@overload
+def index_img(imgs: NiimgLike, index) -> Nifti1Image: ...
+
+
 def index_img(imgs, index) -> Nifti1Image | SurfaceImage:
     """Indexes into a image in the last dimension.
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -926,7 +926,7 @@ def mean_img(
     )
 
 
-def swap_img_hemispheres(img):
+def swap_img_hemispheres(img) -> Nifti1Image:
     """Perform swapping of hemispheres in the indicated NIfTI image.
 
        Use case: synchronizing ROIs across hemispheres.

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -2231,7 +2231,7 @@ def concat_imgs(
     memory_level=0,
     auto_resample=False,
     verbose=0,
-):
+) -> Nifti1Image | SurfaceImage:
     """Concatenate a list of images of varying lengths.
 
     The image list can contain:
@@ -2311,12 +2311,13 @@ def concat_imgs(
         if len(niimgs) == 1:
             return niimgs[0]
 
+        niimgs = list(niimgs)
         for i, img in enumerate(niimgs):
             check_polymesh_equal(img.mesh, niimgs[0].mesh)
             niimgs[i] = at_least_2d(img)
 
         if dtype is None:
-            dtype = extract_data(niimgs[0]).dtype
+            dtype = get_surface_data(niimgs[0]).dtype
 
         output_data = {}
         for part in niimgs[0].data.parts:
@@ -2343,7 +2344,10 @@ def concat_imgs(
 
     iterator, literator = itertools.tee(iter(niimgs))
     try:
-        first_niimg = check_niimg(next(literator), ensure_ndim=ndim)
+        first_niimg = check_niimg(
+            next(literator),
+            ensure_ndim=ndim,  # type: ignore[arg-type]
+        )
     except StopIteration as e:
         raise TypeError("Cannot concatenate empty objects") from e
     except DimensionError as exc:
@@ -2366,7 +2370,10 @@ def concat_imgs(
     for niimg in literator:
         # We check the dimensionality of the niimg
         try:
-            niimg = check_niimg(niimg, ensure_ndim=ndim)
+            niimg = check_niimg(
+                niimg,
+                ensure_ndim=ndim,  # type: ignore[arg-type]
+            )
         except DimensionError as exc:
             # Keep track of the additional dimension in the error
             exc.increment_stack_counter()
@@ -2376,7 +2383,9 @@ def concat_imgs(
     target_shape = first_niimg.shape[:3]
     if dtype is None:
         dtype = _get_data(first_niimg).dtype
-    data = np.ndarray((*target_shape, sum(lengths)), order="F", dtype=dtype)
+    data: np.ndarray = np.ndarray(
+        (*target_shape, sum(lengths)), order="F", dtype=dtype
+    )
     cur_4d_index = 0
     for index, (size, niimg) in enumerate(
         zip(

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -6,7 +6,7 @@ import json
 import warnings
 from collections.abc import Iterable
 from copy import deepcopy
-from typing import Any, cast, overload
+from typing import Any, overload
 
 import numpy as np
 from joblib import Memory
@@ -475,14 +475,15 @@ class BaseMasker(_BaseMasker):
 
         # ensure that the mask_img_ is a 3D binary image
         tmp = check_niimg(self.mask_img, atleast_4d=True)
+
         mask_data = safe_get_data(tmp, ensure_finite=True)
         mask = mask_data.astype(bool).all(axis=3)
-        mask_img_ = new_img_like(cast(Nifti1Image, self.mask_img), mask)
+        mask_img_ = new_img_like(tmp, mask)
 
         # Just check that the mask is valid
         load_mask_img(mask_img_)
         if imgs is not None:
-            check_compatibility_mask_and_images(self.mask_img, imgs)
+            check_compatibility_mask_and_images(mask_img_, imgs)
 
         return mask_img_
 

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -6,7 +6,7 @@ import json
 import warnings
 from collections.abc import Iterable
 from copy import deepcopy
-from typing import Any, overload
+from typing import Any, cast, overload
 
 import numpy as np
 from joblib import Memory
@@ -477,7 +477,7 @@ class BaseMasker(_BaseMasker):
         tmp = check_niimg(self.mask_img, atleast_4d=True)
         mask_data = safe_get_data(tmp, ensure_finite=True)
         mask = mask_data.astype(bool).all(axis=3)
-        mask_img_ = new_img_like(self.mask_img, mask)
+        mask_img_ = new_img_like(cast(Nifti1Image, self.mask_img), mask)
 
         # Just check that the mask is valid
         load_mask_img(mask_img_)

--- a/nilearn/plotting/image/img_plotting.py
+++ b/nilearn/plotting/image/img_plotting.py
@@ -10,7 +10,7 @@ import functools
 import inspect
 import warnings
 from pathlib import Path
-from typing import cast, overload
+from typing import overload
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -20,7 +20,6 @@ from matplotlib import get_backend
 from matplotlib.colors import LinearSegmentedColormap, Normalize
 from matplotlib.gridspec import GridSpecFromSubplotSpec
 from matplotlib.ticker import MaxNLocator
-from nibabel import Nifti1Image
 
 from nilearn import DEFAULT_DIVERGING_CMAP
 from nilearn._utils import logger
@@ -1211,7 +1210,7 @@ def plot_prob_atlas(
     for map_img, color, thr in zip(
         iter_img(maps_img), color_list, threshold, strict=False
     ):
-        data = get_data(cast(Nifti1Image, map_img))
+        data = get_data(map_img)
         # To threshold or choose the level of the contours
         thr = check_threshold(
             thr, data, percentile_func=fast_abs_percentile, name="threshold"

--- a/nilearn/plotting/image/img_plotting.py
+++ b/nilearn/plotting/image/img_plotting.py
@@ -10,7 +10,7 @@ import functools
 import inspect
 import warnings
 from pathlib import Path
-from typing import overload
+from typing import cast, overload
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -20,6 +20,7 @@ from matplotlib import get_backend
 from matplotlib.colors import LinearSegmentedColormap, Normalize
 from matplotlib.gridspec import GridSpecFromSubplotSpec
 from matplotlib.ticker import MaxNLocator
+from nibabel import Nifti1Image
 
 from nilearn import DEFAULT_DIVERGING_CMAP
 from nilearn._utils import logger
@@ -1210,7 +1211,7 @@ def plot_prob_atlas(
     for map_img, color, thr in zip(
         iter_img(maps_img), color_list, threshold, strict=False
     ):
-        data = get_data(map_img)
+        data = get_data(cast(Nifti1Image, map_img))
         # To threshold or choose the level of the contours
         thr = check_threshold(
             thr, data, percentile_func=fast_abs_percentile, name="threshold"


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
-->

- Related to #6184

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- Add return type annotations to several public functions in `nilearn/image/image.py` that were missing them (`check_niimg_4d`, `concat_imgs`, `copy_img`, `index_img`, `iter_img`, `largest_connected_component_img`, `mean_img`, `new_img_like`, `smooth_img`, `swap_img_hemispheres`).
- `binarize_img`, `check_niimg`, `check_niimg_3d`, `clean_img`, `get_data`, `high_variance_confounds`, `load_img`, `math_img` and `threshold_img` already had return type annotations.
- Annotating `concat_imgs` made mypy check its body and surfaced two pre-existing bugs that are fixed here: mutating a `tuple` in place when converting a list of `SurfaceImage` inputs, and a call to `extract_data()` missing a required argument when looking up the dtype.
- Annotating `iter_img` surfaced an mypy issue in `nilearn/plotting/image/img_plotting.py` (narrowed with `cast`, since the image is forced to `Nifti1Image` before the call) and in a decomposition test that reused a loop variable across incompatible types.
- Added `@overload` signatures for `new_img_like`, `index_img`, `iter_img`, `mean_img`, `concat_imgs`, `largest_connected_component_img` and `smooth_img` so their return type is narrowed precisely (e.g. `SurfaceImage` vs `Nifti1Image`, or single image vs `list`) based on the input type, instead of always exposing the full union.
- This PR generated with the help of an LLM (Claude).