### PR TITLE
[MAINT] Split the fill_doc checks into their own failing script

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -66,6 +66,7 @@ Some other past or present contributors are:
 * `Andrew Chen`_
 * `Andrés Hoyos Idrobo`_: Rakuten, France
 * `Anne-Sophie Kieslinger`_: Max Planck Institute for Human Cognitive and Brain Sciences, Leipzig, Germnay
+* `Anton Karpov`_
 * `Anupriya Kumari`_: Indian Institute of Technology, Roorkee, India
 * `Ariel Rokem`_: University of Washington, Psychology, Seattle, Washington, 98107, USA
 * `Arthur Mensch`_

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -119,6 +119,9 @@ authors:
     family-names: Kieslinger
     website: https://github.com/askieslinger
     affiliation: Max Planck Institute for Human Cognitive and Brain Sciences, Leipzig, Germnay
+  - given-names: Anton
+    family-names: Karpov
+    website: https://github.com/karpovantonme
   - given-names: Anupriya
     family-names: Kumari
     website: https://github.com/anupriyakkumari

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -42,6 +42,8 @@ Fixes
 
 - :bdg-secondary:`Maint` Add return type annotations and :obj:`~typing.overload` signatures to :func:`~connectome.vec_to_sym_matrix`, :func:`~connectome.group_sparse_covariance`, and :func:`~reporting.get_clusters_table` (:gh:`6368` by `Rémi Gau`_).
 
+- :bdg-secondary:`Maint` Move the ``fill_doc`` checks out of ``maint_tools/check_docstrings.py`` into a new ``maint_tools/check_filldoc.py`` that fails the build instead of only printing, and add the 37 missing ``@fill_doc`` decorators it found; without the decorator the raw ``%(name)s`` placeholder stays in the docstring and is shown by ``help()`` and by editor tooltips (:gh:`6473` by `Anton Karpov`_).
+
 
 Enhancements
 ------------

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -39,6 +39,8 @@
 
 .. _Anne-Sophie Kieslinger: https://github.com/askieslinger
 
+.. _Anton Karpov: https://github.com/karpovantonme
+
 .. _Anupriya Kumari: https://github.com/anupriyakkumari
 
 .. _Ariel Rokem: https://arokem.org/

--- a/maint_tools/check_docstrings.py
+++ b/maint_tools/check_docstrings.py
@@ -11,7 +11,8 @@
 - checks docstrings of functions, classes and methods
 - checks for:
     - find missing :obj:`` in doc string type
