### PR TITLE
[FIX] Stop changelog anchors drifting between releases

### DIFF
--- a/doc/changes/0.1.0.rst
+++ b/doc/changes/0.1.0.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.1.0
-=====
+Version 0.1.0
+=============
 
 **Released February 2015**
 

--- a/doc/changes/0.1.1.rst
+++ b/doc/changes/0.1.1.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.1.1
-=====
+Version 0.1.1
+=============
 
 **Released February 2015**
 

--- a/doc/changes/0.1.2.rst
+++ b/doc/changes/0.1.2.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.1.2
-=====
+Version 0.1.2
+=============
 
 **Released March 2015**
 

--- a/doc/changes/0.1.3.rst
+++ b/doc/changes/0.1.3.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.1.3
-=====
+Version 0.1.3
+=============
 
 **Released May 2015**
 

--- a/doc/changes/0.1.4.rst
+++ b/doc/changes/0.1.4.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.1.4
-=====
+Version 0.1.4
+=============
 
 **Released July 2015**
 

--- a/doc/changes/0.10.0.rst
+++ b/doc/changes/0.10.0.rst
@@ -1,9 +1,7 @@
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.10.0
-======
+Version 0.10.0
+==============
 
 **Released January 2023**
 

--- a/doc/changes/0.10.1.rst
+++ b/doc/changes/0.10.1.rst
@@ -1,9 +1,7 @@
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.10.1
-======
+Version 0.10.1
+==============
 
 **Released April 2023**
 
@@ -66,8 +64,8 @@ Changes
 - :bdg-secondary:`Maint` Moved packaging from ``setup.py`` and setuptools build backend to ``pyproject.toml`` and hatchling backend. This change comes about as new standards are defined for Python packaging that are better met by the new configuration (:gh:`3635` by `Yasmin Mzayek`_).
 
 
-0.10.1rc1
-=========
+Version 0.10.1rc1
+=================
 
 **Released February 2023**
 

--- a/doc/changes/0.10.2.rst
+++ b/doc/changes/0.10.2.rst
@@ -1,9 +1,7 @@
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.10.2
-======
+Version 0.10.2
+==============
 
 **Released September 2023**
 

--- a/doc/changes/0.10.3.rst
+++ b/doc/changes/0.10.3.rst
@@ -1,9 +1,7 @@
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.10.3
-======
+Version 0.10.3
+==============
 
 **Released January 2024**
 

--- a/doc/changes/0.10.4.rst
+++ b/doc/changes/0.10.4.rst
@@ -1,9 +1,7 @@
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.10.4
-======
+Version 0.10.4
+==============
 
 **Released April 2024**
 

--- a/doc/changes/0.11.0.rst
+++ b/doc/changes/0.11.0.rst
@@ -1,9 +1,7 @@
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.11.0
-======
+Version 0.11.0
+==============
 
 **Released November 2024**
 

--- a/doc/changes/0.11.1.rst
+++ b/doc/changes/0.11.1.rst
@@ -1,9 +1,7 @@
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.11.1
-======
+Version 0.11.1
+==============
 
 **Released december 2024**
 

--- a/doc/changes/0.12.0.rst
+++ b/doc/changes/0.12.0.rst
@@ -1,9 +1,7 @@
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.12.0
-======
+Version 0.12.0
+==============
 
 **Released June 2025**
 

--- a/doc/changes/0.12.1.rst
+++ b/doc/changes/0.12.1.rst
@@ -1,9 +1,7 @@
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.12.1
-======
+Version 0.12.1
+==============
 
 **Released September 2025**
 

--- a/doc/changes/0.13.0.rst
+++ b/doc/changes/0.13.0.rst
@@ -1,9 +1,7 @@
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.13.0
-======
+Version 0.13.0
+==============
 
 **Released January 2026**
 

--- a/doc/changes/0.13.1.rst
+++ b/doc/changes/0.13.1.rst
@@ -1,9 +1,7 @@
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.13.1
-======
+Version 0.13.1
+==============
 
 **Released February 2026**
 

