### PR TITLE
[FIX] view_img displays the mirrored sagittal slice in radiological view

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -78,6 +78,7 @@ Some other past or present contributors are:
 * `Bertrand Thirion`_: Inria, Saclay, France
 * `Binh Nguyen`_
 * `Caglar Cakan`_: Technische Universität Berlin, Berlin, Germany
+* `Cedric Conday`_
 * `Chloe Hampson`_: Florida International University, Miami, United States
 * `Chris Rorden`_: University of South Carolina, USA
 * `Chris Gorgolewski`_: Google LLC

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -171,6 +171,9 @@ authors:
     website: https://github.com/caglorithm
     affiliation: Technische Universität Berlin, Berlin, Germany
     orcid: https://orcid.org/0000-0002-1902-5393
+  - given-names: Cedric
+    family-names: Conday
+    website: https://github.com/CedricConday
   - given-names: Chloe
     family-names: Hampson
     website: https://github.com/chlohamp

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -20,6 +20,8 @@ NEW
 Fixes
 -----
 
+- :bdg-info:`Plotting` Fix :func:`~plotting.view_img` displaying the mirrored sagittal slice in radiological view, because ``_data_to_sprite`` reverses the sagittal axis of the sprite while the slice index and affine handed to the viewer were left unflipped; a cut requested at ``x = +45`` showed the slice lying at ``x = -45``, labelled with the requested coordinate (:gh:`6134` by `Cedric Conday`_).
+
 - :bdg-dark:`Code` Fix :class:`~maskers.NiftiLabelsMasker` raising an ``AttributeError`` when transforming a list of 3D images with ``resampling_target="labels"`` (:gh:`6498` by `Mohammad Sadeghi Hardengi`_).
 
 - :bdg-success:`API` Fix mismatch between parameters in several functions or methods and their docstrings. Also adds an ``interpolation`` parameter to :func:`~.datasets.fetch_neurovault` that was documented but missing from the API (:gh:`6482` by `Rémi Gau`_).

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -20,7 +20,7 @@ NEW
 Fixes
 -----
 
-- :bdg-info:`Plotting` Fix :func:`~plotting.view_img` displaying the mirrored sagittal slice in radiological view, because ``_data_to_sprite`` reverses the sagittal axis of the sprite while the slice index and affine handed to the viewer were left unflipped; a cut requested at ``x = +45`` showed the slice lying at ``x = -45``, labelled with the requested coordinate (:gh:`6502` by `Cedric Conday`_).
+- :bdg-info:`Plotting` Fix :func:`~plotting.view_img` displaying the mirrored sagittal slice in radiological view, because ``_data_to_sprite`` reverses the sagittal axis of the sprite while the slice index and affine handed to the viewer were left unflipped; a cut requested at ``x = +45`` showed the slice lying at ``x = -45``, labeled with the requested coordinate (:gh:`6502` by `Cedric Conday`_).
 
 - :bdg-dark:`Code` Fix :class:`~maskers.NiftiLabelsMasker` raising an ``AttributeError`` when transforming a list of 3D images with ``resampling_target="labels"`` (:gh:`6498` by `Mohammad Sadeghi Hardengi`_).
 

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -20,7 +20,7 @@ NEW
 Fixes
 -----
 
-- :bdg-info:`Plotting` Fix :func:`~plotting.view_img` displaying the mirrored sagittal slice in radiological view, because ``_data_to_sprite`` reverses the sagittal axis of the sprite while the slice index and affine handed to the viewer were left unflipped; a cut requested at ``x = +45`` showed the slice lying at ``x = -45``, labelled with the requested coordinate (:gh:`6134` by `Cedric Conday`_).
+- :bdg-info:`Plotting` Fix :func:`~plotting.view_img` displaying the mirrored sagittal slice in radiological view, because ``_data_to_sprite`` reverses the sagittal axis of the sprite while the slice index and affine handed to the viewer were left unflipped; a cut requested at ``x = +45`` showed the slice lying at ``x = -45``, labelled with the requested coordinate (:gh:`6502` by `Cedric Conday`_).
 
 - :bdg-dark:`Code` Fix :class:`~maskers.NiftiLabelsMasker` raising an ``AttributeError`` when transforming a list of 3D images with ``resampling_target="labels"`` (:gh:`6498` by `Mohammad Sadeghi Hardengi`_).
 

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -63,6 +63,8 @@
 
 .. _Caglar Cakan: https://github.com/caglorithm
 
