### PR TITLE
[MAINT] Benchmark previous stable versions of Nilearn

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -53,8 +53,11 @@
 # - Then we push the new results back to the `benchmarks <https://github.com/nilearn/benchmarks>`_ repo.
 #   This will automatically deploy the new results to `nilearn.github.io/benchmarks <https://nilearn.github.io/benchmarks/>`_.
 #
-# A second, independent set of jobs benchmarks the fixed list of release
-# commits in ``asv_benchmarks/hashestobenchmark.txt`` (see ``CONTRIBUTING.rst``).
+# A second, independent set of jobs, run only on schedule or manual
+# trigger (running the full suite for several commits is too expensive
+# to also run on every pull request), benchmarks the fixed list of
+# release commits in ``asv_benchmarks/hashestobenchmark.txt`` (see
+# ``CONTRIBUTING.rst``).
 # Running the full suite for several commits one after another in a single
 # job is slow, so this is split into a matrix job (one commit per matrix
 # entry, run in parallel on separate runners) followed by a job that
@@ -321,14 +324,10 @@ jobs:
                 git commit --message "Overwrite benchmark HTML with main vs latest release comparison (${{ github.event.repository.updated_at }}_${{ github.run_number }})"
                 git push origin gh-pages
 
-      # TODO: this job and the two below are temporarily also triggered on
-      # pull_request, to validate the matrix + merge mechanism in CI with
-      # the full benchmark suite. Once confirmed, remove "pull_request"
-      # from all three "if:" conditions below.
     list-history-commits:
         if: |
             github.repository == 'nilearn/nilearn' &&
