### PR TITLE
[MAINT] Add return type annotations to connectome and reporting functions

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -61,7 +61,7 @@ Fixes
 
 - :bdg-secondary:`Maint` Allow local installation with ``uv sync`` (:gh:`6024` by `Mathieu Dugré`_)
 
-- :bdg-secondary:`Maint` Add return type annotations and :obj:`~typing.overload` signatures to :func:`~connectome.vec_to_sym_matrix`, :func:`~connectome.group_sparse_covariance`, and :func:`~reporting.get_clusters_table` (:gh:`XXXX` by `Rémi Gau`_).
+- :bdg-secondary:`Maint` Add return type annotations and :obj:`~typing.overload` signatures to :func:`~connectome.vec_to_sym_matrix`, :func:`~connectome.group_sparse_covariance`, and :func:`~reporting.get_clusters_table` (:gh:`6368` by `Rémi Gau`_).
 
 - :bdg-primary:`Doc` Rewrite :class:`~nilearn.decoding.Decoder` :ref:`example <sphx_glr_auto_examples_02_decoding_plot_haxby_grid_search.py>` with incorrect nested cross-validation implementation (:gh:`6059` by `Michelle Wang`_).
 

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -61,6 +61,8 @@ Fixes
 
 - :bdg-secondary:`Maint` Allow local installation with ``uv sync`` (:gh:`6024` by `Mathieu Dugré`_)
 
+- :bdg-secondary:`Maint` Add return type annotations and :obj:`~typing.overload` signatures to :func:`~connectome.vec_to_sym_matrix`, :func:`~connectome.group_sparse_covariance`, and :func:`~reporting.get_clusters_table` (:gh:`XXXX` by `Rémi Gau`_).
+
 - :bdg-primary:`Doc` Rewrite :class:`~nilearn.decoding.Decoder` :ref:`example <sphx_glr_auto_examples_02_decoding_plot_haxby_grid_search.py>` with incorrect nested cross-validation implementation (:gh:`6059` by `Michelle Wang`_).
 
 - :bdg-info:`Plotting` Fix ``nilearn.plotting.view_img`` resampling of non-isotropic images when no background image is used (:gh:`6031` by `Michelle Wang`_).

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -273,7 +273,7 @@ def sym_matrix_to_vec(symmetric, discard_diagonal: bool = False) -> np.ndarray:
     return symmetric[..., tril_mask] / scaling[tril_mask]
 
 
-def vec_to_sym_matrix(vec, diagonal=None):
+def vec_to_sym_matrix(vec, diagonal=None) -> np.ndarray:
     """Return the symmetric matrix given its flattened lower triangular part.
 
     Acts on the last dimension of the array if not 1-dimensional.

--- a/nilearn/connectome/group_sparse_cov.py
+++ b/nilearn/connectome/group_sparse_cov.py
@@ -142,7 +142,7 @@ def group_sparse_covariance(
     probe_function=None,
     precisions_init=None,
     debug=False,
-):
+) -> tuple[np.ndarray, np.ndarray]:
     """Compute sparse precision matrices and covariance matrices.
 
     The precision matrices returned by this function are sparse, and share a

--- a/nilearn/nilearn_typing.py
+++ b/nilearn/nilearn_typing.py
@@ -28,7 +28,8 @@ from numpy import ndarray
 from numpy.typing import DTypeLike
 
 Integer: TypeAlias = int | np.integer
-NonNullScalar: TypeAlias = float | np.floating | Integer
+Float: TypeAlias = float | np.floating
+NonNullScalar: TypeAlias = Float | Integer
 Scalar: TypeAlias = NonNullScalar | None
 
 Annotate: TypeAlias = bool
@@ -72,7 +73,7 @@ HrfModel: TypeAlias = str | Callable | list | None
 HighPass: TypeAlias = Scalar
 KeepMaskedLabels: TypeAlias = bool
 KeepMaskedMaps: TypeAlias = bool