+.. _Cedric Conday: https://github.com/CedricConday
+
 .. _Chloe Hampson: https://github.com/chlohamp
 
 .. _Chris Rorden: https://github.com/neurolabusc

--- a/nilearn/plotting/html_stat_map.py
+++ b/nilearn/plotting/html_stat_map.py
@@ -407,6 +407,21 @@ def _json_view_params(
     if type(vmax).__module__ == "numpy":
         vmax = vmax.tolist()  # json does not deal with numpy array
 
+    # In radiological view, ``_data_to_sprite`` reverses the sagittal axis,
+    # so sprite slice ``i`` holds voxel ``n_x - 1 - i``. The viewer derives
+    # world coordinates as ``affine @ [numSlice + 1, ...]`` and applies no
+    # radiological correction of its own, so the slice index and the affine
+    # are both flipped here. Without this the reported coordinates describe
+    # the mirrored slice, placing every cut in the opposite hemisphere.
+    x_slice = cut_slices[0] - 1
+    if radiological:
+        n_x = shape[0]
+        x_slice = n_x - 1 - x_slice
+        flip_x = np.eye(4)
+        flip_x[0, 0] = -1.0
+        flip_x[0, 3] = n_x + 1.0
+        affine = affine @ flip_x
+
     params = {
         "canvas": html_ids["canvas"],
         "sprite": html_ids["sprite"],
@@ -424,7 +439,7 @@ def _json_view_params(
         "title": title,
         "flagValue": value,
         "numSlice": {
-            "X": cut_slices[0] - 1,
+            "X": x_slice,
             "Y": cut_slices[1] - 1,
             "Z": cut_slices[2] - 1,
         },

--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -289,6 +289,104 @@ def test_json_view_params(affine_eye):
     assert params["colorMap"]["img"] == "colorMap-test-viewer"
 
 
+def _radiological_test_img():
+    """Build an image whose voxel values encode their own x index."""
+    shape = (32, 32, 32)
+    affine = np.diag([-3.0, 3.0, 3.0, 1.0])
+    affine[:3, 3] = [48.0, -48.0, -48.0]
+    data = np.zeros(shape, dtype="float32")
+    for i in range(shape[0]):
+        data[i, :, :] = i
+    return Nifti1Image(data, affine), data, shape, affine
+
+
+def _displayed_slice(data, params, radiological):
+    """Return the volume slice the viewer actually puts on screen.
+
+    ``_data_to_sprite`` lays the sagittal slices out row by row, and
+    ``brainsprite.js`` picks the tile at index ``numSlice["X"]``.
+    """
+    sprite = _data_to_sprite(data, radiological=radiological)
+    n_x, n_y, n_z = data.shape
+    n_rows = int(np.ceil(np.sqrt(n_x)))
+    n_columns = int(np.ceil(n_x / float(n_rows)))
+    tile = int(params["numSlice"]["X"])
+    row, column = tile // n_columns, tile % n_columns
+    block = sprite[
+        row * n_z : (row + 1) * n_z, column * n_y : (column + 1) * n_y
+    ]
+    return int(block.max())
+
+
+def _params_for_cut(shape, affine, img, cut_x, radiological):
+    """Build viewer parameters for a sagittal cut at ``cut_x``."""
+    cut_slices = _get_cut_slices(
+        img, cut_coords=[cut_x, 0.0, 0.0], threshold=None
+    )
+    return _json_view_params(
+        shape,
+        affine,
+        vmin=0,
+        vmax=1,
+        cut_slices=cut_slices,
+        html_ids=_get_brainsprite_html_ids("test-viewer"),
+        radiological=radiological,
+    )
+
+
+@pytest.mark.ai_generated
+@pytest.mark.parametrize("cut_x", [-45.0, -15.0, 0.0, 15.0, 45.0])
+def test_json_view_params_radiological_shows_same_slice(cut_x):
+    """Both views must display the same slice for the same cut.
+
+    Regression test for https://github.com/nilearn/nilearn/issues/6134.
+    ``_data_to_sprite`` reverses the sagittal axis in radiological view,
+    so the tile at ``numSlice["X"]`` holds voxel ``n_x - 1 - X``. The
+    slice index was not flipped to match, so a cut requested at
+    ``x = +45`` displayed the slice lying at ``x = -45`` instead.
+    """
+    img, data, shape, affine = _radiological_test_img()
+
+    neurological = _params_for_cut(shape, affine, img, cut_x, False)
+    radiological = _params_for_cut(shape, affine, img, cut_x, True)
+
+    assert _displayed_slice(data, radiological, True) == _displayed_slice(
+        data, neurological, False
+    )
+
+
+@pytest.mark.ai_generated
+@pytest.mark.parametrize("cut_x", [-45.0, -15.0, 15.0, 45.0])
+def test_json_view_params_radiological_keeps_hemisphere(cut_x):
+    """A cut must stay in the hemisphere it was requested in.
+
+    Regression test for https://github.com/nilearn/nilearn/issues/6134.
+    Because the sagittal axis was reversed for the sprite but not for the
+    slice index, a cut requested at ``x = +45`` displayed the slice lying
+    at ``x = -45``, labelled with the requested coordinate.
+    """
+    img, data, shape, affine = _radiological_test_img()
+
+    params = _params_for_cut(shape, affine, img, cut_x, True)
+    voxel = _displayed_slice(data, params, True)
+    world_x = (affine @ np.array([voxel, 0.0, 0.0, 1.0]))[0]
+
+    assert np.sign(world_x) == np.sign(cut_x)
+
+
+@pytest.mark.ai_generated
+def test_json_view_params_neurological_unchanged():
+    """The neurological view must be left untouched by the fix."""
+    img, _, shape, affine = _radiological_test_img()
+    cut_slices = _get_cut_slices(
+        img, cut_coords=[15.0, 0.0, 0.0], threshold=None
+    )
+    params = _params_for_cut(shape, affine, img, 15.0, False)
+
+    assert np.array_equal(np.asarray(params["affine"]), affine)
+    assert params["numSlice"]["X"] == cut_slices[0] - 1
+
+
 def test_json_view_size():
     """Check that _json_view_size computes the expected viewer dimensions."""
     # Build some minimal sprite Parameters

--- a/nilearn/plotting/tests/test_html_stat_map.py
+++ b/nilearn/plotting/tests/test_html_stat_map.py
@@ -363,7 +363,7 @@ def test_json_view_params_radiological_keeps_hemisphere(cut_x):
     Regression test for https://github.com/nilearn/nilearn/issues/6134.
     Because the sagittal axis was reversed for the sprite but not for the
     slice index, a cut requested at ``x = +45`` displayed the slice lying
-    at ``x = -45``, labelled with the requested coordinate.
+    at ``x = -45``, labeled with the requested coordinate.
     """
     img, data, shape, affine = _radiological_test_img()
 


### PR DESCRIPTION
- Closes #6134

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- Flip the sagittal slice index and the affine handed to the viewer when `radiological=True`, so the slice on screen is the one that was requested. `_data_to_sprite` reverses the sagittal axis for the sprite, so tile `i` holds voxel `n_x - 1 - i`, but `_json_view_params` passed `numSlice["X"]` and `affine` through unchanged. `brainsprite.js` derives the displayed coordinates as `affine @ [numSlice + 1, ...]` and applies no radiological correction of its own, so the reported coordinate described the mirrored slice. A cut requested at `x = +45` displayed the slice lying at `x = -45`, labelled `+45`; the error grows with distance from the midline.
- Add regression tests covering both symptoms: that radiological and neurological view select the same slice for the same cut, and that a cut stays in the hemisphere it was requested in. Both fail on `main`.
- The neurological path is untouched: the affine and slice index are only modified when `radiological=True`, and a test asserts that.

One thing I noticed but deliberately left alone, since it is not what this issue is about: the label describes voxel `numSlice["X"] + 1` while the tile shows voxel `numSlice["X"]`, so there is a one-voxel offset between the two. It is identical in both views and predates this change. Happy to open a separate issue if that is worth pursuing.
