### PR TITLE
[MAINT] Add type annotations to conftest, datasets.struct, image.image, plotting.img_plotting, and surface.surface

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -60,6 +60,8 @@ Enhancements
 Changes
 -------
 
+- :bdg-dark:`Code` Add return type annotations to :func:`~datasets.fetch_icbm152_2009`, :func:`~datasets.fetch_icbm152_brain_gm_mask`, :func:`~datasets.fetch_oasis_vbm`, :func:`~image.crop_img`, :func:`~plotting.plot_carpet`, and to internal helpers ``nilearn.conftest.check_parameters_doctring``, ``nilearn.conftest.check_methods_docstring``, ``nilearn.image.image.smooth_array``, and ``nilearn.surface.surface.combine_hemispheres_meshes`` (:gh:`XXXX` by `Rémi Gau`_).
+
 - :bdg-secondary:`Maint` Drop nilearn versions older than 0.11.0 from ``asv_benchmarks/hashestobenchmark.txt`` (they cannot currently be benchmarked, see ``CONTRIBUTING.rst``), make the benchmark CI workflow fail when a benchmark reports as failed instead of silently ignoring it, fix an always-failing ``IndexImgBenchmark`` slice bound that this newly surfaced, and reorganize ``asv_benchmarks/benchmarks/glm`` to mirror the structure of :mod:`nilearn.glm` (:gh:`6426` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Add type annotations to the public functions in ``nilearn._utils.data_gen`` (:gh:`6420` by `Rémi Gau`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -60,7 +60,7 @@ Enhancements
 Changes
 -------
 
-- :bdg-dark:`Code` Add return type annotations to :func:`~datasets.fetch_icbm152_2009`, :func:`~datasets.fetch_icbm152_brain_gm_mask`, :func:`~datasets.fetch_oasis_vbm`, :func:`~image.crop_img`, :func:`~plotting.plot_carpet`, and to internal helpers ``nilearn.conftest.check_parameters_doctring``, ``nilearn.conftest.check_methods_docstring``, ``nilearn.image.image.smooth_array``, and ``nilearn.surface.surface.combine_hemispheres_meshes`` (:gh:`XXXX` by `Rémi Gau`_).
+- :bdg-dark:`Code` Add return type annotations to :func:`~datasets.fetch_icbm152_2009`, :func:`~datasets.fetch_icbm152_brain_gm_mask`, :func:`~datasets.fetch_oasis_vbm`, :func:`~image.crop_img`, :func:`~plotting.plot_carpet`, and to internal helpers ``nilearn.conftest.check_parameters_doctring``, ``nilearn.conftest.check_methods_docstring``, ``nilearn.image.image.smooth_array``, and ``nilearn.surface.surface.combine_hemispheres_meshes`` (:gh:`6438` by `Rémi Gau`_).
 
 - :bdg-secondary:`Maint` Drop nilearn versions older than 0.11.0 from ``asv_benchmarks/hashestobenchmark.txt`` (they cannot currently be benchmarked, see ``CONTRIBUTING.rst``), make the benchmark CI workflow fail when a benchmark reports as failed instead of silently ignoring it, fix an always-failing ``IndexImgBenchmark`` slice bound that this newly surfaced, and reorganize ``asv_benchmarks/benchmarks/glm`` to mirror the structure of :mod:`nilearn.glm` (:gh:`6426` by `Rémi Gau`_).
 

--- a/nilearn/conftest.py
+++ b/nilearn/conftest.py
@@ -938,7 +938,7 @@ def check_obj_docstring(obj) -> None:
     check_methods_docstring(obj.__class__)
 
 
-def check_parameters_doctring(parameters, doc_dict):
+def check_parameters_doctring(parameters, doc_dict) -> None:
     """Check if all parameters are documented without duplicates and extras."""
     documented = []
     for param in doc_dict:
@@ -961,7 +961,7 @@ def check_parameters_doctring(parameters, doc_dict):
     assert len(documented) == len(set(documented))
 
 
-def check_methods_docstring(cls):
+def check_methods_docstring(cls) -> None:
     """Check if all public functions and parameters are documented."""
     for name, member in cls.__dict__.items():
         if name.startswith("_"):

--- a/nilearn/datasets/struct.py
+++ b/nilearn/datasets/struct.py
@@ -70,7 +70,7 @@ def fetch_icbm152_2009(
     url: Url = None,
     resume: Resume = True,
     verbose: Verbose = 1,
-):
+) -> Bunch:
     """Download and load the ICBM152 template (dated 2009).
 
     For more information
@@ -530,7 +530,7 @@ def fetch_icbm152_brain_gm_mask(
     resume: Resume = True,
     n_iter: int = 2,
     verbose: Verbose = 1,
-):
+) -> Nifti1Image:
     """Download ICBM152 template first, then loads the 'gm' mask.
 
     For more information
@@ -659,7 +659,7 @@ def fetch_oasis_vbm(
     url: Url = None,
     resume: Resume = True,
     verbose: Verbose = 1,
-):
+) -> Bunch:
     """Download and load Oasis "cross-sectional MRI" dataset (416 subjects).
 
     For more information

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -353,7 +353,9 @@ def _fast_smooth_array(arr):
 
 
 @fill_doc
-def smooth_array(arr, affine, fwhm=None, ensure_finite=True, copy=True):
+def smooth_array(
+    arr, affine, fwhm=None, ensure_finite: bool = True, copy: bool = True
+) -> np.ndarray:
     """Smooth images by applying a Gaussian filter.
 
     Apply a Gaussian filter along the three first dimensions of `arr`.
