### PR TITLE
[MAINT] remove slow marker for tests that are not slow anymore

### DIFF
--- a/nilearn/connectome/tests/test_connectivity_matrices.py
+++ b/nilearn/connectome/tests/test_connectivity_matrices.py
@@ -91,7 +91,6 @@ else:
         check(estimator)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize(
     "estimator, check, name",
     nilearn_check_estimator(estimators=ESTIMATORS_TO_CHECK),

--- a/nilearn/connectome/tests/test_group_sparse_cov.py
+++ b/nilearn/connectome/tests/test_group_sparse_cov.py
@@ -52,7 +52,6 @@ else:
         check(estimator)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize(
     "estimator, check, name",
     nilearn_check_estimator(estimators=ESTIMATORS_TO_CHECK),

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -734,7 +734,6 @@ def _get_small_fake_talairach():
     return serialize_niimg(img, gzipped=False)
 
 
-@pytest.mark.slow
 def test_fetch_atlas_talairach(tmp_path, request_mocker, capsys):
     request_mocker.url_mapping["*talairach.nii"] = _get_small_fake_talairach()
     level_values = np.ones((81, 3)) * [0, 1, 2]

--- a/nilearn/decomposition/tests/test_base.py
+++ b/nilearn/decomposition/tests/test_base.py
@@ -40,7 +40,6 @@ def test_fast_svd(n_features):
     )
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 @pytest.mark.parametrize(

--- a/nilearn/decomposition/tests/test_canica.py
+++ b/nilearn/decomposition/tests/test_canica.py
@@ -29,7 +29,6 @@ def test_threshold_bound_error(canica_data_single_img):
         canica.fit(canica_data_single_img)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 def test_percentile_range(rng, canica_data_single_img):
     """Test that a warning is given when thresholds are stressed."""
@@ -88,7 +87,6 @@ def test_canica_square_img(
     assert_array_almost_equal(K_abs, 0, 1)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 def test_component_sign(canica_data, data_type):
     """Check sign of extracted components.

--- a/nilearn/decomposition/tests/test_decomposition_estimators.py
+++ b/nilearn/decomposition/tests/test_decomposition_estimators.py
@@ -55,7 +55,6 @@ else:
         check(estimator)
 
 
-@pytest.mark.slow
 @pytest.mark.flaky(reruns=10, reruns_delay=1)
 @pytest.mark.parametrize(
     "estimator, check, name",
@@ -66,7 +65,6 @@ def test_check_estimator_nilearn(estimator, check, name):  # noqa: ARG001
     check(estimator)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("estimator", [CanICA, DictLearning])
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 def test_fit_errors(
@@ -125,7 +123,6 @@ def test_fit_errors(
         est.fit(decomposition_images, confounds=confounds)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("estimator", [CanICA, DictLearning])
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 def test_masker_attributes_with_fit_mask(
@@ -147,7 +144,6 @@ def test_masker_attributes_with_fit_mask(
     check_decomposition_estimator(est, data_type)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("estimator", [CanICA, DictLearning])
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 def test_masker_attributes_with_fit_masker(
@@ -171,7 +167,6 @@ def test_masker_attributes_with_fit_masker(
     check_decomposition_estimator(est, data_type)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("estimator", [CanICA, DictLearning])
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 def test_transform_confounds(
@@ -208,7 +203,8 @@ def test_transform_confounds(
 
 # TODO passing confounds does not affect output with CanICA, DictLearning
 # @pytest.mark.parametrize("estimator", [CanICA, _MultiPCA, DictLearning])
-@pytest.mark.slow
+
+
 @pytest.mark.parametrize("estimator", [_MultiPCA])
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 def test_with_confounds(
@@ -246,7 +242,6 @@ def test_with_confounds(
     )
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("estimator", [CanICA, DictLearning])
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 @pytest.mark.parametrize("single_subject", [True, False])
@@ -293,7 +288,6 @@ def test_transform(
     est.inverse_transform(signals)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("estimator", [CanICA, DictLearning])
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 def test_transform_errors(
@@ -321,7 +315,6 @@ def test_transform_errors(
         est.transform(canica_data, confounds=confounds)
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 @pytest.mark.parametrize("estimator", [CanICA, DictLearning])
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
@@ -357,7 +350,6 @@ def test_pass_masker_arg_to_estimator(
     check_decomposition_estimator(est, data_type)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("estimator", [CanICA, DictLearning])
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 def test_single_subject_score(canica_img, data_type, estimator):
@@ -392,7 +384,6 @@ def test_single_subject_score(canica_img, data_type, estimator):
     assert np.all(scores >= 0)
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 @pytest.mark.parametrize("estimator", [CanICA, DictLearning])
 @pytest.mark.parametrize("data_type", ["nifti"])
@@ -434,7 +425,6 @@ def test_single_subject_file(data_type, canica_img, estimator, tmp_path):
     est.transform(tmp_file)
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 @pytest.mark.parametrize("estimator", [CanICA, DictLearning])
 @pytest.mark.parametrize("data_type", ["nifti"])

--- a/nilearn/decomposition/tests/test_dict_learning.py
+++ b/nilearn/decomposition/tests/test_dict_learning.py
@@ -14,7 +14,6 @@ from nilearn.maskers import NiftiMasker, SurfaceMasker
 from nilearn.surface.surface import get_data as get_surface_data
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 @pytest.mark.parametrize("n_epochs", [1, 2, 10])
 def test_check_values_epoch_argument_smoke(
@@ -46,7 +45,6 @@ def test_check_values_epoch_argument_smoke(
     check_decomposition_estimator(dict_learning, data_type)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("data_type", ["nifti"])
 def test_dict_learning(
     decomposition_mask_img, canica_components, canica_data, data_type
@@ -108,7 +106,6 @@ def test_dict_learning(
         assert recovered_maps >= 2
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 def test_component_sign(
     decomposition_mask_img, canica_data, data_type

--- a/nilearn/decomposition/tests/test_multi_pca.py
+++ b/nilearn/decomposition/tests/test_multi_pca.py
@@ -16,7 +16,6 @@ from nilearn.decomposition.tests.conftest import (
 from nilearn.maskers import NiftiMasker, SurfaceMasker
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 @pytest.mark.parametrize("length", [1, 2])
 def test_multi_pca(
@@ -55,7 +54,6 @@ def test_multi_pca(
         assert_array_almost_equal(components1, components2)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 def test_multi_pca_with_masker_without_cca_smoke(
     data_type,
@@ -79,7 +77,6 @@ def test_multi_pca_with_masker_without_cca_smoke(
     multi_pca.inverse_transform(multi_pca.transform(decomposition_images[-2:]))
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("with_activation", [False])
 @pytest.mark.parametrize("data_type", ["nifti", "surface"])
 def test_multi_pca_score_single_subject_n_components(

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -677,7 +677,6 @@ def test_crop_image_empty_image(affine_eye, pad):
 
 
 @pytest.mark.thread_unsafe
-@pytest.mark.slow
 @pytest.mark.parametrize("images_to_mean", _images_to_mean())
 def test_mean_img(images_to_mean, tmp_path):
     affine = np.diag((4, 3, 2, 1))
@@ -932,7 +931,6 @@ def test_iter_img_3d_imag_error(affine_eye):
         iter_img(img_3d)
 
 
-@pytest.mark.slow
 def test_iter_img(tmp_path):
     img_4d, _ = generate_fake_fmri(affine=NON_EYE_AFFINE)
 
@@ -1261,7 +1259,6 @@ def test_validity_negative_threshold_value_in_threshold_img(shape_3d_default):
 
 
 @pytest.mark.thread_unsafe
-@pytest.mark.slow
 def test_threshold_img(affine_eye):
     """Smoke test for threshold_img with valid threshold inputs."""
     shape = (10, 20, 30)

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
@@ -123,7 +123,6 @@ def _regression(confounds, tmp_path):
     assert tseries_clean.shape[0] == confounds.shape[0]
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("fmriprep_version", ["1.4.x", "21.x.x"])
 @pytest.mark.filterwarnings("ignore")
 @pytest.mark.parametrize(
@@ -208,7 +207,6 @@ def _corr_tseries(tseries1, tseries2):
     return corr
 
 
-@pytest.mark.slow
 @pytest.mark.filterwarnings("ignore")
 def test_nilearn_standardize_false(tmp_path):
     """Test removing confounds with no standardization."""
@@ -247,7 +245,6 @@ def test_nilearn_standardize_false(tmp_path):
     assert np.mean(tseries_std > 0.9)
 
 
-@pytest.mark.slow
 @pytest.mark.filterwarnings("ignore")
 @pytest.mark.parametrize("standardize_signal", ["zscore_sample", "psc"])
 @pytest.mark.parametrize(

--- a/nilearn/interfaces/tests/test_glm.py
+++ b/nilearn/interfaces/tests/test_glm.py
@@ -6,7 +6,6 @@ from nilearn.glm.first_level import FirstLevelModel
 from nilearn.interfaces.bids import save_glm_to_bids
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 def test_deprecation_save_glm_to_bids(tmp_path):
     """Check deprecation about moved function."""

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -222,7 +222,6 @@ def check_ktest_p_values_distribution_and_mse(all_kstest_pvals, all_mse):
     assert_array_less(np.diff(all_mse.mean(1)), 0)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("model_intercept", [True, False])
 def test_permuted_ols_check_h0_noeffect_labelswap_centered(model_intercept):
     """Check distributions of permutations when tested vars are centered."""
@@ -240,7 +239,6 @@ def test_permuted_ols_check_h0_noeffect_labelswap_centered(model_intercept):
     check_ktest_p_values_distribution_and_mse(all_kstest_pvals, all_mse)
 
 
-@pytest.mark.slow
 def test_permuted_ols_check_h0_noeffect_labelswap_uncentered():
     """Check distributions of permutations when tested vars are uncentered."""
     # create dummy design with no effect
@@ -256,7 +254,6 @@ def test_permuted_ols_check_h0_noeffect_labelswap_uncentered():
     check_ktest_p_values_distribution_and_mse(all_kstest_pvals, all_mse)
 
 
-@pytest.mark.slow
 def test_permuted_ols_check_h0_noeffect_signswap():
     """Check that h0 is close to the theoretical distribution \
     for permuted OLS with sign swap.
@@ -634,7 +631,6 @@ def test_two_sided_recover_positive_and_negative_effects():
     )
 
 
-@pytest.mark.slow
 def test_tfce_smoke_legacy_smoke():
     """Check tfce output of dict with or without permutations."""
     (
@@ -693,7 +689,6 @@ def test_tfce_smoke_legacy_smoke():
     assert out["h0_max_tfce"].size == n_perm
 
 
-@pytest.mark.slow
 def test_cluster_level_parameters_smoke(cluster_level_design, masker):
     """Test combinations of parameters related to cluster-level inference."""
     target_var, tested_var = cluster_level_design

--- a/nilearn/plotting/displays/tests/test_displays.py
+++ b/nilearn/plotting/displays/tests/test_displays.py
@@ -339,7 +339,6 @@ def test_user_given_cmap_with_colorbar(mni152_template_res_2):
     oslicer.close()
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("display", [OrthoSlicer, LYRZProjector])
 def test_data_complete_mask(affine_eye, display):
     """Test for a special case due to matplotlib 2.1.0.
@@ -485,7 +484,6 @@ def test_display_slicers_transparency_warning(
     display.title(f"display mode is {name}")
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("transparency", [None, 0, 0.5, 1])
 @pytest.mark.parametrize(
     "display,name", zip(PROJECTORS, PROJECTOR_KEYS, strict=False)

--- a/nilearn/plotting/image/tests/test_img_plotting.py
+++ b/nilearn/plotting/image/tests/test_img_plotting.py
@@ -117,7 +117,6 @@ def test_plot_functions_same_cut(display_mode, img_3d_rand_eye, tmp_path):
         plt.close()
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 @pytest.mark.parametrize("plot_func", [plot_stat_map, plot_glass_brain])
 def test_plot_threshold_for_uint8(affine_eye, plot_func):
@@ -185,7 +184,6 @@ def test_plot_with_nans(plot_func, img_3d_mni):
 
 
 @pytest.mark.thread_unsafe
-@pytest.mark.slow
 @pytest.mark.parametrize(
     "plot_func", [plot_roi, plot_stat_map, plot_glass_brain]
 )
@@ -220,7 +218,6 @@ def test_plotting_functions_with_display_mode_tiled(plot_func, img_3d_mni):
 
 
 @pytest.mark.thread_unsafe
-@pytest.mark.slow
 @pytest.mark.parametrize("plot_func", [plot_stat_map, plot_img])
 @pytest.mark.parametrize(
     "threshold, expected_ticks",
@@ -282,7 +279,6 @@ def test_plot_asymmetric_colorbar_threshold(
     plt.close()
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 @pytest.mark.parametrize("plot_func", [plot_stat_map, plot_img])
 @pytest.mark.parametrize("vmax", [None, 0])

--- a/nilearn/plotting/image/tests/test_plot_carpet.py
+++ b/nilearn/plotting/image/tests/test_plot_carpet.py
@@ -86,7 +86,6 @@ def test_plot_carpet_with_atlas(matplotlib_pyplot, img_4d_mni, img_atlas):
 
 
 @pytest.mark.thread_unsafe
-@pytest.mark.slow
 def test_plot_carpet_with_atlas_and_labels(
     matplotlib_pyplot, img_4d_mni, img_atlas
 ):

--- a/nilearn/plotting/image/tests/test_plot_glass_brain.py
+++ b/nilearn/plotting/image/tests/test_plot_glass_brain.py
@@ -123,7 +123,6 @@ def test_plot_glass_brain_display_modes_without_img(
     plot_glass_brain(None, display_mode=display_mode)
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 @pytest.mark.parametrize("display_mode", ["lr", "lzry"])
 def test_plot_glass_brain_with_completely_masked_img(

--- a/nilearn/plotting/image/tests/test_plot_img.py
+++ b/nilearn/plotting/image/tests/test_plot_img.py
@@ -33,7 +33,6 @@ def _testdata_3d_for_plotting_for_resampling(img, binary):
     return Nifti1Image(data, affine)
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 @pytest.mark.skipif(not is_gil_enabled(), reason="fails without GIL")
 def test_display_methods(matplotlib_pyplot, img_3d_mni):
@@ -106,7 +105,6 @@ def test_plot_img_with_resampling(matplotlib_pyplot, binary_img, img_3d_mni):
     display.add_edges(img, color="c")
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 @pytest.mark.skipif(not is_gil_enabled(), reason="fails without GIL")
 def test_display_methods_with_display_mode_tiled(

--- a/nilearn/plotting/image/tests/test_plot_prob_atlas.py
+++ b/nilearn/plotting/image/tests/test_plot_prob_atlas.py
@@ -7,7 +7,6 @@ import pytest
 from nilearn.plotting import plot_prob_atlas
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 @pytest.mark.parametrize(
     "params",
@@ -38,7 +37,6 @@ def test_plot_prob_atlas(
         plot_prob_atlas(img_maps, colorbar=colorbar, **params)
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 def test_plot_prob_atlas_radiological_view(matplotlib_pyplot, img_4d_rand_eye):
     """Smoke test for radiological view."""

--- a/nilearn/plotting/image/tests/test_plot_roi.py
+++ b/nilearn/plotting/image/tests/test_plot_roi.py
@@ -31,7 +31,6 @@ def demo_plot_roi(**kwargs):
     plot_roi(img, title="Broca's area", **kwargs)
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 @pytest.mark.parametrize("view_type", ["contours", "continuous"])
 @pytest.mark.parametrize("threshold", [0.5, 0.2])
@@ -65,7 +64,6 @@ def test_plot_roi_view_types(
     )
 
 
-@pytest.mark.slow
 def test_plot_roi_no_int_64_warning(matplotlib_pyplot, recwarn):
     """Make sure that no int64 warning is thrown."""
     demo_plot_roi()
@@ -82,7 +80,6 @@ def test_plot_roi_view_type_error(matplotlib_pyplot):
 
 
 @pytest.mark.thread_unsafe
-@pytest.mark.slow
 def test_demo_plot_roi_output_file(matplotlib_pyplot, tmp_path):
     """Tests plot_roi file saving capabilities."""
     filename = tmp_path / "test.png"
@@ -91,7 +88,6 @@ def test_demo_plot_roi_output_file(matplotlib_pyplot, tmp_path):
 
 
 @pytest.mark.thread_unsafe
-@pytest.mark.slow
 def test_cmap_with_one_level(matplotlib_pyplot, shape_3d_default, affine_eye):
     """Test we can handle cmap with only 1 level.
 
@@ -110,7 +106,6 @@ def test_cmap_with_one_level(matplotlib_pyplot, shape_3d_default, affine_eye):
     plot_roi(img, alpha=0.8, colorbar=True, cmap=cmap)
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 def test_cmap_as_lookup_table(img_labels):
     """Test colormap passed as BIDS lookup table."""
@@ -127,7 +122,6 @@ def test_cmap_as_lookup_table(img_labels):
 
 
 @pytest.mark.thread_unsafe
-@pytest.mark.slow
 @pytest.mark.parametrize("background_label", [None, 0])
 def test_cmap_as_lookup_table_with_background(background_label):
     """Ensure that the background color is dropped from lut.

--- a/nilearn/plotting/image/tests/test_plot_stat_map.py
+++ b/nilearn/plotting/image/tests/test_plot_stat_map.py
@@ -16,7 +16,6 @@ from nilearn.plotting.find_cuts import find_cut_slices
 
 
 @pytest.mark.thread_unsafe
-@pytest.mark.slow
 def test_plot_stat_map_bad_input(matplotlib_pyplot, img_3d_mni, tmp_path):
     """Test for bad input arguments (cf. #510)."""
     filename = tmp_path / "temp.png"
@@ -32,7 +31,6 @@ def test_plot_stat_map_bad_input(matplotlib_pyplot, img_3d_mni, tmp_path):
     )
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 @pytest.mark.parametrize(
     "params", [{}, {"display_mode": "x", "cut_coords": 3}]
@@ -51,7 +49,6 @@ def test_save_plot_stat_map(matplotlib_pyplot, params, img_3d_mni, tmp_path):
 
 
 @pytest.mark.thread_unsafe
-@pytest.mark.slow
 @pytest.mark.parametrize(
     "display_mode,cut_coords",
     [("ortho", (-90, -125, -70)), ("y", 2), ("yx", None)],
@@ -68,7 +65,6 @@ def test_plot_stat_map_cut_coords_and_display_mode(
 
 
 @pytest.mark.thread_unsafe
-@pytest.mark.slow
 def test_plot_stat_map_with_masked_image(
     matplotlib_pyplot, img_3d_mni, affine_mni
 ):
@@ -82,7 +78,6 @@ def test_plot_stat_map_with_masked_image(
 
 
 @pytest.mark.thread_unsafe
-@pytest.mark.slow
 @pytest.mark.parametrize(
     "data",
     [
@@ -127,7 +122,6 @@ def test_plot_stat_map_threshold_for_affine_with_rotation(
     assert plotted_array.mask.any()
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 @pytest.mark.parametrize(
     "params",
@@ -158,7 +152,6 @@ def test_plot_stat_map_colorbar_variations(
 
 
 @pytest.mark.thread_unsafe
-@pytest.mark.slow
 @pytest.mark.parametrize(
     "shape,direction", [((1, 6, 7), "x"), ((5, 1, 7), "y"), ((5, 6, 1), "z")]
 )
@@ -172,7 +165,6 @@ def test_plot_stat_map_singleton_ax_dim(
 
 
 @pytest.mark.thread_unsafe
-@pytest.mark.slow
 def test_outlier_cut_coords(matplotlib_pyplot):
     """Test to plot a subset of a large set of cuts found for a small area."""
     bg_img = load_mni152_template(resolution=2)

--- a/nilearn/plotting/surface/tests/test_plotly_surface_figure.py
+++ b/nilearn/plotting/surface/tests/test_plotly_surface_figure.py
@@ -79,7 +79,6 @@ def test_plotly_show(plotly, renderer):
     assert f"image/{key}" in mock_display.call_args.args[0]
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 @pytest.mark.skipif(
     not is_kaleido_installed(),

--- a/nilearn/plotting/surface/tests/test_surf_plotting.py
+++ b/nilearn/plotting/surface/tests/test_surf_plotting.py
@@ -118,7 +118,6 @@ def test_plot_surf_engine_error_plotly_not_installed(in_memory_mesh):
     not is_kaleido_installed(),
     reason="This test is run only if kaleido is installed.",
 )
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 def test_plot_surf(plt, engine, tmp_path, in_memory_mesh, bg_map):
     """Test nilearn.plotting.surface.surf_plotting.plot_surf function with

--- a/nilearn/plotting/tests/test_baseline_comparisons.py
+++ b/nilearn/plotting/tests/test_baseline_comparisons.py
@@ -67,7 +67,6 @@ SURFACE_FUNCS = {
 }
 
 
-@pytest.mark.slow
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("plot_func", PLOTTING_FUNCS_3D)
 def test_plot_functions_black_bg(plot_func, img_3d_mni):
@@ -78,7 +77,6 @@ def test_plot_functions_black_bg(plot_func, img_3d_mni):
     return plot_func(img_3d_mni, black_bg=True)
 
 
-@pytest.mark.slow
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("plot_func", PLOTTING_FUNCS_3D)
 def test_plot_functions_title(plot_func, img_3d_mni):
@@ -89,7 +87,6 @@ def test_plot_functions_title(plot_func, img_3d_mni):
     return plot_func(img_3d_mni, title="foo")
 
 
-@pytest.mark.slow
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("plot_func", PLOTTING_FUNCS_3D)
 def test_plot_functions_annotate(plot_func, img_3d_mni):
@@ -100,7 +97,6 @@ def test_plot_functions_annotate(plot_func, img_3d_mni):
     return plot_func(img_3d_mni, annotate=False)
 
 
-@pytest.mark.slow
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize(
     "display_mode", ["x", "y", "z", "yx", "xz", "yz", "ortho"]
@@ -150,7 +146,6 @@ def test_plot_roi_contour_colors(affine_mni):
     return fig
 
 
-@pytest.mark.slow
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("plot_func", PLOTTING_FUNCS_3D)
 def test_plot_functions_no_colorbar(plot_func, img_3d_mni):
@@ -165,7 +160,6 @@ def test_plot_functions_no_colorbar(plot_func, img_3d_mni):
 
 
 @pytest.mark.mpl_image_compare
-@pytest.mark.slow
 @pytest.mark.parametrize("plot_func", PLOTTING_FUNCS_3D)
 def test_plot_functions_colorbar_ticks(plot_func, img_3d_mni):
     """Test parameter for colorbar."""
@@ -175,7 +169,6 @@ def test_plot_functions_colorbar_ticks(plot_func, img_3d_mni):
     )
 
 
-@pytest.mark.slow
 @pytest.mark.mpl_image_compare(tolerance=5)
 @pytest.mark.parametrize("plot_func", PLOTTING_FUNCS_3D)
 @pytest.mark.parametrize("vmin", [-1, 1])
@@ -184,7 +177,6 @@ def test_plot_functions_vmin(plot_func, vmin):
     return plot_func(load_sample_motor_activation_image(), vmin=vmin)
 
 
-@pytest.mark.slow
 @pytest.mark.mpl_image_compare(tolerance=5)
 @pytest.mark.parametrize("plot_func", PLOTTING_FUNCS_3D)
 @pytest.mark.parametrize("vmax", [2, 3])
@@ -193,7 +185,6 @@ def test_plot_functions_vmax(plot_func, vmax):
     return plot_func(load_sample_motor_activation_image(), vmax=vmax)
 
 
-@pytest.mark.slow
 @pytest.mark.mpl_image_compare(tolerance=5)
 @pytest.mark.parametrize("plotting_func", PLOTTING_FUNCS_3D)
 def test_plotting_functions_radiological_view(plotting_func):
@@ -226,7 +217,6 @@ def test_add_contours(levels, colors):
 
 
 @pytest.mark.mpl_image_compare
-@pytest.mark.slow
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -262,7 +252,6 @@ def test_plot_carpet_default_params(img_4d_mni, img_3d_ones_mni):
     return plot_carpet(img_4d_mni, mask_img=img_3d_ones_mni)
 
 
-@pytest.mark.slow
 @pytest.mark.mpl_image_compare
 def test_plot_prob_atlas_default_params(img_3d_mni, img_4d_mni):
     """Smoke-test for plot_prob_atlas with default arguments."""
@@ -511,7 +500,6 @@ def test_plot_img_on_surf(bg_on_data, symmetric_cmap, colorbar, title):
     return fig
 
 
-@pytest.mark.slow
 @pytest.mark.mpl_image_compare(tolerance=5)
 @pytest.mark.parametrize(
     "resolution", ["fsaverage3", "fsaverage4", "fsaverage5"]
@@ -583,7 +571,6 @@ def test_surface_fs_data(hemi, resolution):
     return fig
 
 
-@pytest.mark.slow
 @pytest.mark.mpl_image_compare(tolerance=5)
 @pytest.mark.parametrize("hemi", ["left", "right"])
 def test_surface_fs_vertices_order(hemi):
@@ -784,7 +771,6 @@ def test_plot_with_transparency(fn):
     )
 
 
-@pytest.mark.slow
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("fn", [plot_stat_map, plot_img, plot_glass_brain])
 @pytest.mark.parametrize("transparency_range", [None, [0, 2], [2, 4]])
@@ -801,7 +787,6 @@ def test_plot_with_transparency_range(fn, transparency_range):
 IMG_COMPARISON_FUNCS = {plot_img_comparison, plot_bland_altman}
 
 
-@pytest.mark.slow
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("plot_func", IMG_COMPARISON_FUNCS)
 def test_img_comparison_default(
@@ -813,7 +798,6 @@ def test_img_comparison_default(
     return plt.gcf()
 
 
-@pytest.mark.slow
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("plot_func", IMG_COMPARISON_FUNCS)
 @pytest.mark.parametrize("colorbar", [True, False])

--- a/nilearn/plotting/tests/test_img_comparisons.py
+++ b/nilearn/plotting/tests/test_img_comparisons.py
@@ -78,7 +78,6 @@ def test_plot_img_comparison_error(surf_img_1d, img_3d_mni):
         plot_img_comparison(surf_img_1d, img_3d_mni)
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 def test_plot_img_comparison(matplotlib_pyplot, rng, tmp_path):
     """Tests for plot_img_comparison."""
@@ -132,7 +131,6 @@ def test_plot_img_comparison(matplotlib_pyplot, rng, tmp_path):
     assert len(ax_1.patches) == length * 2 * gridsize
 
 
-@pytest.mark.slow
 @pytest.mark.thread_unsafe
 def test_plot_img_comparison_without_plot(matplotlib_pyplot, rng):
     """Tests for plot_img_comparison no plot should return same result."""
@@ -223,7 +221,6 @@ def test_plot_bland_altman_surface(matplotlib_pyplot, surf_img_1d, masker):
     )
 
 
-@pytest.mark.slow
 def test_plot_bland_altman_errors(
     surf_img_1d, surf_mask_1d, img_3d_rand_eye, img_3d_ones_eye
 ):


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this pull request.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the pull request closes multiple issues, includes "closes" before each one is listed.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->
- Closes none

<!-- Please indicate whether LLM tools were used for this pull request
by adding a 'x' in one of the following check box.
Work made with LLM tools has a very different set of typical failure modes
than work done entirely by humans,
it helps others to better trace eventual issues when reviewing the code.
-->
Use of AI tools:
- [ ] LLM tools were used to generate at least part of the content of this pull-request.
- [x] No LLM tools were used to generate any part of the content of this pull-request.

<!-- Please give a brief overview of what has changed in the pull request.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

mostly checking if some the "slow" marker can be removed for some of the tests that seem to run fast enough.

See test timing obtained from https://github.com/nilearn/nilearn/actions/runs/28785759519/job/85352036804#step:11:33 (for example)

<img width="2544" height="1367" alt="newplot" src="https://github.com/user-attachments/assets/f5ff5ea4-74b5-4b32-8865-272cd43ec07d" />
