### PR TITLE
[ENH] Warn when check_niimg loads a non-Nifti1Image SpatialImage

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -98,6 +98,8 @@ Fixes
 Enhancements
 ------------
 
+- :bdg-dark:`Code` Warn when :func:`~image.check_niimg` (and :func:`~image.check_niimg_3d`, :func:`~image.check_niimg_4d`) load a non-:class:`~nibabel.nifti1.Nifti1Image` :class:`~nibabel.spatialimages.SpatialImage`, as most of Nilearn is only thoroughly tested with :class:`~nibabel.nifti1.Nifti1Image` objects (:gh:`XXXX` by `Rémi Gau`_).
+
 - :bdg-success:`API` Allow the ``mask_img`` parameter to :func:`~glm.first_level.first_level_from_bids` to take the value ``"derivatives"`` to generate a mask from the masks in BIDS derivative to use in the model (:gh:`5981` by `Rémi Gau`_).
 
 - :bdg-success:`API` The parameter ``estimator_args`` was added to all decoding estimators to allow to pass parameters directly to the underlying Scikit-Learn estimators (:gh:`5641` by `Rémi Gau`_).

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -872,6 +872,27 @@ n_perm : :obj:`int`, default=10000
     one gets in the p-values estimation.
 """
 
+non_nifti_image_admonition = """
+
+    .. admonition:: Support for non-Nifti images
+
+        This function accepts and preserves the class
+        of any :class:`nibabel.spatialimages.SpatialImage`
+        (for example :class:`~nibabel.nifti2.Nifti2Image`,
+        :class:`~nibabel.freesurfer.mghformat.MGHImage`,
+        or :class:`~nibabel.analyze.AnalyzeImage`),
+        not only :class:`~nibabel.nifti1.Nifti1Image`.
+
+        However, most of Nilearn is only thoroughly tested with
+        :class:`~nibabel.nifti1.Nifti1Image` objects.
+        Using another :class:`~nibabel.spatialimages.SpatialImage`
+        format may lead to unexpected behavior in downstream functions.
+        See :gh:`3469` for more information.
+
+"""
+
+docdict["non_nifti_image_admonition"] = non_nifti_image_admonition
+
 # opening
 docdict["opening"] = """
 opening : :obj:`bool` or :obj:`int`, optional

--- a/nilearn/_utils/docs.py
+++ b/nilearn/_utils/docs.py
@@ -872,7 +872,7 @@ n_perm : :obj:`int`, default=10000
     one gets in the p-values estimation.
 """
 
-non_nifti_image_admonition = """
+docdict["non_nifti_image_admonition"] = """
 
     .. admonition:: Support for non-Nifti images
 
@@ -890,8 +890,6 @@ non_nifti_image_admonition = """
         See :gh:`3469` for more information.
 
 """
-
-docdict["non_nifti_image_admonition"] = non_nifti_image_admonition
 
 # opening
 docdict["opening"] = """

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -8,6 +8,7 @@ from warnings import warn
 import numpy as np
 from nibabel import Nifti1Image, is_proxy, load, spatialimages
 
+from nilearn._utils.docs import fill_doc
 from nilearn._utils.helpers import stringify_path
 from nilearn._utils.logger import find_stack_level
 from nilearn._utils.numpy_conversions import get_target_dtype