@@ -657,7 +659,7 @@ def _crop_img_to(img, slices, copy=True, copy_header=True):
 
     Returns
     -------
-    Niimg-like object
+    Nifti1Image
         Cropped version of the input image.
 
     offset : :obj:`list`, optional
@@ -689,8 +691,13 @@ def _crop_img_to(img, slices, copy=True, copy_header=True):
 
 @fill_doc
 def crop_img(
-    img, rtol=1e-8, copy=True, pad=True, return_offset=False, copy_header=True
-):
+    img,
+    rtol=1e-8,
+    copy: bool = True,
+    pad: bool = True,
+    return_offset: bool = False,
+    copy_header: bool = True,
+) -> Nifti1Image | tuple[Nifti1Image, tuple[slice, ...]]:
     """Crops an image as much as possible.
 
     Will crop `img`, removing as many zero entries as possible without
@@ -726,7 +733,7 @@ def crop_img(
 
     Returns
     -------
-    cropped_im : Niimg-like object
+    cropped_im : Nifti1Image
         Cropped version of the input image
         If the specified image is empty, the original image will be returned.
 
@@ -782,7 +789,7 @@ def crop_img(
 
     # Sets full range if no data are found along the axis
     if coords.shape[1] == 0:
-        start, end = [0, 0, 0], list(data.shape)
+        start, end = np.array([0, 0, 0]), np.array(data.shape[:3])
         pad = False
         warnings.warn(
             f"No values above {rtol}. Returning original image.",

--- a/nilearn/plotting/image/img_plotting.py
+++ b/nilearn/plotting/image/img_plotting.py
@@ -15,6 +15,7 @@ import numpy as np
 import pandas as pd
 from matplotlib import get_backend
 from matplotlib.colors import LinearSegmentedColormap, Normalize
+from matplotlib.figure import Figure
 from matplotlib.gridspec import GridSpecFromSubplotSpec
 from matplotlib.ticker import MaxNLocator
 
@@ -49,6 +50,7 @@ from nilearn.nilearn_typing import (
     OutputFile,
     Radiological,
     ResamplingInterpolation,
+    Standardize,
     Title,
 )
 from nilearn.plotting import cm
@@ -1907,8 +1909,8 @@ def plot_carpet(
     title: Title = None,
     cmap="gray",
     cmap_labels="gist_ncar",
-    standardize=True,
-):
+    standardize: Standardize = True,
+) -> Figure:
     """Plot an image representation of :term:`voxel` intensities across time.
 
     This figure is also known as a "grayplot" or "Power plot".

--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -6,6 +6,7 @@ import pathlib
 import warnings
 from collections.abc import Iterable, Iterator, Mapping
 from pathlib import Path
+from typing import overload
 
 import numpy as np
 import pandas as pd
@@ -1703,7 +1704,7 @@ def _gifti_img_to_mesh(gifti_img):
     return coords, faces
 
 
-def combine_hemispheres_meshes(mesh):
+def combine_hemispheres_meshes(mesh: PolyMesh) -> InMemoryMesh:
     """Combine the left and right hemisphere meshes such that both are
     represented in the same mesh.
 
@@ -1941,7 +1942,15 @@ def load_surf_mesh(surf_mesh) -> InMemoryMesh:
     return mesh
 
 
-def at_least_2d(input):
+@overload
+def at_least_2d(input: SurfaceImage) -> SurfaceImage: ...
+
+
+@overload
+def at_least_2d(input: PolyData) -> PolyData: ...
+
+
+def at_least_2d(input: SurfaceImage | PolyData) -> SurfaceImage | PolyData:
     """Force surface image or polydata to be 2d."""
     if len(input.shape) == 2:
         return input


### PR DESCRIPTION
<!-- Please indicate after the # which issue you're closing with this pull request. -->
- Related to #3568

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- Add return type annotations to `check_parameters_doctring`, `check_methods_docstring` (`conftest.py`), `fetch_icbm152_2009`, `fetch_icbm152_brain_gm_mask`, `fetch_oasis_vbm` (`datasets/struct.py`), `smooth_array`, `crop_img` (`image/image.py`), `plot_carpet` (`plotting/image/img_plotting.py`), `combine_hemispheres_meshes`, and `@overload` signatures for `at_least_2d` (`surface/surface.py`).
- Fix two mypy errors surfaced by annotating `crop_img`'s return type:
  - `start`/`end` were assigned a plain `list` in one branch and an `ndarray` in the other; with `allow_redefinition = false` this is a real conflict once the body is checked. Made the empty-coords branch produce `ndarray`s too (behaviorally identical, since that branch also forces `pad = False` so the arrays are never touched by the later padding math).
  - `tuple[slice]` means a fixed 1-element tuple, not the 3-element tuple `slices` actually produces; used `tuple[slice, ...]` instead, since the code builds it via `list(map(...))[:3]` rather than a literal 3-tuple, so mypy cannot statically prove an exact length of 3.