### PR TITLE
[FIX] avoid duplicate Brainsprite IDs in reports

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -20,6 +20,8 @@ NEW
 Fixes
 -----
 
+- :bdg-info:`Plotting` Fix Brainsprite figures becoming blank or incorrect when multiple masker reports are embedded in the same HTML document by giving each viewer unique DOM element IDs (:gh:`6419` by `Mohammad Sadeghi Hardengi`_).
+
 - :bdg-dark:`Code` Fix :func:`~regions.connected_label_regions` attaching the names given in ``labels`` to the wrong regions, because the sorted labels from ``np.unique`` were put through a ``set`` before being zipped against the names; contiguous labels happened to survive that, but the sparse labels real atlases use did not (:gh:`6445` by `Andrew Chen`_).
 
 - :bdg-dark:`Code` Fix :class:`~maskers.NiftiMapsMasker` silently extracting a zero signal for a map whose weights are negative, because ``_trim_maps`` decides which maps to keep sign-agnostically with ``abs()`` but then builds their support with ``> 0``, so a kept negative map covered no voxel; this matters for the signed ICA and statistical maps the masker targets (:gh:`6443` by `Andrew Chen`_).

--- a/examples/06_manipulating_images/plot_mask_computation.py
+++ b/examples/06_manipulating_images/plot_mask_computation.py
@@ -107,7 +107,7 @@ show()
 # by generating a masker report.
 # This can be done using
 # the :meth:`~nilearn.maskers.NiftiMasker.generate_report` method.
-report = masker.generate_report()
+report = masker.generate_report(engine="brainsprite")
 
 # %%
 #
@@ -155,7 +155,7 @@ show()
 
 masker = NiftiMasker(mask_strategy="epi")
 masker.fit(epi_img)
-report = masker.generate_report()
+report = masker.generate_report(engine="brainsprite")
 report
 
 # %%
@@ -172,7 +172,7 @@ report
 
 masker = NiftiMasker(mask_strategy="epi", mask_args={"opening": 10})
 masker.fit(epi_img)
-report = masker.generate_report()
+report = masker.generate_report(engine="brainsprite")
 report
 
 # %%
@@ -193,7 +193,7 @@ masker = NiftiMasker(
     mask_args={"upper_cutoff": 0.9, "lower_cutoff": 0.8, "opening": False},
 )
 masker.fit(epi_img)
-report = masker.generate_report()
+report = masker.generate_report(engine="brainsprite")
 report
 
 # %%
@@ -209,7 +209,7 @@ report
 
 masker = NiftiMasker(mask_strategy="whole-brain-template")
 masker.fit(epi_img)
-report = masker.generate_report()
+report = masker.generate_report(engine="brainsprite")
 report
 
 # %%
@@ -230,7 +230,7 @@ import numpy as np
 
 masker = NiftiMasker(mask_strategy="epi", target_affine=np.eye(3) * 8)
 masker.fit(epi_img)
-report = masker.generate_report()
+report = masker.generate_report(engine="brainsprite")
 report
 
 # %%

--- a/nilearn/_assets/html/partials/brainsprite.jinja
+++ b/nilearn/_assets/html/partials/brainsprite.jinja
@@ -1,18 +1,18 @@
-<div id="div_viewer">
+<div id="{{ html_ids.viewer }}">
     <!-- this is the canvas that will feature the brain slices -->
-    <canvas id="3Dviewer">
+    <canvas id="{{ html_ids.canvas }}">
         <!-- load a hidden version of the sprite image that includes all (sagittal) brain slices -->
-        <img id="spriteImg"
+        <img id="{{ html_ids.sprite }}"
              class="hidden"
              src="data:image/png;base64,{{ bg_base64 }}"
              alt="background">
         <!-- the colormap -->
-        <img id="colorMap"
+        <img id="{{ html_ids.color_map }}"
              class="hidden"
              src="data:image/png;base64,{{ cm_base64 }}"
              alt="colormap">
         <!-- another sprite image, with an overlay-->
-        <img id="overlayImg"
+        <img id="{{ html_ids.overlay }}"
              class="hidden"
              src="data:image/png;base64,{{ stat_map_base64 }}"
              alt="overlay">
@@ -25,8 +25,8 @@
                    max="100"
                    value="100"
                    class="slider"
-                   id="opacity">
-            <span id="demo"></span>
+                   id="{{ html_ids.opacity }}">
+            <span id="{{ html_ids.opacity_value }}"></span>
         </div>
     {% endif %}
 </div>