--- a/doc/changes/0.14.0.rst
+++ b/doc/changes/0.14.0.rst
@@ -1,9 +1,7 @@
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.14.0
-======
+Version 0.14.0
+==============
 
 **Released June 2026**
 

--- a/doc/changes/0.2.0.rst
+++ b/doc/changes/0.2.0.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.2.0
-=====
+Version 0.2.0
+=============
 
 **Released December 2015**
 

--- a/doc/changes/0.2.1.rst
+++ b/doc/changes/0.2.1.rst
@@ -1,6 +1,6 @@
 
-0.2.1
-=====
+Version 0.2.1
+=============
 
 **Released December 2015**
 

--- a/doc/changes/0.2.2.rst
+++ b/doc/changes/0.2.2.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.2.2
-=====
+Version 0.2.2
+=============
 
 **Released February 2016**
 

--- a/doc/changes/0.2.3.rst
+++ b/doc/changes/0.2.3.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.2.3
-=====
+Version 0.2.3
+=============
 
 **Released February 2016**
 

--- a/doc/changes/0.2.4.rst
+++ b/doc/changes/0.2.4.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.2.4
-=====
+Version 0.2.4
+=============
 
 **Released April 2016**
 

--- a/doc/changes/0.2.5.rst
+++ b/doc/changes/0.2.5.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.2.5.1
-=======
+Version 0.2.5.1
+===============
 
 **Released August 2016**
 
@@ -33,8 +31,8 @@ Fixes
 - :bdg-secondary:`Maint` Broken links and references fixed in docs.
 
 
-0.2.5
-=====
+Version 0.2.5
+=============
 
 **Released June 2016**
 

--- a/doc/changes/0.2.6.rst
+++ b/doc/changes/0.2.6.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.2.6
-=====
+Version 0.2.6
+=============
 
 **Released September 2016**
 

--- a/doc/changes/0.3.0.rst
+++ b/doc/changes/0.3.0.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.3.0
-=====
+Version 0.3.0
+=============
 
 **Released April 2017**
 
@@ -37,8 +35,8 @@ Enhancements
 
 - :bdg-primary:`Doc` :term:`ANOVA` :term:`SVM` example on Haxby datasets ``plot_haxby_anova_svm`` in Decoding section now uses ``SelectPercentile`` to select :term:`voxels<voxel>` rather than ``SelectKBest``.
 
-0.3.0 beta
-===========
+Version 0.3.0 beta
+==================
 
 **Released February 2017**
 

--- a/doc/changes/0.3.1.rst
+++ b/doc/changes/0.3.1.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.3.1
-=====
+Version 0.3.1
+=============
 
 **Released June 2017**
 

--- a/doc/changes/0.4.0.rst
+++ b/doc/changes/0.4.0.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.4.0
-=====
+Version 0.4.0
+=============
 
 **Released November 2017**
 

--- a/doc/changes/0.4.1.rst
+++ b/doc/changes/0.4.1.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.4.1
-=====
+Version 0.4.1
+=============
 
 **Released March 2018**
 

--- a/doc/changes/0.4.2.rst
+++ b/doc/changes/0.4.2.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.4.2
-=====
+Version 0.4.2
+=============
 
 **Released June 2018**
 

--- a/doc/changes/0.5.0.rst
+++ b/doc/changes/0.5.0.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.5.0
-=====
+Version 0.5.0
+=============
 
 **Released November 2018**
 
@@ -77,8 +75,8 @@ Changes
 
 Lots of changes and improvements. Detailed change list for each release follows.
 
-0.5.0 rc
-========
+Version 0.5.0 rc
+================
 
 Highlights
 ----------
@@ -122,8 +120,8 @@ The following people contributed to this release:
     * `Christian Horea`_ (1)
     * `Jerome Dockes`_ (7)
 
-0.5.0 beta
-==========
+Version 0.5.0 beta
+==================
 
 **Released October 2018**
 
@@ -215,8 +213,8 @@ The following people contributed to this release:
     * Yaroslav Halchenko (1)
     * dtyulman (1)
 