-            (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
+            (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         runs-on: ubuntu-24.04
         outputs:
             commits: ${{ steps.list.outputs.commits }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,7 +55,8 @@
 #
 # A second, independent set of jobs, run only on schedule or manual trigger
 # (running the full suite for several commits is too expensive to also run on every pull request),
-# benchmarks the fixed list of release commits in ``asv_benchmarks/hashestobenchmark.txt``(see :ref:`CONTRIBUTING.rst <performance>`).
+# benchmarks the fixed list of release commits in ``asv_benchmarks/hashestobenchmark.txt``
+# (see :ref:`CONTRIBUTING.rst <performance>`).
 # Running the full suite for several commits one after another in a single job is slow,
 # so this is split into a matrix job (one commit per matrix entry, run in parallel on separate runners)
 # followed by a job that downloads every matrix entry's results

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,6 +63,15 @@
 # entry, run in parallel on separate runners) followed by a job that
 # downloads every matrix entry's results and combines them into a single
 # viewable ``asv publish`` output.
+# Because each matrix entry runs on its own GitHub-hosted runner, drawn
+# from a pool of different underlying CPU models, commits compared in
+# this combined view are not guaranteed to have been benchmarked on the
+# same hardware (unlike the single-job ``benchmark`` job above, where
+# every compared commit shares the same runner). Any performance
+# difference spotted here should therefore be treated as a lead, not a
+# conclusion, and confirmed by rerunning the specific benchmark locally
+# for the relevant commits on the same machine, e.g. with
+# ``asv run -b <benchmark_name> HASHFILE:hashestobenchmark.txt``.
 # For now this only uploads that combined view as a workflow artifact;
 # see `issue 5966 <https://github.com/nilearn/nilearn/issues/5966>`_ for
 # the plan to eventually publish it (overwriting the previous one) to the

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -66,13 +66,13 @@
 # .. admonition:: Important
 #    :class: warning
 #
-#       Because each matrix entry runs on its own GitHub-hosted runner,
-#       drawn from a pool of different underlying CPU models,
-#       commits compared in this combined view are not guaranteed to have been benchmarked
-#       on the same hardware (unlike the single-job ``benchmark`` job above, where every compared commit shares the same runner).
-#       Any performance difference spotted here should therefore be treated as a lead, not a conclusion,
-#       and confirmed by rerunning the specific benchmark locally for the relevant commits on the same machine,
-#       for example with ``asv run -b <benchmark_name> HASHFILE:hashestobenchmark.txt``.
+#    Because each matrix entry runs on its own GitHub-hosted runner,
+#    drawn from a pool of different underlying CPU models,
+#    commits compared in this combined view are not guaranteed to have been benchmarked
+#    on the same hardware (unlike the single-job ``benchmark`` job above, where every compared commit shares the same runner).
+#    Any performance difference spotted here should therefore be treated as a lead, not a conclusion,
+#    and confirmed by rerunning the specific benchmark locally for the relevant commits on the same machine,
+#    for example with ``asv run -b <benchmark_name> HASHFILE:hashestobenchmark.txt``.
 #
 ###
 name: Run and deploy Nilearn benchmarks

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -322,11 +322,9 @@ jobs:
                 git push origin gh-pages
 
       # TODO: this job and the two below are temporarily also triggered on
-      # pull_request, and restricted to "-b NiftiMaskerBenchmark", to
-      # validate the matrix + merge mechanism in CI. Once confirmed,
-      # remove "pull_request" from all three "if:" conditions below and
-      # drop the "-b" filter in the "Run all benchmarks for this commit"
-      # step.
+      # pull_request, to validate the matrix + merge mechanism in CI with
+      # the full benchmark suite. Once confirmed, remove "pull_request"
+      # from all three "if:" conditions below.
     list-history-commits:
         if: |
             github.repository == 'nilearn/nilearn' &&
@@ -383,7 +381,7 @@ jobs:
         -   name: Run all benchmarks for this commit
               # "<commit>^!" is git's syntax for "just this one commit"
             run: |
-                asv run --show-stderr --verbose --parallel 2 --machine fv-az1113-357 -b "NiftiMaskerBenchmark" "${{ matrix.commit }}^!" 2>&1 | tee log_${{ matrix.commit }}
+                asv run --show-stderr --verbose --parallel 2 --machine fv-az1113-357 "${{ matrix.commit }}^!" 2>&1 | tee log_${{ matrix.commit }}
 
         -   name: Fail if any benchmark reported as failed
             run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,6 +52,20 @@
 #     (this also works from a local ``asv_benchmarks`` checkout after running ``asv publish``, as described in ``CONTRIBUTING.rst``).
 # - Then we push the new results back to the `benchmarks <https://github.com/nilearn/benchmarks>`_ repo.
 #   This will automatically deploy the new results to `nilearn.github.io/benchmarks <https://nilearn.github.io/benchmarks/>`_.
+#
+# A second, independent set of jobs benchmarks the fixed list of release
+# commits in ``asv_benchmarks/hashestobenchmark.txt`` (see ``CONTRIBUTING.rst``).
+# Running the full suite for several commits one after another in a single
+# job is slow, so this is split into a matrix job (one commit per matrix
+# entry, run in parallel on separate runners) followed by a job that
+# downloads every matrix entry's results and combines them into a single
+# viewable ``asv publish`` output.
+# For now this only uploads that combined view as a workflow artifact;
+# see `issue 5966 <https://github.com/nilearn/nilearn/issues/5966>`_ for
+# the plan to eventually publish it (overwriting the previous one) to the
+# `benchmarks <https://github.com/nilearn/benchmarks>`_ repo as well, so a
+# PR or main HEAD can easily be compared against the last few stable
+# releases.
 ###
 name: Run and deploy Nilearn benchmarks
 
@@ -306,3 +320,146 @@ jobs:
                 git add -A
                 git commit --message "Overwrite benchmark HTML with main vs latest release comparison (${{ github.event.repository.updated_at }}_${{ github.run_number }})"
                 git push origin gh-pages
+
+      # TODO: this job and the two below are temporarily also triggered on
+      # pull_request, and restricted to "-b NiftiMaskerBenchmark", to
+      # validate the matrix + merge mechanism in CI. Once confirmed,
+      # remove "pull_request" from all three "if:" conditions below and
+      # drop the "-b" filter in the "Run all benchmarks for this commit"
+      # step.
+    list-history-commits:
+        if: |
+            github.repository == 'nilearn/nilearn' &&
+            (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
+        runs-on: ubuntu-24.04
+        outputs:
+            commits: ${{ steps.list.outputs.commits }}
+
+        steps:
+        -   uses: actions/checkout@v7
+
+        -   id: list
+              # one matrix entry per non-empty, non-comment line
+            run: |
+                python3 -c "
+                import json
+                with open('asv_benchmarks/hashestobenchmark.txt') as f:
+                    commits = [line.strip() for line in f if line.strip()]
+                print('commits=' + json.dumps(commits))
+                " >> "$GITHUB_OUTPUT"
+
+    benchmark-history:
+        needs: list-history-commits
+        if: needs.list-history-commits.outputs.commits != '[]'
+        runs-on: ubuntu-24.04
+        strategy:
+              # keep benchmarking the other commits even if one fails
+            fail-fast: false
+            matrix:
+                commit: ${{ fromJson(needs.list-history-commits.outputs.commits) }}
+        defaults:
+            run:
+                working-directory: ./asv_benchmarks
+
+        steps:
+        -   uses: actions/checkout@v7
+
+        -   uses: actions/setup-python@v6
+            with:
+                python-version: ${{ env.MIN_PYTHON }}
+
+        -   name: Install asv
+            run: |
+                pip install --upgrade pip
+                pip install asv
+                pip install nilearn
+
+        -   name: Get all the machine info
+            run: asv machine --yes
+
+        -   name: Edit asv-machine.json to a custom machine name
+            run: python ../build_tools/github/set_machine_name.py fv-az1113-357
+
+        -   name: Run all benchmarks for this commit
+              # "<commit>^!" is git's syntax for "just this one commit"
+            run: |
+                asv run --show-stderr --verbose --parallel 2 --machine fv-az1113-357 -b "NiftiMaskerBenchmark" "${{ matrix.commit }}^!" 2>&1 | tee log_${{ matrix.commit }}
+
+        -   name: Fail if any benchmark reported as failed
+            run: |
+                if grep -q "asv: benchmark failed" log_${{ matrix.commit }}; then
+                    echo "::error::One or more benchmarks failed for commit ${{ matrix.commit }}, see the excerpt(s) below"
+                    grep -B 5 "asv: benchmark failed" log_${{ matrix.commit }}
+                    exit 1
+                fi
+
+        -   uses: actions/upload-artifact@v7
+            with:
+                name: history-results-${{ matrix.commit }}
+                path: ./asv_benchmarks/results
+                compression-level: 9
+
+    combine-history:
+        needs: benchmark-history
+        runs-on: ubuntu-24.04
+        defaults:
+            run:
+                working-directory: ./asv_benchmarks
+
+        steps:
+        -   uses: actions/checkout@v7
+
+        -   uses: actions/setup-python@v6
+            with:
+                python-version: ${{ env.MIN_PYTHON }}
+
+        -   name: Install asv
+            run: |
+                pip install --upgrade pip
+                pip install asv
+
+        -   name: Download every commit's results
+            uses: actions/download-artifact@v8
+            with:
+                pattern: history-results-*
+                path: ./asv_benchmarks/downloaded_results
+
+        -   name: Merge per-commit results into a single results directory
+              # "benchmarks.json" (the benchmark suite definition) is
+              # identical across matrix entries, since they all ran the
+              # same benchmark code against different nilearn commits, so
+              # any one copy of it is kept.
+              # The per-commit, per-machine result files are all distinct
+              # and are combined into one shared machine directory.
+            run: |
+                python3 -c "
+                import glob
+                import os
+                import shutil
+
+                os.makedirs('results', exist_ok=True)
+
+                for artifact_dir in glob.glob('downloaded_results/history-results-*'):
+                    suite_definition = os.path.join(artifact_dir, 'benchmarks.json')
+                    if os.path.exists(suite_definition):
+                        shutil.copy(suite_definition, 'results/benchmarks.json')
+
+                    for machine_dir in glob.glob(os.path.join(artifact_dir, '*')):
+                        if not os.path.isdir(machine_dir):
+                            continue
+                        dest = os.path.join('results', os.path.basename(machine_dir))
+                        os.makedirs(dest, exist_ok=True)
+                        for f in glob.glob(os.path.join(machine_dir, '*.json')):
+                            shutil.copy(f, dest)
+                "
+
+        -   name: Create html with the combined results
+            run: asv publish
+
+        -   uses: actions/upload-artifact@v7
+            with:
+                name: Upload combined history benchmark results as an artifact
+                path: |
+                    ./asv_benchmarks/html
+                    ./asv_benchmarks/results
+                compression-level: 9

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,12 +17,11 @@
 #   from the ``repo`` URL configured in ``asv.conf.json``,
 #   asv is temporarily pointed at the already checked out local clone instead
 #   (it contains both commits, as the checkout step fetches full history).
-# - On a push to ``main`` (typically a merged PR), the benchmarks are run
-#   for the ``main`` HEAD and for the most recent git tag (the latest stable release),
+# - On a push to ``main`` (typically a merged PR),
+#   the benchmarks are run for the ``main`` HEAD and for the most recent git tag (the latest stable release),
 #   and this comparison *overwrites* whatever was previously published
 #   on the `benchmarks <https://github.com/nilearn/benchmarks>`_ repo,
-#   rather than being appended to the historical results used
-#   by the schedule/manual runs.
+#   rather than being appended to the historical results used by the schedule/manual runs.
 # - Then it sets up the SSH key to access the `benchmarks <https://github.com/nilearn/benchmarks>`_ repo, pulls it,
 #   and copies the results dir into the current dir.
 #   We will append the new results to these results.
@@ -39,45 +38,42 @@
 #   and fail the workflow if it is found.
 # - Then we create the HTML with all the results via ``asv publish``.
 # - We upload the ``html`` and ``results`` directories as a single artifact so that we can download them later,
-#   e.g. to inspect the results of a PR run without waiting for them to be deployed.
+#   for example to inspect the results of a PR run without waiting for them to be deployed.
 #   To view them after downloading and unzipping the artifact,
 #   the ``html`` directory it contains cannot simply be opened in a browser
 #   (it needs its data served over HTTP, not opened as local ``file://`` pages).
 #   Instead, either:
 #
 #   - run ``python -m http.server`` from inside the unzipped ``html`` directory,
-#     then open the printed URL (e.g. http://localhost:8000) in a browser; or
+#     then open the printed URL (for example http://localhost:8000) in a browser; or
 #   - if `asv <https://asv.readthedocs.io/en/latest/index.html>`_ is installed,
 #     run ``asv preview`` from the unzipped directory that contains both ``html`` and ``results``
-#     (this also works from a local ``asv_benchmarks`` checkout after running ``asv publish``, as described in ``CONTRIBUTING.rst``).
+#     (this also works from a local ``asv_benchmarks`` checkout after running ``asv publish``,
+#     as described in :ref:`CONTRIBUTING.rst <performance>`).
 # - Then we push the new results back to the `benchmarks <https://github.com/nilearn/benchmarks>`_ repo.
 #   This will automatically deploy the new results to `nilearn.github.io/benchmarks <https://nilearn.github.io/benchmarks/>`_.
 #
-# A second, independent set of jobs, run only on schedule or manual
-# trigger (running the full suite for several commits is too expensive
-# to also run on every pull request), benchmarks the fixed list of
-# release commits in ``asv_benchmarks/hashestobenchmark.txt`` (see
-# ``CONTRIBUTING.rst``).
-# Running the full suite for several commits one after another in a single
-# job is slow, so this is split into a matrix job (one commit per matrix
-# entry, run in parallel on separate runners) followed by a job that
-# downloads every matrix entry's results and combines them into a single
-# viewable ``asv publish`` output.
-# Because each matrix entry runs on its own GitHub-hosted runner, drawn
-# from a pool of different underlying CPU models, commits compared in
-# this combined view are not guaranteed to have been benchmarked on the
-# same hardware (unlike the single-job ``benchmark`` job above, where
-# every compared commit shares the same runner). Any performance
-# difference spotted here should therefore be treated as a lead, not a
-# conclusion, and confirmed by rerunning the specific benchmark locally
-# for the relevant commits on the same machine, e.g. with
-# ``asv run -b <benchmark_name> HASHFILE:hashestobenchmark.txt``.
-# For now this only uploads that combined view as a workflow artifact;
-# see `issue 5966 <https://github.com/nilearn/nilearn/issues/5966>`_ for
-# the plan to eventually publish it (overwriting the previous one) to the
-# `benchmarks <https://github.com/nilearn/benchmarks>`_ repo as well, so a
-# PR or main HEAD can easily be compared against the last few stable
-# releases.
+# A second, independent set of jobs, run only on schedule or manual trigger
+# (running the full suite for several commits is too expensive to also run on every pull request),
+# benchmarks the fixed list of release commits in ``asv_benchmarks/hashestobenchmark.txt``(see :ref:`CONTRIBUTING.rst <performance>`).
+# Running the full suite for several commits one after another in a single job is slow,
+# so this is split into a matrix job (one commit per matrix entry, run in parallel on separate runners)
+# followed by a job that downloads every matrix entry's results
+# and combines them into a single viewable ``asv publish`` output.
+# For now this only uploads that combined view as a workflow artifact,
+# so a PR or main HEAD can easily be compared against the last few stable releases.
+#
+# .. admonition:: Important
+#    :class: warning
+#
+#       Because each matrix entry runs on its own GitHub-hosted runner,
+#       drawn from a pool of different underlying CPU models,
+#       commits compared in this combined view are not guaranteed to have been benchmarked
+#       on the same hardware (unlike the single-job ``benchmark`` job above, where every compared commit shares the same runner).
+#       Any performance difference spotted here should therefore be treated as a lead, not a conclusion,
+#       and confirmed by rerunning the specific benchmark locally for the relevant commits on the same machine,
+#       for example with ``asv run -b <benchmark_name> HASHFILE:hashestobenchmark.txt``.
+#
 ###
 name: Run and deploy Nilearn benchmarks
 
@@ -110,10 +106,6 @@ on:
     workflow_dispatch:
 
 concurrency:
-      # include the event name so that,
-      # e.g., a "push" run (which overwrites the published benchmarks)
-      # and a "schedule" run (which appends to them) on the same ref
-      # do not cancel one another
     group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
     cancel-in-progress: true
 
@@ -133,11 +125,11 @@ jobs:
         steps:
         -   uses: actions/checkout@v7
             with:
-                  # fetch all branches and tags
+                # fetch all branches and tags
                 fetch-depth: 0
-                  # on a pull request,
-                  # check out the actual HEAD of the PR branch
-                  # instead of the default synthetic merge commit
+                # on a pull request,
+                # check out the actual HEAD of the PR branch
+                # instead of the default synthetic merge commit
                 ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
         -   uses: actions/setup-python@v6
@@ -249,12 +241,10 @@ jobs:
                 asv run --show-stderr --verbose --parallel 2 --machine fv-az1113-357 HASHFILE:main_release_hashes.txt 2>&1 | tee log_${{ github.event.repository.updated_at }}_${{ github.run_number }}
 
         -   name: Fail if any benchmark reported as failed
-            # asv run keeps going and exits 0 even when individual
-            # benchmarks fail (it only reports them as "asv: benchmark
-            # failed" in the log), and piping its output through "tee"
-            # above already discards its own exit code regardless.
-            # So check the log content explicitly instead of relying on
-            # the exit code of the "asv run" steps above.
+            # asv run keeps going and exits 0 even when individual benchmarks fail
+            # (it only reports them as "asv: benchmark failed" in the log),
+            # and piping its output through "tee" above already discards its own exit code regardless.
+            # So check the log content explicitly instead of relying on the exit code of the "asv run" steps above.
             run: |
                 LOG_FILE=log_${{ github.event.repository.updated_at }}_${{ github.run_number }}
                 if grep -q "asv: benchmark failed" "$LOG_FILE"; then
@@ -345,7 +335,7 @@ jobs:
         -   uses: actions/checkout@v7
 
         -   id: list
-              # one matrix entry per non-empty, non-comment line
+            # one matrix entry per non-empty, non-comment line
             run: |
                 python3 -c "
                 import json
@@ -359,7 +349,7 @@ jobs:
         if: needs.list-history-commits.outputs.commits != '[]'
         runs-on: ubuntu-24.04
         strategy:
-              # keep benchmarking the other commits even if one fails
+            # keep benchmarking the other commits even if one fails
             fail-fast: false
             matrix:
                 commit: ${{ fromJson(needs.list-history-commits.outputs.commits) }}
@@ -387,7 +377,7 @@ jobs:
             run: python ../build_tools/github/set_machine_name.py fv-az1113-357
 
         -   name: Run all benchmarks for this commit
-              # "<commit>^!" is git's syntax for "just this one commit"
+            # "<commit>^!" is git's syntax for "just this one commit"
             run: |
                 asv run --show-stderr --verbose --parallel 2 --machine fv-az1113-357 "${{ matrix.commit }}^!" 2>&1 | tee log_${{ matrix.commit }}
 
@@ -431,12 +421,11 @@ jobs:
                 path: ./asv_benchmarks/downloaded_results
 
         -   name: Merge per-commit results into a single results directory
-              # "benchmarks.json" (the benchmark suite definition) is
-              # identical across matrix entries, since they all ran the
-              # same benchmark code against different nilearn commits, so
-              # any one copy of it is kept.
-              # The per-commit, per-machine result files are all distinct
-              # and are combined into one shared machine directory.
+            # "benchmarks.json" (the benchmark suite definition) is identical across matrix entries,
+            # since they all ran the same benchmark code against different nilearn commits,
+            # so any one copy of it is kept.
+            # The per-commit, per-machine result files are all distinct
+            # and are combined into one shared machine directory.
             run: |
                 python3 -c "
                 import glob

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -379,9 +379,19 @@ jobs:
             run: python ../build_tools/github/set_machine_name.py fv-az1113-357
 
         -   name: Run all benchmarks for this commit
-              # "<commit>^!" is git's syntax for "just this one commit"
+              # "<commit>^!" is git's syntax for "just this one commit".
+              # Each matrix entry runs on its own GitHub-hosted runner,
+              # drawn from a pool of different underlying CPU models, so
+              # unlike the single-job "benchmark" job above (where every
+              # compared commit shares the same runner), the commits
+              # compared here can land on different hardware. That is not
+              # fixable from the workflow file on standard runners, so
+              # "-a rounds=5 -a repeat=10" instead increases the number of
+              # independent measurement rounds and samples per round (vs.
+              # the defaults of 2 and an adaptive up to 10), to shrink
+              # the measurement noise that we *can* control.
             run: |
-                asv run --show-stderr --verbose --parallel 2 --machine fv-az1113-357 "${{ matrix.commit }}^!" 2>&1 | tee log_${{ matrix.commit }}
+                asv run --show-stderr --verbose --parallel 2 --machine fv-az1113-357 -a rounds=5 -a repeat=10 "${{ matrix.commit }}^!" 2>&1 | tee log_${{ matrix.commit }}
 
         -   name: Fail if any benchmark reported as failed
             run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -379,19 +379,9 @@ jobs:
             run: python ../build_tools/github/set_machine_name.py fv-az1113-357
 
         -   name: Run all benchmarks for this commit
-              # "<commit>^!" is git's syntax for "just this one commit".
-              # Each matrix entry runs on its own GitHub-hosted runner,
-              # drawn from a pool of different underlying CPU models, so
-              # unlike the single-job "benchmark" job above (where every
-              # compared commit shares the same runner), the commits
-              # compared here can land on different hardware. That is not
-              # fixable from the workflow file on standard runners, so
-              # "-a rounds=5 -a repeat=10" instead increases the number of
-              # independent measurement rounds and samples per round (vs.
-              # the defaults of 2 and an adaptive up to 10), to shrink
-              # the measurement noise that we *can* control.
+              # "<commit>^!" is git's syntax for "just this one commit"
             run: |
-                asv run --show-stderr --verbose --parallel 2 --machine fv-az1113-357 -a rounds=5 -a repeat=10 "${{ matrix.commit }}^!" 2>&1 | tee log_${{ matrix.commit }}
+                asv run --show-stderr --verbose --parallel 2 --machine fv-az1113-357 "${{ matrix.commit }}^!" 2>&1 | tee log_${{ matrix.commit }}
 
         -   name: Fail if any benchmark reported as failed
             run: |

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1156,6 +1156,8 @@ returned by the ``request_mocker`` pytest fixture, defined in
 ``Sender`` class it contains provide information on how to write a test using
 this fixture. Existing tests can also serve as examples.
 
+.. _performance:
+
 Performance monitoring
 ----------------------
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1274,6 +1274,14 @@ For naming benchmarks, try to follow the following rules:
   and every other benchmark in that file will be reported as failed too,
   even though they do not rely on the missing function.
   A local import inside ``setup()`` confines the failure to that one benchmark.
+
+  Catch the ``ImportError`` and re-raise it as ``NotImplementedError``
+  instead of letting it propagate as-is.
+  asv treats a ``NotImplementedError`` raised in ``setup()`` as "this benchmark
+  does not apply here" and reports it as *skipped*,
+  whereas any other exception (including a bare ``ImportError``) is reported as *failed*,
+  which the CI benchmark workflow treats as a hard failure
+  (see the "Fail if any benchmark reported as failed" step).
   See ``BenchMarkAllEstimators`` in ``asv_benchmarks/benchmarks/discovery.py`` for a concrete example.
 
 Maintenance

--- a/asv_benchmarks/benchmarks/discovery.py
+++ b/asv_benchmarks/benchmarks/discovery.py
@@ -8,9 +8,16 @@ class BenchMarkAllEstimators:
         """Set up for all benchmarks."""
         # Imported locally (nilearn.utils.discovery module was only added
         # in 0.13.0) so that benchmarking older nilearn versions only
-        # fails this benchmark instead of making the whole module fail
+        # affects this benchmark instead of making the whole module fail
         # to import for every benchmark in this file.
-        from nilearn.utils import all_estimators
+        # Raising NotImplementedError (instead of letting ImportError
+        # propagate) makes asv report this as "skipped" rather than
+        # "failed" for those older versions: see asv_runner's
+        # BenchmarkBase.do_setup, which special-cases NotImplementedError.
+        try:
+            from nilearn.utils import all_estimators
+        except ImportError as e:
+            raise NotImplementedError from e
 
         self.all_estimators = all_estimators
 

--- a/asv_benchmarks/benchmarks/plotting/plotting.py
+++ b/asv_benchmarks/benchmarks/plotting/plotting.py
@@ -113,9 +113,16 @@ class BenchMarkPlotDesignMatrixCorrelation:
     def setup(self):
         """Set up for all benchmarks."""
         # Imported locally (added in 0.11.0) so that benchmarking older
-        # nilearn versions only fails this benchmark instead of making
+        # nilearn versions only affects this benchmark instead of making
         # the whole module fail to import for every benchmark in this file.
-        from nilearn.plotting import plot_design_matrix_correlation
+        # Raising NotImplementedError (instead of letting ImportError
+        # propagate) makes asv report this as "skipped" rather than
+        # "failed" for those older versions: see asv_runner's
+        # BenchmarkBase.do_setup, which special-cases NotImplementedError.
+        try:
+            from nilearn.plotting import plot_design_matrix_correlation
+        except ImportError as e:
+            raise NotImplementedError from e
 
         self.plot_design_matrix_correlation = plot_design_matrix_correlation
 

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -52,7 +52,7 @@ Enhancements
 Changes
 -------
 
-- :bdg-secondary:`Maint` Add a matrix job to the benchmark CI workflow that benchmarks each commit in ``asv_benchmarks/hashestobenchmark.txt`` in parallel, then combines the results into a single viewable artifact, instead of benchmarking them one after another in a single, slow job (:gh:`6430` by `Rémi Gau`_).
+- :bdg-secondary:`Maint` Add a matrix job to the benchmark CI workflow that benchmarks each commit in ``asv_benchmarks/hashestobenchmark.txt`` in parallel, then combines the results into a single viewable artifact, instead of benchmarking them one after another in a single, slow job, and make the version-gated local imports in ``discovery.py`` and ``plotting.py`` raise ``NotImplementedError`` so asv reports them as skipped rather than failed on nilearn versions that lack the benchmarked function (:gh:`6430` by `Rémi Gau`_).
 
 - :bdg-secondary:`Maint` Drop nilearn versions older than 0.11.0 from ``asv_benchmarks/hashestobenchmark.txt`` (they cannot currently be benchmarked, see ``CONTRIBUTING.rst``), make the benchmark CI workflow fail when a benchmark reports as failed instead of silently ignoring it, fix an always-failing ``IndexImgBenchmark`` slice bound that this newly surfaced, and reorganize ``asv_benchmarks/benchmarks/glm`` to mirror the structure of :mod:`nilearn.glm` (:gh:`6426` by `Rémi Gau`_).
 

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -52,6 +52,8 @@ Enhancements
 Changes
 -------
 
+- :bdg-secondary:`Maint` Add a matrix job to the benchmark CI workflow that benchmarks each commit in ``asv_benchmarks/hashestobenchmark.txt`` in parallel, then combines the results into a single viewable artifact, instead of benchmarking them one after another in a single, slow job (:gh:`6430` by `Rémi Gau`_).
+
 - :bdg-secondary:`Maint` Drop nilearn versions older than 0.11.0 from ``asv_benchmarks/hashestobenchmark.txt`` (they cannot currently be benchmarked, see ``CONTRIBUTING.rst``), make the benchmark CI workflow fail when a benchmark reports as failed instead of silently ignoring it, fix an always-failing ``IndexImgBenchmark`` slice bound that this newly surfaced, and reorganize ``asv_benchmarks/benchmarks/glm`` to mirror the structure of :mod:`nilearn.glm` (:gh:`6426` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Add type annotations to the public functions in ``nilearn._utils.data_gen`` (:gh:`6420` by `Rémi Gau`_).


### PR DESCRIPTION
- Related to #5966

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

This PR was produced with the help of an AI coding agent (Claude Code).

Running the full benchmark suite for several commits one after another in a single job is slow, and gets worse as more commits are added to `asv_benchmarks/hashestobenchmark.txt`.

Changes proposed in this pull request:

- `list-history-commits`: reads `asv_benchmarks/hashestobenchmark.txt` into a JSON array for use as a matrix.
- `benchmark-history`: a matrix job that benchmarks each commit from that list in parallel, on its own runner (asv's own `--parallel` flag only parallelizes building environments, not running the timed benchmarks themselves, so real parallelism needs separate CI jobs — confirmed by checking `asv run --help`).
- `combine-history`: downloads every matrix entry's results, merges the per-commit/per-machine result files into a single `results` directory, and publishes one combined `asv publish` HTML view as a workflow artifact.

For now this only uploads the combined view as an artifact. The plan (see #5966) is to eventually have it overwrite a previous baseline on the `benchmarks` repo, similar to the existing push-based main-vs-latest-release comparison, so a PR or main HEAD can easily be compared against the last few stable releases.

## Test plan

- [x] Verified locally that the commit-listing script produces valid JSON from `hashestobenchmark.txt`.
- [x] Verified locally that the merge script correctly combines several fake per-commit artifact directories into one `results` directory.
- [x] Verified locally that `asv run "<commit>^!"` correctly benchmarks a single historical commit.
- [x] Verified locally that `asv publish` succeeds without a local `asv-machine.json` (only needed when running new benchmarks, not when publishing existing results).
- [x] Confirm this PR's own CI run actually exercises the matrix + merge mechanism end to end, then remove `pull_request` from the three jobs' triggers and drop the `-b` filter in a follow-up commit.