### PR TITLE
[DOC] Fix eleven parameter names that do not match the signature

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -66,6 +66,7 @@ Some other past or present contributors are:
 * `Andrew Chen`_
 * `Andrés Hoyos Idrobo`_: Rakuten, France
 * `Anne-Sophie Kieslinger`_: Max Planck Institute for Human Cognitive and Brain Sciences, Leipzig, Germnay
+* `Anton Karpov`_
 * `Anupriya Kumari`_: Indian Institute of Technology, Roorkee, India
 * `Ariel Rokem`_: University of Washington, Psychology, Seattle, Washington, 98107, USA
 * `Arthur Mensch`_

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -119,6 +119,9 @@ authors:
     family-names: Kieslinger
     website: https://github.com/askieslinger
     affiliation: Max Planck Institute for Human Cognitive and Brain Sciences, Leipzig, Germnay
+  - given-names: Anton
+    family-names: Karpov
+    website: https://github.com/karpovantonme
   - given-names: Anupriya
     family-names: Kumari
     website: https://github.com/anupriyakkumari

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -42,6 +42,8 @@ Fixes
 
 - :bdg-secondary:`Maint` Add return type annotations and :obj:`~typing.overload` signatures to :func:`~connectome.vec_to_sym_matrix`, :func:`~connectome.group_sparse_covariance`, and :func:`~reporting.get_clusters_table` (:gh:`6368` by `Rémi Gau`_).
 
+- :bdg-primary:`Doc` Fix eleven docstrings naming a parameter the function does not take, including the typos ``lispchitz_constant`` and ``flag_tedata``, and a pair of neighbouring helpers documenting each other's parameter names (:gh:`6474` by `Anton Karpov`_).
+
 
 Enhancements
 ------------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -42,7 +42,7 @@ Fixes
 
 - :bdg-secondary:`Maint` Add return type annotations and :obj:`~typing.overload` signatures to :func:`~connectome.vec_to_sym_matrix`, :func:`~connectome.group_sparse_covariance`, and :func:`~reporting.get_clusters_table` (:gh:`6368` by `Rémi Gau`_).
 
-- :bdg-primary:`Doc` Fix eleven docstrings naming a parameter the function does not take, including the typos ``lispchitz_constant`` and ``flag_tedata``, and a pair of neighbouring helpers documenting each other's parameter names (:gh:`6474` by `Anton Karpov`_).
+- :bdg-primary:`Doc` Fix eleven docstrings naming a parameter the function does not take, including the typos ``lispchitz_constant`` and ``flag_tedata``, and a pair of neighboring helpers documenting each other's parameter names (:gh:`6474` by `Anton Karpov`_).
 
 
 Enhancements

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -39,6 +39,8 @@
 
 .. _Anne-Sophie Kieslinger: https://github.com/askieslinger
 
+.. _Anton Karpov: https://github.com/karpovantonme
+
 .. _Anupriya Kumari: https://github.com/anupriyakkumari
 
 .. _Ariel Rokem: https://arokem.org/