-LowerCutoff: TypeAlias = float | np.floating
+LowerCutoff: TypeAlias = Float
 LowPass: TypeAlias = Scalar
 MemoryLike: TypeAlias = Memory | str | pathlib.Path | None
 MemoryLevel: TypeAlias = Integer
@@ -82,7 +83,7 @@ NiimgLike: TypeAlias = Nifti1Image | str | Path
 Opening: TypeAlias = bool | Integer
 OutputFile: TypeAlias = str | pathlib.Path | None
 Radiological: TypeAlias = bool
-RandomState: TypeAlias = np.floating | Integer | np.random.RandomState | None
+RandomState: TypeAlias = NonNullScalar | np.random.RandomState | None
 ResamplingInterpolation: TypeAlias = Literal["continuous", "nearest"]
 Resolution: TypeAlias = Integer | None
 Resume: TypeAlias = bool
@@ -120,11 +121,11 @@ Threshold: TypeAlias = Scalar | str
 Tfce: TypeAlias = bool
 Title: TypeAlias = str | None
 Tr: TypeAlias = Scalar
-Transparency: TypeAlias = float | np.floating | Integer | NiimgLike | None
+Transparency: TypeAlias = Float | Integer | NiimgLike | None
 TransparencyRange: TypeAlias = list | tuple | None
 TwoSidedTest: TypeAlias = bool
 Url: TypeAlias = str | None
-UpperCutoff: TypeAlias = float | np.floating
+UpperCutoff: TypeAlias = Float
 Verbose: TypeAlias = bool | Integer
 Vmin: TypeAlias = Scalar
 Vmax: TypeAlias = Scalar

--- a/nilearn/reporting/get_clusters_table.py
+++ b/nilearn/reporting/get_clusters_table.py
@@ -370,6 +370,25 @@ def get_clusters_table(
 
         .. nilearn_versionadded:: 0.10.1
 
+    Examples
+    --------
+    >>> from nilearn.datasets import load_sample_motor_activation_image
+    >>> from nilearn.reporting import get_clusters_table
+    >>>
+    >>> img = load_sample_motor_activation_image()
+    >>> table = get_clusters_table(img,
+    ...                            stat_threshold = 4,
+    ...                            cluster_threshold = 20,
+    ...                            two_sided = True,
+    ... )
+    >>> table.head()
+    Cluster   ID     X     Y     Z  Peak Stat Cluster Size (mm3)
+    0          1  42.0 -19.0  19.0   7.941345               7722
+    1         1a  33.0  -7.0  -2.0   7.905312
+    2         1b  42.0  -1.0  13.0   5.470704
+    3          2  39.0 -22.0  58.0   7.941345              36936
+    4         2a   6.0 -10.0  52.0   7.941345
+
     """
     check_params(locals())
 

--- a/nilearn/reporting/get_clusters_table.py
+++ b/nilearn/reporting/get_clusters_table.py
@@ -267,7 +267,9 @@ def get_clusters_table(
     two_sided: bool = False,
     min_distance: NonNullScalar = 8.0,
     return_label_maps: bool = False,
-) -> pd.DataFrame | tuple[pd.DataFrame, list[Nifti1Image | SurfaceImage]]:
+) -> (
+    pd.DataFrame | tuple[pd.DataFrame, list[Nifti1Image] | list[SurfaceImage]]
+):
     """Create pandas dataframe with img cluster statistics.
 
     This function should work on any statistical maps where more extreme values
@@ -412,7 +414,7 @@ def _get_clusters_table_surface(
     two_sided: bool = False,
     return_label_maps: bool = False,
     offset: int = 1,
-) -> pd.DataFrame | tuple[pd.DataFrame, list[Nifti1Image | SurfaceImage]]:
+) -> pd.DataFrame | tuple[pd.DataFrame, list[SurfaceImage]]:
     """Generate cluster table for surface data.
 
     When two_sided is True, this function calls itself recursively
@@ -430,7 +432,7 @@ def _get_clusters_table_surface(
     """
     data = {}
     all_clusters = []