-0.5.0 alpha
-===========
+Version 0.5.0 alpha
+===================
 
 **Released August 2018**
 

--- a/doc/changes/0.5.1.rst
+++ b/doc/changes/0.5.1.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.5.1
-=====
+Version 0.5.1
+=============
 
 **Released April 2019**
 

--- a/doc/changes/0.5.2.rst
+++ b/doc/changes/0.5.2.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.5.2
-=====
+Version 0.5.2
+=============
 
 **Released April 2019**
 

--- a/doc/changes/0.6.0.rst
+++ b/doc/changes/0.6.0.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.6.0
-=====
+Version 0.6.0
+=============
 
 **Released December 2019**
 
@@ -67,8 +65,8 @@ FIXES
 
 **Lots of other fixes in documentation and examples.** More detailed change list follows:
 
-0.6.0rc
-=======
+Version 0.6.0rc
+===============
 
 NEW
 ---
@@ -125,8 +123,8 @@ The following people contributed to this release (in alphabetical order):
 * `Ryan Hammonds`_
 
 
-0.6.0b0
-=======
+Version 0.6.0b0
+===============
 
 **Released November 2019**
 
@@ -167,8 +165,8 @@ The following people contributed to this release (in alphabetical order):
 * `Kshitij Chawla`_
 * `Roberto Guidotti`_
 
-0.6.0a0
-=======
+Version 0.6.0a0
+===============
 
 **Released October 2019**
 

--- a/doc/changes/0.6.1.rst
+++ b/doc/changes/0.6.1.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.6.1
-=====
+Version 0.6.1
+=============
 
 **Released January 2020**
 

--- a/doc/changes/0.6.2.rst
+++ b/doc/changes/0.6.2.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.6.2
-======
+Version 0.6.2
+=============
 
 **Released February 2020**
 

--- a/doc/changes/0.7.0.rst
+++ b/doc/changes/0.7.0.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.7.0
-=====
+Version 0.7.0
+=============
 
 **Released November 2020**
 

--- a/doc/changes/0.7.1.rst
+++ b/doc/changes/0.7.1.rst
@@ -1,9 +1,7 @@
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.7.1
-=====
+Version 0.7.1
+=============
 
 **Released March 2021**
 

--- a/doc/changes/0.8.0.rst
+++ b/doc/changes/0.8.0.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.8.0
-=====
+Version 0.8.0
+=============
 
 **Released June 2021**
 

--- a/doc/changes/0.8.1.rst
+++ b/doc/changes/0.8.1.rst
@@ -1,9 +1,7 @@
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.8.1
-=====
+Version 0.8.1
+=============
 
 **Released September 2021**
 

--- a/doc/changes/0.9.0.rst
+++ b/doc/changes/0.9.0.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.9.0
-=====
+Version 0.9.0
+=============
 
 **Released January 2022**
 

--- a/doc/changes/0.9.1.rst
+++ b/doc/changes/0.9.1.rst
@@ -1,10 +1,8 @@
 
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.9.1
-=====
+Version 0.9.1
+=============
 
 **Released April 2022**
 

--- a/doc/changes/0.9.2.rst
+++ b/doc/changes/0.9.2.rst
@@ -1,9 +1,7 @@
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.9.2
-=========
+Version 0.9.2
+=============
 
 **Released August 2022**
 

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -1,9 +1,7 @@
 .. currentmodule:: nilearn
 
-.. include:: names.rst
-
-0.14.1dev
-=========
+Version 0.14.1dev
+=================
 
 ..
     Each changelog entry should begin with one of the following badges:
@@ -41,6 +39,8 @@ Fixes
 - :bdg-dark:`Code` Allow :func:`~glm.first_level.first_level_from_bids` to work with BIDS dataset that have a single events file in the root of the dataset for all runs (:gh:`6278` by `Rémi Gau`_).
 
 - :bdg-secondary:`Maint` Add return type annotations and :obj:`~typing.overload` signatures to :func:`~connectome.vec_to_sym_matrix`, :func:`~connectome.group_sparse_covariance`, and :func:`~reporting.get_clusters_table` (:gh:`6368` by `Rémi Gau`_).