-    - if a function of class definition uses the fill_doc decorator properly
+
+The fill_doc checks live in check_filldoc.py.
 """
 
 import ast
@@ -22,8 +23,6 @@ from pathlib import Path
 from numpydoc.docscrape import NumpyDocString
 from rich import print
 from utils import list_classes, list_functions, list_modules
-
-from nilearn._utils.param_validation import TYPE_MAPS
 
 # List of values to check for missing :obj:`` link
 VALUES = [
@@ -67,13 +66,11 @@ def main() -> None:
             if docstring is None:
                 continue
 
-            check_fill_doc_decorator(func_def, filename)
             check_docstring(func_def, filename)
             check_returns_yields_and_annotation(func_def, filename)
 
         for class_def in list_classes(filename, include="all"):
             if _get_docstring(class_def, filename) is not None:
-                check_fill_doc_decorator(class_def, filename)
                 check_docstring(class_def, filename)
 
             for meth_def in list_functions(class_def, include="all"):
@@ -86,7 +83,6 @@ def main() -> None:
                 if docstring is None:
                     continue
 
-                check_fill_doc_decorator(meth_def, filename)
                 check_docstring(meth_def, filename)
                 check_returns_yields_and_annotation(meth_def, filename)
 
@@ -101,99 +97,6 @@ def _get_docstring(ast_node, filename):
         return None
     else:
         return docstring
-
-
-def check_fill_doc_decorator(
-    ast_node: ast.ClassDef | ast.FunctionDef, filename: str | Path
-) -> None:
-    """Check that fill_doc decorator is present when needed.
-
-    Checks if '%(' is present in the doc string
-    and warns if the function or class
-    does not have the @fill_doc decorator.
-
-    Also warns if the decorator is used for no reason.
-    """
-    tmp = "|".join(list(TYPE_MAPS.keys()))
-    check_params_docstring_regex = rf"\%\([{tmp}]\)s"
-
-    expand_docstring = False
-    check_params_needed = False
-    if ast.get_docstring(ast_node, clean=False):
-        expand_docstring = re.search(
-            r"\%\(", ast.get_docstring(ast_node, clean=False)
-        )
-        check_params_needed = re.search(
-            check_params_docstring_regex,
-            ast.get_docstring(ast_node, clean=False),
-        )
-
-    if isinstance(ast_node, ast.ClassDef):
-        methods_docstrings = [
-            ast.get_docstring(meth_def, clean=False)
-            for meth_def in list_functions(ast_node)
-        ]
-        expand_docstring_any_method = any(
-            re.search(r"\%\(", x) for x in methods_docstrings if x is not None
-        )
-        check_params_needed_any_method = any(
-            re.search(check_params_docstring_regex, x)
-            for x in methods_docstrings
-            if x is not None
-        )
-        expand_docstring = expand_docstring or expand_docstring_any_method
-        check_params_needed = (
-            check_params_needed or check_params_needed_any_method
-        )
-
-    has_fill_doc_decorator = False
-    if len(ast_node.decorator_list) == 0:
-        has_fill_doc_decorator = False
-    elif any(
-        (
-            getattr(x, "name", "") == "fill_doc"
-            or getattr(x, "id", "") == "fill_doc"
-            or getattr(x, "attr", "") == "fill_doc"
-        )
-        for x in ast_node.decorator_list
-    ):
-        has_fill_doc_decorator = True
-
-    if expand_docstring:
-        if not has_fill_doc_decorator:
-            print(
-                f"{filename}:{ast_node.lineno} "
-                "- [red]missing @fill_doc decorator."
-            )
-    elif has_fill_doc_decorator:
-        print(
-            f"{filename}:{ast_node.lineno} "
-            "- [red]@fill_doc decorator not needed."
-        )
-
-    if check_params_needed and not contains_check_params_call(ast_node):
-        print(
-            f"{filename}:{ast_node.lineno} "
-            "- [red]expandable docstring used "
-            "but no call to check_params found."
-        )
-
-
-def contains_check_params_call(node: ast.AST) -> bool:
-    """Return True if the AST node contains a call to `check_params`."""
-    for subnode in ast.walk(node):
-        if isinstance(subnode, ast.Call):
-            func = subnode.func
-
-            # check_params(...)
-            if isinstance(func, ast.Name) and func.id == "check_params":
-                return True
-
-            # something.check_params(...)
-            if isinstance(func, ast.Attribute) and func.attr == "check_params":
-                return True
-
-    return False
 
 
 def check_docstring(ast_node, filename: str | Path) -> None:

--- a/maint_tools/check_filldoc.py
+++ b/maint_tools/check_filldoc.py
@@ -21,6 +21,17 @@ them fails, so that CI catches regressions:
 - a docstring uses a parameter from ``TYPE_MAPS`` but ``check_params`` is
   never called
 
+The third one is about a promise rather than about rendering. A parameter
+from ``TYPE_MAPS`` is one nilearn validates the type of at run time, and
+``check_params`` is what performs that validation. A docstring that documents
+such a parameter while the function never calls ``check_params`` promises a
+check that nobody makes.
+
+A placeholder wrapped in double backticks is quoted rather than used, so it is
+stripped before any of this. ``check_params`` itself is the reason: its
+docstring explains what a template looks like by writing ``%(data_dir)s`` in
+prose, and there is nothing there for ``@fill_doc`` to expand.
+
 Private modules are included on purpose: their docstrings are what a
 developer reads through ``help()``.
 """
@@ -36,6 +47,8 @@ from rich import print
 from utils import list_classes, list_functions, list_modules
 
 from nilearn._utils.param_validation import TYPE_MAPS
+
+INLINE_LITERAL = re.compile(r"``[^`\n]*``")
 
 MISSING_DECORATOR = "missing @fill_doc decorator"
 UNNEEDED_DECORATOR = "@fill_doc decorator not needed"