--- a/nilearn/_utils/data_gen.py
+++ b/nilearn/_utils/data_gen.py
@@ -690,7 +690,7 @@ def _generate_signals_from_precisions(
         A list of precision matrices. Every matrix must be square (with the
         same size) and positive definite.
 
-    min_samples, max_samples : :obj:`int`, optional
+    min_n_samples, max_n_samples : :obj:`int`, optional
         The number of samples drawn for each timeseries is taken at random
         between these two numbers. Defaults are 50 and 100.
 

--- a/nilearn/decoding/fista.py
+++ b/nilearn/decoding/fista.py
@@ -36,7 +36,7 @@ def _check_lipschitz_continuous(
       continuity (i.e. it corresponds to the size of the vector that `f`
       takes as an argument).
 
-    lispchitz_constant : float,
+    lipschitz_constant : float,
       Constant associated to the Lipschitz continuity.
 
     n_trials : int,

--- a/nilearn/glm/first_level/first_level.py
+++ b/nilearn/glm/first_level/first_level.py
@@ -2308,7 +2308,7 @@ def _get_masks_files(
 
     Parameters
     ----------
-    dataset_path : :obj:`pathlib.Path`
+    derivatives_path : :obj:`pathlib.Path`
         Directory of the derivatives BIDS dataset.
 
     sub_label : :obj:`str`
@@ -2544,7 +2544,7 @@ def _check_args_first_level_from_bids(
         Filters are of the form (field, label).
         Only one filter per field allowed.
 
-    derivatives_path : :obj:`str`
+    derivatives_folder : :obj:`str`
         Fullpath of the BIDS dataset derivative folder.
 
     """

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -535,7 +535,7 @@ def _smooth_surface_img(
 
     Parameters
     ----------
-    imgs : SurfaceImage
+    img : SurfaceImage
         The surface whose is to be smoothed.
         In the case of 2D data, each sample is smoothed independently.
 

--- a/nilearn/interfaces/fmriprep/load_confounds_utils.py
+++ b/nilearn/interfaces/fmriprep/load_confounds_utils.py
@@ -311,7 +311,7 @@ def get_confounds_file(image_file, flag_full_aroma, flag_tedana):
     flag_full_aroma : :obj:`bool`
         True if the input is a full ICA-AROMA output, False otherwise.
 
-    flag_tedata : :obj:`bool`
+    flag_tedana : :obj:`bool`
         True if the input is a TEDANA optimally combined output,
         False otherwise.
 
@@ -489,7 +489,7 @@ def _check_images(image_file, flag_full_aroma, flag_tedana: bool) -> None:
     flag_full_aroma : bool
         True if the input is a full ICA-AROMA output, False otherwise.
 
-    flag_tedata : :obj:`bool`
+    flag_tedana : :obj:`bool`
         True if the input is a TEDANA optimally combined output
 
     Raises

--- a/nilearn/plotting/img_comparison.py
+++ b/nilearn/plotting/img_comparison.py
@@ -44,12 +44,12 @@ def plot_img_comparison(
 
     Parameters
     ----------
-    ref_img : 3D Niimg-like object or :obj:`~nilearn.surface.SurfaceImage` \
+    ref_imgs : 3D Niimg-like object or :obj:`~nilearn.surface.SurfaceImage` \
               or a :obj:`list` of \
               3D Niimg-like object or :obj:`~nilearn.surface.SurfaceImage`
         Reference image.
 
-    src_img : 3D Niimg-like object or :obj:`~nilearn.surface.SurfaceImage` \
+    src_imgs : 3D Niimg-like object or :obj:`~nilearn.surface.SurfaceImage` \
               or a :obj:`list` of \
               3D Niimg-like object or :obj:`~nilearn.surface.SurfaceImage`
         Source image.

--- a/nilearn/plotting/surface/_niivue_backend.py
+++ b/nilearn/plotting/surface/_niivue_backend.py
@@ -38,7 +38,7 @@ def matplotlib_cm_to_niivue_cm(
 
     Parameters
     ----------
-    cmap_name : str or Colormap
+    cmap : str or Colormap
         Name of the colormap to convert.
 
     Returns


### PR DESCRIPTION
- Closes #6468

Use of AI tools:
- [ ] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

## Changes proposed in this pull request

Eleven docstrings name a parameter the function does not take. Same class of thing as #6468, second pass over what is left.

### Renames the code made and the docs did not follow

| Where | Documented | Signature |
|---|---|---|
| `_generate_signals_from_precisions` | `min_samples, max_samples` | `min_n_samples, max_n_samples` |
| `_smooth_surface_img` | `imgs` | `img` |
| `plot_img_comparison` | `ref_img`, `src_img` | `ref_imgs`, `src_imgs` |
| `matplotlib_cm_to_niivue_cm` | `cmap_name` | `cmap` |

`plot_img_comparison` is the clearest of them: the description already reads "or a list of 3D Niimg-like object", so the plural in the signature is the intended one and only the name lagged behind.

### Two typos

- `_check_lipschitz_continuous` documents **`lispchitz_constant`**, the argument is `lipschitz_constant`
- `get_confounds_file` and `_check_images` both document **`flag_tedata`**, the argument is `flag_tedana`

### One pair with the names swapped

- `_get_masks_files` documents `dataset_path`, takes `derivatives_path`
- `_check_args_first_level_from_bids` documents `derivatives_path`, takes `derivatives_folder`

They sit in the same module, which is presumably how the names crossed over.

### Not included

Eight more, where the parameter was not renamed but removed, so the fix is a judgement call rather than a rename: `_mock_bids_dataset` and `_mock_bids_derivatives` (`base_dir`), `prox_tvl1` (`callback`), the two `_graph_net_*_data_function` (`y`), `make_stat_maps_contrast_clusters` (`stat_img`, `mask_img`), `check_embedded_masker` (`instance`).

One of those is worth a look on its own: `make_stat_maps_contrast_clusters` documents `clusters_tsvs`, and the parameter is still in the signature but **commented out**. The docstring is describing an argument that is currently switched off.

### On the author list

I added myself through `CITATION.cff` and regenerated `doc/changes/names.rst` with `maint_tools/citation_cff_maint.py`, as the file header asks. In #6473 I edited `names.rst` by hand before noticing that, and will fix it there too.

### Checks

Docstrings only, no code touched. The sweep reported 24 before and 13 after, and the thirteen left are the eight above plus five already known.