+
+- :bdg-primary:`Doc` Fix changelog anchors on ``changes/whats_new.html`` drifting to a different entry after every release, by renaming each release heading to ``Version X.Y.Z`` so it always gets a stable id (numeric-only headings like ``0.14.0`` could not be turned into a valid HTML id and fell back to a position-dependent counter), and by adding a Sphinx extension that inserts a stable, version-scoped anchor before every ``Fixes``/``Enhancements``/``Changes``/... subsection at build time (:gh:`6456` by `Rémi Gau`_).
 
 Enhancements
 ------------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -40,7 +40,7 @@ Fixes
 
 - :bdg-secondary:`Maint` Add return type annotations and :obj:`~typing.overload` signatures to :func:`~connectome.vec_to_sym_matrix`, :func:`~connectome.group_sparse_covariance`, and :func:`~reporting.get_clusters_table` (:gh:`6368` by `Rémi Gau`_).
 
-- :bdg-primary:`Doc` Fix changelog anchors on ``changes/whats_new.html`` drifting to a different entry after every release, by renaming each release heading to ``Version X.Y.Z`` so it always gets a stable id (numeric-only headings like ``0.14.0`` could not be turned into a valid HTML id and fell back to a position-dependent counter), and by adding a Sphinx extension that inserts a stable, version-scoped anchor before every ``Fixes``/``Enhancements``/``Changes``/... subsection at build time (:gh:`6456` by `Rémi Gau`_).
+- :bdg-primary:`Doc` Fix changelog anchors on ``changes/whats_new.html`` drifting to a different entry after every release, by renaming each release heading to ``Version X.Y.Z`` so it always gets a stable id (numeric-only headings like ``0.14.0`` could not be turned into a valid HTML id and fell back to a position-dependent counter), and by adding a Sphinx extension that inserts a stable, version-scoped anchor before every ``Fixes``/``Enhancements``/``Changes``/... subsection at build time (:gh:`6460` by `Rémi Gau`_).
 
 Enhancements
 ------------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -30,7 +30,6 @@ Fixes
 
 - :bdg-secondary:`Maint` Add return type annotations and :obj:`~typing.overload` signatures to :func:`~connectome.vec_to_sym_matrix`, :func:`~connectome.group_sparse_covariance`, and :func:`~reporting.get_clusters_table` (:gh:`6368` by `Rémi Gau`_).
 
-- :bdg-primary:`Doc` Fix changelog anchors on ``changes/whats_new.html`` drifting to a different entry after every release, by renaming each release heading to ``Version X.Y.Z`` so it always gets a stable id (numeric-only headings like ``0.14.0`` could not be turned into a valid HTML id and fell back to a position-dependent counter), and by adding a Sphinx extension that inserts a stable, version-scoped anchor before every ``Fixes``/``Enhancements``/``Changes``/... subsection at build time (:gh:`6460` by `Rémi Gau`_).
 
 Enhancements
 ------------

--- a/doc/changes/whats_new.rst
+++ b/doc/changes/whats_new.rst
@@ -5,6 +5,8 @@
 What's new
 ==========
 