@@ -97,6 +98,7 @@ def ensure_finite_data(
     return data
 
 
+@fill_doc
 def load_niimg(niimg, dtype=None):
     """Load a niimg, check if it is a nibabel SpatialImage and cast if needed.
 
@@ -105,6 +107,8 @@ def load_niimg(niimg, dtype=None):
     niimg : Niimg-like object
         See :ref:`extracting_data`.
         Image to load.
+
+        %(non_nifti_image_admonition)s
 
     %(dtype)s
 
@@ -138,6 +142,19 @@ def load_niimg(niimg, dtype=None):
             )
             if copy_header:
                 niimg.header.set_data_dtype(target_dtype)
+
+    if not isinstance(
+        niimg, Nifti1Image
+    ) and not niimg.__class__.__name__.startswith("_"):
+        warn(
+            f"Loaded image is a {niimg.__class__.__name__}, "
+            "not a Nifti1Image. Most of Nilearn is only thoroughly "
+            "tested with Nifti1Image objects, "
+            "so downstream behavior may be affected. "
+            "See https://github.com/nilearn/nilearn/issues/3469 "
+            "for more information.",
+            stacklevel=find_stack_level(),
+        )
 
     return niimg
 

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -3054,6 +3054,8 @@ def check_niimg(
         and that :func:`nilearn.image.get_data` returns a result,
         raise :obj:`TypeError` otherwise.
 
+        %(non_nifti_image_admonition)s
+
     ensure_ndim : {3, 4, None}, default=None
         Indicate the dimensionality of the expected niimg.
         An error is raised if the niimg is of another dimensionality.
@@ -3204,6 +3206,8 @@ def check_niimg_3d(niimg: Any, dtype: Any = None) -> Nifti1Image:
         :func:`nilearn.image.get_data` returns a result,
         raise :obj:`TypeError` otherwise.
 
+        %(non_nifti_image_admonition)s
+
     %(dtype)s
 
     Returns
@@ -3308,6 +3312,8 @@ def check_niimg_4d(
         If it is an object, check if the affine attribute present
         and that :func:`nilearn.image.get_data` returns a result,
         raise :obj:`TypeError` otherwise.
+
+        %(non_nifti_image_admonition)s
 
     return_iterator : :obj:`bool`, default=False
         If True, an iterator of 3D images is returned.

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -2239,6 +2239,65 @@ def test_check_niimg_bool_error(img_3d_zeros_eye):
         check_niimg(img_3d_zeros_eye, dtype=bool)
 
 
+@pytest.mark.ai_generated
+@pytest.mark.parametrize(
+    "check_function,ndim",
+    [(check_niimg, 3), (check_niimg_3d, 3), (check_niimg_4d, 4)],
+)
+@pytest.mark.parametrize("image_class", [MGHImage, AnalyzeImage])
+def test_check_niimg_non_nifti_warning(
+    check_function,
+    ndim,
+    image_class,
+    shape_3d_default,
+    shape_4d_default,
+    affine_eye,
+):
+    """Check that a warning is raised for non-Nifti images.
+
+    check_niimg, check_niimg_3d and check_niimg_4d accept and preserve any
+    nibabel SpatialImage, but most of Nilearn is only thoroughly tested
+    with Nifti1Image. See gh-3469.
+    """
+    shape = shape_3d_default if ndim == 3 else shape_4d_default
+    array = np.random.default_rng(0).random(shape).astype("f4")
+    img = image_class(array, affine=affine_eye)
+
+    with pytest.warns(UserWarning, match="not a Nifti1Image"):
+        check_function(img)
+
+
+@pytest.mark.ai_generated
+@pytest.mark.parametrize(
+    "check_function,ndim",
+    [(check_niimg, 3), (check_niimg_3d, 3), (check_niimg_4d, 4)],
+)
+@pytest.mark.parametrize("image_class", [Nifti1Image, Nifti2Image])
+def test_check_niimg_no_warning_for_nifti(
+    check_function,
+    ndim,
+    image_class,
+    shape_3d_default,
+    shape_4d_default,
+    affine_eye,
+):
+    """Check that no non-Nifti warning is raised for Nifti1Image \
+       and Nifti2Image.
+
+    Nifti2Image is a subclass of Nifti1Image in nibabel, so it shares the
+    same tested code paths and should not trigger the warning.
+    """
+    shape = shape_3d_default if ndim == 3 else shape_4d_default
+    array = np.random.default_rng(0).random(shape).astype("f4")
+    img = image_class(array, affine=affine_eye)
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        check_function(img)
+
+    assert not any("not a Nifti1Image" in str(w.message) for w in recorded)
+
+
 @pytest.mark.thread_unsafe
 def test_check_niimg_return_iterator_4d_input(
     img_3d_zeros_eye, img_4d_zeros_eye


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
-->

Related to #3469

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- While annotating return types in `nilearn.image.image.check_niimg` (#6184), I found that `check_niimg`/`check_niimg_3d`/`check_niimg_4d` (via `nilearn._utils.niimg.load_niimg`) already accept and preserve any `nibabel.spatialimages.SpatialImage` subtype at runtime, not only `Nifti1Image`. I posted a detailed investigation as a comment on #3469.
- `load_niimg` now emits a `UserWarning` when the loaded image is not a `Nifti1Image`, since most of Nilearn is only thoroughly tested with `Nifti1Image` objects and downstream behavior may be affected otherwise.
  - `Nifti2Image` is exempted: it is a genuine subclass of `Nifti1Image` in nibabel and shares the same tested code path, so it would be a false positive.
  - Internal nilearn sentinel classes (e.g. the lazy `_MNI152Template` used as the default background image in plotting functions) are exempted by leading-underscore class name, since warning about nilearn's own internal plumbing isn't useful to users. This was found via a real test failure (`test_nifti_label_masker_brainsprite`) before being excluded.
- Added a shared `%(non_nifti_image_admonition)s` docstring snippet in `nilearn._utils.docs` (same pattern as the existing `sk_compatible_admonition`), injected into `check_niimg`, `check_niimg_3d`, `check_niimg_4d` and `load_niimg` docstrings.
- Added the missing `@fill_doc` decorator to `load_niimg`, fixing a pre-existing bug where its `%(dtype)s` placeholder was never substituted.
- Added parametrized tests covering `MGHImage`/`AnalyzeImage` (should warn) and `Nifti1Image`/`Nifti2Image` (should not warn) across `check_niimg`, `check_niimg_3d` and `check_niimg_4d`.
- This PR generated with the help of an LLM (Claude).