### PR TITLE
[FIX] Improve tested_vars validation in permuted_ols

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -20,6 +20,8 @@ NEW
 Fixes
 -----
 
+- :bdg-dark:`Code` Clarify that :func:`~mass_univariate.permuted_ols` requires numerical ``tested_vars`` and raise a clear error for non-numerical data (:gh:`6501` by `Mohammad Sadeghi Hardengi`_).
+
 - :bdg-dark:`Code` Fix :class:`~maskers.NiftiLabelsMasker` raising an ``AttributeError`` when transforming a list of 3D images with ``resampling_target="labels"`` (:gh:`6498` by `Mohammad Sadeghi Hardengi`_).
 
 - :bdg-success:`API` Fix mismatch between parameters in several functions or methods and their docstrings. Also adds an ``interpolation`` parameter to :func:`~.datasets.fetch_neurovault` that was documented but missing from the API (:gh:`6482` by `Rémi Gau`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -20,7 +20,7 @@ NEW
 Fixes
 -----
 
-- :bdg-dark:`Code` Clarify that :func:`~mass_univariate.permuted_ols` requires numerical ``tested_vars`` and raise a clear error for non-numerical data (:gh:`6501` by `Mohammad Sadeghi Hardengi`_).
+- :bdg-dark:`Code` Clarify that :func:`~mass_univariate.permuted_ols` requires numerical or boolean ``tested_vars`` and raise a clear error for unsupported data (:gh:`6501` by `Mohammad Sadeghi Hardengi`_).
 
 - :bdg-dark:`Code` Fix :class:`~maskers.NiftiLabelsMasker` raising an ``AttributeError`` when transforming a list of 3D images with ``resampling_target="labels"`` (:gh:`6498` by `Mohammad Sadeghi Hardengi`_).
 

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -380,8 +380,8 @@ def permuted_ols(
     Parameters
     ----------
     tested_vars : array-like, shape=(n_samples, n_regressors)
-        Numerical explanatory variates, fitted and tested independently from
-        each others.
+        Numerical or boolean explanatory variates, fitted and tested
+        independently from each others.
 
     target_vars : array-like, shape=(n_samples, n_descriptors)
         :term:`fMRI` data to analyze according
@@ -944,7 +944,9 @@ def _sanitize_inputs_permuted_ols(
         np.issubdtype(tested_vars.dtype, np.number)
         or np.issubdtype(tested_vars.dtype, np.bool_)
     ):
-        raise TypeError("'tested_vars' must contain numerical values.")
+        raise TypeError(
+            "'tested_vars' must contain numerical or boolean values."
+        )
 
     # check n_jobs (number of CPUs)
     if n_jobs < 0:

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -380,7 +380,7 @@ def permuted_ols(
     Parameters
     ----------
     tested_vars : array-like, shape=(n_samples, n_regressors)
-        Numerical or boolean explanatory variates, fitted and tested
+        Numerical or boolean labels for explanatory variates; fitted and tested 
         independently of each other.
 
     target_vars : array-like, shape=(n_samples, n_descriptors)

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -380,7 +380,8 @@ def permuted_ols(
     Parameters
     ----------
     tested_vars : array-like, shape=(n_samples, n_regressors)
-        Explanatory variates, fitted and tested independently from each others.
+        Numerical explanatory variates, fitted and tested independently from
+        each others.
 
     target_vars : array-like, shape=(n_samples, n_descriptors)
         :term:`fMRI` data to analyze according
@@ -938,6 +939,13 @@ def _check_inputs_permuted_ols(
 def _sanitize_inputs_permuted_ols(
     n_jobs, output_type, tfce, threshold, target_vars, tested_vars
 ):
+    tested_vars = np.asanyarray(tested_vars)
+    if not (
+        np.issubdtype(tested_vars.dtype, np.number)
+        or np.issubdtype(tested_vars.dtype, np.bool_)
+    ):
+        raise TypeError("'tested_vars' must contain numerical values.")
+
     # check n_jobs (number of CPUs)
     if n_jobs < 0:
         n_jobs = max(1, joblib.cpu_count() - int(n_jobs) + 1)

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -381,7 +381,7 @@ def permuted_ols(
     ----------
     tested_vars : array-like, shape=(n_samples, n_regressors)
         Numerical or boolean explanatory variates, fitted and tested
-        independently from each others.
+        independently of each other.
 
     target_vars : array-like, shape=(n_samples, n_descriptors)
         :term:`fMRI` data to analyze according

--- a/nilearn/mass_univariate/permuted_least_squares.py
+++ b/nilearn/mass_univariate/permuted_least_squares.py
@@ -380,7 +380,7 @@ def permuted_ols(
     Parameters
     ----------
     tested_vars : array-like, shape=(n_samples, n_regressors)
-        Numerical or boolean labels for explanatory variates; fitted and tested 
+        Numerical or boolean labels for explanatory variates; fitted and tested
         independently of each other.
 
     target_vars : array-like, shape=(n_samples, n_descriptors)

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -959,9 +959,20 @@ def test_permuted_ols_non_numerical_tested_vars_error(dummy_design):
     tested_var = np.resize(["face", "house"], target_var.shape[0])
 
     with pytest.raises(
-        TypeError, match="'tested_vars' must contain numerical values"
+        TypeError,
+        match="'tested_vars' must contain numerical or boolean values",
     ):
         permuted_ols(tested_var, target_var, n_perm=0)
+
+
+def test_permuted_ols_boolean_tested_vars(dummy_design):
+    """Check that boolean tested variables are supported."""
+    target_var, *_ = dummy_design
+    tested_var = np.resize([True, False], target_var.shape[0])
+
+    output = permuted_ols(tested_var, target_var, n_perm=0)
+
+    assert output["t"].shape == (1, target_var.shape[1])
 
 
 def test_permuted_ols_type_n_perm(dummy_design):

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -953,7 +953,6 @@ def test_permuted_ols_target_vars_error(dummy_design):
         )
 
 
-@pytest.mark.ai_generated
 def test_permuted_ols_non_numerical_tested_vars_error(dummy_design):
     """Check that tested variables contain numerical values."""
     target_var, *_ = dummy_design

--- a/nilearn/mass_univariate/tests/test_permuted_least_squares.py
+++ b/nilearn/mass_univariate/tests/test_permuted_least_squares.py
@@ -953,6 +953,18 @@ def test_permuted_ols_target_vars_error(dummy_design):
         )
 
 
+@pytest.mark.ai_generated
+def test_permuted_ols_non_numerical_tested_vars_error(dummy_design):
+    """Check that tested variables contain numerical values."""
+    target_var, *_ = dummy_design
+    tested_var = np.resize(["face", "house"], target_var.shape[0])
+
+    with pytest.raises(
+        TypeError, match="'tested_vars' must contain numerical values"
+    ):
+        permuted_ols(tested_var, target_var, n_perm=0)
+
+
 def test_permuted_ols_type_n_perm(dummy_design):
     """Checks type n_perm."""
     target_var, tested_var, *_ = dummy_design


### PR DESCRIPTION
- Closes #6488

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- Document that `tested_vars` must contain numerical explanatory variates.
- Validate `tested_vars` near the public API boundary and report a clear error for non-numerical data.
- Add regression coverage for non-numerical input while preserving existing numerical and one-dimensional input behavior.

Tests:

- `.venv/bin/pytest -q nilearn/mass_univariate/tests/test_permuted_least_squares.py`
- `.venv/bin/prek run --files nilearn/mass_univariate/permuted_least_squares.py nilearn/mass_univariate/tests/test_permuted_least_squares.py`
