### PR TITLE
[MAINT] Add return type annotations to conftest.py fixtures and estimator_checks.py check functions

### DIFF
--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -27,7 +27,7 @@ import warnings
 from copy import deepcopy
 from pathlib import Path
 from tempfile import TemporaryDirectory, mkdtemp
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
@@ -1194,7 +1194,7 @@ def check_img_estimator_verbose(estimator_orig) -> None:
     assert len(output_2) >= len(output), f"\n{output=}\n{output_2=}"
 
 
-def check_verbosity_embedded_masker(estimator_orig):
+def check_verbosity_embedded_masker(estimator_orig) -> None:
     """Check control of verbosity of embedded maskers / estimators.
 
     Only for decoder and GLM
@@ -1241,7 +1241,7 @@ def check_verbosity_embedded_masker(estimator_orig):
             assert re.search(r"Computation of .* done in", outputs[verbose])
 
 
-def check_warning_embedded_masker(estimator_orig):
+def check_warning_embedded_masker(estimator_orig) -> None:
     """Check no excessive warning thrown by embedded masker."""
     estimator = clone(estimator_orig)
 
@@ -1825,7 +1825,7 @@ def check_img_estimator_pipeline_consistency(estimator_orig) -> None:
             assert_allclose_dense_sparse(result, result_pipe)
 
 
-def check_img_estimator_dtype_bool(estimator_orig):
+def check_img_estimator_dtype_bool(estimator_orig) -> None:
     """Raise error for dtype bool or
     cast bool input to int for inverse_transform.
     """
@@ -1859,7 +1859,7 @@ def check_img_estimator_dtype_bool(estimator_orig):
         estimator.inverse_transform(signal)
 
 
-def check_img_estimator_dtypes_transform(estimator_orig):
+def check_img_estimator_dtypes_transform(estimator_orig) -> None:
     """Check estimator can fit and run for transform \
        with inputs of varying dtypes.
 
@@ -1874,7 +1874,7 @@ def check_img_estimator_dtypes_transform(estimator_orig):
     if not hasattr(estimator_orig, "transform"):
         return
 
-    dtype_list = [None]
+    dtype_list: list[Any] = [None]
     if hasattr(estimator_orig, "dtype"):
         dtype_list = [
             np.float32,
@@ -1886,9 +1886,9 @@ def check_img_estimator_dtypes_transform(estimator_orig):
             None,
         ]
 
-    memory_list = [None]
+    memory_list: list[Any] = [None]
     if hasattr(estimator_orig, "memory"):
-        memory = [None, Path(mkdtemp())]
+        memory_list = [None, Path(mkdtemp())]
 
     for input_dtype in [np.float32, "float64", np.int32, "i4"]:
         for dtype in dtype_list:
@@ -1901,7 +1901,7 @@ def check_img_estimator_dtypes_transform(estimator_orig):
                 if hasattr(estimator, "memory"):
                     estimator.memory = memory
 
