### PR TITLE
[MAINT] Add return type annotations to nilearn.utils.discovery

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -44,7 +44,7 @@ Enhancements
 Changes
 -------
 
-- :bdg-dark:`Code` Add return type annotations to :func:`~utils.all_displays`, :func:`~utils.all_estimators`, and :func:`~utils.all_functions` (:gh:`XXXX` by `Rémi Gau`_).
+- :bdg-dark:`Code` Add return type annotations to :func:`~utils.all_displays`, :func:`~utils.all_estimators`, and :func:`~utils.all_functions` (:gh:`6409` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.glm` (:gh:`6370` by `Rémi Gau`_).
 

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -44,6 +44,8 @@ Enhancements
 Changes
 -------
 
+- :bdg-dark:`Code` Add return type annotations to :func:`~utils.all_displays`, :func:`~utils.all_estimators`, and :func:`~utils.all_functions` (:gh:`XXXX` by `Rémi Gau`_).
+
 - :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.glm` (:gh:`6370` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Add return type annotations to public functions in :mod:`nilearn.regions` (:gh:`6369` by `Rémi Gau`_).

--- a/nilearn/utils/discovery.py
+++ b/nilearn/utils/discovery.py
@@ -2,6 +2,7 @@
 
 import inspect
 import pkgutil
+from collections.abc import Callable
 from importlib import import_module
 from operator import itemgetter
 from pathlib import Path
@@ -75,7 +76,7 @@ def _get_all_classes():
     return all_classes
 
 
-def all_estimators(type_filter=None):
+def all_estimators(type_filter=None) -> list[tuple[str, type]]:
     """Get a list of all estimators from `nilearn`.
 
     This function crawls the module and gets all classes that inherit
@@ -172,7 +173,7 @@ def _is_checked_function(item):
     )
 
 
-def all_functions():
+def all_functions() -> list[tuple[str, Callable]]:
     """Get a list of all functions from `nilearn`.
 
     Returns
@@ -224,7 +225,7 @@ def all_functions():
     return sorted(set(all_functions), key=itemgetter(0))
 
 
-def all_displays(type_filter=None):
+def all_displays(type_filter=None) -> list[tuple[str, type]]:
     """Get a list of all 'displays' objects from `nilearn`.
 
     Parameters

--- a/nilearn/utils/discovery.py
+++ b/nilearn/utils/discovery.py
@@ -76,7 +76,9 @@ def _get_all_classes():
     return all_classes
 
 
-def all_estimators(type_filter=None) -> list[tuple[str, type]]:
+def all_estimators(
+    type_filter=None,
+) -> list[tuple[str, type[NilearnBaseEstimator]]]:
     """Get a list of all estimators from `nilearn`.
 
     This function crawls the module and gets all classes that inherit


### PR DESCRIPTION
<!-- Please indicate after the # which issue you're closing with this pull request. -->
- Related to #3568

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- Add return type annotations to `all_displays`, `all_estimators`, and `all_functions` in `nilearn.utils.discovery`.
- Add a changelog entry.