+.. include:: names.rst
+
 .. _latest:
 .. include:: latest.rst
 .. _v0.14.0:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -67,6 +67,7 @@ warnings.filterwarnings(
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
+    "changelog_anchors",
     "gh_substitutions",
     "myst_parser",
     "numpydoc",
@@ -190,6 +191,15 @@ exclude_patterns = [
     "tune_toc.rst",
     "includes/big_toc_css.rst",
     "includes/bigger_toc_css.rst",
+    # Per-version changelog fragments are only ever meant to be pulled into
+    # changes/whats_new.rst via ".. include::"; building them as their own
+    # standalone pages as well duplicates every anchor they define and
+    # trips Sphinx's duplicate-label warning.
+    *(
+        str(p.relative_to(Path(__file__).parent))
+        for p in Path(__file__).parent.glob("changes/*.rst")
+        if p.name not in ("whats_new.rst", "names.rst")
+    ),
 ]
 
 # List of directories, relative to source directory, that shouldn't be

--- a/doc/maintenance.rst
+++ b/doc/maintenance.rst
@@ -409,16 +409,14 @@ For example::
     - :bdg-info:`Plotting` ...
 
 We also need to write a "Highlights" section promoting the most important additions that come with this new release.
-Finally, we need to change the title from ``X.Y.Z.dev`` to ``X.Y.Z``:
+Finally, we need to change the title from ``Version X.Y.Z.dev`` to ``Version X.Y.Z``:
 
 .. code-block:: RST
 
    .. currentmodule:: nilearn
 
-   .. include:: names.rst
-
-   X.Y.Z
-   =====
+   Version X.Y.Z
+   =============
 
    **Released MONTH YEAR**
 
@@ -631,10 +629,8 @@ sections for the version currently under development:
 
    .. currentmodule:: nilearn
 
-   .. include:: names.rst
-
-   X.Y.Z+1.dev
-   =========
+   Version X.Y.Z+1.dev
+   ====================
 
    ..
     Each changelog entry should begin with one of the following badges:

--- a/doc/sphinxext/changelog_anchors.py
+++ b/doc/sphinxext/changelog_anchors.py
@@ -1,0 +1,109 @@
+"""Give changelog subsections stable, version-scoped HTML anchors.
+
+``doc/changes/whats_new.rst`` concatenates every per-release changelog
+fragment (``doc/changes/<version>.rst``), each of which repeats the same
+subsection titles (``Fixes``, ``Changes``, ``Enhancements``, ...). Docutils
+only gives the first occurrence of a repeated heading a readable id; every
+later one falls back to a sequential ``id123``-style id whose value shifts
+whenever a new release is inserted earlier in the document (see
+https://github.com/nilearn/nilearn/issues/6456).
+
+This module rewrites the changelog fragments in place, right before Sphinx
+reads them, inserting an explicit ``.. _v<version>-<subsection>:`` label
+before each subsection heading. The label is derived purely from the
+fragment's own version heading and the subsection text, so it never needs to
+be hand-maintained: it is recomputed from scratch on every doc build and is
+idempotent (re-running it is a no-op).
+"""
+
+import re
+from pathlib import Path
+
+TOP_UNDERLINE = re.compile(r"^=+$")
+SUB_UNDERLINE = re.compile(r"^[\-^]{3,}$")
+GENERATED_LABEL = re.compile(r"^\.\. _v[0-9][\w.-]*:$")
+
+
+def _slugify(text):
+    return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+
+
+def _version_prefix(title):
+    version = re.sub(r"^version\s+", "", title.strip(), flags=re.IGNORECASE)
+    version = re.sub(r"dev$", "", version, flags=re.IGNORECASE)
+    return "v" + _slugify(version)
+
+
+def _strip_generated_labels(lines):
+    out = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        if (
+            GENERATED_LABEL.match(lines[i].strip())
+            and i + 1 < n
+            and lines[i + 1].strip() == ""
+        ):
+            i += 2
+            continue
+        out.append(lines[i])
+        i += 1
+    return out
+
+
+def _insert_labels(lines):
+    out = []
+    prefix = None
+    used = set()
+    i = 0
+    n = len(lines)
+    while i < n:
+        title = lines[i].strip()
+        is_heading = i + 1 < n and title
+
+        if is_heading and TOP_UNDERLINE.match(lines[i + 1].strip()):
+            prefix = _version_prefix(title)
+            used = set()
+            out.append(lines[i])
+            out.append(lines[i + 1])
+            i += 2
+            continue
+
+        if is_heading and SUB_UNDERLINE.match(lines[i + 1].strip()) and prefix:
+            slug = _slugify(title)
+            anchor = f"{prefix}-{slug}"
+            n_dup = 1
+            while anchor in used:
+                n_dup += 1
+                anchor = f"{prefix}-{slug}-{n_dup}"
+            used.add(anchor)
+            out.append(f".. _{anchor}:")
+            out.append("")
+
+        out.append(lines[i])
+        i += 1
+    return out
+
+
+def _process(path):
+    original = path.read_text(encoding="utf-8")
+    lines = original.splitlines()
+    lines = _strip_generated_labels(lines)
+    lines = _insert_labels(lines)
+    updated = "\n".join(lines) + "\n"
+    if updated != original:
+        path.write_text(updated, encoding="utf-8")
+
+
+def insert_changelog_anchors(app):
+    changes_dir = Path(app.srcdir) / "changes"
+    if not changes_dir.is_dir():
+        return
+    for path in sorted(changes_dir.glob("*.rst")):
+        if path.name in ("whats_new.rst", "names.rst"):
+            continue
+        _process(path)
+
+
+def setup(app):
+    app.connect("builder-inited", insert_changelog_anchors)

--- a/doc/sphinxext/changelog_anchors.py
+++ b/doc/sphinxext/changelog_anchors.py
@@ -2,18 +2,23 @@
 
 ``doc/changes/whats_new.rst`` concatenates every per-release changelog
 fragment (``doc/changes/<version>.rst``), each of which repeats the same
-subsection titles (``Fixes``, ``Changes``, ``Enhancements``, ...). Docutils
-only gives the first occurrence of a repeated heading a readable id; every
-later one falls back to a sequential ``id123``-style id whose value shifts
-whenever a new release is inserted earlier in the document (see
-https://github.com/nilearn/nilearn/issues/6456).
+subsection titles (``Fixes``, ``Changes``, ``Enhancements``, ...).
+Docutils only gives the first occurrence
+of a repeated heading a readable id;
+every later one falls back to a sequential ``id123``-style id
+whose value shifts whenever a new release
+is inserted earlier in the document
+(see https://github.com/nilearn/nilearn/issues/6456).
 
-This module rewrites the changelog fragments in place, right before Sphinx
-reads them, inserting an explicit ``.. _v<version>-<subsection>:`` label
-before each subsection heading. The label is derived purely from the
-fragment's own version heading and the subsection text, so it never needs to
-be hand-maintained: it is recomputed from scratch on every doc build and is
-idempotent (re-running it is a no-op).
+This module rewrites the changelog fragments in place,
+right before Sphinx reads them,
+inserting an explicit ``.. _v<version>-<subsection>:`` label
+before each subsection heading.
+The label is derived purely from the fragment's own version heading
+and the subsection text,
+so it never needs to be hand-maintained:
+it is recomputed from scratch on every doc build
+and is idempotent (re-running it is a no-op).
 """
 
 import re

--- a/doc/sphinxext/changelog_anchors.py
+++ b/doc/sphinxext/changelog_anchors.py
@@ -24,6 +24,11 @@ and is idempotent (re-running it is a no-op).
 import re
 from pathlib import Path
 
+from sphinx.application import Sphinx
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
+
 TOP_UNDERLINE = re.compile(r"^=+$")
 SUB_UNDERLINE = re.compile(r"^[\-^]{3,}$")
 GENERATED_LABEL = re.compile(r"^\.\. _v[0-9][\w.-]*:$")
@@ -34,13 +39,19 @@ def _slugify(text: str) -> str:
 
 
 def _version_prefix(title: str) -> str:
-    """Add version prefix and remove dev suffix."""
+    """Turn a release heading into a stable anchor prefix, e.g. ``v0-14-0``.
+
+    The leading "Version" word is dropped, and any trailing "dev" suffix
+    is stripped so the prefix stays the same before and after a release
+    (when ``latest.rst``, e.g. "Version 0.14.1dev", is renamed to
+    ``0.14.1.rst`` with title "Version 0.14.1").
+    """
     version = re.sub(r"^version\s+", "", title.strip(), flags=re.IGNORECASE)
     version = re.sub(r"dev$", "", version, flags=re.IGNORECASE)
     return "v" + _slugify(version)
 
 
-def _strip_generated_labels(lines) -> list[str]:
+def _strip_generated_labels(lines: list[str]) -> list[str]:
     """Skip eventual generated labels from a previous run.
 
     This way they are not added twice.
@@ -61,7 +72,20 @@ def _strip_generated_labels(lines) -> list[str]:
     return out
 
 
-def _insert_labels(lines: list[str]) -> list[str]:
+def _insert_labels(lines: list[str], path: Path) -> list[str]:
+    """Insert a stable anchor label before every subsection heading.
+
+    Each label is scoped to the nearest preceding top-level (version)
+    heading, so a file with several version headings (some old changelog
+    fragments bundle a release and its release candidates in one file)
+    gets a distinct prefix for each one.
+
+    Two subsections under the same version heading with the same title
+    (e.g. two ``Fixes`` sections) would otherwise get the same anchor;
+    when that happens a numbered suffix is appended to keep anchors
+    unique, and a build warning is emitted so the duplicate title can be
+    reworded instead.
+    """
     out = []
     prefix = None
     used = set()
@@ -83,6 +107,15 @@ def _insert_labels(lines: list[str]) -> list[str]:
         if is_heading and SUB_UNDERLINE.match(lines[i + 1].strip()) and prefix:
             slug = _slugify(title)
             anchor = f"{prefix}-{slug}"
+            if anchor in used:
+                logger.warning(
+                    "%s:%d: subsection title %r duplicates another one "
+                    "under the same release heading; consider renaming "
+                    "it so it gets its own stable anchor",
+                    path,
+                    i + 1,
+                    title,
+                )
             n_dup = 1
             while anchor in used:
                 n_dup += 1
@@ -101,15 +134,19 @@ def _process(path: Path) -> None:
     original = path.read_text(encoding="utf-8")
     lines = original.splitlines()
     lines = _strip_generated_labels(lines)
-    lines = _insert_labels(lines)
+    lines = _insert_labels(lines, path)
     updated = "\n".join(lines) + "\n"
     # Only save the files if it was modified
     if updated != original:
         path.write_text(updated, encoding="utf-8")
 
 
-def insert_changelog_anchors(app):
-    """Update anchors of subsection titles in all changelog files."""
+def insert_changelog_anchors(app: Sphinx) -> None:
+    """Update anchors of subsection titles in all changelog files.
+
+    Connected to the ``builder-inited`` event so it runs, and rewrites
+    ``doc/changes/*.rst`` on disk, before Sphinx reads any source file.
+    """
     changes_dir = Path(app.srcdir) / "changes"
     if not changes_dir.is_dir():
         return
@@ -119,5 +156,6 @@ def insert_changelog_anchors(app):
         _process(path)
 
 
-def setup(app):
+def setup(app: Sphinx) -> None:
+    """Register the ``builder-inited`` hook with Sphinx."""
     app.connect("builder-inited", insert_changelog_anchors)

--- a/doc/sphinxext/changelog_anchors.py
+++ b/doc/sphinxext/changelog_anchors.py
@@ -1,10 +1,10 @@
 """Give changelog subsections stable, version-scoped HTML anchors.
 
 ``doc/changes/whats_new.rst`` concatenates every per-release changelog
-fragment (``doc/changes/<version>.rst``), each of which repeats the same
-subsection titles (``Fixes``, ``Changes``, ``Enhancements``, ...).
-Docutils only gives the first occurrence
-of a repeated heading a readable id;
+fragment (``doc/changes/<version>.rst``),
+each of which repeats the same subsection titles
+(``Fixes``, ``Changes``, ``Enhancements``, ...).
+Docutils only gives the first occurrence of a repeated heading a readable id;
 every later one falls back to a sequential ``id123``-style id
 whose value shifts whenever a new release
 is inserted earlier in the document
@@ -29,17 +29,22 @@ SUB_UNDERLINE = re.compile(r"^[\-^]{3,}$")
 GENERATED_LABEL = re.compile(r"^\.\. _v[0-9][\w.-]*:$")
 
 
-def _slugify(text):
+def _slugify(text: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
 
 
-def _version_prefix(title):
+def _version_prefix(title: str) -> str:
+    """Add version prefix and remove dev suffix."""
     version = re.sub(r"^version\s+", "", title.strip(), flags=re.IGNORECASE)
     version = re.sub(r"dev$", "", version, flags=re.IGNORECASE)
     return "v" + _slugify(version)
 
 
-def _strip_generated_labels(lines):
+def _strip_generated_labels(lines) -> list[str]:
+    """Skip eventual generated labels from a previous run.
+
+    This way they are not added twice.
+    """
     out = []
     i = 0
     n = len(lines)
@@ -56,7 +61,7 @@ def _strip_generated_labels(lines):
     return out
 
 
-def _insert_labels(lines):
+def _insert_labels(lines: list[str]) -> list[str]:
     out = []
     prefix = None
     used = set()
@@ -67,6 +72,7 @@ def _insert_labels(lines):
         is_heading = i + 1 < n and title
 
         if is_heading and TOP_UNDERLINE.match(lines[i + 1].strip()):
+            # store prefix to use for the following subsections
             prefix = _version_prefix(title)
             used = set()
             out.append(lines[i])
@@ -90,17 +96,20 @@ def _insert_labels(lines):
     return out
 
 
-def _process(path):
+def _process(path: Path) -> None:
+    """Update anchors of subsection titles in a single changelog file."""
     original = path.read_text(encoding="utf-8")
     lines = original.splitlines()
     lines = _strip_generated_labels(lines)
     lines = _insert_labels(lines)
     updated = "\n".join(lines) + "\n"
+    # Only save the files if it was modified
     if updated != original:
         path.write_text(updated, encoding="utf-8")
 
 
 def insert_changelog_anchors(app):
+    """Update anchors of subsection titles in all changelog files."""
     changes_dir = Path(app.srcdir) / "changes"
     if not changes_dir.is_dir():
         return


### PR DESCRIPTION
- Closes #6456

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

Section anchors on `changes/whats_new.html` (e.g. `#id196`) drift to a different entry after every release, so links people share to a specific changelog entry silently start pointing somewhere else. This has two independent causes:

- Per-release headings (`0.14.0`, `0.13.1`, ...) are purely numeric, and docutils can't derive an HTML id from a title with no letters in it, so it falls back to a sequential `idN` counter.
- Subsection headings (`Fixes`, `Changes`, `Enhancements`, ...) repeat verbatim across every one of the ~45 changelog fragment files concatenated into `whats_new.rst`, and docutils only gives the first occurrence a readable id; every later one also falls back to the same `idN` counter.

Both fallbacks are based on the section's *position* in the document, so any new content added earlier in the file (i.e. every new release) shifts every anchor after it - matching what's reported in the issue (`#id196` on dev vs `#id1` on stable for the same release).

Fix:
- Rename every changelog title from `X.Y.Z` to `Version X.Y.Z`, so the auto-generated id is always valid and unique, with no anchor to hand-maintain.
- Add a small Sphinx extension (`doc/sphinxext/changelog_anchors.py`) that inserts a stable, version-scoped anchor (e.g. `.. _v0-14-0-fixes:`) before each subsection, computed fresh from the file's own heading at every doc build - not something a maintainer needs to add or update during a release.
- Exclude the per-version changelog fragments from being built as their own standalone pages in `doc/conf.py`, since they are only ever meant to be pulled into `whats_new.rst` via `.. include::`; building them separately as well caused the new anchors to collide (duplicate-label warnings).
- Update `doc/maintenance.rst`'s documented release template to match the new title format.

## Test plan

- [x] Verified in an isolated Sphinx build (same file contents, `gh_substitutions` + `sphinx_design` extensions) that every top-level version heading and every subsection heading gets a stable, non-`idN` primary anchor, with zero duplicate-label warnings.
- [x] `pre-commit run --all-files` passes on the changed files.
- [ ] Full `tox -e doc` build in CI.