-    label_maps: list[Nifti1Image | SurfaceImage] = []
+    label_maps: list[SurfaceImage] = []
 
     if not two_sided:
         cols = [
@@ -524,7 +526,7 @@ def _get_clusters_table_volume(
     two_sided: bool = False,
     min_distance: NonNullScalar = 8.0,
     return_label_maps: bool = False,
-) -> pd.DataFrame | tuple[pd.DataFrame, list[Nifti1Image | SurfaceImage]]:
+) -> pd.DataFrame | tuple[pd.DataFrame, list[Nifti1Image]]:
     """Generate cluster table for volume data.
 
     For parameters, see `get_clusters_table`.
@@ -534,7 +536,7 @@ def _get_clusters_table_volume(
 
     cols = ["Cluster ID", "X", "Y", "Z", "Peak Stat", "Cluster Size (mm3)"]
 
-    label_maps: list[Nifti1Image | SurfaceImage] = []
+    label_maps: list[Nifti1Image] = []
 
     # check that stat_img is niimg-like object and 3D
     stat_img = check_niimg_3d(stat_img)

--- a/nilearn/reporting/get_clusters_table.py
+++ b/nilearn/reporting/get_clusters_table.py
@@ -5,7 +5,7 @@ import warnings
 from collections import OrderedDict
 from decimal import Decimal
 from string import ascii_lowercase
-from typing import Literal, overload
+from typing import Literal, cast, overload
 
 import numpy as np
 import pandas as pd
@@ -382,7 +382,7 @@ def get_clusters_table(
 
     if is_volume:
         return _get_clusters_table_volume(
-            stat_img,
+            cast(Nifti1Image, stat_img),
             stat_threshold,
             cluster_threshold=cluster_threshold,
             two_sided=two_sided,
@@ -399,7 +399,7 @@ def get_clusters_table(
         )
 
     return _get_clusters_table_surface(
-        stat_img,
+        cast(SurfaceImage, stat_img),
         stat_threshold,
         cluster_threshold=cluster_threshold,
         two_sided=two_sided,
@@ -408,13 +408,13 @@ def get_clusters_table(
 
 
 def _get_clusters_table_surface(
-    stat_img,
-    stat_threshold,
+    stat_img: SurfaceImage,
+    stat_threshold: float | int | np.floating | np.integer,
     cluster_threshold: ClusterThreshold = 0,
     two_sided: bool = False,
     return_label_maps: bool = False,
-    offset=1,
-):
+    offset: int = 1,
+) -> pd.DataFrame | tuple[pd.DataFrame, list[Nifti1Image | SurfaceImage]]:
     """Generate cluster table for surface data.
 
     When two_sided is True, this function calls itself recursively
