### PR TITLE
[MAINT] add return type annotations to all pytest fixtures

### DIFF
--- a/nilearn/_utils/data_gen.py
+++ b/nilearn/_utils/data_gen.py
@@ -236,7 +236,7 @@ def generate_labeled_regions(
     labels=None,
     affine=None,
     dtype="int32",
-):
+) -> Nifti1Image:
     """Generate a 3D volume with labeled regions.
 
     Parameters
@@ -263,7 +263,7 @@ def generate_labeled_regions(
 
     Returns
     -------
-    Niimg-like object
+    Nifti1Image
         Data has shape "shape", containing region labels.
 
     """
@@ -942,7 +942,7 @@ def create_fake_bids_dataset(
     n_vertices=0,
     n_voxels=4,
     spaces=None,
-):
+) -> Path:
     """Create a fake :term:`BIDS` dataset directory with dummy files.
 
     Returns fake dataset directory name.

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -3309,6 +3309,7 @@ def check_masker_smooth(estimator_orig) -> None:
 
     assert hasattr(estimator, "smoothing_fwhm")
 
+    imgs: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         imgs = _img_3d_rand()
     else:

--- a/nilearn/_utils/tests/test_data_gen.py
+++ b/nilearn/_utils/tests/test_data_gen.py
@@ -98,7 +98,7 @@ def _bids_path_template(
     space=None,
     desc=None,
     extra_entity=None,
-):
+) -> str:
     """Create a BIDS filepath from a template.
 
     File path is relative to the BIDS root folder.

--- a/nilearn/_utils/tests/test_niimg.py
+++ b/nilearn/_utils/tests/test_niimg.py
@@ -23,13 +23,13 @@ from nilearn.image import get_data, new_img_like
 
 
 @pytest.fixture
-def img1(affine_eye):
+def img1(affine_eye) -> Nifti1Image:
     data = np.ones((2, 2, 2, 2))
     return Nifti1Image(data, affine=affine_eye)
 
 
 @pytest.fixture
-def img_binary(affine_eye, has_inf, has_nan, non_bin):
+def img_binary(affine_eye, has_inf, has_nan, non_bin) -> Nifti1Image:
     data = np.ones((3, 3, 3, 3))
 
     if has_inf:

