### PR TITLE
[FIX] Handle lists when resampling NiftiLabelsMasker data

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -20,6 +20,8 @@ NEW
 Fixes
 -----
 
+- :bdg-dark:`Code` Fix :class:`~maskers.NiftiLabelsMasker` raising an ``AttributeError`` when transforming a list of 3D images with ``resampling_target="labels"`` (:gh:`6497` by `Mohammad Sadeghi Hardengi`_).
+
 - :bdg-success:`API` Fix Fix mismatch between parameters in several functions or methods and their docstrings. Also adds an ``interpolation`` parameter to :func:`~.datasets.fetch_neurovault` that was documented but missing from the API (:gh:`6482` by `Rémi Gau`_).
 
 - :bdg-primary:`Doc` Fix docstrings that name a parameter which is not in the signature (:func:`~plotting.plot_img_comparison`, :meth:`~plotting.displays.PlotlySurfaceFigure.add_contours` and seven private helpers), the documented default of ``two_sided_test`` in ``calculate_tfce``, and the sentence stating that a source image is resampled to match itself (:gh:`6469` by `Anton Karpov`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -20,7 +20,7 @@ NEW
 Fixes
 -----
 
-- :bdg-dark:`Code` Fix :class:`~maskers.NiftiLabelsMasker` raising an ``AttributeError`` when transforming a list of 3D images with ``resampling_target="labels"`` (:gh:`6497` by `Mohammad Sadeghi Hardengi`_).
+- :bdg-dark:`Code` Fix :class:`~maskers.NiftiLabelsMasker` raising an ``AttributeError`` when transforming a list of 3D images with ``resampling_target="labels"`` (:gh:`6498` by `Mohammad Sadeghi Hardengi`_).
 
 - :bdg-success:`API` Fix Fix mismatch between parameters in several functions or methods and their docstrings. Also adds an ``interpolation`` parameter to :func:`~.datasets.fetch_neurovault` that was documented but missing from the API (:gh:`6482` by `Rémi Gau`_).
 

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -3501,7 +3501,7 @@ def check_masker_transform_resampling(estimator_orig) -> None:
     input_shape = (28, 29, 30, n_sample)
     imgs = Nifti1Image(_rng().random(input_shape), _affine_eye())
 
-    # using a list of images as regression test for #6497 
+    # using a list of images as regression test for #6497
     imgs_with_different_fov = [
         Nifti1Image(_rng().random((20, 21, 22)), _affine_eye())
     ]

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -3501,6 +3501,7 @@ def check_masker_transform_resampling(estimator_orig) -> None:
     input_shape = (28, 29, 30, n_sample)
     imgs = Nifti1Image(_rng().random(input_shape), _affine_eye())
 
+    # using a list of images as regression test for #6497 
     imgs_with_different_fov = [
         Nifti1Image(_rng().random((20, 21, 22)), _affine_eye())
     ]

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -3501,9 +3501,9 @@ def check_masker_transform_resampling(estimator_orig) -> None:
     input_shape = (28, 29, 30, n_sample)
     imgs = Nifti1Image(_rng().random(input_shape), _affine_eye())
 
-    imgs_with_different_fov = Nifti1Image(
-        _rng().random((20, 21, 22)), _affine_eye()
-    )
+    imgs_with_different_fov = [
+        Nifti1Image(_rng().random((20, 21, 22)), _affine_eye())
+    ]
 
     mask_shape = (15, 16, 17)
     mask_img = Nifti1Image(np.ones(mask_shape), _affine_eye())

--- a/nilearn/maskers/nifti_labels_masker.py
+++ b/nilearn/maskers/nifti_labels_masker.py
@@ -743,7 +743,8 @@ class NiftiLabelsMasker(_LabelMaskerMixin, BaseMasker):
         target_shape = None
         target_affine = None
         if self.resampling_target == "labels":
-            if not check_same_fov(labels_img_, imgs):
+            imgs_ = check_niimg(imgs, atleast_4d=True)
+            if not check_same_fov(labels_img_, imgs_):
                 warnings.warn(
                     (
                         "Resampling images at transform time...\n"
@@ -753,6 +754,7 @@ class NiftiLabelsMasker(_LabelMaskerMixin, BaseMasker):
                     ),
                     stacklevel=find_stack_level(),
                 )
+            del imgs_
 
             target_shape = labels_img_.shape[:3]
             target_affine = labels_img_.affine

--- a/nilearn/maskers/tests/test_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_nifti_labels_masker.py
@@ -523,6 +523,36 @@ def test_nifti_labels_masker_resampling_to_labels(
     assert fmri11_img_r.shape == ((*masker.labels_img_.shape[:3], length))
 
 
+@pytest.mark.ai_generated
+def test_nifti_labels_masker_resampling_list_to_labels(affine_eye):
+    """Test resampling a list of 3D images to labels."""
+    labels = np.zeros((2, 2, 2), dtype=np.int8)
+    labels[1, ...] = 1
+    labels_affine = affine_eye.copy()
+    labels_affine[:3, 3] = 1
+    labels_img = Nifti1Image(labels, labels_affine)
+
+    imgs = []
+    for value in (1.0, 2.0):
+        data = np.full((4, 4, 4), value)
+        data[0, 0, :2] = (value + 1, value + 2)
+        imgs.append(Nifti1Image(data, affine_eye))
+
+    masker = NiftiLabelsMasker(
+        labels_img,
+        resampling_target="labels",
+        standardize=None,
+    )
+
+    with pytest.warns(
+        UserWarning, match="Resampling images at transform time"
+    ):
+        signals = masker.fit_transform(imgs)
+
+    assert signals.shape == (2, 1)
+    assert_almost_equal(signals, [[1.0], [2.0]])
+
+
 def test_nifti_labels_masker_resampling_to_clipped_labels(
     affine_eye, shape_3d_default, n_regions, length
 ):

--- a/nilearn/maskers/tests/test_nifti_labels_masker.py
+++ b/nilearn/maskers/tests/test_nifti_labels_masker.py
@@ -523,36 +523,6 @@ def test_nifti_labels_masker_resampling_to_labels(
     assert fmri11_img_r.shape == ((*masker.labels_img_.shape[:3], length))
 
 
-@pytest.mark.ai_generated
-def test_nifti_labels_masker_resampling_list_to_labels(affine_eye):
-    """Test resampling a list of 3D images to labels."""
-    labels = np.zeros((2, 2, 2), dtype=np.int8)
-    labels[1, ...] = 1
-    labels_affine = affine_eye.copy()
-    labels_affine[:3, 3] = 1
-    labels_img = Nifti1Image(labels, labels_affine)
-
-    imgs = []
-    for value in (1.0, 2.0):
-        data = np.full((4, 4, 4), value)
-        data[0, 0, :2] = (value + 1, value + 2)
-        imgs.append(Nifti1Image(data, affine_eye))
-
-    masker = NiftiLabelsMasker(
-        labels_img,
-        resampling_target="labels",
-        standardize=None,
-    )
-
-    with pytest.warns(
-        UserWarning, match="Resampling images at transform time"
-    ):
-        signals = masker.fit_transform(imgs)
-
-    assert signals.shape == (2, 1)
-    assert_almost_equal(signals, [[1.0], [2.0]])
-
-
 def test_nifti_labels_masker_resampling_to_clipped_labels(
     affine_eye, shape_3d_default, n_regions, length
 ):


### PR DESCRIPTION
- Closes #6497

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- Normalize Niimg iterables before comparing their field of view when `resampling_target="labels"`.
- Update the shared masker resampling estimator check to exercise a list containing a 3D image with a different field of view.
- Preserve the existing resampling warning behavior for labels and maps maskers.

Root cause:

`transform_single_imgs` passed the original input directly to `check_same_fov` in the labels-target branch. For a list of 3D images, that input has no `shape` or `affine`. The data-target branch already normalized the input with `check_niimg(..., atleast_4d=True)` before its field-of-view comparison; this change applies the same established normalization to the labels-target branch.

Validation:

- `pytest -q nilearn/maskers/tests/test_nifti_labels_masker.py nilearn/maskers/tests/test_nifti_maps_masker.py` (341 passed, 66 xfailed)
- shared `check_masker_transform_resampling` checks for both masker classes (4 passed)
- pre-commit hooks for the modified files