### PR TITLE
[MAINT] Add return type annotations to public functions in nilearn.masking

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -167,6 +167,8 @@ Enhancements
 Changes
 -------
 
+- :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.masking` (:gh:`XXXX` by `Rémi Gau`_).
+
 - :bdg-danger:`Deprecation` The function ``nilearn.datasets.utils.load_sample_motor_activation_image`` and ``nilearn.datasets.fetch_neurovault_motor_task`` were removed. Use :func:`~datasets.load_sample_motor_activation_image` instead (:gh:`5995` by `Rémi Gau`_).
 
 - :bdg-danger:`Deprecation` The private functions ``nilearn._utils.niimg_conversions.check_niimg*`` have been removed, please use their public equivalent :func:`~image.check_niimg`, :func:`~image.check_niimg_3d` and :func:`~image.check_niimg_4d` (:gh:`5995` by `Rémi Gau`_).

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -831,7 +831,7 @@ def compute_multi_brain_mask(
     memory=None,
     verbose=0,
     mask_type="whole-brain",
-):
+) -> Nifti1Image:
     """Compute the whole-brain, grey-matter or white-matter mask \
     for a list of images.
 

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -756,7 +756,7 @@ def compute_brain_mask(
     memory=None,
     verbose=0,
     mask_type="whole-brain",
-):
+) -> Nifti1Image:
     """Compute the whole-brain, grey-matter or white-matter mask.
 
     This mask is calculated using MNI152 1mm-resolution template mask onto the

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -670,7 +670,7 @@ def compute_multi_background_mask(
     n_jobs=1,
     memory=None,
     verbose=0,
-):
+) -> Nifti1Image:
     """Compute a common mask for several runs or subjects of data.
 
     Uses the mask-finding algorithms to extract masks for each run

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -552,7 +552,7 @@ def compute_background_mask(
     target_shape=None,
     memory=None,
     verbose=0,
-):
+) -> Nifti1Image:
     """Compute a brain mask for the images by guessing \
     the value of the background from the border of the image.
 

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -458,7 +458,7 @@ def compute_multi_epi_mask(
     n_jobs=1,
     memory=None,
     verbose=0,
-):
+) -> Nifti1Image:
     """Compute a common mask for several runs or subjects of :term:`fMRI` data.
 
     Uses the mask-finding algorithms to extract masks for each run

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -337,7 +337,7 @@ def compute_epi_mask(
     target_shape=None,
     memory=None,
     verbose=0,
-):
+) -> Nifti1Image:
     """Compute a brain mask from :term:`fMRI` data in 3D or \
     4D :class:`numpy.ndarray`.
 

--- a/nilearn/masking.py
+++ b/nilearn/masking.py
@@ -188,7 +188,7 @@ def extrapolate_out_mask(data, mask, iterations=1):
 # Utilities to compute masks
 #
 @fill_doc
-def intersect_masks(mask_imgs, threshold=0.5, connected=True):
+def intersect_masks(mask_imgs, threshold=0.5, connected=True) -> Nifti1Image:
     """Compute intersection of several masks.
 
     Given a list of input mask images, generate the output image which


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
-->

Related to #6184

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- Add return type annotations (`-> Nifti1Image`) to several public functions in `nilearn/masking.py` that were missing them: `intersect_masks`, `compute_epi_mask`, `compute_multi_epi_mask`, `compute_background_mask`, `compute_multi_background_mask`, `compute_brain_mask`, `compute_multi_brain_mask`.
- `apply_mask` (`-> np.ndarray`) and `unmask` (already overloaded, `Nifti1Image | list[Nifti1Image]`) already had correct return type annotations.
- Verified that the `Returns` docstring section of each of these nine functions matches its annotated return type; no docstring fixes were needed.
- This PR generated with the help of an LLM (Claude).