### PR TITLE
[FIX] Fix broken "View this page"/"Edit this page" links on generated API reference pages

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -32,6 +32,8 @@ Fixes
 
 - :bdg-dark:`Code` Fix :func:`~image.resample_img` raising an ``AttributeError`` instead of resampling correctly when ``target_affine`` is passed as a :obj:`list` or :obj:`tuple` together with ``target_shape`` (:gh:`6408` by `Rémi Gau`_).
 
+- :bdg-primary:`Doc` Fix the "View this page" and "Edit this page" buttons leading to a 404 on autosummary-generated API reference pages (e.g. :func:`~image.concat_imgs`), by hiding them there since those ``.rst`` files are generated at build time and never committed to the repository (:gh:`6435` by `Rémi Gau`_).
+
 - :bdg-secondary:`Maint` Add return type annotations to :func:`~interfaces.fsl.get_design_from_fslmat`, :func:`~interfaces.bids.parse_bids_filename`, :func:`~interfaces.fmriprep.load_confounds`, and :func:`~interfaces.fmriprep.load_confounds_strategy` (:gh:`6362` by `Rémi Gau`_).
 
 - :bdg-secondary:`Maint` Add return type annotations and :obj:`~typing.overload` signatures to :func:`~connectome.vec_to_sym_matrix`, :func:`~connectome.group_sparse_covariance`, and :func:`~reporting.get_clusters_table` (:gh:`6368` by `Rémi Gau`_).

--- a/doc/templates/components/edit-this-page.html
+++ b/doc/templates/components/edit-this-page.html
@@ -34,12 +34,14 @@
 {%- endmacro -%}
 
 {% block link_available -%}
-    {{ furo_edit_button(determine_page_edit_link() ) }}
+    {%- if not pagename.startswith("modules/generated/") -%}
+        {{ furo_edit_button(determine_page_edit_link() ) }}
+    {%- endif -%}
 {%- endblock link_available %}
 
 {% block link_not_available %}
     {# Make nice things happen, on Read the Docs #}
-    {%- if READTHEDOCS and conf_py_path and page_source_suffix and github_user != "None" and github_repo != "None" and github_version and pagename and page_source_suffix %}
+    {%- if not pagename.startswith("modules/generated/") and READTHEDOCS and conf_py_path and page_source_suffix and github_user != "None" and github_repo != "None" and github_version and pagename and page_source_suffix %}
 
         {% set url = "https://github.com/" + github_user + "/" + github_repo + "/edit/" + github_version + conf_py_path + pagename + page_source_suffix %}
 

--- a/doc/templates/components/view-this-page.html
+++ b/doc/templates/components/view-this-page.html
@@ -1,0 +1,40 @@
+{#
+  Adapted from https://github.com/pradyunsg/furo/blob/main/src/furo/theme/furo/components/view-this-page.html
+  Required to properly link the view button in the examples from the doc to source document in the github repo,
+  and to hide it for autosummary-generated API reference pages that have no rst source committed to the repo.
+#}
+
+{% extends "basic-ng/components/view-this-page.html" %}
+
+{% from "basic-ng/components/view-this-page.html" import determine_page_view_link with context %}
+{%- macro furo_view_button(url) -%}
+    {%- if 'doc/auto_examples' in url -%}
+
+        {% set url = url|replace("doc/auto_examples", "examples")|replace(".rst", ".py")|replace("index.py", "README.rst")|replace("?plain=true", "") %}
+
+    {%- endif -%}
+    <div class="view-this-page">
+        <a class="muted-link" href="{{ url }}" title="{{ _("View this page") }}">
+            <svg>
+                <use href="#svg-eye"></use>
+            </svg>
+            <span class="visually-hidden">{{ _("View this page") }}</span>
+        </a>
+    </div>
+{%- endmacro -%}
+
+{% block link_available -%}
+    {%- if not pagename.startswith("modules/generated/") -%}
+        {{ furo_view_button(determine_page_view_link() ) }}
+    {%- endif -%}
+{%- endblock link_available %}
+
+{% block link_not_available %}
+    {# Make nice things happen, on Read the Docs #}
+    {%- if not pagename.startswith("modules/generated/") and READTHEDOCS and conf_py_path and page_source_suffix and github_user != "None" and github_repo != "None" and github_version and pagename and page_source_suffix %}
+
+        {% set url = "https://github.com/" + github_user + "/" + github_repo + "/blob/" + github_version + conf_py_path + pagename + page_source_suffix + "?plain=true" %}
+
+        {{ furo_view_button(url) }}
+    {%- endif -%}
+{% endblock link_not_available %}


### PR DESCRIPTION
- Closes #6277

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- The furo theme's "View this page" / "Edit this page" buttons build their GitHub URL from the page name relative to `doc/`. For autosummary-generated API reference pages (e.g. `nilearn.image.concat_imgs`), the corresponding `.rst` file lives under `doc/modules/generated/`, which is entirely gitignored and only produced at doc-build time — so the buttons always pointed at a 404.
- Hide both buttons for pages under `doc/modules/generated/`, since there is no committed source file to link to there. A correct per-object "[source]" link (via `sphinx.ext.linkcode`) is already shown on those pages, linking straight to the actual Python source.
- While at it, extended the existing `auto_examples` special-casing (previously only applied to the "Edit this page" button) to the "View this page" button as well, since it had the same dead-link problem, just unreported.