--- a/nilearn/_assets/js/brainsprite_opacity.jinja
+++ b/nilearn/_assets/js/brainsprite_opacity.jinja
@@ -1,12 +1,33 @@
-var brain
-$(window).on("load", function () {
+(function () {
+var brain;
+function initializeBrainSprite() {
+if (brain) {
+return;
+}
 brain = brainsprite({{ params }});
-});
-var slider = document.getElementById("opacity");
-var output = document.getElementById("demo");
+var slider = document.getElementById("{{ html_ids.opacity }}");
+var output = document.getElementById("{{ html_ids.opacity_value }}");
 slider.oninput = function () {
 output.innerHTML = this.value;
 brain.overlay.opacity = this.value / 100;
 brain.init();
 brain.drawAll();
+};
 }
+var images = [
+document.getElementById("{{ html_ids.sprite }}"),
+document.getElementById("{{ html_ids.overlay }}"),
+document.getElementById("{{ html_ids.color_map }}")
+];
+if (images.every(function (image) { return image.complete; })) {
+initializeBrainSprite();
+} else {
+images.forEach(function (image) {
+image.addEventListener("load", function () {
+if (images.every(function (item) { return item.complete; })) {
+initializeBrainSprite();
+}
+}, {once: true});
+});
+}
+})();

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -693,6 +693,7 @@ class BaseMasker(_BaseMasker):
             bg_img=bg_img,
             cmap=self.cmap if cmap is None else cmap,
             symmetric_cmap=False,
+            unique_id=self._report_content["unique_id"],
         )
 
         self._reporting_data["bg_base64"] = json_view["bg_base64"]