@@ -432,7 +432,7 @@ def _get_clusters_table_surface(
     """
     data = {}
     all_clusters = []
-    label_maps = []
+    label_maps: list[Nifti1Image | SurfaceImage] = []
 
     if not two_sided:
         cols = [
@@ -492,13 +492,16 @@ def _get_clusters_table_surface(
                 cluster_threshold=cluster_threshold,
                 two_sided=False,
             )
-            clusters, label_map = _get_clusters_table_surface(
-                temp_stat_map,
-                stat_threshold * sign,
-                cluster_threshold=cluster_threshold,
-                two_sided=False,
-                return_label_maps=True,
-                offset=offset,
+            clusters, label_map = cast(
+                tuple[pd.DataFrame, list[SurfaceImage]],
+                _get_clusters_table_surface(
+                    cast(SurfaceImage, temp_stat_map),
+                    stat_threshold * sign,
+                    cluster_threshold=cluster_threshold,
+                    two_sided=False,
+                    return_label_maps=True,
+                    offset=offset,
+                ),
             )
 
             offset += len(clusters)
@@ -517,13 +520,13 @@ def _get_clusters_table_surface(
 
 
 def _get_clusters_table_volume(
-    stat_img,
+    stat_img: Nifti1Image,
     stat_threshold: float | int | np.floating | np.integer,
     cluster_threshold: ClusterThreshold = 0,
     two_sided: bool = False,
     min_distance: float | int | np.floating | np.integer = 8.0,
     return_label_maps: bool = False,
-):
+) -> pd.DataFrame | tuple[pd.DataFrame, list[Nifti1Image | SurfaceImage]]:
     """Generate cluster table for volume data.
 
     For parameters, see `get_clusters_table`.
@@ -533,7 +536,7 @@ def _get_clusters_table_volume(
 
     cols = ["Cluster ID", "X", "Y", "Z", "Peak Stat", "Cluster Size (mm3)"]
 
-    label_maps = []
+    label_maps: list[Nifti1Image | SurfaceImage] = []
 
     # check that stat_img is niimg-like object and 3D
     stat_img = check_niimg_3d(stat_img)

--- a/nilearn/reporting/get_clusters_table.py
+++ b/nilearn/reporting/get_clusters_table.py
@@ -371,8 +371,6 @@ def get_clusters_table(
     """
     check_params(locals())
 
-    is_volume = not isinstance(stat_img, SurfaceImage)
-
     stat_img = threshold_img(
         img=stat_img,
         threshold=stat_threshold,
@@ -380,9 +378,9 @@ def get_clusters_table(
         two_sided=two_sided,
     )
 
-    if is_volume:
+    if not isinstance(stat_img, SurfaceImage):
         return _get_clusters_table_volume(
-            cast(Nifti1Image, stat_img),
+            stat_img,
             stat_threshold,
             cluster_threshold=cluster_threshold,
             two_sided=two_sided,
@@ -399,7 +397,7 @@ def get_clusters_table(
         )
 
     return _get_clusters_table_surface(
-        cast(SurfaceImage, stat_img),
+        stat_img,
         stat_threshold,
         cluster_threshold=cluster_threshold,
         two_sided=two_sided,
@@ -495,7 +493,7 @@ def _get_clusters_table_surface(
             clusters, label_map = cast(
                 tuple[pd.DataFrame, list[SurfaceImage]],
                 _get_clusters_table_surface(
-                    cast(SurfaceImage, temp_stat_map),
+                    temp_stat_map,
                     stat_threshold * sign,
                     cluster_threshold=cluster_threshold,
                     two_sided=False,

--- a/nilearn/reporting/get_clusters_table.py
+++ b/nilearn/reporting/get_clusters_table.py
@@ -8,7 +8,7 @@ from string import ascii_lowercase
 
 import numpy as np
 import pandas as pd
-from nibabel import affines
+from nibabel import Nifti1Image, affines
 from scipy.ndimage import (
     center_of_mass,
     generate_binary_structure,
@@ -222,7 +222,7 @@ def get_clusters_table(
     two_sided: bool = False,
     min_distance: float | int | np.floating | np.integer = 8.0,
     return_label_maps: bool = False,
-):
+) -> pd.DataFrame | tuple[pd.DataFrame, list[Nifti1Image | SurfaceImage]]:
     """Create pandas dataframe with img cluster statistics.
 
     This function should work on any statistical maps where more extreme values

--- a/nilearn/reporting/get_clusters_table.py
+++ b/nilearn/reporting/get_clusters_table.py
@@ -5,6 +5,7 @@ import warnings
 from collections import OrderedDict
 from decimal import Decimal
 from string import ascii_lowercase
+from typing import Literal, overload
 
 import numpy as np
 import pandas as pd
@@ -23,7 +24,7 @@ from nilearn._utils.niimg import safe_get_data
 from nilearn._utils.param_validation import check_params
 from nilearn.image import check_niimg_3d, new_img_like, threshold_img
 from nilearn.image.resampling import coord_transform
-from nilearn.nilearn_typing import ClusterThreshold
+from nilearn.nilearn_typing import ClusterThreshold, NiimgLike
 from nilearn.surface.surface import SurfaceImage, find_surface_clusters
 
 
@@ -214,9 +215,53 @@ def _pare_subpeaks(xyz, ijk, vals, min_distance):
     return ijk, vals
 
 
+@overload
+def get_clusters_table(
+    stat_img: NiimgLike,
+    stat_threshold: float | int | np.floating | np.integer,
+    cluster_threshold: ClusterThreshold = ...,
+    two_sided: bool = ...,
+    min_distance: float | int | np.floating | np.integer = ...,
+    return_label_maps: Literal[False] = ...,
+) -> pd.DataFrame: ...
+
+
+@overload
+def get_clusters_table(
+    stat_img: NiimgLike,
+    stat_threshold: float | int | np.floating | np.integer,
+    cluster_threshold: ClusterThreshold = ...,
+    two_sided: bool = ...,
+    min_distance: float | int | np.floating | np.integer = ...,
+    return_label_maps: Literal[True] = ...,
+) -> tuple[pd.DataFrame, list[Nifti1Image]]: ...
+
+
+@overload
+def get_clusters_table(
+    stat_img: SurfaceImage,
+    stat_threshold: float | int | np.floating | np.integer,
+    cluster_threshold: ClusterThreshold = ...,
+    two_sided: bool = ...,
+    min_distance: float | int | np.floating | np.integer = ...,
+    return_label_maps: Literal[False] = ...,
+) -> pd.DataFrame: ...
+
+
+@overload
+def get_clusters_table(
+    stat_img: SurfaceImage,
+    stat_threshold: float | int | np.floating | np.integer,
+    cluster_threshold: ClusterThreshold = ...,
+    two_sided: bool = ...,
+    min_distance: float | int | np.floating | np.integer = ...,
+    return_label_maps: Literal[True] = ...,
+) -> tuple[pd.DataFrame, list[SurfaceImage]]: ...
+
+
 @fill_doc
 def get_clusters_table(
-    stat_img,
+    stat_img: NiimgLike | SurfaceImage,
     stat_threshold: float | int | np.floating | np.integer,
     cluster_threshold: ClusterThreshold = 0,
     two_sided: bool = False,

--- a/nilearn/reporting/get_clusters_table.py
+++ b/nilearn/reporting/get_clusters_table.py
@@ -24,7 +24,7 @@ from nilearn._utils.niimg import safe_get_data
 from nilearn._utils.param_validation import check_params
 from nilearn.image import check_niimg_3d, new_img_like, threshold_img
 from nilearn.image.resampling import coord_transform
-from nilearn.nilearn_typing import ClusterThreshold, NiimgLike
+from nilearn.nilearn_typing import ClusterThreshold, NiimgLike, NonNullScalar
 from nilearn.surface.surface import SurfaceImage, find_surface_clusters
 
 
@@ -218,10 +218,10 @@ def _pare_subpeaks(xyz, ijk, vals, min_distance):
 @overload
 def get_clusters_table(
     stat_img: NiimgLike,
-    stat_threshold: float | int | np.floating | np.integer,
+    stat_threshold: NonNullScalar,
     cluster_threshold: ClusterThreshold = ...,
     two_sided: bool = ...,
-    min_distance: float | int | np.floating | np.integer = ...,
+    min_distance: NonNullScalar = ...,
     return_label_maps: Literal[False] = ...,
 ) -> pd.DataFrame: ...
 
@@ -229,10 +229,10 @@ def get_clusters_table(
 @overload
 def get_clusters_table(
     stat_img: NiimgLike,
-    stat_threshold: float | int | np.floating | np.integer,
+    stat_threshold: NonNullScalar,
     cluster_threshold: ClusterThreshold = ...,
     two_sided: bool = ...,
-    min_distance: float | int | np.floating | np.integer = ...,
+    min_distance: NonNullScalar = ...,
     return_label_maps: Literal[True] = ...,
 ) -> tuple[pd.DataFrame, list[Nifti1Image]]: ...
 
@@ -240,10 +240,10 @@ def get_clusters_table(
 @overload
 def get_clusters_table(
     stat_img: SurfaceImage,
-    stat_threshold: float | int | np.floating | np.integer,
+    stat_threshold: NonNullScalar,
     cluster_threshold: ClusterThreshold = ...,
     two_sided: bool = ...,
-    min_distance: float | int | np.floating | np.integer = ...,
+    min_distance: NonNullScalar = ...,
     return_label_maps: Literal[False] = ...,
 ) -> pd.DataFrame: ...
 
@@ -251,10 +251,10 @@ def get_clusters_table(
 @overload
 def get_clusters_table(
     stat_img: SurfaceImage,
-    stat_threshold: float | int | np.floating | np.integer,
+    stat_threshold: NonNullScalar,
     cluster_threshold: ClusterThreshold = ...,
     two_sided: bool = ...,
-    min_distance: float | int | np.floating | np.integer = ...,
+    min_distance: NonNullScalar = ...,
     return_label_maps: Literal[True] = ...,
 ) -> tuple[pd.DataFrame, list[SurfaceImage]]: ...
 
@@ -262,10 +262,10 @@ def get_clusters_table(
 @fill_doc
 def get_clusters_table(
     stat_img: NiimgLike | SurfaceImage,
-    stat_threshold: float | int | np.floating | np.integer,
+    stat_threshold: NonNullScalar,
     cluster_threshold: ClusterThreshold = 0,
     two_sided: bool = False,
-    min_distance: float | int | np.floating | np.integer = 8.0,
+    min_distance: NonNullScalar = 8.0,
     return_label_maps: bool = False,
 ) -> pd.DataFrame | tuple[pd.DataFrame, list[Nifti1Image | SurfaceImage]]:
     """Create pandas dataframe with img cluster statistics.
@@ -409,7 +409,7 @@ def get_clusters_table(
 
 def _get_clusters_table_surface(
     stat_img: SurfaceImage,
-    stat_threshold: float | int | np.floating | np.integer,
+    stat_threshold: NonNullScalar,
     cluster_threshold: ClusterThreshold = 0,
     two_sided: bool = False,
     return_label_maps: bool = False,
@@ -521,10 +521,10 @@ def _get_clusters_table_surface(
 
 def _get_clusters_table_volume(
     stat_img: Nifti1Image,
-    stat_threshold: float | int | np.floating | np.integer,
+    stat_threshold: NonNullScalar,
     cluster_threshold: ClusterThreshold = 0,
     two_sided: bool = False,
-    min_distance: float | int | np.floating | np.integer = 8.0,
+    min_distance: NonNullScalar = 8.0,
     return_label_maps: bool = False,
 ) -> pd.DataFrame | tuple[pd.DataFrame, list[Nifti1Image | SurfaceImage]]:
     """Generate cluster table for volume data.


### PR DESCRIPTION
- Relates #6184
- Relates #5824

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- Add `-> np.ndarray` to `vec_to_sym_matrix` in `nilearn/connectome/connectivity_matrices.py`
- Add `-> tuple[np.ndarray, np.ndarray]` to `group_sparse_covariance` in `nilearn/connectome/group_sparse_cov.py`
- Add `-> pd.DataFrame | tuple[pd.DataFrame, list[Nifti1Image | SurfaceImage]]` to `get_clusters_table` in `nilearn/reporting/get_clusters_table.py`
- Add four `@overload` signatures to `get_clusters_table` capturing the `stat_img` type (`NiimgLike` vs `SurfaceImage`) × `return_label_maps` (`Literal[False]` vs `Literal[True]`), so callers get precise label-map element types
- Annotate private helpers `_get_clusters_table_volume` (`stat_img: Nifti1Image`) and `_get_clusters_table_surface` (`stat_img: SurfaceImage`) with full parameter and return types
- Replace all occurrences of the verbose `float | int | np.floating | np.integer` with the `NonNullScalar` alias from `nilearn.nilearn_typing`
- add example section to get_cluster_table

_This pull request was generated with the assistance of Claude (Sonnet 4.6)._