### PR TITLE
[MAINT] Add type annotations to functions in nilearn.signal and nilearn.surface

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -171,6 +171,8 @@ Enhancements
 Changes
 -------
 
+- :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.signal` (:gh:`XXXX` by `Rémi Gau`_).
+
 - :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.image` (:gh:`6338` by `Rémi Gau`_).
 
 - :bdg-danger:`Deprecation` The function ``nilearn.datasets.utils.load_sample_motor_activation_image`` and ``nilearn.datasets.fetch_neurovault_motor_task`` were removed. Use :func:`~datasets.load_sample_motor_activation_image` instead (:gh:`5995` by `Rémi Gau`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -171,7 +171,7 @@ Enhancements
 Changes
 -------
 
-- :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.signal` (:gh:`XXXX` by `Rémi Gau`_).
+- :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.signal` and :mod:`nilearn.surface` (:gh:`XXXX` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.image` (:gh:`6338` by `Rémi Gau`_).
 

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -27,6 +27,7 @@ import warnings
 from copy import deepcopy
 from pathlib import Path
 from tempfile import TemporaryDirectory, mkdtemp
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -1762,7 +1763,9 @@ def check_img_estimator_pickle(estimator_orig) -> None:
         if isinstance(unpickled_result, np.ndarray):
             assert_allclose_dense_sparse(result[method], unpickled_result)
         elif isinstance(unpickled_result, SurfaceImage):
-            assert_surface_image_equal(result[method], unpickled_result)
+            assert_surface_image_equal(
+                cast(SurfaceImage, result[method]), unpickled_result
+            )
         elif isinstance(unpickled_result, Nifti1Image):
             check_imgs_equal(result[method], unpickled_result)
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -183,13 +183,18 @@ def check_volume_for_fit(imgs) -> None:
             raise ValueError("The image is empty.")
 
 
-def get_data(img: NiimgLike) -> np.ndarray:
+def get_data(img: NiimgLike | SpatialImage) -> np.ndarray:
     """Get the image data as a :class:`numpy.ndarray`.
 
     Parameters
     ----------
     img : Niimg-like object or iterable of Niimg-like objects
         See :ref:`extracting_data`.
+        Besides :class:`~nibabel.nifti1.Nifti1Image`, any other
+        :class:`~nibabel.spatialimages.SpatialImage` subtype accepted
+        by nibabel (e.g. :class:`~nibabel.nifti2.Nifti2Image`,
+        :class:`~nibabel.freesurfer.mghformat.MGHImage`,
+        :class:`~nibabel.analyze.AnalyzeImage`) is also accepted.
 
     Returns
     -------

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -210,6 +210,25 @@ def test_get_data(tmp_path, shape_3d_default):
     assert len(data.shape) == 4
 
 
+@pytest.mark.ai_generated
+@pytest.mark.parametrize(
+    "image_class", [Nifti1Image, Nifti2Image, MGHImage, AnalyzeImage]
+)
+def test_get_data_spatial_image_subtypes(image_class, shape_3d_default):
+    """Check get_data works with any nibabel SpatialImage subtype.
+
+    get_data delegates to check_niimg, which accepts any object
+    that is an instance of nibabel.spatialimages.SpatialImage,
+    not only Nifti1Image.
+    """
+    array = np.random.default_rng(0).random(shape_3d_default).astype("float32")
+    img = image_class(array, affine=np.eye(4))
+
+    data = get_data(img)
+
+    assert_array_equal(data, array)
+
+
 def test_high_variance_confounds(shape_3d_default):
     """Check high_variance_confounds returns proper shape.
 

--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -328,7 +328,7 @@ def butterworth(
     padtype="odd",
     padlen=None,
     copy=False,
-):
+) -> np.ndarray:
     """Apply a low-pass, high-pass or band-pass \
     `Butterworth filter <https://en.wikipedia.org/wiki/Butterworth_filter>`_.
 

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -6,14 +6,14 @@ import pathlib
 import warnings
 from collections.abc import Iterable, Mapping
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
 import sklearn.cluster
 import sklearn.preprocessing
+from nibabel import Nifti1Image, gifti, load, nifti1
 from nibabel import freesurfer as fs
-from nibabel import gifti, load, nifti1
 from scipy import interpolate, sparse
 from scipy.sparse import csr_matrix
 from scipy.sparse.csgraph import connected_components
@@ -908,7 +908,7 @@ def _stringify(word_list):
 
 
 # function to figure out datatype and load data
-def load_surf_data(surf_data):
+def load_surf_data(surf_data) -> np.ndarray:
     """Load data to be represented on a surface mesh.
 
     Parameters
@@ -954,7 +954,9 @@ def load_surf_data(surf_data):
             )
 
             if surf_data.endswith(("nii", "nii.gz", "mgz")):
-                data_part = np.squeeze(get_vol_data(load(surf_data)))
+                data_part = np.squeeze(
+                    get_vol_data(cast(Nifti1Image, load(surf_data)))
+                )
             elif surf_data.endswith(("area", "curv", "sulc", "thickness")):
                 data_part = fs.io.read_morph_data(surf_data)
             elif surf_data.endswith("annot"):

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -620,7 +620,7 @@ def vol_to_surf(
     mask_img=None,
     inner_mesh=None,
     depth=None,
-):
+) -> np.ndarray:
     """Extract surface data from a Nifti image.
 
     .. nilearn_versionadded:: 0.4.0

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -1209,7 +1209,7 @@ def _validate_mesh(mesh) -> None:
 
 
 # function to figure out datatype and load data
-def load_surf_mesh(surf_mesh):
+def load_surf_mesh(surf_mesh) -> "InMemoryMesh":
     """Load a surface :term:`mesh` geometry.
 
     Parameters

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -6,14 +6,15 @@ import pathlib
 import warnings
 from collections.abc import Iterable, Mapping
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 import pandas as pd
 import sklearn.cluster
 import sklearn.preprocessing
-from nibabel import Nifti1Image, gifti, load, nifti1
 from nibabel import freesurfer as fs
+from nibabel import gifti, load, nifti1
+from nibabel.spatialimages import SpatialImage
 from scipy import interpolate, sparse
 from scipy.sparse import csr_matrix
 from scipy.sparse.csgraph import connected_components
@@ -954,9 +955,14 @@ def load_surf_data(surf_data) -> np.ndarray:
             )
 
             if surf_data.endswith(("nii", "nii.gz", "mgz")):
-                data_part = np.squeeze(
-                    get_vol_data(cast(Nifti1Image, load(surf_data)))
-                )
+                loaded_img = load(surf_data)
+                if not isinstance(loaded_img, SpatialImage):
+                    raise TypeError(
+                        "Data given cannot be loaded because it is"
+                        " not compatible with nibabel format:\n"
+                        f"{surf_data!r}"
+                    )
+                data_part = np.squeeze(get_vol_data(loaded_img))
             elif surf_data.endswith(("area", "curv", "sulc", "thickness")):
                 data_part = fs.io.read_morph_data(surf_data)
             elif surf_data.endswith("annot"):

--- a/nilearn/surface/utils.py
+++ b/nilearn/surface/utils.py
@@ -6,9 +6,17 @@ import numpy as np
 
 from nilearn._utils.logger import find_stack_level
 from nilearn.exceptions import MeshDimensionError
+from nilearn.surface.surface import (
+    PolyData,
+    PolyMesh,
+    SurfaceImage,
+    SurfaceMesh,
+)
 
 
-def assert_polydata_close(data_1, data_2, **kwargs) -> None:
+def assert_polydata_close(
+    data_1: PolyData, data_2: PolyData, **kwargs
+) -> None:
     """Check that 2 PolyData data are close."""
     set_1 = set(data_1.parts.keys())
     set_2 = set(data_2.parts.keys())
@@ -25,7 +33,7 @@ def assert_polydata_close(data_1, data_2, **kwargs) -> None:
             )
 
 
-def assert_polydata_equal(data_1, data_2) -> None:
+def assert_polydata_equal(data_1: PolyData, data_2: PolyData) -> None:
     """Check that 2 PolyData data are equal."""
     set_1 = set(data_1.parts.keys())
     set_2 = set(data_2.parts.keys())
@@ -42,14 +50,14 @@ def assert_polydata_equal(data_1, data_2) -> None:
             )
 
 
-def assert_polymesh_equal(mesh_1, mesh_2) -> None:
+def assert_polymesh_equal(mesh_1: PolyMesh, mesh_2: PolyMesh) -> None:
     """Check that 2 PolyMeshes are equal."""
     assert_polymesh_have_same_keys(mesh_1, mesh_2)
     for key in mesh_1.parts:
         assert_surface_mesh_equal(mesh_1.parts[key], mesh_2.parts[key])
 
 
-def assert_polymesh_have_same_keys(mesh_1, mesh_2) -> None:
+def assert_polymesh_have_same_keys(mesh_1: PolyMesh, mesh_2: PolyMesh) -> None:
     """Check that 2 polymeshes have the same keys."""
     set_1 = set(mesh_1.parts.keys())
     set_2 = set(mesh_2.parts.keys())
@@ -60,7 +68,7 @@ def assert_polymesh_have_same_keys(mesh_1, mesh_2) -> None:
         )
 
 
-def check_polymesh_equal(mesh_1, mesh_2) -> None:
+def check_polymesh_equal(mesh_1: PolyMesh, mesh_2: PolyMesh) -> None:
     """Check polymesh at-least have same number of vertices if not equal."""
     try:
         assert_polymesh_equal(mesh_1, mesh_2)
@@ -75,7 +83,9 @@ def check_polymesh_equal(mesh_1, mesh_2) -> None:
         )
 
 
-def assert_same_number_vertices(mesh_1, mesh_2) -> None:
+def assert_same_number_vertices(
+    mesh_1: SurfaceMesh, mesh_2: SurfaceMesh
+) -> None:
     """Assert 2 meshes or polymeshes have the same number of vertices."""
     if mesh_1.n_vertices != mesh_2.n_vertices:
         raise MeshDimensionError(
@@ -84,7 +94,9 @@ def assert_same_number_vertices(mesh_1, mesh_2) -> None:
         )
 
 
-def assert_surface_mesh_equal(mesh_1, mesh_2) -> None:
+def assert_surface_mesh_equal(
+    mesh_1: SurfaceMesh, mesh_2: SurfaceMesh
+) -> None:
     """Check that 2 SurfaceMeshes are equal."""
     if not np.array_equal(mesh_1.coordinates, mesh_2.coordinates):
         raise MeshDimensionError("Meshes do not have the same coordinates.")
@@ -92,13 +104,17 @@ def assert_surface_mesh_equal(mesh_1, mesh_2) -> None:
         raise MeshDimensionError("Meshes do not have the same faces.")
 
 
-def assert_surface_image_equal(img_1, img_2) -> None:
+def assert_surface_image_equal(
+    img_1: SurfaceImage, img_2: SurfaceImage
+) -> None:
     """Check that 2 SurfaceImages are equal."""
     assert_polymesh_equal(img_1.mesh, img_2.mesh)
     assert_polydata_equal(img_1.data, img_2.data)
 
 
-def assert_surface_image_close(img_1, img_2, **kwargs) -> None:
+def assert_surface_image_close(
+    img_1: SurfaceImage, img_2: SurfaceImage, **kwargs
+) -> None:
     """Check that 2 SurfaceImages are close."""
     assert_polymesh_equal(img_1.mesh, img_2.mesh)
     assert_polydata_close(img_1.data, img_2.data, **kwargs)


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
-->

- Related to #3568 

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- `nilearn/signal.py`: Add return type annotation (`-> np.ndarray`) to `butterworth`, which was missing it. `clean` and `high_variance_confounds` already had correct return type annotations.
- `nilearn/surface/surface.py`: Add return type annotations to `vol_to_surf` (`-> np.ndarray`), `load_surf_data` (`-> np.ndarray`), and `load_surf_mesh` (`-> InMemoryMesh`).
- `nilearn/image/image.py`: Widen `get_data`'s parameter type to `NiimgLike | SpatialImage`. `get_data` (via `check_niimg` -> `load_niimg`) already accepts any `nibabel.spatialimages.SpatialImage` subtype at runtime (e.g. `Nifti2Image`, `MGHImage`, `AnalyzeImage`), not only `Nifti1Image` -- the type hint just didn't reflect that. Scoped to `get_data`'s own annotation rather than widening the shared `NiimgLike` alias, since that alias is used at runtime via `isinstance(x, NiimgLike)` / `get_args(NiimgLike)` in ~25 places across the codebase to route between volume and surface handling; widening it globally would change that routing behavior well beyond `get_data`. Added a parametrized test covering `Nifti1Image`, `Nifti2Image`, `MGHImage` and `AnalyzeImage`.
- `nilearn/surface/utils.py`: Add parameter type annotations (`PolyData`, `PolyMesh`, `SurfaceMesh`, `SurfaceImage`) to the mesh/image comparison helpers (`assert_polydata_close`, `assert_polydata_equal`, `assert_polymesh_equal`, `assert_polymesh_have_same_keys`, `check_polymesh_equal`, `assert_same_number_vertices`, `assert_surface_mesh_equal`, `assert_surface_image_equal`, `assert_surface_image_close`). No circular import: `surface.py` never imports from `utils.py`, and `nilearn/surface/__init__.py` always loads `surface.py` first as a side effect of package initialization, so a plain top-level import works. Annotating `assert_surface_image_equal` surfaced a real looseness in `check_img_estimator_pickle` (`nilearn/_utils/estimator_checks.py`), fixed with a `cast`.
- Verified that the `Returns` docstring section of all functions touched matches their annotated return type; updated `get_data`'s docstring to mention the broader set of accepted `SpatialImage` subtypes.
- This PR generated with the help of an LLM (Claude).