--- a/nilearn/maskers/tests/test_html_report.py
+++ b/nilearn/maskers/tests/test_html_report.py
@@ -4,6 +4,8 @@ More generic tests (those that apply to all maskers)
 should go into nilearn/_utils/estimator_checks.
 """
 
+import json
+import re
 from collections import Counter
 from pathlib import Path
 from typing import Any
@@ -474,6 +476,7 @@ def test_nifti_masker_overlaid_report(
 
 @pytest.mark.thread_unsafe
 @pytest.mark.skipif(not is_gil_enabled(), reason="may fail without GIL")
+@pytest.mark.ai_generated
 def test_nifti_masker_brainsprite(
     matplotlib_pyplot,  # noqa: ARG001
     img_fmri,
@@ -484,9 +487,34 @@ def test_nifti_masker_brainsprite(
         masker, extra_warnings_allowed=True, engine="brainsprite"
     )
     masker.fit(img_fmri)
-    generate_and_check_masker_report(
+    first_report = generate_and_check_masker_report(
         masker, extra_warnings_allowed=True, engine="brainsprite"
     )
+    second_report = generate_and_check_masker_report(
+        masker, extra_warnings_allowed=True, engine="brainsprite"
+    )
+
+    configs = []
+    combined_html = f"{first_report}{second_report}"
+    for report in (first_report, second_report):
+        config_match = re.search(r"brainsprite\((\{.*\})\);", str(report))
+        assert config_match is not None
+        config = json.loads(config_match.group(1))
+        configs.append(config)
+
+        for element_id in (
+            config["canvas"],
+            config["sprite"],
+            config["overlay"]["sprite"],
+            config["colorMap"]["img"],
+        ):
+            assert f'id="{element_id}"' in str(report)
+            assert combined_html.count(f'id="{element_id}"') == 1
+
+    assert configs[0]["canvas"] != configs[1]["canvas"]
+    assert configs[0]["sprite"] != configs[1]["sprite"]
+    assert configs[0]["overlay"]["sprite"] != configs[1]["overlay"]["sprite"]
+    assert configs[0]["colorMap"]["img"] != configs[1]["colorMap"]["img"]
 
 
 @pytest.mark.thread_unsafe

--- a/nilearn/maskers/tests/test_html_report.py
+++ b/nilearn/maskers/tests/test_html_report.py
@@ -481,7 +481,7 @@ def test_nifti_masker_brainsprite(
     matplotlib_pyplot,  # noqa: ARG001
     img_fmri,
 ):
-    """Check that NiftiMasker work with brainsprite engine."""
+    """Check that NiftiMasker Brainsprite reports use unique DOM IDs."""
     masker = NiftiMasker(standardize=None)
     generate_and_check_masker_report(
         masker, extra_warnings_allowed=True, engine="brainsprite"

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
+import uuid
 import warnings
 from base64 import b64encode
 from io import BytesIO
@@ -345,12 +346,31 @@ def _resample_stat_map(
     return stat_map_img, mask_img
 
 
+def _get_brainsprite_html_ids(
+    unique_id: str | None = None,
+) -> dict[str, str]:
+    """Return unique HTML element IDs for a Brainsprite viewer."""
+    if unique_id is None:
+        unique_id = uuid.uuid4().hex
+
+    return {
+        "viewer": f"div_viewer-{unique_id}",
+        "canvas": f"3Dviewer-{unique_id}",
+        "sprite": f"spriteImg-{unique_id}",
+        "overlay": f"overlayImg-{unique_id}",
+        "color_map": f"colorMap-{unique_id}",
+        "opacity": f"opacity-{unique_id}",
+        "opacity_value": f"demo-{unique_id}",
+    }
+
+
 def _json_view_params(
     shape,
     affine,
     vmin,
     vmax,
     cut_slices,
+    html_ids,
     black_bg=False,
     opacity=1,
     draw_cross=True,
@@ -382,11 +402,11 @@ def _json_view_params(
         vmax = vmax.tolist()  # json does not deal with numpy array
 
     params = {
-        "canvas": "3Dviewer",
-        "sprite": "spriteImg",
+        "canvas": html_ids["canvas"],
+        "sprite": html_ids["sprite"],
         "nbSlice": {"X": shape[0], "Y": shape[1], "Z": shape[2]},
         "overlay": {
-            "sprite": "overlayImg",
+            "sprite": html_ids["overlay"],
             "nbSlice": {"X": shape[0], "Y": shape[1], "Z": shape[2]},
             "opacity": opacity,
         },
@@ -407,7 +427,11 @@ def _json_view_params(
     }
 
     if colorbar:
-        params["colorMap"] = {"img": "colorMap", "min": vmin, "max": vmax}
+        params["colorMap"] = {
+            "img": html_ids["color_map"],
+            "min": vmin,
+            "max": vmax,
+        }
     return params
 
 
@@ -531,6 +555,7 @@ def _json_view_to_html(
     html_view = view_img_tpl.render(
         page_title=json_view["params"]["title"] or "Slice viewer",
         params=json.dumps(json_view["params"]),
+        html_ids=json_view["html_ids"],
         bg_base64=json_view["bg_base64"],
         cm_base64=json_view["cm_base64"],
         stat_map_base64=json_view["stat_map_base64"],
@@ -746,6 +771,7 @@ def create_brainsprite(
     opacity=1,
     radiological=False,
     show_lr=True,
+    unique_id=None,
 ) -> dict[str, Any]:
     """Wrap most of view_img to reuse it in other places."""
     # Prepare the color map and thresholding
@@ -784,12 +810,15 @@ def create_brainsprite(
         radiological,
     )
 
+    html_ids = _get_brainsprite_html_ids(unique_id)
+    json_view["html_ids"] = html_ids
     json_view["params"] = _json_view_params(
         stat_map_img.shape,
         stat_map_img.affine,
         colors["vmin"],
         colors["vmax"],
         cut_slices,
+        html_ids,
         black_bg,
         opacity,
         draw_cross,

--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -1,4 +1,6 @@
 import base64
+import json
+import re
 from io import BytesIO
 
 import numpy as np
@@ -15,6 +17,7 @@ from nilearn.plotting.html_stat_map import (
     _bytes_io_to_base64,
     _data_to_sprite,
     _get_bg_mask_and_cmap,
+    _get_brainsprite_html_ids,
     _get_cut_slices,
     _is_isotropic,
     _json_view_data,
@@ -257,6 +260,7 @@ def test_resample_stat_map(affine_eye):
     )
 
 
+@pytest.mark.ai_generated
 def test_json_view_params(affine_eye):
     """Check that _json_view_params generates the expected structure."""
     # Try to generate some sprite parameters
@@ -266,6 +270,7 @@ def test_json_view_params(affine_eye):
         vmin=0,
         vmax=1,
         cut_slices=[1, 1, 1],
+        html_ids=_get_brainsprite_html_ids("test-viewer"),
         black_bg=True,
         opacity=0.5,
         draw_cross=False,
@@ -278,6 +283,10 @@ def test_json_view_params(affine_eye):
     # Just check that a structure was generated,
     # and test a single parameter
     assert params["overlay"]["opacity"] == 0.5
+    assert params["canvas"] == "3Dviewer-test-viewer"
+    assert params["sprite"] == "spriteImg-test-viewer"
+    assert params["overlay"]["sprite"] == "overlayImg-test-viewer"
+    assert params["colorMap"]["img"] == "colorMap-test-viewer"
 
 
 def test_json_view_size():
@@ -341,15 +350,19 @@ def test_json_view_data(black_bg, cbar, radiological):
 @pytest.mark.parametrize("black_bg", [True, False])
 @pytest.mark.parametrize("cbar", [True, False])
 @pytest.mark.parametrize("radiological", [True, False])
+@pytest.mark.ai_generated
 def test_json_view_to_html(affine_eye, black_bg, cbar, radiological):
     """Check that _json_view_to_html builds a valid viewer."""
     data, json_view = _get_data_and_json_view(black_bg, cbar, radiological)
+    html_ids = _get_brainsprite_html_ids("test-viewer")
+    json_view["html_ids"] = html_ids
     json_view["params"] = _json_view_params(
         data.shape,
         affine_eye,
         vmin=0,
         vmax=1,
         cut_slices=[1, 1, 1],
+        html_ids=html_ids,
         black_bg=True,
         opacity=1,
         draw_cross=True,
@@ -361,6 +374,58 @@ def test_json_view_to_html(affine_eye, black_bg, cbar, radiological):
 
     html_view = _json_view_to_html(json_view)
     check_html_view_img(html_view)
+
+
+@pytest.mark.ai_generated
+def test_brainsprite_viewers_have_unique_element_ids():
+    """Check that multiple viewers bind to their own HTML elements."""
+    img, _ = _simulate_img()
+    views = [
+        view_img(img, resampling_interpolation="nearest"),
+        view_img(img, resampling_interpolation="nearest"),
+    ]
+    configs = []
+    all_dom_ids = []
+
+    for view in views:
+        config_match = re.search(r"brainsprite\((\{.*\})\);", str(view))
+        assert config_match is not None
+        config = json.loads(config_match.group(1))
+        configs.append(config)
+
+        element_ids = [
+            config["canvas"],
+            config["sprite"],
+            config["overlay"]["sprite"],
+            config["colorMap"]["img"],
+        ]
+        for element_id in element_ids:
+            assert f'id="{element_id}"' in str(view)
+
+        dom_ids = set(
+            re.findall(
+                r'id="((?:div_viewer|3Dviewer|spriteImg|overlayImg|'
+                r'colorMap|opacity|demo)-[^"]+)"',
+                str(view),
+            )
+        )
+        assert len(dom_ids) == 7
+        all_dom_ids.append(dom_ids)
+
+    first_ids = {
+        configs[0]["canvas"],
+        configs[0]["sprite"],
+        configs[0]["overlay"]["sprite"],
+        configs[0]["colorMap"]["img"],
+    }
+    second_ids = {
+        configs[1]["canvas"],
+        configs[1]["sprite"],
+        configs[1]["overlay"]["sprite"],
+        configs[1]["colorMap"]["img"],
+    }
+    assert first_ids.isdisjoint(second_ids)
+    assert all_dom_ids[0].isdisjoint(all_dom_ids[1])
 
 
 def test_get_cut_slices(affine_eye):

--- a/nilearn/reporting/mixin.py
+++ b/nilearn/reporting/mixin.py
@@ -343,8 +343,14 @@ class ReportMixin:
         return html_report
 
     def _set_brainsprite_data(self):
+        from nilearn.plotting.html_stat_map import _get_brainsprite_html_ids
+
+        report_content = self._report_content
+        report_content["html_ids"] = _get_brainsprite_html_ids(
+            report_content["unique_id"]
+        )
+
         if self._has_report_data():
-            report_content = self._report_content
             report_content["bg_base64"] = self._reporting_data["bg_base64"]
             report_content["cm_base64"] = self._reporting_data["cm_base64"]
             report_content["params"] = self._reporting_data["params"]


### PR DESCRIPTION
- Closes #6419

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- Generate a unique set of DOM IDs in Python for every Brainsprite viewer and pass the same IDs to the HTML template and Brainsprite JSON configuration.
- Scope viewer initialization and opacity controls to each viewer so multiple masker reports can coexist in one document.
- Add standalone and masker-report regression tests plus a changelog entry.

## Root cause

Every Brainsprite instance used the fixed IDs `3Dviewer`, `spriteImg`, `overlayImg`, and `colorMap`. When multiple masker reports were embedded in one page, `document.getElementById` returned elements from the first viewer, so later Brainsprite instances redrew the first canvas and left their own canvas blank. The wrapper and opacity-control IDs and the global `brain` variable also collided.

## Validation

- `.tox/latest/bin/pytest -q -n auto --timeout=60 nilearn/plotting/tests/test_html_stat_map.py nilearn/reporting/tests nilearn/maskers/tests/test_html_report.py` — 136 passed, 1 skipped.
- `.venv/bin/pre-commit run --all-files` — all hooks passed.
- Browser-tested a saved HTML document containing two Brainsprite masker reports: both canvases initialized and all 14 viewer-specific IDs were unique.
- Browser-tested a saved standalone `view_img()` viewer.
- Inspected masker report `_repr_html_()` output for per-viewer configuration/DOM binding.
- Confirmed a default Matplotlib masker report does not contain Brainsprite markup.

## Environments tested

- macOS, Python 3.13.13, tox `latest` dependency environment.
- Codex in-app Chromium browser using saved standalone HTML served locally.

