### PR TITLE
[FIX] Use inclusion_filters instead of exclusion_filters for ds000030 fetch

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -22,6 +22,8 @@ NEW
 Fixes
 -----
 
+- :bdg-dark:`Code` Fix ``examples/04_glm_first_level/plot_bids_features.py``, ``doc/get_data_examples.py``, and ``doc/visual_testing/reporter_visual_inspection_suite.py`` downloading the full FSL derivatives for the ``bart`` and ``taskswitch`` tasks of the ``ds000030`` dataset in addition to ``stopsignal``, because the ``*task-task*`` exclusion filter did not match the ``derivatives/task/sub-*/taskswitch.feat`` folder name; switch to ``inclusion_filters`` to only fetch the files needed for the ``stopsignal`` analysis (:gh:`6432` by `Rémi Gau`_).
+
 - :bdg-warning:`Test` Fix the ``test_html`` GitHub Actions workflow to set ``NILEARN_DATA`` to the same path used to restore its dataset cache, and add ``NILEARN_DATA`` to ``tox.ini``'s shared ``passenv`` list so ``tox`` actually forwards it to the ``generate_html``/``test_html`` environments, since without it nilearn's fetchers default to ``~/nilearn_data`` instead and every dataset was silently re-downloaded from the network on every run regardless of whether the cache was restored (:gh:`6427` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Fix the ``build-docs`` GitHub Actions workflow so the monthly dataset cache is only saved once per month, by a full build, instead of on every run, which was causing it to be evicted from the repository's Actions cache quota (or frozen with only a partial-build subset of the data) and forcing datasets such as ``development_fmri`` and ``difumo_atlases`` to be re-downloaded live from OSF, a frequent source of flaky ``test_html`` and ``build-docs`` failures (:gh:`6425` by `Rémi Gau`_).

--- a/doc/get_data_examples.py
+++ b/doc/get_data_examples.py
@@ -22,23 +22,23 @@ def main(args=sys.argv) -> None:
     datasets.fetch_atlas_schaefer_2018()
 
     _, urls = datasets.fetch_ds000030_urls()
-    exclusion_patterns = [
-        "*group*",
-        "*phenotype*",
-        "*mriqc*",
-        "*parameter_plots*",
-        "*physio_plots*",
-        "*space-fsaverage*",
-        "*space-T1w*",
-        "*dwi*",
-        "*beh*",
-        "*task-bart*",
-        "*task-rest*",
-        "*task-scap*",
-        "*task-task*",
-    ]
+    # Only keep the files for the ``stopsignal`` task that are actually
+    # needed by examples/04_glm_first_level/plot_bids_features.py:
+    # the raw functional data and events, the relevant fMRIPrep
+    # derivatives, and the FSL ``stopsignal.feat`` derivatives used
+    # for comparison. Restricting the download with
+    # ``inclusion_filters`` this way, rather than trying to list every
+    # folder to exclude, avoids pulling in the (much larger)
+    # derivatives of the other tasks acquired for this subject.
+    inclusion_patterns = ["*sub-*stopsignal*"]
+    # Some fMRIPrep derivatives are also generated in other output
+    # spaces that are not used in that example.
+    exclusion_patterns = ["*_space-T1w*", "*_space-fsaverage*"]
     urls = datasets.select_from_index(
-        urls, exclusion_filters=exclusion_patterns, n_subjects=1
+        urls,
+        inclusion_filters=inclusion_patterns,
+        exclusion_filters=exclusion_patterns,
+        n_subjects=1,
     )
     datasets.fetch_openneuro_dataset(urls=urls)
 

--- a/doc/get_data_examples.py
+++ b/doc/get_data_examples.py
@@ -26,14 +26,24 @@ def main(args=sys.argv) -> None:
     # needed by examples/04_glm_first_level/plot_bids_features.py:
     # the raw functional data and events, the relevant fMRIPrep
     # derivatives, and the FSL ``stopsignal.feat`` derivatives used
-    # for comparison. Restricting the download with
+    # for comparison.
+    # Restricting the download with
     # ``inclusion_filters`` this way, rather than trying to list every
     # folder to exclude, avoids pulling in the (much larger)
     # derivatives of the other tasks acquired for this subject.
     inclusion_patterns = ["*sub-*stopsignal*"]
-    # Some fMRIPrep derivatives are also generated in other output
-    # spaces that are not used in that example.
-    exclusion_patterns = ["*_space-T1w*", "*_space-fsaverage*"]
+    # Some fMRIPrep and FSL derivatives are are not used in that example.
+    exclusion_patterns = [
+        "*_space-T1w*",
+        "*_space-fsaverage*",
+        "*cope*gz",
+        "*jpg",
+        "*png",
+        "*txt",
+        "*tiff",
+        "*gif",
+        "*res4D*",
+    ]
     urls = datasets.select_from_index(
         urls,
         inclusion_filters=inclusion_patterns,

--- a/doc/visual_testing/reporter_visual_inspection_suite.py
+++ b/doc/visual_testing/reporter_visual_inspection_suite.py
@@ -131,23 +131,15 @@ def report_flm_adhd_dmn(build_type):
 def _fetch_bids_data():
     _, urls = fetch_ds000030_urls()
 
-    exclusion_patterns = [
-        "*group*",
-        "*phenotype*",
-        "*mriqc*",
-        "*parameter_plots*",
-        "*physio_plots*",
-        "*space-fsaverage*",
-        "*space-T1w*",
-        "*dwi*",
-        "*beh*",
-        "*task-bart*",
-        "*task-rest*",
-        "*task-scap*",
-        "*task-task*",
-    ]
+    # See examples/04_glm_first_level/plot_bids_features.py for the
+    # rationale behind these filters.
+    inclusion_patterns = ["*sub-*stopsignal*"]
+    exclusion_patterns = ["*_space-T1w*", "*_space-fsaverage*"]
     urls = select_from_index(
-        urls, exclusion_filters=exclusion_patterns, n_subjects=1
+        urls,
+        inclusion_filters=inclusion_patterns,
+        exclusion_filters=exclusion_patterns,
+        n_subjects=1,
     )
 
     data_dir, _ = fetch_openneuro_dataset(urls=urls)

--- a/doc/visual_testing/reporter_visual_inspection_suite.py
+++ b/doc/visual_testing/reporter_visual_inspection_suite.py
@@ -134,7 +134,17 @@ def _fetch_bids_data():
     # See examples/04_glm_first_level/plot_bids_features.py for the
     # rationale behind these filters.
     inclusion_patterns = ["*sub-*stopsignal*"]
-    exclusion_patterns = ["*_space-T1w*", "*_space-fsaverage*"]
+    exclusion_patterns = [
+        "*_space-T1w*",
+        "*_space-fsaverage*",
+        "*cope*gz",
+        "*jpg",
+        "*png",
+        "*txt",
+        "*tiff",
+        "*gif",
+        "*res4D*",
+    ]
     urls = select_from_index(
         urls,
         inclusion_filters=inclusion_patterns,

--- a/examples/04_glm_first_level/plot_bids_features.py
+++ b/examples/04_glm_first_level/plot_bids_features.py
@@ -51,9 +51,18 @@ _, urls = fetch_ds000030_urls()
 # avoids pulling in the (much larger) derivatives
 # of the other tasks acquired for this subject.
 inclusion_patterns = ["*sub-*stopsignal*"]
-# Some fMRIPrep derivatives are also generated in other output spaces
-# that are not used in this example.
-exclusion_patterns = ["*_space-T1w*", "*_space-fsaverage*"]
+# Some fMRIPrep and FSL derivatives are are not used in that example.
+exclusion_patterns = [
+    "*_space-T1w*",
+    "*_space-fsaverage*",
+    "*cope*gz",
+    "*jpg",
+    "*png",
+    "*txt",
+    "*tiff",
+    "*gif",
+    "*res4D*",
+]
 urls = select_from_index(
     urls,
     inclusion_filters=inclusion_patterns,

--- a/examples/04_glm_first_level/plot_bids_features.py
+++ b/examples/04_glm_first_level/plot_bids_features.py
@@ -42,23 +42,23 @@ from nilearn.datasets import (
 
 _, urls = fetch_ds000030_urls()
 
-exclusion_patterns = [
-    "*group*",
-    "*phenotype*",
-    "*mriqc*",
-    "*parameter_plots*",
-    "*physio_plots*",
-    "*space-fsaverage*",
-    "*space-T1w*",
-    "*dwi*",
-    "*beh*",
-    "*task-bart*",
-    "*task-rest*",
-    "*task-scap*",
-    "*task-task*",
-]
+# Only keep the files for the ``stopsignal`` task that are actually
+# needed for this example: the raw functional data and events,
+# the relevant fMRIPrep derivatives, and the FSL ``stopsignal.feat``
+# derivatives used later on for comparison.
+# Restricting the download with a ``inclusion_filters`` this way,
+# rather than trying to list every folder to exclude,
+# avoids pulling in the (much larger) derivatives
+# of the other tasks acquired for this subject.
+inclusion_patterns = ["*sub-*stopsignal*"]
+# Some fMRIPrep derivatives are also generated in other output spaces
+# that are not used in this example.
+exclusion_patterns = ["*_space-T1w*", "*_space-fsaverage*"]
 urls = select_from_index(
-    urls, exclusion_filters=exclusion_patterns, n_subjects=1
+    urls,
+    inclusion_filters=inclusion_patterns,
+    exclusion_filters=exclusion_patterns,
+    n_subjects=1,
 )
 
 data_dir, _ = fetch_openneuro_dataset(urls=urls)


### PR DESCRIPTION
<!-- Please indicate after the # which issue you're closing with this pull request. -->
- Closes #6048

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- The `exclusion_filters` used in `examples/04_glm_first_level/plot_bids_features.py`, `doc/get_data_examples.py`, and `doc/visual_testing/reporter_visual_inspection_suite.py` to restrict the `ds000030` download to a single subject/task did not work as intended: `derivatives/task/sub-*/{bart,taskswitch}.feat` do not contain a `task-task` substring, so the `*task-task*` pattern never excluded them, and the full FSL derivatives for those two unrelated tasks were downloaded alongside the `stopsignal` ones.
- Switch all three scripts to `inclusion_filters=["*sub-*stopsignal*"]` (plus two small `exclusion_filters` to drop unused fMRIPrep output-space variants: `space-T1w` and `space-fsaverage`), which only pulls the files actually needed for the `stopsignal` analysis.

**Extra data being downloaded before this fix**, measured against the actual local cache produced by the old `exclusion_filters`:

| | files | size |
|---|---|---|
| Old (`exclusion_filters`) | 719 | 776.2 MB |
| New (`inclusion_filters`) | 168 | 253.1 MB |
| **Excess removed** | **553** | **523.1 MB (67% of the total)** |

Breakdown of the 553 excess files:
- `bart.feat` derivatives (wrong task): 204 files, 149.7 MB
- `taskswitch.feat` derivatives (wrong task): 321 files, 151.1 MB
- raw + fMRIPrep anat derivatives (never read by `first_level_from_bids`, which only globs `func/` derivatives): 19 files, 207.2 MB
- misc top-level metadata not required by `first_level_from_bids` (`README`, `dataset_description.json`, `participants.tsv`, other tasks' sidecar jsons, fMRIPrep HTML reports): 9 files, 15.1 MB

Verified end-to-end against a clean cache directory: `first_level_from_bids` + contrast computation + FSL comparison still run successfully with the reduced file set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)