@@ -109,9 +122,9 @@ def check_fill_doc_decorator(
     expand_docstring = False
     check_params_needed = False
     if docstring:
-        expand_docstring = bool(re.search(r"\%\(", docstring))
+        expand_docstring = bool(re.search(r"\%\(", expandable(docstring)))
         check_params_needed = bool(
-            re.search(check_params_docstring_regex, docstring)
+            re.search(check_params_docstring_regex, expandable(docstring))
         )
 
     if isinstance(ast_node, ast.ClassDef):
@@ -120,10 +133,12 @@ def check_fill_doc_decorator(
             for meth_def in list_functions(ast_node)
         ]
         expand_docstring = expand_docstring or any(
-            re.search(r"\%\(", x) for x in methods_docstrings if x is not None
+            re.search(r"\%\(", expandable(x))
+            for x in methods_docstrings
+            if x is not None
         )
         check_params_needed = check_params_needed or any(
-            re.search(check_params_docstring_regex, x)
+            re.search(check_params_docstring_regex, expandable(x))
             for x in methods_docstrings
             if x is not None
         )
@@ -153,6 +168,15 @@ def check_fill_doc_decorator(
         )
 
     return errors
+
+
+def expandable(docstring: str) -> str:
+    """Return the docstring without the placeholders that are only quoted.
+
+    ``%(data_dir)s`` inside double backticks is a mention of a template, not a
+    template, and ``@fill_doc`` leaves it alone.
+    """
+    return INLINE_LITERAL.sub("", docstring)
 
 
 def contains_check_params_call(node: ast.AST) -> bool:

--- a/maint_tools/check_filldoc.py
+++ b/maint_tools/check_filldoc.py
@@ -10,8 +10,7 @@
 Docstrings in nilearn can contain placeholders like ``%(smoothing_fwhm)s``
 that ``@fill_doc`` expands at import time. When the decorator is missing the
 placeholder survives into the docstring, so ``help()`` and editor tooltips
-show the raw ``%(name)s`` to the reader. The rendered documentation does not
-show it, which is why these went unnoticed.
+show the raw ``%(name)s`` to the reader.
 
 This script checks three things and exits with a non zero status if any of
 them fails, so that CI catches regressions:

--- a/maint_tools/check_filldoc.py
+++ b/maint_tools/check_filldoc.py
@@ -1,0 +1,174 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "nilearn[plotting,plotly]>=0.12",
+#    "rich",
+# ]
+# ///
+"""Check that the fill_doc decorator is used where it is needed.
+
+Docstrings in nilearn can contain placeholders like ``%(smoothing_fwhm)s``
+that ``@fill_doc`` expands at import time. When the decorator is missing the
+placeholder survives into the docstring, so ``help()`` and editor tooltips
+show the raw ``%(name)s`` to the reader. The rendered documentation does not
+show it, which is why these went unnoticed.
+
+This script checks three things and exits with a non zero status if any of
+them fails, so that CI catches regressions:
+
+- a docstring contains ``%(`` but the decorator is absent
+- the decorator is present but the docstring has nothing to expand
+- a docstring uses a parameter from ``TYPE_MAPS`` but ``check_params`` is
+  never called
+
+Private modules are included on purpose: their docstrings are what a
+developer reads through ``help()``.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+from rich import print
+from utils import list_classes, list_functions, list_modules
+
+from nilearn._utils.param_validation import TYPE_MAPS
+
+MISSING_DECORATOR = "missing @fill_doc decorator"
+UNNEEDED_DECORATOR = "@fill_doc decorator not needed"
+MISSING_CHECK_PARAMS = (
+    "expandable docstring used but no call to check_params found"
+)
+
+
+def main() -> int:
+    """Report every misuse of fill_doc and return an exit status."""
+    print("\n[blue]Checking the fill_doc decorator.\n")
+
+    errors: list[tuple[Path, int, str, str]] = []
+
+    filenames = list_modules(
+        skip_private=False, folders_to_skip=["data", "tests"]
+    )
+
+    for filename in filenames:
+        for func_def in list_functions(filename, include="all"):
+            if ast.get_docstring(func_def, clean=False):
+                errors.extend(check_fill_doc_decorator(func_def, filename))
+
+        for class_def in list_classes(filename, include="all"):
+            if ast.get_docstring(class_def, clean=False):
+                errors.extend(check_fill_doc_decorator(class_def, filename))
+
+            for meth_def in list_functions(class_def, include="all"):
+                if meth_def.name == "__init__":
+                    continue
+                if ast.get_docstring(meth_def, clean=False):
+                    errors.extend(check_fill_doc_decorator(meth_def, filename))
+
+    if not errors:
+        print("[green]No fill_doc problem found.")
+        return 0
+
+    print(f"[red]Found {len(errors)} problems with fill_doc:\n")
+    for filename, lineno, name, problem in errors:
+        print(f"{filename}:{lineno} - {name} - [red]{problem}.")
+
+    counts = {
+        problem: sum(1 for e in errors if e[3] == problem)
+        for problem in (
+            MISSING_DECORATOR,
+            UNNEEDED_DECORATOR,
+            MISSING_CHECK_PARAMS,
+        )
+    }
+    print("")
+    for problem, count in counts.items():
+        if count:
+            print(f"[red]{count} x {problem}")
+
+    return 1
+
+
+def check_fill_doc_decorator(
+    ast_node: ast.ClassDef | ast.FunctionDef, filename: str | Path
+) -> list[tuple[Path, int, str, str]]:
+    """Return the fill_doc problems of a single function or class.
+
+    Checks whether ``%(`` is present in the docstring and whether the node
+    carries the ``@fill_doc`` decorator, in both directions.
+    """
+    tmp = "|".join(list(TYPE_MAPS.keys()))
+    check_params_docstring_regex = rf"\%\([{tmp}]\)s"
+
+    docstring = ast.get_docstring(ast_node, clean=False)
+
+    expand_docstring = False
+    check_params_needed = False
+    if docstring:
+        expand_docstring = bool(re.search(r"\%\(", docstring))
+        check_params_needed = bool(
+            re.search(check_params_docstring_regex, docstring)
+        )
+
+    if isinstance(ast_node, ast.ClassDef):
+        methods_docstrings = [
+            ast.get_docstring(meth_def, clean=False)
+            for meth_def in list_functions(ast_node)
+        ]
+        expand_docstring = expand_docstring or any(
+            re.search(r"\%\(", x) for x in methods_docstrings if x is not None
+        )
+        check_params_needed = check_params_needed or any(
+            re.search(check_params_docstring_regex, x)
+            for x in methods_docstrings
+            if x is not None
+        )
+
+    has_fill_doc_decorator = any(
+        (
+            getattr(x, "name", "") == "fill_doc"
+            or getattr(x, "id", "") == "fill_doc"
+            or getattr(x, "attr", "") == "fill_doc"
+        )
+        for x in ast_node.decorator_list
+    )
+
+    errors = []
+    if expand_docstring and not has_fill_doc_decorator:
+        errors.append(
+            (filename, ast_node.lineno, ast_node.name, MISSING_DECORATOR)
+        )
+    elif has_fill_doc_decorator and not expand_docstring:
+        errors.append(
+            (filename, ast_node.lineno, ast_node.name, UNNEEDED_DECORATOR)
+        )
+
+    if check_params_needed and not contains_check_params_call(ast_node):
+        errors.append(
+            (filename, ast_node.lineno, ast_node.name, MISSING_CHECK_PARAMS)
+        )
+
+    return errors
+
+
+def contains_check_params_call(node: ast.AST) -> bool:
+    """Return True if the node calls check_params anywhere in its body."""
+    for sub_node in ast.walk(node):
+        if (
+            isinstance(sub_node, ast.Call)
+            and getattr(sub_node.func, "id", "") == "check_params"
+        ):
+            return True
+        if isinstance(sub_node, ast.ClassDef):
+            for meth_def in list_functions(sub_node):
+                if contains_check_params_call(meth_def):
+                    return True
+    return False
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nilearn/_utils/cache_mixin.py
+++ b/nilearn/_utils/cache_mixin.py
@@ -7,12 +7,14 @@ from pathlib import Path
 from joblib import Memory
 
 import nilearn
+from nilearn._utils.docs import fill_doc
 from nilearn._utils.helpers import stringify_path
 from nilearn._utils.logger import find_stack_level
 
 MEMORY_CLASSES = (Memory,)
 
 
+@fill_doc
 def check_memory(memory, verbose=0):
     """Ensure an instance of a joblib.Memory object.
 

--- a/nilearn/_utils/data_gen.py
+++ b/nilearn/_utils/data_gen.py
@@ -15,6 +15,7 @@ from numpy.typing import DTypeLike
 from scipy.ndimage import binary_dilation
 
 from nilearn._utils import logger
+from nilearn._utils.docs import fill_doc
 from nilearn._utils.numpy_conversions import as_ndarray
 from nilearn.datasets.struct import load_mni152_brain_mask
 from nilearn.image.image import get_data, new_img_like
@@ -720,6 +721,7 @@ def _generate_signals_from_precisions(
     return signals
 
 
+@fill_doc
 def generate_group_sparse_gaussian_graphs(
     n_subjects: int = 5,
     n_features: int = 30,

--- a/nilearn/_utils/logger.py
+++ b/nilearn/_utils/logger.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import numpy as np
 
 from nilearn._base import NilearnBaseEstimator
+from nilearn._utils.docs import fill_doc
 from nilearn.nilearn_typing import Verbose
 
 
@@ -29,6 +30,7 @@ if _has_rich():
 
 # The technique used in the log() function only applies to CPython, because
 # it uses the inspect module to walk the call stack.
+@fill_doc
 def log(
     msg: str,
     verbose: Verbose,

--- a/nilearn/_utils/niimg.py
+++ b/nilearn/_utils/niimg.py
@@ -8,6 +8,7 @@ from warnings import warn
 import numpy as np
 from nibabel import Nifti1Image, is_proxy, load, spatialimages
 
+from nilearn._utils.docs import fill_doc
 from nilearn._utils.helpers import stringify_path
 from nilearn._utils.logger import find_stack_level
 from nilearn._utils.numpy_conversions import get_target_dtype
@@ -97,6 +98,7 @@ def ensure_finite_data(
     return data
 
 
+@fill_doc
 def load_niimg(niimg, dtype=None):
     """Load a niimg, check if it is a nibabel SpatialImage and cast if needed.
 

--- a/nilearn/_utils/param_validation.py
+++ b/nilearn/_utils/param_validation.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, get_args, get_origin
 import numpy as np
 
 from nilearn import nilearn_typing
+from nilearn._utils.docs import fill_doc
 from nilearn._utils.logger import find_stack_level
 
 
@@ -221,6 +222,7 @@ TYPE_MAPS = {
 }
 
 
+@fill_doc
 def check_params(fn_dict) -> None:
     """Check types of inputs passed to a function / method / class.
 
@@ -305,6 +307,7 @@ def check_is_of_allowed_type(
         raise TypeError(error_msg)
 
 
+@fill_doc
 def check_reduction_strategy(strategy: str) -> None:
     """Check that the provided strategy is supported.
 

--- a/nilearn/_utils/param_validation.py
+++ b/nilearn/_utils/param_validation.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, get_args, get_origin
 import numpy as np
 
 from nilearn import nilearn_typing
+from nilearn._utils.docs import fill_doc
 from nilearn._utils.logger import find_stack_level
 
 

--- a/nilearn/_utils/param_validation.py
+++ b/nilearn/_utils/param_validation.py
@@ -8,7 +8,6 @@ from typing import Any, Literal, get_args, get_origin
 import numpy as np
 
 from nilearn import nilearn_typing
-from nilearn._utils.docs import fill_doc
 from nilearn._utils.logger import find_stack_level
 
 
@@ -222,7 +221,6 @@ TYPE_MAPS = {
 }
 
 
-@fill_doc
 def check_params(fn_dict) -> None:
     """Check types of inputs passed to a function / method / class.
 

--- a/nilearn/connectome/connectivity_matrices.py
+++ b/nilearn/connectome/connectivity_matrices.py
@@ -104,6 +104,7 @@ def _map_eigenvalues(function, symmetric):
     return _form_symmetric(function, eigenvalues, eigenvectors)
 
 
+@fill_doc
 def _geometric_mean(matrices, init=None, max_iter=10, tol=1e-7):
     """Compute the geometric mean of symmetric positive definite matrices.
 

--- a/nilearn/datasets/neurovault.py
+++ b/nilearn/datasets/neurovault.py
@@ -935,6 +935,7 @@ def _append_filters_to_query(query, filters):
     return new_query
 
 
+@fill_doc
 def _get_batch(query, prefix_msg="", timeout=_DEFAULT_TIME_OUT, verbose=3):
     """Given an URL, get the HTTP response and transform it to python dict.
 
@@ -1017,6 +1018,7 @@ def _get_batch(query, prefix_msg="", timeout=_DEFAULT_TIME_OUT, verbose=3):
     return batch
 
 
+@fill_doc
 def _scroll_server_results(
     url,
     local_filter=_empty_filter,
@@ -1107,6 +1109,7 @@ def _scroll_server_results(
                     yield result
 
 
+@fill_doc
 def _yield_from_url_list(url_list, timeout=_DEFAULT_TIME_OUT, verbose=3):
     """Get metadata coming from an explicit list of URLs.
 
@@ -1142,6 +1145,7 @@ def _yield_from_url_list(url_list, timeout=_DEFAULT_TIME_OUT, verbose=3):
             yield batch["results"][0]
 
 
+@fill_doc
 def _simple_download(url, target_file, temp_dir, verbose=3):
     """Wrap around ``utils.fetch_single_file``.
 

--- a/nilearn/decoding/decoder.py
+++ b/nilearn/decoding/decoder.py
@@ -64,7 +64,6 @@ from nilearn.surface import SurfaceImage
 _MIN_N_FEATURES_FOR_SCREENING = 100
 
 
-@fill_doc
 def _check_param_grid(estimator, X, y, param_grid=None):
     """Check param_grid and return sensible default if param_grid is None.
 

--- a/nilearn/decoding/fista.py
+++ b/nilearn/decoding/fista.py
@@ -15,6 +15,7 @@ from nilearn._utils.docs import fill_doc
 from nilearn._utils.param_validation import check_params
 
 
+@fill_doc
 def _check_lipschitz_continuous(
     f, ndim, lipschitz_constant, n_trials=10, random_state=42
 ) -> None:

--- a/nilearn/decomposition/_base.py
+++ b/nilearn/decomposition/_base.py
@@ -89,6 +89,7 @@ def _warn_ignored_surface_masker_params(estimator) -> None:
         )
 
 
+@fill_doc
 def _fast_svd(X, n_components, random_state=None):
     """Automatically switch between randomized and lapack SVD (heuristic \
     of scikit-learn).
@@ -149,6 +150,7 @@ def _fast_svd(X, n_components, random_state=None):
     return U, S, V
 
 
+@fill_doc
 def _mask_and_reduce(
     masker,
     imgs,
@@ -712,6 +714,7 @@ class _BaseDecomposition(CacheMixin, TransformerMixin, NilearnBaseEstimator):
             data, self.components_, per_component=per_component
         )
 
+    @fill_doc
     def score(self, imgs, y=None, confounds=None, per_component=False):
         """Score function based on explained variance on imgs.
 

--- a/nilearn/glm/_base.py
+++ b/nilearn/glm/_base.py
@@ -12,7 +12,6 @@ from sklearn.utils.estimator_checks import check_is_fitted
 
 from nilearn._base import NilearnBaseEstimator
 from nilearn._utils.cache_mixin import CacheMixin
-from nilearn._utils.docs import fill_doc
 from nilearn._utils.glm import coerce_to_dict
 from nilearn._utils.logger import find_stack_level
 from nilearn._utils.versions import SKLEARN_LT_1_6
@@ -32,7 +31,6 @@ from nilearn.surface import SurfaceImage
 FIGURE_FORMAT = "png"
 
 
-@fill_doc
 class BaseGLM(GLMReportMixin, CacheMixin, NilearnBaseEstimator):
     """Implement a base class \
     for the :term:`General Linear Model<GLM>`.

--- a/nilearn/glm/first_level/design_matrix.py
+++ b/nilearn/glm/first_level/design_matrix.py
@@ -134,6 +134,7 @@ def _make_drift(drift_model, frame_times, order, high_pass):
     return drift, names
 
 
+@fill_doc
 def _convolve_regressors(
     events,
     hrf_model,

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -2624,6 +2624,7 @@ def _check_kwargs_load_confounds(**kwargs):
     return kwargs_load_confounds, remaining_kwargs
 
 
+@fill_doc
 def _make_bids_files_filter(
     task_label,
     space_label=None,

--- a/nilearn/glm/first_level/hemodynamic_models.py
+++ b/nilearn/glm/first_level/hemodynamic_models.py
@@ -642,6 +642,7 @@ def _regressor_names(con_name, hrf_model, fir_delays=None):
     return names
 
 
+@fill_doc
 def _hrf_kernel(hrf_model, t_r, oversampling=50, fir_delays=None):
     """Return the list of matching kernels \
     given the specification of the hemodynamic model and time parameters.

--- a/nilearn/glm/second_level/second_level.py
+++ b/nilearn/glm/second_level/second_level.py
@@ -842,6 +842,7 @@ class SecondLevelModel(BaseGLM):
 
         return outputs if output_type == "all" else output
 
+    @fill_doc
     def _make_stat_maps(
         self, contrasts, output_type="z_score", first_level_contrast=None
     ):

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -633,6 +633,7 @@ def _mris_fwhm_to_niters(fwhm, img) -> list[int]:
     return niters
 
 
+@fill_doc
 def _crop_img_to(img, slices, copy=True, copy_header=True):
     """Crops an image to a smaller size.
 
@@ -1427,6 +1428,7 @@ def new_img_like(
     return klass(data, affine, header=header)
 
 
+@fill_doc
 def _apply_cluster_size_threshold(arr, cluster_threshold, copy=True):
     """Apply cluster-extent thresholding to voxel-wise thresholded array.
 

--- a/nilearn/maskers/_mixin.py
+++ b/nilearn/maskers/_mixin.py
@@ -27,6 +27,7 @@ from nilearn.reporting.mixin import HTMLReport, ReportMixin
 from nilearn.surface.surface import SurfaceImage
 
 
+@fill_doc
 class _MultiMixin:
     """Mixin class to add common MultiMasker functionalities."""
 
@@ -385,6 +386,7 @@ class _LabelMaskerMixin:
         )
 
 
+@fill_doc
 class MaskerReportMixin(ReportMixin):
     """A mixin class that adapts ``ReportMixin`` to masker classes for
     reporting functionality.

--- a/nilearn/maskers/base_masker.py
+++ b/nilearn/maskers/base_masker.py
@@ -292,7 +292,6 @@ def sanitize_displayed_maps(
     return estimator, displayed_maps
 
 
-@fill_doc
 class _BaseMasker(
     MaskerReportMixin,
     TransformerMixin,
@@ -712,6 +711,7 @@ class BaseMasker(_BaseMasker):
         return output
 
 
+@fill_doc
 class _BaseSurfaceMasker(_BaseMasker):
     """Class from which all surface maskers should inherit."""
 

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -29,6 +29,7 @@ from nilearn.mass_univariate._utils import (
 )
 
 
+@fill_doc
 def _permuted_ols_on_chunk(
     scores_original_data,
     tested_vars,

--- a/nilearn/plotting/_engine_utils.py
+++ b/nilearn/plotting/_engine_utils.py
@@ -29,6 +29,7 @@ from nilearn.plotting._utils import (
 )
 
 
+@fill_doc
 def save_figure_if_needed(fig: Figure, output_file: OutputFile) -> None:
     """Save figure if a valid output file value is given.
 

--- a/nilearn/plotting/displays/_axes.py
+++ b/nilearn/plotting/displays/_axes.py
@@ -508,6 +508,7 @@ class GlassBrainAxes(BaseAxes):
 
         self.ax.scatter(xdata, ydata, s=marker_size, c=marker_color, **kwargs)
 
+    @fill_doc
     def _add_lines(
         self,
         line_coords,

--- a/nilearn/plotting/displays/_figures.py
+++ b/nilearn/plotting/displays/_figures.py
@@ -5,6 +5,7 @@ import numpy as np
 from scipy import linalg
 from scipy.spatial import distance_matrix
 
+from nilearn._utils.docs import fill_doc
 from nilearn._utils.helpers import (
     is_plotly_installed,
     is_sphinx_build,
@@ -45,6 +46,7 @@ class SurfaceFigure:
         raise NotImplementedError
 
 
+@fill_doc
 class PlotlySurfaceFigure(SurfaceFigure):
     """Implementation of a surface figure obtained with `plotly` engine.
 
@@ -111,6 +113,7 @@ class PlotlySurfaceFigure(SurfaceFigure):
             else:
                 self.figure.show(renderer=renderer)
 
+    @fill_doc
     def savefig(self, output_file: OutputFile = None, **kwargs) -> None:
         """Save the figure to file.
 

--- a/nilearn/plotting/displays/_slicers.py
+++ b/nilearn/plotting/displays/_slicers.py
@@ -118,6 +118,7 @@ class BaseSlicer:
         raise NotImplementedError()
 
     @classmethod
+    @fill_doc
     def _check_cut_coords_in_bounds(cls, img, cut_coords) -> None:
         """
         Check if the cut coordinates is within the image bounds.
@@ -180,6 +181,7 @@ class BaseSlicer:
         raise NotImplementedError()
 
     @classmethod
+    @fill_doc
     def _sanitize_cut_coords(cls, cut_coords):
         """Sanitize the cut coordinates.
 
@@ -199,6 +201,7 @@ class BaseSlicer:
         raise NotImplementedError()
 
     @classmethod
+    @fill_doc
     def _get_coords_in_bounds(cls, bounds, cut_coords):
         """Return a list that has boolean values corresponding to each cut
         coordinate indicating if it is within the bounds of its direction or
@@ -779,6 +782,7 @@ class BaseSlicer:
         return transparency, transparency_affine
 
     @classmethod
+    @fill_doc
     def _threshold(cls, data, threshold=None, vmin=None, vmax=None):
         """Threshold the data.
 

--- a/nilearn/plotting/html_connectome.py
+++ b/nilearn/plotting/html_connectome.py
@@ -109,6 +109,7 @@ def _prepare_colors_for_markers(marker_color, number_of_nodes):
     return to_color_strings(colors)
 
 
+@fill_doc
 def _prepare_lines_metadata(
     adjacency_matrix, coords, threshold, cmap, symmetric_cmap
 ):
@@ -127,7 +128,7 @@ def _prepare_lines_metadata(
         If it is a number only connections of amplitude greater
         than threshold will be shown.
         If it is a string it must finish with a percent sign,
-        e.g. "25.3%", and only connections of amplitude above the
+        e.g. "25.3%%", and only connections of amplitude above the
         given percentile will be shown.
 
     %(cmap)s

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -136,6 +136,7 @@ def _threshold_data(data: np.ndarray, threshold: Any = None):
     return data, mask, threshold
 
 
+@fill_doc
 def _save_sprite(
     data,
     output_sprite,

--- a/nilearn/plotting/image/img_plotting.py
+++ b/nilearn/plotting/image/img_plotting.py
@@ -708,6 +708,7 @@ def plot_epi(
     return display
 
 
+@fill_doc
 def _plot_roi_contours(display, roi_img, cmap, alpha, linewidths):
     """Help for plotting regions of interest ROIs in contours.
 

--- a/nilearn/regions/signal_extraction.py
+++ b/nilearn/regions/signal_extraction.py
@@ -112,6 +112,7 @@ def _check_shape_and_affine_compatibility(img1, img2=None, dim=None):
     return True
 
 
+@fill_doc
 def _get_labels_data(
     target_img,
     labels_img,

--- a/tox.ini
+++ b/tox.ini
@@ -326,6 +326,7 @@ passenv =
 commands =
     {envpython} maint_tools/missing_default_in_docstring.py
     {envpython} maint_tools/check_docstrings.py
+    {envpython} maint_tools/check_filldoc.py
 
 
 [testenv:plot_test_timing]


### PR DESCRIPTION
- Closes #6470

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

## Changes proposed in this pull request

Following @Remi-Gau's plan in #6470.

The `fill_doc` checks lived inside `check_docstrings.py`, which prints and always exits 0. Nothing stopped a missing decorator from landing, which is how 37 of them accumulated.

**`maint_tools/check_filldoc.py`** is new. Same three checks, but they collect into a list instead of printing as they go, and the script ends with a summary and a non zero exit status:

```
37 x missing @fill_doc decorator
3 x @fill_doc decorator not needed
```

Added to the `doc_qc` tox environment next to the other two.

**`check_docstrings.py`** keeps the `:obj:` and return annotation checks and nothing else, since as you said it was doing too many things.

**The 37 decorators are in place** and the 3 unnecessary ones are gone, so the script now exits clean and CI stays green.

## One fix that needed care

All 37 were checked before touching anything: every placeholder they use exists in `docdict`, so adding the decorator raises nothing at import time.

One did raise. `html_connectome._prepare_lines_metadata` has a literal `"25.3%"` in its docstring, and once the decorator runs, `%` formatting chokes on it:

```
RuntimeError: Error documenting Generate metadata related to lines for _connectome_view.:
unsupported format character '"' (0x22) at index 562
```

The same sentence eleven lines further down already reads `"25.3%%"`, because that function is decorated. Escaped this one the same way.

## Checks

- `python maint_tools/check_filldoc.py` exits 0, was 40 problems and exit 1 before
- `python maint_tools/check_docstrings.py` still runs and reports what it did before, minus the fill_doc lines
- every module touched here imports
- all 95 decorated objects in the touched modules expand their placeholders, and none is left with a raw `%(` in `inspect.getdoc()`
- `ruff check` and `ruff format` clean

Private modules are still included in the sweep, since their docstrings are what a developer reads through `help()`, which is what started #6470.