### PR TITLE
[MAINT] Add return type annotation to find_cut_slices

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -60,6 +60,8 @@ Enhancements
 Changes
 -------
 
+- :bdg-dark:`Code` Add a return type annotation to :func:`~plotting.find_cut_slices` (:gh:`XXXX` by `Rémi Gau`_).
+
 - :bdg-secondary:`Maint` Drop nilearn versions older than 0.11.0 from ``asv_benchmarks/hashestobenchmark.txt`` (they cannot currently be benchmarked, see ``CONTRIBUTING.rst``), make the benchmark CI workflow fail when a benchmark reports as failed instead of silently ignoring it, fix an always-failing ``IndexImgBenchmark`` slice bound that this newly surfaced, and reorganize ``asv_benchmarks/benchmarks/glm`` to mirror the structure of :mod:`nilearn.glm` (:gh:`6426` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Add type annotations to the public functions in ``nilearn._utils.data_gen`` (:gh:`6420` by `Rémi Gau`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -60,7 +60,7 @@ Enhancements
 Changes
 -------
 
-- :bdg-dark:`Code` Add a return type annotation to :func:`~plotting.find_cut_slices` (:gh:`XXXX` by `Rémi Gau`_).
+- :bdg-dark:`Code` Add a return type annotation to :func:`~plotting.find_cut_slices` (:gh:`6450` by `Rémi Gau`_).
 
 - :bdg-secondary:`Maint` Drop nilearn versions older than 0.11.0 from ``asv_benchmarks/hashestobenchmark.txt`` (they cannot currently be benchmarked, see ``CONTRIBUTING.rst``), make the benchmark CI workflow fail when a benchmark reports as failed instead of silently ignoring it, fix an always-failing ``IndexImgBenchmark`` slice bound that this newly surfaced, and reorganize ``asv_benchmarks/benchmarks/glm`` to mirror the structure of :mod:`nilearn.glm` (:gh:`6426` by `Rémi Gau`_).
 

--- a/nilearn/plotting/find_cuts.py
+++ b/nilearn/plotting/find_cuts.py
@@ -229,7 +229,9 @@ def _transform_cut_coords(cut_coords, direction, affine):
     return np.atleast_1d(cut_coords)
 
 
-def find_cut_slices(img, direction="z", n_cuts=7, spacing="auto"):
+def find_cut_slices(
+    img, direction="z", n_cuts=7, spacing="auto"
+) -> np.ndarray:
     """Find 'good' cross-section slicing positions along a given axis.
 
     Parameters
@@ -287,7 +289,7 @@ def find_cut_slices(img, direction="z", n_cuts=7, spacing="auto"):
     orig_data = np.abs(safe_get_data(img))
     this_shape = orig_data.shape[axis]
 
-    if not isinstance(n_cuts, numbers.Number):
+    if not isinstance(n_cuts, numbers.Real):
         raise TypeError(
             "The number of cuts (n_cuts) must be an integer "
             "greater than or equal to 1. "
@@ -297,7 +299,7 @@ def find_cut_slices(img, direction="z", n_cuts=7, spacing="auto"):
     # BF issue #575: Return all the slices along and axis if this axis
     # is the display mode and there are at least as many requested
     # n_slices as there are slices.
-    if n_cuts > this_shape:
+    if float(n_cuts) > this_shape:
         warnings.warn(
             "Too many cuts requested for the data: "
             f"n_cuts={n_cuts}, data size={this_shape}.",
@@ -316,8 +318,9 @@ def find_cut_slices(img, direction="z", n_cuts=7, spacing="auto"):
     # to control floating point error problems
     # during given input value "n_cuts"
     epsilon = np.finfo(np.float32).eps
-    difference = abs(round(n_cuts) - n_cuts)
-    if round(n_cuts) < 1.0 or difference > epsilon:
+    n_cuts_as_float = float(n_cuts)
+    difference = abs(round(n_cuts_as_float) - n_cuts_as_float)
+    if round(n_cuts_as_float) < 1.0 or difference > epsilon:
         message = (
             f"Image has {this_shape} slices in direction {direction}. "
             "Therefore, the number of cuts "
@@ -326,7 +329,7 @@ def find_cut_slices(img, direction="z", n_cuts=7, spacing="auto"):
         )
         raise ValueError(message)
     else:
-        n_cuts = round(n_cuts)
+        n_cuts = round(n_cuts_as_float)
 
     if spacing == "auto":
         spacing = max(int(0.5 / n_cuts * data.shape[axis]), 1)
@@ -386,10 +389,10 @@ def find_cut_slices(img, direction="z", n_cuts=7, spacing="auto"):
         cut_coords.append(best_candidate)
         cut_coords = np.unique(cut_coords).tolist()
 
-    cut_coords = np.array(cut_coords)
-    cut_coords.sort()
+    cut_coords_array = np.array(cut_coords)
+    cut_coords_array.sort()
 
-    return _transform_cut_coords(cut_coords, direction, affine)
+    return _transform_cut_coords(cut_coords_array, direction, affine)
 
 
 def find_parcellation_cut_coords(


### PR DESCRIPTION
<!-- Please indicate after the # which issue you're closing with this pull request. -->
- Related to #3568

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- Add a return type annotation (`-> np.ndarray`) to `find_cut_slices`.
- Annotating its return type surfaced two mypy issues once the body was checked:
  - `isinstance(n_cuts, numbers.Number)` narrows `n_cuts` to the abstract `numbers.Number` type, which numpy/typeshed's stubs don't equip with comparison operators or `round()` support (only `numbers.Real` does, which is what the code actually needs) — switched the check to `numbers.Real`, and convert to a concrete `float` for the arithmetic via a separate `n_cuts_as_float` variable, so the original `n_cuts` value/type is preserved verbatim in the warning/error messages (no behavior change).
  - `cut_coords` was reassigned from a `list` to an `ndarray` at the end; with `allow_redefinition = false` this is a real conflict once the body is checked. Used a separate `cut_coords_array` variable for the final `ndarray` instead.