### PR TITLE
[FIX] Rollback jlite configuration for Py3.10

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -96,21 +96,21 @@ autodoc_default_options = {
     "member-order": "bysource",
 }
 
-try:
-    import jupyterlite_sphinx  # noqa: F401
+# try:
+#     import jupyterlite_sphinx
 
-    extensions.append("jupyterlite_sphinx")
-    with_jupyterlite = True
-except ImportError:
-    # In some cases we don't want to require jupyterlite_sphinx
-    # to be installed,
-    # e.g. the doc-min-dependencies build
-    warnings.warn(
-        "jupyterlite_sphinx is not installed, you need to install it "
-        "if you want JupyterLite links to appear in the API documentation",
-        stacklevel=2,
-    )
-    with_jupyterlite = False
+#     extensions.append("jupyterlite_sphinx")
+#     with_jupyterlite = True
+# except ImportError:
+#     # In some cases we don't want to require jupyterlite_sphinx
+#     # to be installed,
+#     # e.g. the doc-min-dependencies build
+#     warnings.warn(
+#         "jupyterlite_sphinx is not installed, you need to install it "
+#         "if you want JupyterLite links to appear in the API documentation",
+#         stacklevel=2,
+#     )
+#     with_jupyterlite = False
 
 
 # Get rid of spurious warnings due to some interaction between
@@ -502,35 +502,34 @@ sphinx_gallery_conf = {
     },
     "default_thumb_file": "logos/nilearn-desaturate-100.png",
     "within_subsection_order": "ExampleTitleSortKey",
-    # Disallow jupyterlite for examples in gallery
-    # as most of them requires loading too much data in the browser
-    "jupyterlite": None,
+    # # Disallow jupyterlite for examples in gallery
+    # # as most of them requires loading too much data in the browser
+    # "jupyterlite": None,
 }
 
 
-if with_jupyterlite:
-    global_enable_try_examples = True
-    jupyterlite_bind_ipynb_suffix = False
-    try_examples_global_button_text = "Try it in your browser!"
-    try_examples_global_warning_text = (
-        "Running the nilearn examples in JupyterLite is experimental"
-        " and you may encounter some unexpected behavior.\n\n"
-        " The main difference is that imports will take a lot longer"
-        " than usual, for example the first `import nilearn` can take"
-        " roughly 10-20s.\n\nIf you notice problems, feel free to open"
-        " an [issue](https://github.com/nilearn/nilearn/issues/new/choose) "
-        "about it."
-    )
-    # Work around https://github.com/jupyterlite/pyodide-kernel/issues/166
-    # and https://github.com/pyodide/micropip/issues/223 by installing the
-    # dependencies first, and then nilearn from Anaconda.org.
-    try_examples_preamble = """
-# Jupyterlite specific code
-import matplotlib
-import pandas
-await piplite.install(scikit-learn==1.8.0, index_urls='https://pypi.anaconda.org/scientific-python-nightly-wheels/simple')",
-%pip install -q nilearn
-"""
+# if with_jupyterlite:
+#     global_enable_try_examples = True
+#     jupyterlite_bind_ipynb_suffix = False
+#     try_examples_global_button_text = "Try it in your browser!"
+#     try_examples_global_warning_text = (
+#         "Running the nilearn examples in JupyterLite is experimental"
+#         " and you may encounter some unexpected behavior.\n\n"
+#         " The main difference is that imports will take a lot longer"
+#         " than usual, for example the first `import nilearn` can take"
+#         " roughly 10-20s.\n\nIf you notice problems, feel free to open"
+#         " an [issue](https://github.com/nilearn/nilearn/issues/new/choose) "
+#         "about it."
+#     )
+#     # Work around https://github.com/jupyterlite/pyodide-kernel/issues/166
+#     # and https://github.com/pyodide/micropip/issues/223 by installing the
+#     # dependencies first, and then nilearn from Anaconda.org.
+#     try_examples_preamble = """
+#     # Jupyterlite specific code
+#     import matplotlib
+#     import pandas
+#     %pip install -q nilearn
+#     """
 
 mermaid_version = "11.4.0"
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -528,6 +528,7 @@ if with_jupyterlite:
 # Jupyterlite specific code
 import matplotlib
 import pandas
+await piplite.install(scikit-learn==1.8.0, index_urls='https://pypi.anaconda.org/scientific-python-nightly-wheels/simple')",
 %pip install -q nilearn
 """
 

--- a/doc/jupyter-lite.json
+++ b/doc/jupyter-lite.json
@@ -3,7 +3,7 @@
   "jupyter-config-data": {
     "litePluginSettings": {
       "@jupyterlite/pyodide-kernel-extension:kernel": {
-        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v314.0.2/full/pyodide.js"
+        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.29.4/full/pyodide.js"
       }
     }
   }

--- a/doc/jupyter-lite.json
+++ b/doc/jupyter-lite.json
@@ -3,7 +3,7 @@
   "jupyter-config-data": {
     "litePluginSettings": {
       "@jupyterlite/pyodide-kernel-extension:kernel": {
-        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.29.4/full/pyodide.js"
+        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v314.0.2/full/pyodide.js"
       }
     }
   }


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this pull request.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the pull request closes multiple issues, includes "closes" before each one is listed.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->
- Relates to #6390 

<!-- Please indicate whether LLM tools were used for this pull request
by adding a 'x' in one of the following check box.
Work made with LLM tools has a very different set of typical failure modes
than work done entirely by humans,
it helps others to better trace eventual issues when reviewing the code.
-->
Use of AI tools:
- [ ] LLM tools were used to generate at least part of the content of this pull-request.
- [x] No LLM tools were used to generate any part of the content of this pull-request.

<!-- Please give a brief overview of what has changed in the pull request.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- ~Bumps pyodide from version 0.29.4 to version 314.0.2~
- ~Newer version should include wheel for sklearn 1.8~
- ~Grab sklearn 1.8.0 wheel from conda for jlite config~
- Comment out jlite configuation while we still support Python 3.10