--- a/nilearn/_utils/tests/test_param_validation.py
+++ b/nilearn/_utils/tests/test_param_validation.py
@@ -16,7 +16,7 @@ from nilearn._utils.param_validation import (
 
 
 @pytest.fixture
-def matrix():
+def matrix() -> np.ndarray:
     return np.array(
         [[-3.0, 2.0, -1.0, 0.0, -4.0], [4.0, -6.0, 5.0, 1.0, -3.0]]
     )

--- a/nilearn/conftest.py
+++ b/nilearn/conftest.py
@@ -1,6 +1,10 @@
 """Configuration and extra fixtures for pytest."""
 
 import inspect
+from collections.abc import Callable, Generator
+from pathlib import Path
+from types import ModuleType
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -75,7 +79,7 @@ def pytest_configure(config):  # noqa: ARG001
 
 
 @pytest.fixture(autouse=True)
-def close_all():
+def close_all() -> Generator[None, None, None]:
     """Close all matplotlib figures."""
     yield
     if matplotlib is not None:
@@ -92,7 +96,7 @@ def _rng(seed=42):
 
 
 @pytest.fixture()
-def rng():
+def rng() -> np.random.Generator:
     """Return a seeded random number generator."""
     return _rng()
 
@@ -116,7 +120,7 @@ def _affine_mni() -> np.ndarray:
 
 
 @pytest.fixture()
-def affine_mni():
+def affine_mni() -> np.ndarray:
     """Return an affine corresponding to 2mm isotropic MNI template."""
     return _affine_mni()
 
@@ -130,7 +134,7 @@ def _affine_eye() -> np.ndarray:
 
 
 @pytest.fixture()
-def affine_eye():
+def affine_eye() -> np.ndarray:
     """Return an identity matrix affine."""
     return _affine_eye()
 
@@ -183,25 +187,25 @@ def _shape_4d_long():
 
 
 @pytest.fixture()
-def shape_3d_default():
+def shape_3d_default() -> tuple[int, int, int]:
     """Return default shape for a 3D image."""
     return _shape_3d_default()
 
 
 @pytest.fixture
-def shape_3d_large():
+def shape_3d_large() -> tuple[int, int, int]:
     """Shape usually used for maps images."""
     return _shape_3d_large()
 
 
 @pytest.fixture()
-def shape_4d_default():
+def shape_4d_default() -> tuple[int, int, int, int]:
     """Return default shape for a 4D image."""
     return _shape_4d_default()
 
 
 @pytest.fixture()
-def shape_4d_long():
+def shape_4d_long() -> tuple[int, int, int, int]:
     """Return long shape for a 4D image."""
     return _shape_4d_long()
 
@@ -229,7 +233,7 @@ def _img_3d_rand(affine=None):
 
 
 @pytest.fixture()
-def img_3d_rand_eye():
+def img_3d_rand_eye() -> Nifti1Image:
     """Return random 3D Nifti1Image in MNI space."""
     return _img_3d_rand()
 
@@ -245,13 +249,13 @@ def _img_3d_mni(affine=None):
 
 
 @pytest.fixture()
-def img_3d_mni():
+def img_3d_mni() -> Nifti1Image:
     """Return a default random 3D Nifti1Image in MNI space."""
     return _img_3d_mni()
 
 
 @pytest.fixture()
-def img_3d_mni_as_file(tmp_path):
+def img_3d_mni_as_file(tmp_path) -> Path:
     """Return path to a random 3D Nifti1Image in MNI space saved to disk."""
     filename = tmp_path / "img.nii"
     _img_3d_mni().to_filename(filename)
@@ -271,7 +275,7 @@ def _img_3d_zeros(shape=None, affine=None):
 
 
 @pytest.fixture
-def img_3d_zeros_eye():
+def img_3d_zeros_eye() -> Nifti1Image:
     """Return a zeros-filled 3D Nifti1Image (identity affine)."""
     return _img_3d_zeros()
 
@@ -289,13 +293,13 @@ def _img_3d_ones(shape=None, affine=None):
 
 
 @pytest.fixture
-def img_3d_ones_eye():
+def img_3d_ones_eye() -> Nifti1Image:
     """Return a ones-filled 3D Nifti1Image (identity affine)."""
     return _img_3d_ones()
 
 
 @pytest.fixture
-def img_3d_ones_mni():
+def img_3d_ones_mni() -> Nifti1Image:
     """Return a ones-filled 3D Nifti1Image (identity affine)."""
     return _img_3d_ones(shape=_shape_3d_default(), affine=_affine_mni())
 
@@ -312,7 +316,7 @@ def _img_mask_mni():
 
 
 @pytest.fixture
-def img_mask_mni():
+def img_mask_mni() -> Nifti1Image:
     """Return a 3D nifti mask in MNI space with some 1s in the center."""
     return _img_mask_mni()
 
@@ -323,7 +327,7 @@ def _img_mask_eye():
 
 
 @pytest.fixture
-def img_mask_eye():
+def img_mask_eye() -> Nifti1Image:
     """Return a 3D nifti mask with identity affine with 1s in the center."""
     return _img_mask_eye()
 
@@ -364,37 +368,37 @@ def _img_4d_mni(shape=None, affine=None):
 
 
 @pytest.fixture
-def img_4d_zeros_eye():
+def img_4d_zeros_eye() -> Nifti1Image:
     """Return a default zeros filled 4D Nifti1Image (identity affine)."""
     return _img_4d_zeros()
 
 
 @pytest.fixture
-def img_4d_ones_eye():
+def img_4d_ones_eye() -> Nifti1Image:
     """Return a default ones filled 4D Nifti1Image (identity affine)."""
     return _img_ones(_shape_4d_default(), _affine_eye())
 
 
 @pytest.fixture
-def img_4d_rand_eye():
+def img_4d_rand_eye() -> Nifti1Image:
     """Return a default random filled 4D Nifti1Image (identity affine)."""
     return _img_4d_rand_eye()
 
 
 @pytest.fixture
-def img_4d_mni():
+def img_4d_mni() -> Nifti1Image:
     """Return a default random filled 4D Nifti1Image."""
     return _img_4d_mni()
 
 
 @pytest.fixture
-def img_4d_rand_eye_medium():
+def img_4d_rand_eye_medium() -> Nifti1Image:
     """Return a default random filled 4D Nifti1Image of medium length."""
     return _img_4d_rand_eye_medium()
 
 
 @pytest.fixture
-def img_4d_long_mni(rng, shape_4d_long, affine_mni):
+def img_4d_long_mni(rng, shape_4d_long, affine_mni) -> Nifti1Image:
     """Return a default random filled long 4D Nifti1Image."""
     return Nifti1Image(rng.uniform(size=shape_4d_long), affine=affine_mni)
 
@@ -403,7 +407,7 @@ def img_4d_long_mni(rng, shape_4d_long, affine_mni):
 
 
 @pytest.fixture()
-def img_atlas(shape_3d_default, affine_mni):
+def img_atlas(shape_3d_default, affine_mni) -> dict[str, Any]:
     """Return an atlas and its labels."""
     atlas = np.ones(shape_3d_default, dtype="int32")
     atlas[2:5, :, :] = 2
@@ -472,7 +476,7 @@ def generate_regions_ts(n_features, n_regions) -> np.ndarray:
 
 
 @pytest.fixture
-def n_regions():
+def n_regions() -> int:
     """Return a default number of regions for maps."""
     return _n_regions()
 
@@ -533,7 +537,7 @@ def img_labels(n_regions) -> Nifti1Image:
 
 
 @pytest.fixture
-def length():
+def length() -> int:
     """Return a default length for 4D images."""
     return 10
 
@@ -565,7 +569,7 @@ def img_fmri(shape_3d_default, affine_eye, length, rng) -> Nifti1Image:
 
 # ------------------------ SURFACE ------------------------#
 @pytest.fixture
-def single_mesh(rng):
+def single_mesh(rng) -> list[np.ndarray]:
     """Create random coordinates and faces for a single mesh.
 
     This does not generate meaningful surfaces.
@@ -576,7 +580,7 @@ def single_mesh(rng):
 
 
 @pytest.fixture
-def in_memory_mesh(single_mesh):
+def in_memory_mesh(single_mesh) -> InMemoryMesh:
     """Create a random InMemoryMesh.
 
     This does not generate meaningful surfaces.
@@ -615,7 +619,7 @@ def _make_mesh():
 
 
 @pytest.fixture()
-def surf_mesh():
+def surf_mesh() -> PolyMesh:
     """Return _make_mesh as a function allowing it to be used as a fixture."""
     return _make_mesh()
 
@@ -634,7 +638,7 @@ def _make_surface_img(n_samples=1):
 
 
 @pytest.fixture
-def surf_img_2d():
+def surf_img_2d() -> Callable[..., SurfaceImage]:
     """Return a 2D SurfaceImage.
 
     The shape of the data will be (n_vertices, n_samples).
@@ -655,7 +659,7 @@ def _surf_img_1d():
 
 
 @pytest.fixture
-def surf_img_1d():
+def surf_img_1d() -> SurfaceImage:
     """Return a 1D SurfaceImage.
 
     The shape of the data will be (n_vertices,).
@@ -664,7 +668,7 @@ def surf_img_1d():
 
 
 @pytest.fixture
-def surf_img_ones_1d(surf_mesh):
+def surf_img_ones_1d(surf_mesh) -> SurfaceImage:
     """Return a 1D SurfaceImage with only 1."""
     data = {
         "left": np.ones((surf_mesh.parts["left"].n_vertices, 1)),
@@ -701,7 +705,7 @@ def _surf_mask_1d():
 
 
 @pytest.fixture
-def surf_mask_1d():
+def surf_mask_1d() -> SurfaceImage:
     """Create a sample surface mask using the sample mesh.
     This will create a mask with n_zeros zeros (default is 4) and the
     rest ones.
@@ -712,7 +716,7 @@ def surf_mask_1d():
 
 
 @pytest.fixture
-def surf_mask_2d():
+def surf_mask_2d() -> Callable[..., SurfaceImage]:
     """Create a sample surface mask using the sample mesh.
     This will create a mask with n_zeros zeros (default is 4) and the
     rest ones.
@@ -724,7 +728,7 @@ def surf_mask_2d():
 
 
 @pytest.fixture
-def surf_label_img(surf_mesh):
+def surf_label_img(surf_mesh) -> SurfaceImage:
     """Return a sample surface label image using the sample mesh.
     Has two regions with values 0 and 1 respectively.
     """
@@ -736,7 +740,7 @@ def surf_label_img(surf_mesh):
 
 
 @pytest.fixture
-def surf_three_labels_img(surf_mesh):
+def surf_three_labels_img(surf_mesh) -> SurfaceImage:
     """Return a sample surface label image using the sample mesh.
     Has 3 regions with values 0, 1 and 2.
     """
@@ -803,7 +807,7 @@ def _flip_surf_img_parts(poly_obj):
 
 
 @pytest.fixture
-def flip_surf_img_parts():
+def flip_surf_img_parts() -> Callable[..., Any]:
     """Flip hemispheres of a surface image data or mesh."""
     return _flip_surf_img_parts
 
@@ -816,7 +820,7 @@ def _flip_surf_img(img):
 
 
 @pytest.fixture
-def flip_surf_img():
+def flip_surf_img() -> Callable[..., SurfaceImage]:
     """Flip hemispheres of a surface image."""
     return _flip_surf_img
 
@@ -831,7 +835,7 @@ def _drop_surf_img_part(img, part_name="right"):
 
 
 @pytest.fixture
-def drop_surf_img_part():
+def drop_surf_img_part() -> Callable[..., SurfaceImage]:
     """Remove one hemisphere from a SurfaceImage."""
     return _drop_surf_img_part
 
@@ -844,7 +848,7 @@ def _make_surface_img_and_design(n_samples=5):
 
 
 @pytest.fixture()
-def surface_glm_data():
+def surface_glm_data() -> Callable[..., tuple[SurfaceImage, pd.DataFrame]]:
     """Create a surface image and design matrix for testing."""
     return _make_surface_img_and_design
 
@@ -853,7 +857,7 @@ def surface_glm_data():
 
 
 @pytest.fixture(scope="function")
-def matplotlib_pyplot():
+def matplotlib_pyplot() -> Generator[ModuleType, None, None]:
     """Set up and teardown fixture for matplotlib.
 
     This fixture checks if we can import matplotlib. If not, the tests will be
@@ -872,7 +876,7 @@ def matplotlib_pyplot():
 
 
 @pytest.fixture(scope="function")
-def plotly():
+def plotly() -> Generator[ModuleType, None, None]:
     """Check if we can import plotly.
 
     If not, the tests will be skipped.
@@ -888,7 +892,7 @@ def plotly():
 
 
 @pytest.fixture
-def transparency_image(rng, affine_mni):
+def transparency_image(rng, affine_mni) -> Nifti1Image:
     """Return 3D image to use as transparency image.
 
     Make sure that values are not just between 0 and 1.

--- a/nilearn/conftest.py
+++ b/nilearn/conftest.py
@@ -142,7 +142,7 @@ def affine_eye() -> np.ndarray:
 # ------------------------ SHAPES ------------------------#
 
 
-def _shape_3d_default():
+def _shape_3d_default() -> tuple[int, int, int]:
     """Return default shape for a 3D image.
 
     Mostly used for set up in other fixtures in other testing modules.
@@ -152,7 +152,7 @@ def _shape_3d_default():
     return (7, 8, 9)
 
 
-def _shape_3d_large():
+def _shape_3d_large() -> tuple[int, int, int]:
     """Shape usually used for maps images.
 
     Mostly used for set up in other fixtures in other testing modules.
@@ -162,7 +162,7 @@ def _shape_3d_large():
     return (29, 30, 31)
 
 
-def _shape_4d_default():
+def _shape_4d_default() -> tuple[int, int, int, int]:
     """Return default shape for a 4D image.
 
     Mostly used for set up in other fixtures in other testing modules.
@@ -172,14 +172,14 @@ def _shape_4d_default():
     return (7, 8, 9, 5)
 
 
-def _shape_4d_medium():
+def _shape_4d_medium() -> tuple[int, int, int, int]:
     """Return default shape for a long 4D image."""
     # avoid having identical shapes values,
     # because this fails to detect if the code does not handle dimensions well.
     return (7, 8, 9, 100)
 
 
-def _shape_4d_long():
+def _shape_4d_long() -> tuple[int, int, int, int]:
     """Return default shape for a long 4D image."""
     # avoid having identical shapes values,
     # because this fails to detect if the code does not handle dimensions well.
@@ -210,18 +210,18 @@ def shape_4d_long() -> tuple[int, int, int, int]:
     return _shape_4d_long()
 
 
-def _img_zeros(shape, affine):
+def _img_zeros(shape, affine) -> Nifti1Image:
     return Nifti1Image(np.zeros(shape), affine)
 
 
-def _img_ones(shape, affine):
+def _img_ones(shape, affine) -> Nifti1Image:
     return Nifti1Image(np.ones(shape), affine)
 
 
 # ------------------------ 3D IMAGES ------------------------#
 
 
-def _img_3d_rand(affine=None):
+def _img_3d_rand(affine=None) -> Nifti1Image:
     """Return random 3D Nifti1Image in MNI space.
 
     Mostly used for set up in other fixtures in other testing modules.
@@ -238,7 +238,7 @@ def img_3d_rand_eye() -> Nifti1Image:
     return _img_3d_rand()
 
 
-def _img_3d_mni(affine=None):
+def _img_3d_mni(affine=None) -> Nifti1Image:
     if affine is None:
         affine = _affine_mni()
     data_positive = np.zeros((7, 7, 3))
@@ -262,7 +262,7 @@ def img_3d_mni_as_file(tmp_path) -> Path:
     return filename
 
 
-def _img_3d_zeros(shape=None, affine=None):
+def _img_3d_zeros(shape=None, affine=None) -> Nifti1Image:
     """Return a default zeros filled 3D Nifti1Image (identity affine).
 
     Mostly used for set up in other fixtures in other testing modules.
@@ -280,7 +280,7 @@ def img_3d_zeros_eye() -> Nifti1Image:
     return _img_3d_zeros()
 
 
-def _img_3d_ones(shape=None, affine=None):
+def _img_3d_ones(shape=None, affine=None) -> Nifti1Image:
     """Return a ones-filled 3D Nifti1Image (identity affine).
 
     Mostly used for set up in other fixtures in other testing modules.
@@ -304,13 +304,13 @@ def img_3d_ones_mni() -> Nifti1Image:
     return _img_3d_ones(shape=_shape_3d_default(), affine=_affine_mni())
 
 
-def _mask_data():
+def _mask_data() -> np.ndarray:
     mask_data = np.zeros(_shape_3d_default(), dtype="int32")
     mask_data[3:6, 3:6, 3:6] = 1
     return mask_data
 
 
-def _img_mask_mni():
+def _img_mask_mni() -> Nifti1Image:
     """Return a 3D nifti mask in MNI space with some 1s in the center."""
     return Nifti1Image(_mask_data(), _affine_mni())
 
@@ -321,7 +321,7 @@ def img_mask_mni() -> Nifti1Image:
     return _img_mask_mni()
 
 
-def _img_mask_eye():
+def _img_mask_eye() -> Nifti1Image:
     """Return a 3D nifti mask with identity affine with 1s in the center."""
     return Nifti1Image(_mask_data(), _affine_eye())
 
@@ -335,7 +335,7 @@ def img_mask_eye() -> Nifti1Image:
 # ------------------------ 4D IMAGES ------------------------#
 
 
-def _img_4d_zeros(shape=None, affine=None):
+def _img_4d_zeros(shape=None, affine=None) -> Nifti1Image:
     """Return a default zeros filled 4D Nifti1Image (identity affine).
 
     Mostly used for set up in other fixtures in other testing modules.
@@ -347,19 +347,19 @@ def _img_4d_zeros(shape=None, affine=None):
     return _img_zeros(shape, affine)
 
 
-def _img_4d_rand_eye():
+def _img_4d_rand_eye() -> Nifti1Image:
     """Return a default random filled 4D Nifti1Image (identity affine)."""
     data = _rng().random(_shape_4d_default())
     return Nifti1Image(data, _affine_eye())
 
 
-def _img_4d_rand_eye_medium():
+def _img_4d_rand_eye_medium() -> Nifti1Image:
     """Return a random 4D Nifti1Image (identity affine, many volumes)."""
     data = _rng().random(_shape_4d_medium())
     return Nifti1Image(data, _affine_eye())
 
 
-def _img_4d_mni(shape=None, affine=None):
+def _img_4d_mni(shape=None, affine=None) -> Nifti1Image:
     if shape is None:
         shape = _shape_4d_default()
     if affine is None:
@@ -422,7 +422,7 @@ def img_atlas(shape_3d_default, affine_mni) -> dict[str, Any]:
     }
 
 
-def _n_regions():
+def _n_regions() -> int:
     """Return a default number of regions for maps."""
     return 9
 
@@ -589,7 +589,7 @@ def in_memory_mesh(single_mesh) -> InMemoryMesh:
     return InMemoryMesh(coordinates=coords, faces=faces)
 
 
-def _make_mesh():
+def _make_mesh() -> PolyMesh:
     """Create a sample mesh with two parts: left and right, and total of
     9 vertices and 10 faces.
 
@@ -647,7 +647,7 @@ def surf_img_2d() -> Callable[..., SurfaceImage]:
     return _make_surface_img
 
 
-def _surf_img_1d():
+def _surf_img_1d() -> SurfaceImage:
     """Return a 1D SurfaceImage.
 
     The shape of the data will be (n_vertices,).
@@ -690,7 +690,7 @@ def _make_surface_mask(n_zeros=4):
     return SurfaceImage(mesh, data)
 
 
-def _surf_mask_1d():
+def _surf_mask_1d() -> SurfaceImage:
     """Create a sample surface mask using the sample mesh.
     This will create a mask with n_zeros zeros (default is 4) and the
     rest ones.
@@ -799,7 +799,7 @@ def surf_maps_img() -> SurfaceImage:
     return _surf_maps_img()
 
 
-def _flip_surf_img_parts(poly_obj):
+def _flip_surf_img_parts(poly_obj) -> dict:
     """Flip hemispheres of a surface image data or mesh."""
     keys = list(poly_obj.parts.keys())
     keys = [keys[-1], *keys[:-1]]
@@ -812,7 +812,7 @@ def flip_surf_img_parts() -> Callable[..., Any]:
     return _flip_surf_img_parts
 
 
-def _flip_surf_img(img):
+def _flip_surf_img(img) -> SurfaceImage:
     """Flip hemispheres of a surface image."""
     return SurfaceImage(
         _flip_surf_img_parts(img.mesh), _flip_surf_img_parts(img.data)
@@ -825,7 +825,7 @@ def flip_surf_img() -> Callable[..., SurfaceImage]:
     return _flip_surf_img
 
 
-def _drop_surf_img_part(img, part_name="right"):
+def _drop_surf_img_part(img, part_name="right") -> SurfaceImage:
     """Remove one hemisphere from a SurfaceImage."""
     mesh_parts = img.mesh.parts.copy()
     mesh_parts.pop(part_name)
@@ -840,7 +840,9 @@ def drop_surf_img_part() -> Callable[..., SurfaceImage]:
     return _drop_surf_img_part
 
 
-def _make_surface_img_and_design(n_samples=5):
+def _make_surface_img_and_design(
+    n_samples=5,
+) -> tuple[SurfaceImage, pd.DataFrame]:
     des = pd.DataFrame(
         _rng().standard_normal((n_samples, 3)), columns=["", "", ""]
     )

--- a/nilearn/connectome/tests/test_connectivity_matrices.py
+++ b/nilearn/connectome/tests/test_connectivity_matrices.py
@@ -191,7 +191,9 @@ def signals() -> list[np.ndarray]:
 
 
 @pytest.fixture
-def signals_and_covariances(cov_estimator):
+def signals_and_covariances(
+    cov_estimator,
+) -> tuple[list[np.ndarray], list[np.ndarray]] | None:
     signals, _ = _signals()
     emp_covs = []
     ledoit_covs = []
@@ -206,6 +208,7 @@ def signals_and_covariances(cov_estimator):
         return signals, ledoit_covs
     elif isinstance(cov_estimator, EmpiricalCovariance):
         return signals, emp_covs
+    return None
 
 
 def test_check_square():

--- a/nilearn/datasets/tests/conftest.py
+++ b/nilearn/datasets/tests/conftest.py
@@ -44,7 +44,7 @@ from nilearn.datasets.tests._testing import list_to_archive
 
 
 @pytest.fixture(autouse=True)
-def temp_nilearn_data_dir(tmp_path_factory, monkeypatch):
+def temp_nilearn_data_dir(tmp_path_factory, monkeypatch) -> None:
     """Monkeypatch user home directory and NILEARN_DATA env variable.
 
     This ensures that tests that use nilearn.datasets will not load datasets
@@ -66,7 +66,7 @@ def temp_nilearn_data_dir(tmp_path_factory, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def request_mocker(monkeypatch):
+def request_mocker(monkeypatch) -> "Sender":
     """Monkeypatch requests and urllib functions for sending requests.
 
     This ensures that test functions do not retrieve data from the network, but

--- a/nilearn/datasets/tests/test_atlas.py
+++ b/nilearn/datasets/tests/test_atlas.py
@@ -3,7 +3,9 @@
 import itertools
 import re
 import xml.etree.ElementTree as ET
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -180,7 +182,7 @@ def _test_atlas_instance_should_match_data(atlas, is_symm):
 
 
 @pytest.fixture
-def fsl_fetcher(name):
+def fsl_fetcher(name) -> Callable[..., Any]:
     return (
         fetch_atlas_juelich
         if name == "Juelich"
@@ -201,7 +203,7 @@ def test_fetch_atlas_fsl_errors(prob, fsl_fetcher, tmp_path):
 
 
 @pytest.fixture
-def atlas_data():
+def atlas_data() -> np.ndarray:
     # Create false atlas
     atlas_data = np.zeros((10, 10, 10), dtype="int32")
     # Create an interhemispheric map
@@ -540,7 +542,7 @@ def test_fetch_atlas_difumo(tmp_path, request_mocker, capsys):
 
 
 @pytest.fixture
-def aal_archive_root(version):
+def aal_archive_root(version) -> Path:
     if version == "SPM12":
         return Path("aal", "atlas")
     else:

--- a/nilearn/datasets/tests/test_func.py
+++ b/nilearn/datasets/tests/test_func.py
@@ -79,7 +79,7 @@ def _load_localizer_index():
 
 
 @pytest.fixture()
-def localizer_mocker(request_mocker):
+def localizer_mocker(request_mocker) -> None:
     """Mock the index for localizer dataset."""
     index, tsv_files = _load_localizer_index()
     request_mocker.url_mapping["https://osf.io/hwbm2/download"] = json.dumps(

--- a/nilearn/datasets/tests/test_neurovault.py
+++ b/nilearn/datasets/tests/test_neurovault.py
@@ -246,7 +246,7 @@ def _neurovault(match, request):  # noqa: ARG001
 
 
 @pytest.fixture(autouse=True)
-def neurovault_mocker(request_mocker):
+def neurovault_mocker(request_mocker) -> None:
     """Mock neurovault fetcher."""
     request_mocker.url_mapping["*neurovault.org*"] = _neurovault
 

--- a/nilearn/decoding/tests/conftest.py
+++ b/nilearn/decoding/tests/conftest.py
@@ -1,12 +1,13 @@
 """Fixture for decoding tests."""
 
 import warnings
+from collections.abc import Generator
 
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def suppress_specific_decoding_warning():
+def suppress_specific_decoding_warning() -> Generator[None, None, None]:
     """Ignore internal decoding warnings."""
     with warnings.catch_warnings():
         messages = (

--- a/nilearn/decomposition/tests/conftest.py
+++ b/nilearn/decomposition/tests/conftest.py
@@ -27,7 +27,7 @@ N_COMPONENTS = 4
 
 
 @pytest.fixture(autouse=True)
-def suppress_specific_decoding_warning() -> Generator[None, None, None]:
+def suppress_specific_decomposition_warning() -> Generator[None, None, None]:
     """Ignore internal decoding warnings."""
     with warnings.catch_warnings():
         messages = "Objective did not converge.*|"

--- a/nilearn/decomposition/tests/conftest.py
+++ b/nilearn/decomposition/tests/conftest.py
@@ -111,7 +111,9 @@ def decomposition_masker(
     ).fit()
 
 
-def _decomposition_images_surface(rng, decomposition_mesh, with_activation):
+def _decomposition_images_surface(
+    rng, decomposition_mesh, with_activation
+) -> list[Nifti1Image | SurfaceImage]:
     return [
         _decomposition_img(
             "surface",

--- a/nilearn/decomposition/tests/conftest.py
+++ b/nilearn/decomposition/tests/conftest.py
@@ -1,6 +1,7 @@
 """Fixtures for decomposition tests."""
 
 import warnings
+from collections.abc import Generator
 
 import numpy as np
 import pytest
@@ -26,7 +27,7 @@ N_COMPONENTS = 4
 
 
 @pytest.fixture(autouse=True)
-def suppress_specific_decoding_warning():
+def suppress_specific_decoding_warning() -> Generator[None, None, None]:
     """Ignore internal decoding warnings."""
     with warnings.catch_warnings():
         messages = "Objective did not converge.*|"

--- a/nilearn/glm/tests/_testing.py
+++ b/nilearn/glm/tests/_testing.py
@@ -6,19 +6,19 @@ import pandas as pd
 from nilearn.conftest import _rng
 
 
-def _conditions():
+def _conditions() -> list[str]:
     return ["c0", "c0", "c0", "c1", "c1", "c1", "c2", "c2", "c2"]
 
 
-def _onsets():
+def _onsets() -> list[int]:
     return [0, 70, 100, 10, 30, 90, 30, 40, 60]
 
 
-def _durations():
+def _durations() -> np.ndarray:
     return np.ones(len(_onsets()))
 
 
-def modulated_event_paradigm():
+def modulated_event_paradigm() -> pd.DataFrame:
     events = pd.DataFrame(
         {
             "trial_type": _conditions(),
@@ -30,7 +30,7 @@ def modulated_event_paradigm():
     return events
 
 
-def block_paradigm():
+def block_paradigm() -> pd.DataFrame:
     events = pd.DataFrame(
         {
             "trial_type": _conditions(),
@@ -41,7 +41,7 @@ def block_paradigm():
     return events
 
 
-def modulated_block_paradigm():
+def modulated_block_paradigm() -> pd.DataFrame:
     durations = 5 + 5 * _rng().uniform(size=len(_onsets()))
     modulation = 1 + _rng().uniform(size=len(_onsets()))
     events = pd.DataFrame(
@@ -55,7 +55,7 @@ def modulated_block_paradigm():
     return events
 
 
-def spm_paradigm(block_duration):
+def spm_paradigm(block_duration) -> tuple[pd.DataFrame, np.ndarray]:
     frame_times = np.linspace(0, 99, 100)
     conditions = ["c0", "c0", "c0", "c1", "c1", "c1", "c2", "c2", "c2"]
     onsets = [30, 50, 70, 10, 30, 80, 30, 40, 60]
@@ -66,7 +66,7 @@ def spm_paradigm(block_duration):
     return events, frame_times
 
 
-def design_with_null_durations():
+def design_with_null_durations() -> pd.DataFrame:
     durations = _durations()
     durations[2] = 0
     durations[5] = 0
@@ -81,7 +81,7 @@ def design_with_null_durations():
     return events
 
 
-def design_with_nan_durations():
+def design_with_nan_durations() -> pd.DataFrame:
     durations = _durations()
     durations[2] = np.nan
     durations[5] = np.nan
@@ -111,7 +111,7 @@ def design_with_nan_onsets():
     return events
 
 
-def design_with_negative_onsets():
+def design_with_negative_onsets() -> pd.DataFrame:
     onsets = _onsets()
     onsets[0] = -32
     events = pd.DataFrame(
@@ -124,7 +124,7 @@ def design_with_negative_onsets():
     return events
 
 
-def duplicate_events_paradigm():
+def duplicate_events_paradigm() -> pd.DataFrame:
     conditions = ["c0", "c0", "c0", "c0", "c1", "c1"]
     onsets = [10, 30, 70, 70, 10, 30]
     durations = [1.0, 1.0, 1.0, 1.0, 1.0, 1]

--- a/nilearn/glm/tests/test_check_events_file_uses_tab_separators.py
+++ b/nilearn/glm/tests/test_check_events_file_uses_tab_separators.py
@@ -25,7 +25,7 @@ def make_data_for_test_runs():
     return data_for_temp_datafile, delimiters
 
 
-def _create_test_file(temp_csv, test_data, delimiter):
+def _create_test_file(temp_csv, test_data, delimiter) -> None:
     test_data = pd.DataFrame(test_data)
     test_data.to_csv(temp_csv, sep=delimiter)
 

--- a/nilearn/glm/tests/test_contrasts.py
+++ b/nilearn/glm/tests/test_contrasts.py
@@ -1,3 +1,6 @@
+from collections.abc import Callable
+from typing import Any
+
 import numpy as np
 import pytest
 import scipy.stats as st
@@ -47,7 +50,7 @@ def test_expression_to_contrast_vector_error():
 
 
 @pytest.fixture
-def set_up_glm():
+def set_up_glm() -> Callable[..., Any]:
     def _set_up_glm(rng, noise_model, bins=100):
         n, p, q = 100, 80, 10
         X, Y = (

--- a/nilearn/glm/tests/test_first_level_from_bids.py
+++ b/nilearn/glm/tests/test_first_level_from_bids.py
@@ -21,7 +21,7 @@ from nilearn.interfaces.bids import get_bids_files
 from nilearn.surface import SurfaceImage
 
 
-def _inputs_for_new_bids_dataset():
+def _inputs_for_new_bids_dataset() -> tuple[int, int, list[str], list[int]]:
     n_sub = 2
     n_ses = 2
     tasks = ["main"]
@@ -42,7 +42,7 @@ def bids_dataset(tmp_path_factory) -> Path:
     )
 
 
-def _new_bids_dataset(base_dir=None):
+def _new_bids_dataset(base_dir=None) -> Path:
     """Create a new BIDS dataset for testing purposes.
 
     Use if the dataset needs to be modified after creation.
@@ -57,7 +57,7 @@ def _new_bids_dataset(base_dir=None):
 
 def _check_output_first_level_from_bids(
     n_sub, models, imgs, events, confounds
-):
+) -> None:
     assert len(models) == n_sub
     assert all(isinstance(model, FirstLevelModel) for model in models)
 

--- a/nilearn/glm/tests/test_first_level_from_bids.py
+++ b/nilearn/glm/tests/test_first_level_from_bids.py
@@ -30,7 +30,7 @@ def _inputs_for_new_bids_dataset():
 
 
 @pytest.fixture(scope="session")
-def bids_dataset(tmp_path_factory):
+def bids_dataset(tmp_path_factory) -> Path:
     """Create a fake BIDS dataset for testing purposes.
 
     Only use if the dataset does not need to me modified.

--- a/nilearn/glm/tests/test_hemodynamic_models.py
+++ b/nilearn/glm/tests/test_hemodynamic_models.py
@@ -35,13 +35,13 @@ HRF_MODELS = [
 
 
 @pytest.fixture
-def expected_integral(hrf_model):
+def expected_integral(hrf_model) -> int:
     """Return the expected integral for the given hrf model."""
     return 1 if hrf_model in [spm_hrf, glover_hrf] else 0
 
 
 @pytest.fixture
-def expected_length(t_r):
+def expected_length(t_r) -> int:
     """Return the expected hrf kernel length for the given TR."""
     return int(32 / t_r * 50)
 

--- a/nilearn/glm/tests/test_io.py
+++ b/nilearn/glm/tests/test_io.py
@@ -178,7 +178,7 @@ def test_save_glm_to_bids_serialize_affine(tmp_path):
 
 
 @pytest.fixture
-def n_cols_design_matrix():
+def n_cols_design_matrix() -> int:
     """Return expected number of column in design matrix."""
     return 3
 

--- a/nilearn/glm/tests/test_thresholding.py
+++ b/nilearn/glm/tests/test_thresholding.py
@@ -62,7 +62,7 @@ def _data_norm_isf(shape):
 
 
 @pytest.fixture
-def data_norm_isf(shape_3d_default):
+def data_norm_isf(shape_3d_default) -> np.ndarray:
     return _data_norm_isf(shape_3d_default)
 
 

--- a/nilearn/glm/tests/test_thresholding.py
+++ b/nilearn/glm/tests/test_thresholding.py
@@ -56,7 +56,7 @@ def test_fdr_error(rng):
         fdr_threshold(x, 1.5)
 
 
-def _data_norm_isf(shape):
+def _data_norm_isf(shape) -> np.ndarray:
     p = np.prod(shape)
     return norm.isf(np.linspace(1.0 / p, 1.0 - 1.0 / p, p)).reshape(shape)
 

--- a/nilearn/image/tests/conftest.py
+++ b/nilearn/image/tests/conftest.py
@@ -7,7 +7,7 @@ from nilearn import image
 
 
 @pytest.fixture
-def img_4d_ones_eye_default_header(img_4d_ones_eye):
+def img_4d_ones_eye_default_header(img_4d_ones_eye) -> Nifti1Image:
     """Return a 4D Nifti1Image with default header.
 
     The header is created by new_img_like and is not modified. The image is
@@ -21,7 +21,7 @@ def img_4d_ones_eye_default_header(img_4d_ones_eye):
 
 
 @pytest.fixture
-def img_4d_ones_eye_tr2(img_4d_ones_eye):
+def img_4d_ones_eye_tr2(img_4d_ones_eye) -> Nifti1Image:
     """Return a 4D Nifti1Image with otherwise default header, except TR 2.0.
 
     The header is the default one created by new_img_like, but the TR is
@@ -35,7 +35,7 @@ def img_4d_ones_eye_tr2(img_4d_ones_eye):
 
 
 @pytest.fixture
-def img_4d_mni_tr2(img_4d_mni):
+def img_4d_mni_tr2(img_4d_mni) -> Nifti1Image:
     """Return a 4D Nifti1Image with MNI affine and header, and TR 2.0.
 
     The header has the MNI affine, and the TR is changed to 2.0. The image is

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -3,7 +3,7 @@
 import platform
 import re
 import warnings
-from collections.abc import Iterable
+from collections.abc import Generator, Iterable
 from pathlib import Path
 
 import joblib
@@ -162,12 +162,12 @@ def _mean_ground_truth(imgs):
 
 
 @pytest.fixture(scope="session")
-def smooth_array_data():
+def smooth_array_data() -> np.ndarray:
     return _new_data_for_smooth_array()
 
 
 @pytest.fixture(scope="session")
-def stat_img_test_data():
+def stat_img_test_data() -> Nifti1Image:
     shape = (20, 20, 30)
     affine = _affine_eye()
     data = np.zeros(shape, dtype="int32")
@@ -2363,7 +2363,9 @@ def test_check_niimg_wildcards(affine_eye, shape, wildcards, tmp_path):
 
 
 @pytest.fixture
-def img_in_home_folder(img_3d_mni):
+def img_in_home_folder(
+    img_3d_mni,
+) -> Generator[Nifti1Image, None, None]:
     """Create a test file in the home folder.
 
     Teardown: use yield instead of return to make sure the file
@@ -2458,7 +2460,7 @@ def test_check_niimg_wildcards_one_file_name(img_3d_zeros_eye, tmp_path):
 
 
 @pytest.fixture
-def set_expand_path_wildcards():
+def set_expand_path_wildcards() -> Generator[None, None, None]:
     """Toggles EXPAND_PATH_WILDCARDS before and after a test."""
     # Test when global variable is set to False => no globbing allowed
     ni.EXPAND_PATH_WILDCARDS = False

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -100,14 +100,16 @@ NON_EYE_AFFINE = np.array(
 )
 
 
-def _new_data_for_smooth_array():
+def _new_data_for_smooth_array() -> np.ndarray:
     # Impulse in 3D
     data = np.zeros((40, 41, 42))
     data[20, 20, 20] = 1
     return data
 
 
-def _make_largest_cc_img_test_data():
+def _make_largest_cc_img_test_data() -> tuple[
+    Nifti1Image, Nifti1Image, tuple[tuple[int, int, int], tuple[int, int, int]]
+]:
     shapes = ((10, 11, 12), (13, 14, 15))
     regions = [1, 3]
 
@@ -116,7 +118,9 @@ def _make_largest_cc_img_test_data():
     return img1, img2, shapes
 
 
-def _images_to_mean():
+def _images_to_mean() -> tuple[
+    list[Nifti1Image], list[Nifti1Image], list[Nifti1Image], list[Nifti1Image]
+]:
     """Return a mixture of 4D and 3D images."""
     rng = _rng()
 
@@ -139,7 +143,7 @@ def _images_to_mean():
     return imgs
 
 
-def _check_fwhm(data, affine, fwhm):
+def _check_fwhm(data, affine, fwhm) -> None:
     """Expect a full-width at half maximum of fwhm / voxel_size."""
     vmax = data.max()
     above_half_max = data > 0.5 * vmax
@@ -151,7 +155,7 @@ def _check_fwhm(data, affine, fwhm):
         assert_equal(proj.sum(), fwhm / np.abs(affine[axis, axis]))
 
 
-def _mean_ground_truth(imgs):
+def _mean_ground_truth(imgs) -> np.ndarray:
     arrays = []
     for img in imgs:
         img = get_data(img)
@@ -1136,7 +1140,7 @@ def test_input_in_threshold_img_several_timepoints(
     _check_thresholded_output(original_image, thr_img, threshold)
 
 
-def _check_thresholded_output(input, output, threshold):
+def _check_thresholded_output(input, output, threshold) -> None:
     """Check data was properly thresholed.
 
     Assumes:

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
@@ -1,5 +1,4 @@
 import re
-from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -379,7 +378,7 @@ SUFFIXES = np.array(["", "_derivative1", "_power2", "_derivative1_power2"])
 
 
 @pytest.fixture
-def expected_suffixes(motion) -> Any:
+def expected_suffixes(motion):
     """Return expected suffix."""
     expectation = {
         "basic": slice(1),
@@ -387,7 +386,7 @@ def expected_suffixes(motion) -> Any:
         "power2": np.array([True, False, True, False]),
         "full": slice(4),
     }
-    return SUFFIXES[expectation[motion]]  # type: ignore[call-overload]
+    return SUFFIXES[expectation[motion]]
 
 
 @pytest.mark.parametrize("fmriprep_version", ["1.4.x", "21.x.x"])

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
@@ -91,7 +91,7 @@ def _simu_img(tmp_path, trend, demean):
     return img, mask_conf, mask_rand, test_confounds, sample_mask
 
 
-def _handle_non_steady(confounds):
+def _handle_non_steady(confounds) -> pd.DataFrame:
     """Simulate non steady state correctly while increase the length.
 
     - The first row is non-steady state,
@@ -111,7 +111,7 @@ def _handle_non_steady(confounds):
     )
 
 
-def _regression(confounds, tmp_path):
+def _regression(confounds, tmp_path) -> None:
     """Perform simple regression with NiftiMasker."""
     # Simulate data
     img, mask_conf, _, _, _ = _simu_img(tmp_path, trend=False, demean=False)
@@ -447,7 +447,7 @@ missing_params = ["trans_y", "trans_x_derivative1", "rot_z_power2"]
 missing_keywords = ["cosine", "global_signal"]
 
 
-def _remove_confounds(conf_file):
+def _remove_confounds(conf_file) -> None:
     legal_confounds = pd.read_csv(conf_file, delimiter="\t", encoding="utf-8")
     remove_columns = []
     for missing_kw in missing_keywords:

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -378,7 +379,7 @@ SUFFIXES = np.array(["", "_derivative1", "_power2", "_derivative1_power2"])
 
 
 @pytest.fixture
-def expected_suffixes(motion):
+def expected_suffixes(motion) -> Any:
     """Return expected suffix."""
     expectation = {
         "basic": slice(1),
@@ -386,7 +387,7 @@ def expected_suffixes(motion):
         "power2": np.array([True, False, True, False]),
         "full": slice(4),
     }
-    return SUFFIXES[expectation[motion]]
+    return SUFFIXES[expectation[motion]]  # type: ignore[call-overload]
 
 
 @pytest.mark.parametrize("fmriprep_version", ["1.4.x", "21.x.x"])

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds_components.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds_components.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pandas as pd
 import pytest
 
@@ -10,7 +12,7 @@ from nilearn.interfaces.fmriprep.tests._testing import create_tmp_filepath
 
 
 @pytest.fixture
-def expected_parameters(strategy_keywords):
+def expected_parameters(strategy_keywords) -> Any:
     """Return expected parameters for a given strategy."""
     expectation = {
         "compcor": {"compcor": "anat_combined", "n_compcor": 6},

--- a/nilearn/interfaces/fmriprep/tests/test_load_confounds_components.py
+++ b/nilearn/interfaces/fmriprep/tests/test_load_confounds_components.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pandas as pd
 import pytest
 
@@ -12,7 +10,7 @@ from nilearn.interfaces.fmriprep.tests._testing import create_tmp_filepath
 
 
 @pytest.fixture
-def expected_parameters(strategy_keywords) -> Any:
+def expected_parameters(strategy_keywords: str):
     """Return expected parameters for a given strategy."""
     expectation = {
         "compcor": {"compcor": "anat_combined", "n_compcor": 6},
@@ -22,8 +20,7 @@ def expected_parameters(strategy_keywords) -> Any:
         return expectation[strategy_keywords]
     elif strategy_keywords != "high_pass":
         return {strategy_keywords: "full"}
-    else:
-        return False
+    return False
 
 
 @pytest.mark.parametrize("fmriprep_version", ["1.4.x", "21.x.x"])

--- a/nilearn/interfaces/tests/test_query.py
+++ b/nilearn/interfaces/tests/test_query.py
@@ -131,7 +131,7 @@ def test_infer_slice_timing_start_time_from_dataset(tmp_path):
     assert StartTime == expected_StartTime
 
 
-def _rm_all_json_files_from_bids_dataset(bids_path):
+def _rm_all_json_files_from_bids_dataset(bids_path) -> None:
     """Remove all json and make sure that get_bids_files does not find any."""
     for x in bids_path.glob("**/*.json"):
         x.unlink()

--- a/nilearn/maskers/tests/conftest.py
+++ b/nilearn/maskers/tests/conftest.py
@@ -9,7 +9,7 @@ from nilearn.surface import SurfaceImage
 
 
 @pytest.fixture
-def data_1(shape_3d_default):
+def data_1(shape_3d_default) -> np.ndarray:
     """Return 3D zeros with a few 10 in the center."""
     data = np.zeros(shape_3d_default)
     data[2:-2, 2:-2, 2:-2] = 10
@@ -17,13 +17,13 @@ def data_1(shape_3d_default):
 
 
 @pytest.fixture
-def mask_img_1(data_1, affine_eye):
+def mask_img_1(data_1, affine_eye) -> Nifti1Image:
     """Return a mask image."""
     return Nifti1Image(data_1.astype("uint8"), affine_eye)
 
 
 @pytest.fixture
-def shape_mask():
+def shape_mask() -> tuple[int, int, int]:
     """Shape for masks."""
     return (13, 14, 15)
 

--- a/nilearn/maskers/tests/test_baseline_comparisons.py
+++ b/nilearn/maskers/tests/test_baseline_comparisons.py
@@ -29,7 +29,11 @@ from nilearn.maskers import (
     SurfaceMapsMasker,
     SurfaceMasker,
 )
-from nilearn.surface.surface import at_least_2d, find_surface_clusters
+from nilearn.surface.surface import (
+    SurfaceImage,
+    at_least_2d,
+    find_surface_clusters,
+)
 
 
 def loaded_motor_activation_image():
@@ -146,12 +150,12 @@ def test_nifti_spheres_masker_create_summary_figure_for_report():
     return masker._create_figure_for_report()[0]
 
 
-def _fs_inflated_sulcal():
+def _fs_inflated_sulcal() -> SurfaceImage:
     """Load fs average sulcal data on inflated surface."""
     return load_fsaverage_data(mesh_type="inflated")
 
 
-def _surface_mask_img():
+def _surface_mask_img() -> SurfaceImage:
     """Generate surface mask including only high curvature regions."""
     return threshold_img(
         _fs_inflated_sulcal(), 0.5, cluster_threshold=50, two_sided=False

--- a/nilearn/maskers/tests/test_html_report.py
+++ b/nilearn/maskers/tests/test_html_report.py
@@ -6,6 +6,7 @@ should go into nilearn/_utils/estimator_checks.
 
 from collections import Counter
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -120,19 +121,21 @@ def generate_and_check_masker_report(
 
 
 @pytest.fixture
-def niftimapsmasker_inputs():
+def niftimapsmasker_inputs() -> dict[str, Any]:
     """Return inputs for nifti maps masker."""
     return {"maps_img": _img_maps(n_regions=3)}
 
 
 @pytest.fixture
-def labels(n_regions):
+def labels(n_regions) -> list[str]:
     """Return labels for label masker."""
     return ["background"] + [f"region_{i}" for i in range(1, n_regions + 1)]
 
 
 @pytest.fixture
-def input_parameters(masker_class, img_mask_eye, labels, img_labels):
+def input_parameters(
+    masker_class, img_mask_eye, labels, img_labels
+) -> dict[str, Any] | None:
     """Define inputs for each type masker."""
     if masker_class in (NiftiMasker, MultiNiftiMasker):
         return {"mask_img": img_mask_eye}
@@ -157,6 +160,7 @@ def input_parameters(masker_class, img_mask_eye, labels, img_labels):
         }
     if masker_class is SurfaceMapsMasker:
         return {"maps_img": _surf_maps_img()}
+    return None
 
 
 @pytest.mark.slow

--- a/nilearn/maskers/tests/test_mixin.py
+++ b/nilearn/maskers/tests/test_mixin.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from sklearn import clone
 
@@ -24,7 +26,9 @@ from nilearn.maskers.tests.test_html_report import (
 
 
 @pytest.fixture
-def masker(request, img_maps, surf_maps_img, img_labels, surf_label_img):
+def masker(
+    request, img_maps, surf_maps_img, img_labels, surf_label_img
+) -> Any:
     """Fixture to construct a masker instance with proper input."""
     cls, arg, reports = request.param
 

--- a/nilearn/maskers/tests/test_mixin.py
+++ b/nilearn/maskers/tests/test_mixin.py
@@ -1,6 +1,5 @@
-from typing import Any
-
 import pytest
+from nibabel import Nifti1Image
 from sklearn import clone
 
 from nilearn._utils.helpers import is_gil_enabled
@@ -23,12 +22,13 @@ from nilearn.maskers import (
 from nilearn.maskers.tests.test_html_report import (
     generate_and_check_masker_report,
 )
+from nilearn.surface import SurfaceImage
 
 
 @pytest.fixture
 def masker(
     request, img_maps, surf_maps_img, img_labels, surf_label_img
-) -> Any:
+) -> SurfaceImage | Nifti1Image:
     """Fixture to construct a masker instance with proper input."""
     cls, arg, reports = request.param
 

--- a/nilearn/maskers/tests/test_nifti_masker.py
+++ b/nilearn/maskers/tests/test_nifti_masker.py
@@ -335,7 +335,7 @@ def test_compute_epi_mask(affine_eye):
 
 
 @pytest.fixture
-def expected_mask(mask_args):
+def expected_mask(mask_args) -> np.ndarray:
     """Create an expected mask."""
     mask = np.zeros((9, 9, 5))
     if mask_args == {}:

--- a/nilearn/maskers/tests/test_surface_maps_masker.py
+++ b/nilearn/maskers/tests/test_surface_maps_masker.py
@@ -184,7 +184,7 @@ def test_surface_maps_masker_mask_img_masks_all_maps_error(surf_mesh):
 
 
 @pytest.fixture
-def non_overlapping_maps(surf_mesh):
+def non_overlapping_maps(surf_mesh) -> SurfaceImage:
     """Generate maps with non-overlapping regions.
 
     Each vertex belongs to only 1 region.
@@ -212,7 +212,7 @@ def non_overlapping_maps(surf_mesh):
 
 
 @pytest.fixture
-def overlapping_maps(surf_mesh):
+def overlapping_maps(surf_mesh) -> SurfaceImage:
     """Generate maps with overlapping regions.
 
     Some vertices have non null value for 2 different regions.

--- a/nilearn/mass_univariate/tests/test_utils.py
+++ b/nilearn/mass_univariate/tests/test_utils.py
@@ -15,7 +15,7 @@ from nilearn.mass_univariate.tests._testing import (
 
 
 @pytest.fixture
-def null():
+def null() -> list[int]:
     """Return a dummy null distribution that can be reused across tests."""
     return [-10, -9, -9, -3, -2, -1, -1, 0, 1, 1, 1, 2, 3, 3, 4, 4, 7, 8, 8, 9]
 
@@ -151,7 +151,7 @@ def test_null_to_p_array(rng):
 
 
 @pytest.fixture
-def _arr4d():
+def _arr4d() -> np.ndarray:
     _arr4d = np.zeros((10, 10, 10, 1))
     _arr4d[:2, :2, :2, 0] = 5  # 8-voxel cluster, high intensity
     _arr4d[7:, 7:, 7:, 0] = 1  # 27-voxel cluster, low intensity

--- a/nilearn/plotting/conftest.py
+++ b/nilearn/plotting/conftest.py
@@ -1,5 +1,7 @@
 """Fixtures for tests for plotting."""
 
+from typing import Any
+
 import numpy as np
 import pytest
 from nibabel import Nifti1Image
@@ -22,7 +24,7 @@ def mni152_template_res_2() -> Nifti1Image:
 
 
 @pytest.fixture
-def adjacency():
+def adjacency() -> np.ndarray:
     """Adjacency matrix symmetric up to 1e-3 relative tolerance."""
     return np.array(
         [
@@ -35,12 +37,12 @@ def adjacency():
 
 
 @pytest.fixture
-def node_coords():
+def node_coords() -> np.ndarray:
     """Array of node coordinates for testing."""
     return np.arange(3 * 4).reshape(4, 3)
 
 
 @pytest.fixture
-def params_plot_connectome():
+def params_plot_connectome() -> dict[str, Any]:
     """Return basic set of parameters for testing plot_connectome."""
     return {"edge_threshold": 0.38, "title": "threshold=0.38", "node_size": 10}

--- a/nilearn/plotting/displays/tests/test_displays.py
+++ b/nilearn/plotting/displays/tests/test_displays.py
@@ -142,7 +142,7 @@ def test_get_index_from_direction_exception():
 
 
 @pytest.fixture
-def cut_coords(name):
+def cut_coords(name) -> int | tuple[int, ...] | list[int]:
     """Select appropriate cut coords."""
     if name == "mosaic":
         return 3

--- a/nilearn/plotting/image/tests/test_img_plotting.py
+++ b/nilearn/plotting/image/tests/test_img_plotting.py
@@ -38,7 +38,7 @@ PLOTTING_FUNCS_4D = {plot_prob_atlas, plot_carpet}
 PLOTTING_FUNCS_3D = ALL_PLOTTING_FUNCS.difference(PLOTTING_FUNCS_4D)
 
 
-def _add_nans_to_img(img, affine_mni=None):
+def _add_nans_to_img(img, affine_mni=None) -> Nifti1Image:
     """Add nans in test image data."""
     if affine_mni is None:
         affine_mni = _affine_mni()

--- a/nilearn/plotting/image/tests/test_plot_connectome.py
+++ b/nilearn/plotting/image/tests/test_plot_connectome.py
@@ -9,7 +9,7 @@ from nilearn.plotting import plot_connectome
 
 
 @pytest.fixture
-def non_symmetric_matrix():
+def non_symmetric_matrix() -> np.ndarray:
     """Non symmetric adjacency matrix."""
     return np.array(
         [

--- a/nilearn/plotting/image/tests/test_plot_img.py
+++ b/nilearn/plotting/image/tests/test_plot_img.py
@@ -13,7 +13,7 @@ from nilearn.image import get_data
 from nilearn.plotting import plot_img
 
 
-def _testdata_3d_for_plotting_for_resampling(img, binary):
+def _testdata_3d_for_plotting_for_resampling(img, binary) -> Nifti1Image:
     """Return testing data for resampling tests.
 
     Data can be binarize or not.

--- a/nilearn/plotting/surface/tests/conftest.py
+++ b/nilearn/plotting/surface/tests/conftest.py
@@ -1,5 +1,7 @@
 """Test fixtures used by nilearn.plotting.surface tests."""
 
+from types import ModuleType
+
 import numpy as np
 import pytest
 
@@ -34,13 +36,13 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture
-def engine(request):
+def engine(request) -> str:
     """Return each of the engines detected by pytest_generate_tests."""
     return request.param
 
 
 @pytest.fixture
-def plt(request, engine):
+def plt(request, engine) -> ModuleType | None:
     """Return the fixture for setup and teardown of test depending on the
     engine.
     """
@@ -48,6 +50,7 @@ def plt(request, engine):
         return request.getfixturevalue("matplotlib_pyplot")
     elif engine == "plotly":
         return request.getfixturevalue("plotly")
+    return None
 
 
 @pytest.fixture

--- a/nilearn/plotting/tests/test_baseline_comparisons.py
+++ b/nilearn/plotting/tests/test_baseline_comparisons.py
@@ -656,7 +656,7 @@ def test_plot_event_x_lim(rng):
 
 
 @pytest.fixture
-def matrix_to_plot(rng):
+def matrix_to_plot(rng) -> np.ndarray:
     """Return a random 50x50 matrix to plot."""
     return rng.random((50, 50)) * 10 - 5
 

--- a/nilearn/plotting/tests/test_engine_utils.py
+++ b/nilearn/plotting/tests/test_engine_utils.py
@@ -62,7 +62,7 @@ def test_colorscale_no_threshold():
 
 
 @pytest.fixture
-def expected_abs_threshold(threshold):
+def expected_abs_threshold(threshold) -> float | None:
     """Return the expected absolute threshold."""
     expected = {"0%": 1.5, "50%": 7.55, "99%": 13}
     return (
@@ -121,7 +121,7 @@ def test_colorscale_symmetric_cmap(vmin, vmax):
 
 
 @pytest.fixture
-def expected_vmin_vmax(values, vmax, vmin):
+def expected_vmin_vmax(values, vmax, vmin) -> tuple[float, float]:
     """Return expected vmin and vmax."""
     if vmax is None:
         return (min(values), max(values))

--- a/nilearn/plotting/tests/test_find_cuts.py
+++ b/nilearn/plotting/tests/test_find_cuts.py
@@ -339,7 +339,7 @@ def _parcellation_3_roi(
     x_map_c,
     y_map_c,
     z_map_c,
-):
+) -> np.ndarray:
     """Return data defining 3 parcellations."""
     data = np.zeros((100, 100, 100))
 
@@ -495,7 +495,7 @@ def test_find_parcellation_cut_coords_hemispheres(affine_mni):
 
 def _proba_parcellation_2_roi(
     x_map_a, y_map_a, z_map_a, x_map_b, y_map_b, z_map_b
-):
+) -> np.ndarray:
     """Return data defining probabilistic atlas with 2 rois."""
     arr1 = np.zeros((100, 100, 100))
     arr1[

--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -6,9 +6,9 @@ import pytest
 from matplotlib import pyplot as plt
 from nibabel import Nifti1Image
 
-from nilearn import image
 from nilearn.conftest import _img_3d_rand
 from nilearn.image import get_data, new_img_like
+from nilearn.image.resampling import to_matrix_vector
 from nilearn.plotting._engine_utils import colorscale
 from nilearn.plotting.html_stat_map import (
     StatMapView,
@@ -41,7 +41,7 @@ def check_html_view_img(html_view, title=None):
         assert f"<title>Nilearn - {title}</title>" in str(html_view)
 
 
-def _simulate_img(affine=None):
+def _simulate_img(affine=None) -> tuple[Nifti1Image, np.ndarray]:
     """Simulate data with one "spot".
 
     Returns
@@ -58,13 +58,13 @@ def _simulate_img(affine=None):
     return img, data
 
 
-def _check_affine(affine):
+def _check_affine(affine) -> None:
     """Check positive, isotropic, near-diagonal affine."""
     assert affine[0, 0] == affine[1, 1]
     assert affine[2, 2] == affine[1, 1]
     assert affine[0, 0] > 0
 
-    A, _ = image.resampling.to_matrix_vector(affine)
+    A, _ = to_matrix_vector(affine)
     assert np.all((np.abs(A) > 0.001).sum(axis=0) == 1), (
         "the affine transform was not near-diagonal"
     )
@@ -388,7 +388,7 @@ def test_view_img_3d(img_3d_mni, view_img_kwargs, expected_output_title):
 def test_view_img_4d(img_3d_mni):
     """Test for 4D images."""
     # convert into 4D (with only 1 timepoint)
-    img_4d_mni = image.new_img_like(
+    img_4d_mni = new_img_like(
         img_3d_mni, get_data(img_3d_mni)[:, :, :, np.newaxis]
     )
     html_view = view_img(img_4d_mni)

--- a/nilearn/plotting/tests/test_img_comparisons.py
+++ b/nilearn/plotting/tests/test_img_comparisons.py
@@ -14,7 +14,7 @@ from nilearn.plotting import plot_bland_altman, plot_img_comparison
 # ruff: noqa: ARG001
 
 
-def _mask():
+def _mask() -> Nifti1Image:
     affine = _affine_mni()
     data_positive = np.zeros((7, 7, 3))
     data_positive[1:-1, 2:-1, 1:] = 1

--- a/nilearn/plotting/tests/test_utils.py
+++ b/nilearn/plotting/tests/test_utils.py
@@ -75,7 +75,7 @@ def test_should_raise_import_error_for_version_check(matplotlib_pyplot):  # noqa
 
 
 @pytest.fixture
-def data_pos_neg():
+def data_pos_neg() -> np.ndarray:
     """Fixture for data with both positive and negative values."""
     # min: -0.5, max: 3.0
     return np.array(
@@ -84,21 +84,21 @@ def data_pos_neg():
 
 
 @pytest.fixture
-def data_pos(data_pos_neg):
+def data_pos(data_pos_neg) -> np.ndarray:
     """Fixture for data with only positive values."""
     # min: 0.5, max: 3.0
     return np.abs(data_pos_neg)
 
 
 @pytest.fixture
-def data_neg(data_pos_neg):
+def data_neg(data_pos_neg) -> np.ndarray:
     """Fixture for data with only negative values."""
     # min: -3, max: -0.5
     return -np.abs(data_pos_neg)
 
 
 @pytest.fixture
-def data_masked(data_pos_neg):
+def data_masked(data_pos_neg) -> np.ma.MaskedArray:
     """Fixture for data with masked values."""
     # min: -0.5, max: 1.5
     return np.ma.masked_greater(data_pos_neg, 2.0)

--- a/nilearn/regions/tests/test_parcellations.py
+++ b/nilearn/regions/tests/test_parcellations.py
@@ -85,7 +85,7 @@ def test_check_estimator_nilearn(estimator, check, name):  # noqa: ARG001
 
 
 @pytest.fixture
-def image_1():
+def image_1() -> Nifti1Image:
     data = np.zeros((10, 11, 12, 5))
     data[9, 10, 2] = 1
     data[4, 9, 3] = 2
@@ -93,7 +93,7 @@ def image_1():
 
 
 @pytest.fixture
-def image_2():
+def image_2() -> Nifti1Image:
     data = np.ones((10, 11, 12, 10))
     data[6, 7, 8] = 2
     data[9, 10, 11] = 3
@@ -431,12 +431,12 @@ def test_transform_list_3d_input_images(affine_eye):
 
 
 @pytest.fixture
-def n_samples():
+def n_samples() -> int:
     return 10
 
 
 @pytest.fixture
-def surface_img_for_parcellation(rng, n_samples):
+def surface_img_for_parcellation(rng, n_samples) -> SurfaceImage:
     mesh = {
         "left": flat_mesh(10, 8),
         "right": flat_mesh(9, 7),

--- a/nilearn/regions/tests/test_region_extractor.py
+++ b/nilearn/regions/tests/test_region_extractor.py
@@ -26,12 +26,12 @@ from nilearn.regions.region_extractor import (
 
 
 @pytest.fixture
-def negative_regions():
+def negative_regions() -> bool:
     return False
 
 
 @pytest.fixture
-def dummy_map(shape_3d_default, n_regions):
+def dummy_map(shape_3d_default, n_regions) -> Nifti1Image:
     """Generate a small dummy map.
 
     Use for error testing
@@ -40,7 +40,7 @@ def dummy_map(shape_3d_default, n_regions):
 
 
 @pytest.fixture
-def map_img_3d(rng, affine_eye, shape_3d_default):
+def map_img_3d(rng, affine_eye, shape_3d_default) -> Nifti1Image:
     map_img = np.zeros(shape_3d_default) + 0.1 * rng.standard_normal(
         size=shape_3d_default
     )
@@ -51,7 +51,7 @@ N_REGIONS = 3
 
 
 @pytest.fixture
-def maps(negative_regions, n_regions, shape_3d_large):
+def maps(negative_regions, n_regions, shape_3d_large) -> Nifti1Image:
     return generate_maps(
         shape=shape_3d_large,
         n_regions=n_regions,
@@ -61,7 +61,9 @@ def maps(negative_regions, n_regions, shape_3d_large):
 
 
 @pytest.fixture
-def maps_and_mask(n_regions, shape_3d_large):
+def maps_and_mask(
+    n_regions, shape_3d_large
+) -> tuple[Nifti1Image, Nifti1Image]:
     return generate_maps(
         shape=shape_3d_large, n_regions=n_regions, random_state=42
     )

--- a/nilearn/regions/tests/test_signal_extraction.py
+++ b/nilearn/regions/tests/test_signal_extraction.py
@@ -74,17 +74,17 @@ def _create_mask_with_3_regions_from_labels_data(labels_data, affine):
 
 
 @pytest.fixture
-def labels_data():
+def labels_data() -> np.ndarray:
     return _make_label_data()
 
 
 @pytest.fixture
-def labels_img():
+def labels_img() -> Nifti1Image:
     return Nifti1Image(_make_label_data(_shape_3d_default()), _affine_eye())
 
 
 @pytest.fixture
-def mask_img():
+def mask_img() -> Nifti1Image:
     mask_data = np.zeros(_shape_3d_default())
     mask_data[1:-1, 1:-1, 1:-1] = 1
     return Nifti1Image(mask_data, _affine_eye())
@@ -96,14 +96,14 @@ def signals() -> np.ndarray:
 
 
 @pytest.fixture
-def fmri_img():
+def fmri_img() -> Nifti1Image:
     return generate_fake_fmri(shape=_shape_3d_default(), affine=_affine_eye())[
         0
     ]
 
 
 @pytest.fixture
-def labeled_regions():
+def labeled_regions() -> Nifti1Image:
     labels = list(range(N_REGIONS + 1))  # 0 is background
     return generate_labeled_regions(
         shape=_shape_3d_default(), n_regions=N_REGIONS, labels=labels

--- a/nilearn/regions/tests/test_signal_extraction.py
+++ b/nilearn/regions/tests/test_signal_extraction.py
@@ -51,7 +51,7 @@ N_REGIONS = 8
 N_TIMEPOINTS = 17
 
 
-def _make_label_data(shape=None):
+def _make_label_data(shape=None) -> np.ndarray:
     if shape is None:
         shape = _shape_3d_default()
     labels_data = np.zeros(shape, dtype="int32")
@@ -67,7 +67,9 @@ def _make_label_data(shape=None):
     return labels_data
 
 
-def _create_mask_with_3_regions_from_labels_data(labels_data, affine):
+def _create_mask_with_3_regions_from_labels_data(
+    labels_data, affine
+) -> Nifti1Image:
     """Create a mask containing only 3 regions."""
     mask_data = (labels_data == 1) + (labels_data == 2) + (labels_data == 5)
     return Nifti1Image(mask_data.astype(np.int8), affine)
@@ -112,7 +114,7 @@ def labeled_regions() -> Nifti1Image:
 
 def _all_voxel_of_each_region_have_same_values(
     data, labels_data, n_regions, signals
-):
+) -> None:
     for n in range(1, n_regions + 1):
         sigs = data[labels_data == n, :]
         assert_almost_equal(sigs[0, :], signals[:, n - 1])

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -51,7 +51,7 @@ def _simu_img():
     return img, mask, conf
 
 
-def _cov_conf(tseries, conf):
+def _cov_conf(tseries, conf) -> np.ndarray:
     conf_n = StandardScaler().fit_transform(conf)
     _ = StandardScaler().fit_transform(tseries)
     cov_mat = np.dot(tseries.T, conf_n)

--- a/nilearn/tests/test_masking.py
+++ b/nilearn/tests/test_masking.py
@@ -641,7 +641,7 @@ def test_unmask_error_shape(rng, affine_eye, shape_4d_default):
 
 
 @pytest.fixture
-def img_2d_mask_bottom_right(affine_eye):
+def img_2d_mask_bottom_right(affine_eye) -> Nifti1Image:
     """Return 3D nifti binary mask image with bottom right filled.
 
     +---+---+---+---+
@@ -661,7 +661,7 @@ def img_2d_mask_bottom_right(affine_eye):
 
 
 @pytest.fixture
-def img_2d_mask_center(affine_eye):
+def img_2d_mask_center(affine_eye) -> Nifti1Image:
     """Return 3D nifti binary mask image with center filled.
 
     +---+---+---+---+

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -1359,7 +1359,7 @@ def test_clean_psc_butterworth(rng):
         )
 
 
-def _assert_correlation_almost_1(signal_1, signal_2):
+def _assert_correlation_almost_1(signal_1, signal_2) -> None:
     """Check that correlation between 2 signals equal to 1."""
     assert_almost_equal(
         np.corrcoef(signal_1[:, 0], signal_2[:, 0])[0, 1],

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -730,13 +730,13 @@ def test_clean_runs():
 
 
 @pytest.fixture
-def signals():
+def signals() -> np.ndarray:
     """Return generic signal."""
     return generate_signals(n_features=41, n_confounds=5, length=45)[0]
 
 
 @pytest.fixture
-def confounds():
+def confounds() -> np.ndarray:
     """Return generic condounds."""
     return generate_signals(n_features=41, n_confounds=5, length=45)[2]
 


### PR DESCRIPTION
- Relates to #3568 

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- Add return type annotations to all 185 `@pytest.fixture` functions across 37 test files and conftest modules
- Fixtures returning values use concrete return types; yield-based fixtures use `Generator[T, None, None]` from `collections.abc`; setup-only fixtures annotated `-> None`
- Add necessary imports (`Generator`, `Iterator`, `Callable`, etc.) where missing