### PR TITLE
[MAINT] Add return type annotations to public functions in nilearn.regions

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -173,6 +173,8 @@ Enhancements
 Changes
 -------
 
+- :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.regions` (:gh:`XXXX` by `Rémi Gau`_).
+
 - :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.signal` and :mod:`nilearn.surface` (:gh:`6353` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.masking` (:gh:`6345` by `Rémi Gau`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -173,7 +173,7 @@ Enhancements
 Changes
 -------
 
-- :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.regions` (:gh:`XXXX` by `Rémi Gau`_).
+- :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.regions` (:gh:`6369` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.signal` and :mod:`nilearn.surface` (:gh:`6353` by `Rémi Gau`_).
 

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -4,6 +4,7 @@ import collections.abc
 import numbers
 import warnings
 from copy import deepcopy
+from typing import overload
 
 import numpy as np
 from nibabel import Nifti1Image
@@ -586,6 +587,24 @@ class RegionExtractor(NiftiMapsMasker):
         super().fit(imgs)
 
         return self
+
+
+@overload
+def connected_label_regions(
+    labels_img,
+    min_size: float | None = ...,
+    connect_diag: bool = ...,
+    labels: None = ...,
+) -> Nifti1Image: ...
+
+
+@overload
+def connected_label_regions(
+    labels_img,
+    min_size: float | None = ...,
+    connect_diag: bool = ...,
+    labels: list[str] | np.ndarray = ...,
+) -> tuple[Nifti1Image, list[str]]: ...
 
 
 def connected_label_regions(

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -654,9 +654,10 @@ def connected_label_regions(
     new_labels_img : :class:`nibabel.nifti1.Nifti1Image`
         A new image comprising of regions extracted on an input labels_img.
 
-    new_labels : :obj:`list`, optional
-        If labels are provided, new labels assigned to region extracted will
-        be returned. Otherwise, only new labels image will be returned.
+    new_labels : :obj:`list` of :obj:`str`
+        If ``labels`` are provided,
+        new labels assigned to region extracted will be returned.
+        Otherwise, only ``new_labels_img`` will be returned.
 
     See Also
     --------

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -6,6 +6,7 @@ import warnings
 from copy import deepcopy
 
 import numpy as np
+from nibabel import Nifti1Image
 from scipy.ndimage import label
 from scipy.stats import scoreatpercentile
 
@@ -147,7 +148,7 @@ def connected_regions(
     extract_type="local_regions",
     smoothing_fwhm=6,
     mask_img=None,
-):
+) -> tuple[Nifti1Image, list[int]] | tuple[None, None]:
     """Extract brain connected regions into separate regions.
 
     .. note::
@@ -589,7 +590,7 @@ class RegionExtractor(NiftiMapsMasker):
 
 def connected_label_regions(
     labels_img, min_size=None, connect_diag=True, labels=None
-):
+) -> Nifti1Image | tuple[Nifti1Image, list[str]]:
     """Extract connected regions from a brain atlas image \
     defined by labels (integers).
 

--- a/nilearn/regions/region_extractor.py
+++ b/nilearn/regions/region_extractor.py
@@ -187,13 +187,15 @@ def connected_regions(
 
     Returns
     -------
-    regions_extracted_img : :class:`nibabel.nifti1.Nifti1Image`
+    regions_extracted_img : :class:`nibabel.nifti1.Nifti1Image` or None
         Gives the image in 4D of extracted brain regions.
         Each 3D image consists of only one separated region.
+        Returns None if no supra-threshold regions are found.
 
-    index_of_each_map : :class:`numpy.ndarray`
-        An array of list of indices where each index denotes the identity
+    index_of_each_map : :obj:`list` of :obj:`int` or None
+        List of indices where each index denotes the identity
         of each extracted region to their family of brain maps.
+        Returns None if no supra-threshold regions are found.
 
     See Also
     --------

--- a/nilearn/regions/rena_clustering.py
+++ b/nilearn/regions/rena_clustering.py
@@ -530,7 +530,7 @@ def _nearest_neighbor_grouping(X, connectivity, n_clusters, threshold=1e-7):
 @fill_doc
 def recursive_neighbor_agglomeration(
     X, mask_img, n_clusters, n_iter=10, threshold=1e-7, verbose=0
-):
+) -> tuple[int, np.ndarray]:
     """Recursive neighbor agglomeration (:term:`ReNA`).
 
     It performs iteratively the nearest neighbor grouping.

--- a/nilearn/regions/signal_extraction.py
+++ b/nilearn/regions/signal_extraction.py
@@ -324,8 +324,9 @@ def img_to_signals_labels(
         Corresponding labels for each signal. signal[:, n] was extracted from
         the region with label labels[n].
 
-    masked_atlas : Niimg-like object
+    masked_atlas : :class:`nibabel.nifti1.Nifti1Image`
         Regions definition as labels after applying the mask.
+        Only returned when ``return_masked_atlas=True``.
 
     See Also
     --------
@@ -541,7 +542,7 @@ def img_to_signals_maps(
         Signals extracted from each region.
         Shape is: (scans number, number of regions intersecting mask)
 
-    labels : :obj:`list`
+    labels : :obj:`list` of :obj:`int`
         maps_img[..., labels[n]] is the region that has been used to extract
         signal region_signals[:, n].
 

--- a/nilearn/regions/signal_extraction.py
+++ b/nilearn/regions/signal_extraction.py
@@ -235,7 +235,7 @@ def img_to_signals_labels(
     keep_masked_labels=False,
     return_masked_atlas=True,
     n_jobs=1,
-):
+) -> tuple[np.ndarray, list] | tuple[np.ndarray, list, Nifti1Image]:
     """Extract region signals from image.
 
     This function is applicable to regions defined by labels.
@@ -364,7 +364,7 @@ def img_to_signals_labels(
 
 def signals_to_img_labels(
     signals, labels_img, mask_img=None, background_label=0, order="F"
-):
+) -> Nifti1Image:
     """Create image from region signals defined as labels.
 
     The same region signal is used for each :term:`voxel` of the
@@ -481,7 +481,9 @@ def signals_to_img_labels(
 
 
 @fill_doc
-def img_to_signals_maps(imgs, maps_img, mask_img=None, keep_masked_maps=False):
+def img_to_signals_maps(
+    imgs, maps_img, mask_img=None, keep_masked_maps=False
+) -> tuple[np.ndarray, list[int]]:
     """Extract region signals from image.
 
     This function is applicable to regions defined by maps.
@@ -584,7 +586,9 @@ def img_to_signals_maps(imgs, maps_img, mask_img=None, keep_masked_maps=False):
     return region_signals, list(maps)
 
 
-def signals_to_img_maps(region_signals, maps_img, mask_img=None):
+def signals_to_img_maps(
+    region_signals, maps_img, mask_img=None
+) -> Nifti1Image:
     """Create image from region signals defined as maps.
 
     region_signals, mask_img must have the same shapes and affines.

--- a/nilearn/regions/signal_extraction.py
+++ b/nilearn/regions/signal_extraction.py
@@ -7,6 +7,7 @@ or as weights in one image per region (maps).
 
 import warnings
 from functools import partial
+from typing import Literal, overload
 
 import numpy as np
 from joblib import Parallel, delayed
@@ -224,6 +225,34 @@ def _get_labels_data(
 
 
 # FIXME: naming scheme is not really satisfying. Any better idea appreciated.
+@overload
+def img_to_signals_labels(
+    imgs,
+    labels_img,
+    mask_img=...,
+    background_label=...,
+    order=...,
+    strategy=...,
+    keep_masked_labels=...,
+    return_masked_atlas: Literal[True] = ...,
+    n_jobs=...,
+) -> tuple[np.ndarray, list, Nifti1Image]: ...
+
+
+@overload
+def img_to_signals_labels(
+    imgs,
+    labels_img,
+    mask_img=...,
+    background_label=...,
+    order=...,
+    strategy=...,
+    keep_masked_labels=...,
+    return_masked_atlas: Literal[False] = ...,
+    n_jobs=...,
+) -> tuple[np.ndarray, list]: ...
+
+
 @fill_doc
 def img_to_signals_labels(
     imgs,

--- a/nilearn/regions/signal_extraction.py
+++ b/nilearn/regions/signal_extraction.py
@@ -433,7 +433,7 @@ def signals_to_img_labels(
     -------
     img : :class:`nibabel.nifti1.Nifti1Image`
         Reconstructed image. dtype is that of "signals", affine and shape are
-        those of labels_img.
+        those of ``labels_img``.
 
     See Also
     --------
@@ -645,7 +645,7 @@ def signals_to_img_maps(
     Returns
     -------
     img : :class:`nibabel.nifti1.Nifti1Image`
-        Reconstructed image. affine and shape are those of maps_img.
+        Reconstructed image. Affine and shape are those of ``maps_img``.
 
     See Also
     --------


### PR DESCRIPTION
- Closes #6184

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- Add `-> tuple[int, np.ndarray]` to `recursive_neighbor_agglomeration` in `nilearn/regions/rena_clustering.py`
- Add `-> tuple[Nifti1Image, list[int]] | tuple[None, None]` to `connected_regions` in `nilearn/regions/region_extractor.py`
- Add `-> Nifti1Image | tuple[Nifti1Image, list[str]]` to `connected_label_regions` in `nilearn/regions/region_extractor.py`
- Add `-> tuple[np.ndarray, list] | tuple[np.ndarray, list, Nifti1Image]` to `img_to_signals_labels` in `nilearn/regions/signal_extraction.py`
- Add `-> Nifti1Image` to `signals_to_img_labels` in `nilearn/regions/signal_extraction.py`
- Add `-> tuple[np.ndarray, list[int]]` to `img_to_signals_maps` in `nilearn/regions/signal_extraction.py`
- Add `-> Nifti1Image` to `signals_to_img_maps` in `nilearn/regions/signal_extraction.py`