-                input_dtype = np.dtype(input_dtype)
+                input_dtype = np.dtype(input_dtype)  # type: ignore[call-overload]
 
                 X, y = generate_data_to_fit(estimator)
                 if (
@@ -1960,7 +1960,7 @@ def check_img_estimator_dtypes_transform(estimator_orig):
                         assert_array_equal(s1, s2)
 
 
-def check_img_estimator_dtypes(estimator_orig):
+def check_img_estimator_dtypes(estimator_orig) -> None:
     """Check estimator can fit and run several methods \
        with inputs of varying dtypes.
 
@@ -1972,7 +1972,7 @@ def check_img_estimator_dtypes(estimator_orig):
 
     input_dtype np.int64 not tested: see no_int64_nifti in nilearn/conftest.py
     """
-    dtype_list = [None]
+    dtype_list: list[Any] = [None]
     if hasattr(estimator_orig, "dtype"):
         dtype_list = [
             np.float32,
@@ -1984,9 +1984,9 @@ def check_img_estimator_dtypes(estimator_orig):
             None,
         ]
 
-    memory_list = [None]
+    memory_list: list[Any] = [None]
     if hasattr(estimator_orig, "memory"):
-        memory = [None, Path(mkdtemp())]
+        memory_list = [None, Path(mkdtemp())]
 
     for input_dtype in [np.float32, "float64", np.int32, "i4"]:
         for dtype in dtype_list:
@@ -1999,7 +1999,7 @@ def check_img_estimator_dtypes(estimator_orig):
                 if hasattr(estimator, "memory"):
                     estimator.memory = memory
 
-                input_dtype = np.dtype(input_dtype)
+                input_dtype = np.dtype(input_dtype)  # type: ignore[call-overload]
 
                 X, y = generate_data_to_fit(estimator)
                 if (
@@ -2037,7 +2037,7 @@ def check_img_estimator_dtypes(estimator_orig):
                         getattr(estimator, method)(X)
 
 
-def check_img_estimator_dtypes_inverse_transform(estimator_orig):
+def check_img_estimator_dtypes_inverse_transform(estimator_orig) -> None:
     """Check estimator can inverse_transform with inputs of varying dtypes.
 
     inverse transform should generate images and conserve dtype.
@@ -2046,7 +2046,7 @@ def check_img_estimator_dtypes_inverse_transform(estimator_orig):
     we must handle deal with the fact that nibabel won't create
     images with np.int64
     """
-    dtype_list = [None]
+    dtype_list: list[Any] = [None]
     if hasattr(estimator_orig, "dtype"):
         dtype_list = [
             np.float32,
@@ -2095,7 +2095,7 @@ def check_img_estimator_dtypes_inverse_transform(estimator_orig):
             ):
                 output_img = output_img[0]
 
-            target_dtype = get_target_dtype(np.dtype(input_dtype), dtype)
+            target_dtype = get_target_dtype(np.dtype(input_dtype), dtype)  # type: ignore[call-overload]
             if target_dtype is None:
                 target_dtype = input_dtype
 
@@ -2374,7 +2374,7 @@ def check_supervised_img_estimator_y_no_nan(estimator_orig) -> None:
             estimator.fit(X, y)
 
 
-def check_decoder_empty_data_messages(estimator_orig):
+def check_decoder_empty_data_messages(estimator_orig) -> None:
     """Check that empty images are caught properly.
 
     Run on both surfance and volume data.
@@ -2411,17 +2411,17 @@ def check_decoder_empty_data_messages(estimator_orig):
     estimator = clone(estimator_orig)
 
     imgs = _make_surface_img(n_samples)
-    data = {
+    data = {  # type: ignore[assignment]
         part: np.empty(0).reshape((imgs.data.parts[part].shape[0], 0))
         for part in imgs.data.parts
     }
-    X = SurfaceImage(imgs.mesh, data)
+    X = SurfaceImage(imgs.mesh, data)  # type: ignore[assignment]
 
     with pytest.raises(ValueError, match="empty"):
         estimator.fit(X, y)
 
 
-def check_decoder_compatibility_mask_image(estimator_orig):
+def check_decoder_compatibility_mask_image(estimator_orig) -> None:
     """Check compatibility of the mask_img and images for decoders.
 
     Compatibility should be check for fit, score, predict, decision function.
@@ -2461,7 +2461,7 @@ def check_decoder_compatibility_mask_image(estimator_orig):
 
         input = (_make_surface_img(3),)
         if method == "score":
-            input = (_make_surface_img(3), y)
+            input = (_make_surface_img(3), y)  # type: ignore[assignment]
 
         with pytest.raises(
             TypeError,
@@ -2554,7 +2554,7 @@ def check_decoder_with_arrays(estimator_orig) -> None:
         assert_array_equal(result_1, result_2)
 
 
-def check_decoder_estimator_args(estimator_orig):
+def check_decoder_estimator_args(estimator_orig) -> None:
     """Check extra_parameters can be passed to the sklearn estimator."""
     if isinstance(estimator_orig, BaseSpaceNet):
         # BaseSpaceNet do not have an embedded sklearn estimator
@@ -2570,7 +2570,7 @@ def check_decoder_estimator_args(estimator_orig):
     assert estimator.estimator_.max_iter == 5000
 
 
-def check_decoder_screening_n_features(estimator_orig):
+def check_decoder_screening_n_features(estimator_orig) -> None:
     """Set screening_n_features gives the requested number of weights / CV.
 
     screening_n_features determines the number of seelcted features per CV
@@ -3003,7 +3003,7 @@ def check_masker_transformer(estimator_orig) -> None:
     assert_array_equal(signal_1, signal_2)
 
 
-def check_masker_transformer_high_variance_confounds(estimator_orig):
+def check_masker_transformer_high_variance_confounds(estimator_orig) -> None:
     """Check high_variance_confounds use in maskers.
 
     Make sure that using high_variance_confounds returns different result.
@@ -3015,6 +3015,7 @@ def check_masker_transformer_high_variance_confounds(estimator_orig):
 
     length = 10
 
+    input_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         data = _rng().random((*_shape_3d_default(), length))
         input_img = Nifti1Image(data, _affine_eye())
@@ -3037,10 +3038,10 @@ def check_masker_transformer_high_variance_confounds(estimator_orig):
 
         dataframe = pd.DataFrame(array)
 
-        tmp_dir = Path(tmp_dir)
-        dataframe.to_csv(tmp_dir / "confounds.csv")
+        tmp_path = Path(tmp_dir)
+        dataframe.to_csv(tmp_path / "confounds.csv")
 
-        for c in [array, dataframe, tmp_dir / "confounds.csv"]:
+        for c in [array, dataframe, tmp_path / "confounds.csv"]:
             confounds = [c] if isinstance(estimator, _MultiMixin) else c
 
             estimator = clone(estimator)
@@ -3058,7 +3059,7 @@ def check_masker_transformer_high_variance_confounds(estimator_orig):
             )
 
 
-def check_masker_transformer_sample_mask(estimator_orig):
+def check_masker_transformer_sample_mask(estimator_orig) -> None:
     """Check sample_mask use in maskers.
 
     Make sure that using sample_mask returns different result
@@ -3070,6 +3071,7 @@ def check_masker_transformer_sample_mask(estimator_orig):
     """
     estimator = clone(estimator_orig)
 
+    input_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         input_img = _img_4d_rand_eye()
     else:
@@ -3099,21 +3101,21 @@ def check_masker_transformer_sample_mask(estimator_orig):
     assert_array_equal(signal_2, signal_3)
 
     # list of explicit index
-    sample_mask = [[1, 2, 4]]
+    sample_mask = [[1, 2, 4]]  # type: ignore[assignment]
 
     signal_4 = estimator.transform(input_img, sample_mask=sample_mask)
 
     assert_array_equal(signal_2, signal_4)
 
     # list of logical index
-    sample_mask = [[False, True, True, False, True]]
+    sample_mask = [[False, True, True, False, True]]  # type: ignore[assignment]
 
     signal_5 = estimator.transform(input_img, sample_mask=sample_mask)
 
     assert_array_equal(signal_2, signal_5)
 
 
-def check_masker_with_confounds(estimator_orig):
+def check_masker_with_confounds(estimator_orig) -> None:
     """Test fit_transform with confounds.
 
     Check different types of confounds
@@ -3129,6 +3131,7 @@ def check_masker_with_confounds(estimator_orig):
     estimator = clone(estimator_orig)
 
     length = 20
+    input_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         input_img = Nifti1Image(
             _rng().random((*_shape_3d_default(), length)), affine=_affine_eye()
@@ -3150,17 +3153,17 @@ def check_masker_with_confounds(estimator_orig):
         assert_raises(AssertionError, assert_array_equal, signal_1, signal_2)
 
     with TemporaryDirectory() as tmp_dir:
-        tmp_dir = Path(tmp_dir)
-        dataframe.to_csv(tmp_dir / "confounds.csv")
+        tmp_path = Path(tmp_dir)
+        dataframe.to_csv(tmp_path / "confounds.csv")
         signal_2 = estimator.fit_transform(
-            input_img, confounds=tmp_dir / "confounds.csv"
+            input_img, confounds=tmp_path / "confounds.csv"
         )
 
         assert_raises(AssertionError, assert_array_equal, signal_1, signal_2)
 
-        dataframe.to_csv(tmp_dir / "confounds.tsv", sep="\t")
+        dataframe.to_csv(tmp_path / "confounds.tsv", sep="\t")
         signal_2 = estimator.fit_transform(
-            input_img, confounds=tmp_dir / "confounds.tsv"
+            input_img, confounds=tmp_path / "confounds.tsv"
         )
 
         assert_raises(AssertionError, assert_array_equal, signal_1, signal_2)
@@ -3176,10 +3179,12 @@ def check_masker_with_confounds(estimator_orig):
         )
 
 
-def check_masker_refit(estimator_orig):
+def check_masker_refit(estimator_orig) -> None:
     """Check masker can be refitted and give different results."""
     estimator = clone(estimator_orig)
 
+    mask_img_1: Nifti1Image | SurfaceImage
+    mask_img_2: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         # using larger images to be compatible
         # with regions extraction tests
@@ -3216,13 +3221,15 @@ def check_masker_refit(estimator_orig):
             assert_surface_image_equal(fitted_mask_1, fitted_mask_2)
 
 
-def check_masker_empty_data_messages(estimator_orig):
+def check_masker_empty_data_messages(estimator_orig) -> None:
     """Check that empty images are caught properly.
 
     Replaces sklearn check_estimators_empty_data_messages.
     """
     estimator = clone(estimator_orig)
 
+    imgs: Nifti1Image | SurfaceImage
+    mask_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         data = np.zeros((64, 64, 0))
         imgs = Nifti1Image(data, np.eye(4))
@@ -3230,11 +3237,11 @@ def check_masker_empty_data_messages(estimator_orig):
         mask_img = Nifti1Image(mask, affine=_affine_eye())
     else:
         imgs = _make_surface_img()
-        data = {
+        surf_data = {
             part: np.empty(0).reshape((imgs.data.parts[part].shape[0], 0))
             for part in imgs.data.parts
         }
-        imgs = SurfaceImage(imgs.mesh, data)
+        imgs = SurfaceImage(imgs.mesh, surf_data)
 
         mask_img = _make_surface_mask()
 
@@ -3658,7 +3665,7 @@ def check_surface_masker_fit_transform_errors(estimator_orig) -> None:
         estimator.transform(_drop_surf_img_part(imgs))
 
 
-def check_surface_masker_list_surf_images_no_mask(estimator_orig):
+def check_surface_masker_list_surf_images_no_mask(estimator_orig) -> None:
     """Test transform / inverse_transform on list of surface images.
 
     No mask provided at init.
@@ -3707,9 +3714,9 @@ def check_surface_masker_list_surf_images_no_mask(estimator_orig):
         if isinstance(estimator, _MultiMixin) and isinstance(imgs, list):
             assert isinstance(signals, list)
             assert all(isinstance(x, np.ndarray) for x in signals)
-            assert all(x.shape == (1, estimator.n_elements_) for x in signals)
+            assert all(x.shape == (1, estimator.n_elements_) for x in signals)  # type: ignore[attr-defined]
 
-            img = estimator.inverse_transform(signals[0])
+            img = estimator.inverse_transform(signals[0])  # type: ignore[attr-defined]
             assert img.shape == (_make_surface_img().mesh.n_vertices, 1)
 
         elif n_sample == 0:
@@ -3735,8 +3742,8 @@ def check_surface_masker_list_surf_images_no_mask(estimator_orig):
         )
         assert isinstance(signals, list)
         assert all(isinstance(x, np.ndarray) for x in signals)
-        assert signals[0].shape == (5, estimator.n_elements_)
-        assert signals[1].shape == (2, estimator.n_elements_)
+        assert signals[0].shape == (5, estimator.n_elements_)  # type: ignore[attr-defined]
+        assert signals[1].shape == (2, estimator.n_elements_)  # type: ignore[attr-defined]
     else:
         # TODO Turn that into a dimension error like for NiftiMaskers
         # TODO error msg should give hint as to how to fix:
@@ -3747,7 +3754,7 @@ def check_surface_masker_list_surf_images_no_mask(estimator_orig):
             estimator.fit([_make_surface_img(5), _make_surface_img(5)])
 
 
-def check_surface_masker_list_surf_images_with_mask(estimator_orig):
+def check_surface_masker_list_surf_images_with_mask(estimator_orig) -> None:
     """Test transform / inverse_transform on list of surface images.
 
     Check that 1D mask or 2D mask work.
@@ -3809,10 +3816,11 @@ def check_surface_masker_list_surf_images_with_mask(estimator_orig):
                 assert isinstance(signals, list)
                 assert all(isinstance(x, np.ndarray) for x in signals)
                 assert all(
-                    x.shape == (1, estimator.n_elements_) for x in signals
+                    x.shape == (1, estimator.n_elements_)  # type: ignore[attr-defined]
+                    for x in signals
                 )
 
-                img = estimator.inverse_transform(signals[0])
+                img = estimator.inverse_transform(signals[0])  # type: ignore[attr-defined]
                 assert img.shape == (_make_surface_img().mesh.n_vertices, 1)
 
             elif n_sample == 0:
@@ -3863,7 +3871,7 @@ def check_surface_masker_list_surf_images_with_mask(estimator_orig):
 # ------------------ NIFTI MASKER CHECKS ------------------
 
 
-def check_nifti_masker_fit_transform(estimator_orig):
+def check_nifti_masker_fit_transform(estimator_orig) -> None:
     """Run several checks on maskers.
 
     - can fit 3D / 4D image
@@ -3899,12 +3907,12 @@ def check_nifti_masker_fit_transform(estimator_orig):
         assert len(signal) == 2
         for x in signal:
             assert isinstance(x, np.ndarray)
-            if estimator.n_elements_ == 1:
+            if estimator.n_elements_ == 1:  # type: ignore[attr-defined]
                 assert x.ndim == 0
                 assert x.shape == ()
             else:
                 assert x.ndim == 1
-                assert x.shape == (estimator.n_elements_,)
+                assert x.shape == (estimator.n_elements_,)  # type: ignore[attr-defined]
     else:
         assert isinstance(signal, np.ndarray)
         assert signal.ndim == 2
@@ -4183,7 +4191,9 @@ def check_multimasker_transformer_sample_mask(estimator_orig) -> None:
         estimator.fit_transform(input_imgs, sample_mask=1)
 
 
-def check_multimasker_transformer_high_variance_confounds(estimator_orig):
+def check_multimasker_transformer_high_variance_confounds(
+    estimator_orig,
+) -> None:
     """Check high_variance_confounds in multi maskers with data many samples.
 
     Make sure that using high_variance_confounds returns different result.
@@ -4197,6 +4207,7 @@ def check_multimasker_transformer_high_variance_confounds(estimator_orig):
 
     length = _img_4d_rand_eye_medium().shape[3]
 
+    input_imgs: list[Nifti1Image] | list[SurfaceImage]
     if accept_niimg_input(estimator):
         input_imgs = [_img_4d_rand_eye_medium(), _img_4d_rand_eye_medium()]
     else:
@@ -4219,10 +4230,10 @@ def check_multimasker_transformer_high_variance_confounds(estimator_orig):
 
         dataframe = pd.DataFrame(array)
 
-        tmp_dir = Path(tmp_dir)
-        dataframe.to_csv(tmp_dir / "confounds.csv")
+        tmp_path = Path(tmp_dir)
+        dataframe.to_csv(tmp_path / "confounds.csv")
 
-        for c in [array, dataframe, tmp_dir / "confounds.csv"]:
+        for c in [array, dataframe, tmp_path / "confounds.csv"]:
             confounds = [c, c]
 
             estimator = clone(estimator)

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1906,7 +1906,7 @@ def check_img_estimator_dtypes_transform(estimator_orig) -> None:
                 X, y = generate_data_to_fit(estimator)
                 if (
                     isinstance(estimator, NiftiMasker)
-                    and input_dtype == np.int32
+                    and input_np_dtype == np.int32
                 ):
                     # Needed for NiftiMasker because the default strategy
                     # returns an empty mask

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -767,6 +767,7 @@ def generate_data_to_fit(estimator: NilearnBaseEstimator):
         return X, y
 
     elif is_masker(estimator):
+        imgs: Nifti1Image | SurfaceImage
         if accept_niimg_input(estimator):
             imgs = Nifti1Image(
                 _rng().random(_shape_3d_large()) + 10.0,
@@ -2629,6 +2630,7 @@ def check_masker_detrending(estimator_orig) -> None:
     """
     estimator = clone(estimator_orig)
 
+    input_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         input_img = _img_4d_rand_eye_medium()
     else:
@@ -2658,6 +2660,7 @@ def check_masker_standardization(estimator_orig) -> None:
     if not is_gil_enabled():
         pytest.xfail("May fail without the GIL")
 
+    input_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator_orig):
         signals = _rng().standard_normal(
             size=(np.prod(_shape_3d_default()), n_samples)
@@ -2757,6 +2760,7 @@ def check_masker_compatibility_mask_image(estimator_orig) -> None:
     estimator = clone(estimator_orig)
 
     mask_img: Nifti1Image | SurfaceImage
+    input_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         mask_img = _img_mask_mni()
         input_img = _make_surface_img()
@@ -2774,7 +2778,7 @@ def check_masker_compatibility_mask_image(estimator_orig) -> None:
         mask = np.zeros(_shape_3d_large(), dtype=np.int8)
         mask[1:-1, 1:-1, 1:-1] = 1
         mask_img = Nifti1Image(mask, _affine_eye())
-        image_to_transform = _make_surface_img()
+        image_to_transform: Nifti1Image | SurfaceImage = _make_surface_img()
     else:
         mask_img = _make_surface_mask()
         image_to_transform = _img_3d_mni()
@@ -2819,7 +2823,7 @@ def check_masker_mask_img_from_imgs(estimator_orig) -> None:
     if accept_niimg_input(estimator):
         # Small image with shape=(7, 8, 9) would fail with MultiNiftiMasker
         # giving mask_img_that mask all the data : do not know why!!!
-        input_img = Nifti1Image(
+        input_img: Nifti1Image | SurfaceImage = Nifti1Image(
             _rng().random(_shape_3d_large()), _affine_eye()
         )
 
@@ -2854,6 +2858,8 @@ def check_masker_mask_img(estimator_orig) -> None:
     estimator = clone(estimator_orig)
 
     binary_mask_img: Nifti1Image | SurfaceImage
+    non_binary_mask_img: Nifti1Image | SurfaceImage
+    input_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         # Small image with shape=(7, 8, 9) would fail with MultiNiftiMasker
         # giving mask_img_that mask all the data : do not know why!!!
@@ -2945,6 +2951,7 @@ def check_masker_clean(estimator_orig) -> None:
     """
     estimator = clone(estimator_orig)
 
+    input_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         input_img = _img_4d_rand_eye_medium()
     else:
@@ -2982,6 +2989,7 @@ def check_masker_transformer(estimator_orig) -> None:
         assert next(iter(tmp)) == "imgs"
         assert "X" not in tmp
 
+    input_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         input_img = _img_4d_rand_eye_medium()
     else:
@@ -3244,6 +3252,7 @@ def check_masker_fit_with_empty_mask(estimator_orig) -> None:
     estimator = clone(estimator_orig)
 
     mask_img: Nifti1Image | SurfaceImage
+    imgs: list[Nifti1Image] | SurfaceImage
     if accept_niimg_input(estimator):
         mask_img = _img_3d_zeros()
         imgs = [_img_3d_rand()]
@@ -3271,6 +3280,7 @@ def check_masker_fit_with_non_finite_in_mask(estimator_orig) -> None:
     estimator = clone(estimator_orig)
 
     mask_img: Nifti1Image | SurfaceImage
+    imgs: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         # _shape_3d_large() is used,
         # this test would fail for RegionExtractor otherwise
@@ -3354,7 +3364,9 @@ def check_masker_inverse_transform(estimator_orig) -> None:
         # using different shape for imgs, mask
         # to force resampling
         input_shape = (28, 29, 30)
-        imgs = Nifti1Image(_rng().random(input_shape), _affine_eye())
+        imgs: Nifti1Image | SurfaceImage = Nifti1Image(
+            _rng().random(input_shape), _affine_eye()
+        )
 
         mask_shape = (15, 16, 17)
         mask_img: Nifti1Image | SurfaceImage = Nifti1Image(
@@ -3399,6 +3411,7 @@ def check_masker_inverse_transform(estimator_orig) -> None:
 
         if accept_niimg_input(estimator):
             actual_shape = new_imgs.shape
+            assert isinstance(imgs, Nifti1Image)
             assert_array_almost_equal(imgs.affine, new_imgs.affine)
         else:
             actual_shape = new_imgs.data.shape
@@ -4077,6 +4090,8 @@ def check_multimasker_with_confounds(estimator_orig) -> None:
 
     length = _img_4d_rand_eye_medium().shape[3]
 
+    input_imgs: list[Nifti1Image] | list[SurfaceImage]
+    single_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         input_imgs = [_img_4d_rand_eye_medium(), _img_4d_rand_eye_medium()]
         single_img = _img_4d_rand_eye_medium()
@@ -4127,6 +4142,8 @@ def check_multimasker_transformer_sample_mask(estimator_orig) -> None:
 
     length = _img_4d_rand_eye_medium().shape[3]
 
+    input_imgs: list[Nifti1Image] | list[SurfaceImage]
+    single_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         input_imgs = [_img_4d_rand_eye_medium(), _img_4d_rand_eye_medium()]
         single_img = _img_4d_rand_eye_medium()
@@ -4344,6 +4361,7 @@ def check_masker_generate_report(estimator_orig) -> None:
     if not is_gil_enabled():
         pytest.xfail("May fail without the GIL")
 
+    input_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         input_img = _img_3d_rand()
     else:
@@ -4379,6 +4397,7 @@ def check_masker_generate_report(estimator_orig) -> None:
 def check_masker_generate_report_constant(estimator_orig) -> None:
     """Check report is constant across calls."""
     estimator = clone(estimator_orig)
+    input_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         input_img = _img_3d_rand()
     else:
@@ -4473,6 +4492,7 @@ def check_masker_generate_report_false(estimator_orig) -> None:
 
     estimator.reports = False
 
+    input_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         input_img = _img_4d_rand_eye_medium()
     else:
@@ -4499,6 +4519,7 @@ def check_multimasker_generate_report(estimator_orig) -> None:
     if not is_gil_enabled():
         pytest.xfail("May fail without the GIL")
 
+    input_img: list[Nifti1Image] | list[SurfaceImage]
     if accept_niimg_input(estimator):
         input_img = [_img_4d_rand_eye_medium(), _img_4d_rand_eye_medium()]
     else:

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -2756,6 +2756,7 @@ def check_masker_compatibility_mask_image(estimator_orig) -> None:
     """
     estimator = clone(estimator_orig)
 
+    mask_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         mask_img = _img_mask_mni()
         input_img = _make_surface_img()
@@ -2852,6 +2853,7 @@ def check_masker_mask_img(estimator_orig) -> None:
     """
     estimator = clone(estimator_orig)
 
+    binary_mask_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         # Small image with shape=(7, 8, 9) would fail with MultiNiftiMasker
         # giving mask_img_that mask all the data : do not know why!!!
@@ -3241,6 +3243,7 @@ def check_masker_fit_with_empty_mask(estimator_orig) -> None:
     """Check mask that excludes all voxels raise an error."""
     estimator = clone(estimator_orig)
 
+    mask_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         mask_img = _img_3d_zeros()
         imgs = [_img_3d_rand()]
@@ -3267,6 +3270,7 @@ def check_masker_fit_with_non_finite_in_mask(estimator_orig) -> None:
     """
     estimator = clone(estimator_orig)
 
+    mask_img: Nifti1Image | SurfaceImage
     if accept_niimg_input(estimator):
         # _shape_3d_large() is used,
         # this test would fail for RegionExtractor otherwise
@@ -3353,7 +3357,9 @@ def check_masker_inverse_transform(estimator_orig) -> None:
         imgs = Nifti1Image(_rng().random(input_shape), _affine_eye())
 
         mask_shape = (15, 16, 17)
-        mask_img = Nifti1Image(np.ones(mask_shape), _affine_eye())
+        mask_img: Nifti1Image | SurfaceImage = Nifti1Image(
+            np.ones(mask_shape), _affine_eye()
+        )
 
         if isinstance(estimator, NiftiSpheresMasker):
             tmp = mask_img.shape

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1901,7 +1901,7 @@ def check_img_estimator_dtypes_transform(estimator_orig) -> None:
                 if hasattr(estimator, "memory"):
                     estimator.memory = memory
 
-                input_dtype = np.dtype(input_dtype)  # type: ignore[call-overload]
+                input_np_dtype = np.dtype(cast(Any, input_dtype))
 
                 X, y = generate_data_to_fit(estimator)
                 if (
@@ -1915,12 +1915,12 @@ def check_img_estimator_dtypes_transform(estimator_orig) -> None:
                 if isinstance(X, Nifti1Image):
                     data = get_data(X)
                     X = Nifti1Image(
-                        data.astype(input_dtype),
+                        data.astype(input_np_dtype),
                         affine=_affine_eye(),
-                        dtype=input_dtype,
+                        dtype=input_np_dtype,
                     )
                 else:
-                    X.data._set_dtype(input_dtype)
+                    X.data._set_dtype(input_np_dtype)
 
                 estimator = fit_estimator(estimator, X, y)
 
@@ -1934,9 +1934,9 @@ def check_img_estimator_dtypes_transform(estimator_orig) -> None:
                 if not isinstance(result, list):
                     result = [result]
 
-                target_dtype = get_target_dtype(input_dtype, dtype)
+                target_dtype = get_target_dtype(input_np_dtype, dtype)
                 if target_dtype is None:
-                    target_dtype = input_dtype
+                    target_dtype = input_np_dtype
 
                 for s in result:
                     output_dtype = s.dtype
@@ -1999,12 +1999,12 @@ def check_img_estimator_dtypes(estimator_orig) -> None:
                 if hasattr(estimator, "memory"):
                     estimator.memory = memory
 
-                input_dtype = np.dtype(input_dtype)  # type: ignore[call-overload]
+                input_np_dtype = np.dtype(cast(Any, input_dtype))
 
                 X, y = generate_data_to_fit(estimator)
                 if (
                     isinstance(estimator, NiftiMasker)
-                    and input_dtype == np.int32
+                    and input_np_dtype == np.int32
                 ):
                     # Needed for NiftiMasker because the default strategy
                     # returns an empty mask
@@ -2013,12 +2013,12 @@ def check_img_estimator_dtypes(estimator_orig) -> None:
                 if isinstance(X, Nifti1Image):
                     data = get_data(X)
                     X = Nifti1Image(
-                        data.astype(input_dtype),
+                        data.astype(input_np_dtype),
                         affine=_affine_eye(),
-                        dtype=input_dtype,
+                        dtype=input_np_dtype,
                     )
                 else:
-                    X.data._set_dtype(input_dtype)
+                    X.data._set_dtype(input_np_dtype)
 
                 estimator = fit_estimator(estimator, X, y)
 
@@ -2401,24 +2401,24 @@ def check_decoder_empty_data_messages(estimator_orig) -> None:
     )
 
     data = np.zeros((64, 64, 0))
-    X = Nifti1Image(data, np.eye(4))
+    X_as_vol = Nifti1Image(data, np.eye(4))
 
     y = _rng().random(y.shape)
 
     with pytest.raises(ValueError, match="empty"):
-        estimator.fit(X, y)
+        estimator.fit(X_as_vol, y)
 
     estimator = clone(estimator_orig)
 
     imgs = _make_surface_img(n_samples)
-    data = {  # type: ignore[assignment]
+    surf_data = {
         part: np.empty(0).reshape((imgs.data.parts[part].shape[0], 0))
         for part in imgs.data.parts
     }
-    X = SurfaceImage(imgs.mesh, data)  # type: ignore[assignment]
+    X_as_surf = SurfaceImage(imgs.mesh, surf_data)
 
     with pytest.raises(ValueError, match="empty"):
-        estimator.fit(X, y)
+        estimator.fit(X_as_surf, y)
 
 
 def check_decoder_compatibility_mask_image(estimator_orig) -> None:
@@ -2459,15 +2459,16 @@ def check_decoder_compatibility_mask_image(estimator_orig) -> None:
         if not hasattr(estimator, method):
             continue
 
-        input = (_make_surface_img(3),)
+        input_data: tuple[SurfaceImage] | tuple[SurfaceImage, Any]
+        input_data = (_make_surface_img(3),)
         if method == "score":
-            input = (_make_surface_img(3), y)  # type: ignore[assignment]
+            input_data = (_make_surface_img(3), y)
 
         with pytest.raises(
             TypeError,
             match=("Mask and input images must be of compatible types"),
         ):
-            getattr(estimator, method)(*input)
+            getattr(estimator, method)(*input_data)
 
 
 def check_decoder_with_surface_data(estimator_orig) -> None:
@@ -3082,6 +3083,8 @@ def check_masker_transformer_sample_mask(estimator_orig) -> None:
 
     assert signal_1.ndim == 2
 
+    sample_mask: np.ndarray | list[list[int]] | list[list[bool]]
+
     # index sample to keep
     sample_mask = np.asarray([1, 2, 4])
 
@@ -3101,14 +3104,14 @@ def check_masker_transformer_sample_mask(estimator_orig) -> None:
     assert_array_equal(signal_2, signal_3)
 
     # list of explicit index
-    sample_mask = [[1, 2, 4]]  # type: ignore[assignment]
+    sample_mask = [[1, 2, 4]]
 
     signal_4 = estimator.transform(input_img, sample_mask=sample_mask)
 
     assert_array_equal(signal_2, signal_4)
 
     # list of logical index
-    sample_mask = [[False, True, True, False, True]]  # type: ignore[assignment]
+    sample_mask = [[False, True, True, False, True]]
 
     signal_5 = estimator.transform(input_img, sample_mask=sample_mask)
 

--- a/nilearn/conftest.py
+++ b/nilearn/conftest.py
@@ -677,7 +677,7 @@ def surf_img_ones_1d(surf_mesh) -> SurfaceImage:
     return SurfaceImage(surf_mesh, data)
 
 
-def _make_surface_mask(n_zeros=4):
+def _make_surface_mask(n_zeros: int = 4) -> SurfaceImage:
     mesh = _make_mesh()
     data = {}
     for key, val in mesh.parts.items():

--- a/nilearn/conftest.py
+++ b/nilearn/conftest.py
@@ -624,7 +624,7 @@ def surf_mesh() -> PolyMesh:
     return _make_mesh()
 
 
-def _make_surface_img(n_samples=1):
+def _make_surface_img(n_samples: int = 1) -> SurfaceImage:
     """Create data with increasing values for each vertex."""
     mesh = _make_mesh()
     data = {}

--- a/nilearn/glm/first_level/design_matrix.py
+++ b/nilearn/glm/first_level/design_matrix.py
@@ -239,7 +239,7 @@ def make_first_level_design_matrix(
     high_pass=0.01,
     drift_order=1,
     fir_delays=None,
-    add_regs=None,
+    add_regs: np.ndarray | pd.DataFrame | None = None,
     add_reg_names=None,
     min_onset=-24,
     oversampling=50,
@@ -365,20 +365,21 @@ def make_first_level_design_matrix(
     # check that additional regressor specification is correct
     n_add_regs = 0
     if add_regs is not None:
+        add_regs_as_array: np.ndarray
         if isinstance(add_regs, pd.DataFrame):
-            add_regs_ = add_regs.to_numpy()
+            add_regs_as_array = add_regs.to_numpy()
             add_reg_names = add_regs.columns.tolist()
         else:
-            add_regs_ = np.atleast_2d(add_regs)  # type: ignore[assignment]
+            add_regs_as_array = np.atleast_2d(add_regs)
 
-        if np.any(np.isnan(add_regs_.ravel())):
+        if np.any(np.isnan(add_regs_as_array.ravel())):
             raise ValueError("Extra regressors contain NaN values.")
 
-        n_add_regs = add_regs_.shape[1]
-        assert add_regs_.shape[0] == np.size(frame_times), (
+        n_add_regs = add_regs_as_array.shape[1]
+        assert add_regs_as_array.shape[0] == np.size(frame_times), (
             "Incorrect specification of additional regressors: "
-            f"length of regressors provided: {add_regs_.shape[0]}, number of "
-            f"time-frames: {np.size(frame_times)}."
+            f"length of regressors provided: {add_regs_as_array.shape[0]}, "
+            f"number of time-frames: {np.size(frame_times)}."
         )
 
     # check that additional regressor names are well specified
@@ -408,7 +409,9 @@ def make_first_level_design_matrix(
     if add_regs is not None:
         # add user-supplied regressors and corresponding names
         matrix = (
-            np.hstack((matrix, add_regs)) if matrix is not None else add_regs
+            np.hstack((matrix, add_regs_as_array))
+            if matrix is not None
+            else add_regs_as_array
         )
         names += add_reg_names
 

--- a/nilearn/glm/first_level/design_matrix.py
+++ b/nilearn/glm/first_level/design_matrix.py
@@ -369,7 +369,7 @@ def make_first_level_design_matrix(
             add_regs_ = add_regs.to_numpy()
             add_reg_names = add_regs.columns.tolist()
         else:
-            add_regs_ = np.atleast_2d(add_regs)
+            add_regs_ = np.atleast_2d(add_regs)  # type: ignore[assignment]
 
         if np.any(np.isnan(add_regs_.ravel())):
             raise ValueError("Extra regressors contain NaN values.")


### PR DESCRIPTION
- Closes #3568

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- Add `-> SurfaceImage` return type annotation to `_make_surface_mask` and `_make_surface_img` in `nilearn/conftest.py`
- Add `-> None` return type annotations to all 19 public `check_*` functions in `nilearn/_utils/estimator_checks.py` that were missing them
- Fix all resulting mypy errors in `nilearn/_utils/estimator_checks.py`:
  - Declare explicit `Nifti1Image | SurfaceImage` union types before `if/else` branches that assign different image types
  - Rename `tmp_dir = Path(tmp_dir)` to `tmp_path` to avoid `str`/`Path` reassignment conflicts
  - Annotate `dtype_list: list[Any]` to allow the conditional mixed-type reassignment
  - Fix dead-code bug where `memory = [None, Path(...)]` should have been `memory_list = [None, Path(...)]`
  - Add `# type: ignore[call-overload]` for `np.dtype()` called with union-typed argument
  - Add `# type: ignore[attr-defined]` for `_MultiMixin.n_elements_` accesses (attribute lives on subclasses)
  - Add `# type: ignore[assignment]` for sequential variable reuse across incompatible types