### PR TITLE
[MAINT] Add return type annotations to nilearn.plotting.matrix

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -115,6 +115,7 @@ Some other past or present contributors are:
 * `Gustav Magnusson`_: Linköping University, Linköping
 * `Hande Gözükan`_: Inria, Saclay, France
 * `Hao-Ting Wang`_: Montréal Geriatrics Institute (CRIUGM), Montréal, Canada
+* `Hariom Patidar`_
 * `Himanshu Aggarwal`_: Inria, Saclay, France
 * `Hugo Delhaye`_: SIMEXP, Université de Montréal, Montréal, Canada
 * `Ian Abenes`_

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -348,6 +348,9 @@ authors:
     affiliation: Montréal Geriatrics Institute (CRIUGM), Montréal, Canada
     email: wang.hao-ting@criugm.qc.ca
     orcid: https://orcid.org/0000-0003-4078-2038
+  - given-names: Hariom
+    family-names: Patidar
+    website: https://github.com/HariomPtdr
   - given-names: Himanshu
     family-names: Aggarwal
     website: https://github.com/man-shu

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -62,7 +62,7 @@ Enhancements
 
 - :bdg-dark:`Code` Improve type annotations (and :obj:`~typing.overload` signatures where the return type depends on the arguments given) in :mod:`nilearn.glm` (:gh:`6370`), :mod:`nilearn.regions` (:gh:`6369`), :mod:`nilearn.connectome` (:gh:`6368`), :mod:`nilearn.reporting` (:gh:`6368`), :mod:`nilearn.interfaces` (:gh:`6362`), :mod:`nilearn.image` (:gh:`6408`, :gh:`6438`), :mod:`nilearn.utils`, :mod:`nilearn.surface` (:gh:`6410`), :mod:`nilearn.datasets`  (:gh:`6438`),  :mod:`nilearn.plotting` (:gh:`6438` and :gh:`6439`),  :mod:`nilearn.glm` and :mod:`nilearn.mass_univariate` (:gh:`6439`) (by `Rémi Gau`_).
 
-- :bdg-dark:`Code` Add return type annotations and ``Returns`` docstring sections to the private helpers of :mod:`nilearn.plotting` matrix utilities (:gh:`PRNUM` by `Hariom Patidar`_).
+- :bdg-dark:`Code` Add return type annotations and ``Returns`` docstring sections to the private helpers of :mod:`nilearn.plotting` matrix utilities (:gh:`6510` by `Hariom Patidar`_).
 
 - :bdg-primary:`Doc` Add ``Examples`` docstring sections for one function in the public API: :func:`~nilearn.masking.compute_epi_mask` (:gh:`6306` by `Marco Flores`_).
 

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -62,6 +62,8 @@ Enhancements
 
 - :bdg-dark:`Code` Improve type annotations (and :obj:`~typing.overload` signatures where the return type depends on the arguments given) in :mod:`nilearn.glm` (:gh:`6370`), :mod:`nilearn.regions` (:gh:`6369`), :mod:`nilearn.connectome` (:gh:`6368`), :mod:`nilearn.reporting` (:gh:`6368`), :mod:`nilearn.interfaces` (:gh:`6362`), :mod:`nilearn.image` (:gh:`6408`, :gh:`6438`), :mod:`nilearn.utils`, :mod:`nilearn.surface` (:gh:`6410`), :mod:`nilearn.datasets`  (:gh:`6438`),  :mod:`nilearn.plotting` (:gh:`6438` and :gh:`6439`),  :mod:`nilearn.glm` and :mod:`nilearn.mass_univariate` (:gh:`6439`) (by `Rémi Gau`_).
 
+- :bdg-dark:`Code` Add return type annotations and ``Returns`` docstring sections to the private helpers of :mod:`nilearn.plotting` matrix utilities (:gh:`PRNUM` by `Hariom Patidar`_).
+
 - :bdg-primary:`Doc` Add ``Examples`` docstring sections for one function in the public API: :func:`~nilearn.masking.compute_epi_mask` (:gh:`6306` by `Marco Flores`_).
 
 - :bdg-primary:`Doc` Add ``Examples`` docstring section to :func:`~nilearn.utils.all_displays`, :func:`~nilearn.utils.all_estimators`, :func:`~nilearn.utils.all_functions` (:gh:`6322`, :gh:`6324`, :gh:`6325` by `Alice Schiavone`_).

--- a/doc/changes/names.rst
+++ b/doc/changes/names.rst
@@ -137,6 +137,8 @@
 
 .. _Hao-Ting Wang: https://wanghaoting.com/
 
+.. _Hariom Patidar: https://github.com/HariomPtdr
+
 .. _Himanshu Aggarwal: https://github.com/man-shu
 
 .. _Hugo Delhaye: https://github.com/HugoDelhaye

--- a/nilearn/plotting/matrix/_utils.py
+++ b/nilearn/plotting/matrix/_utils.py
@@ -11,11 +11,17 @@ VALID_REORDER_VALUES = (True, False, "single", "complete", "average")
 VALID_TRI_VALUES = ("full", "lower", "diag")
 
 
-def mask_matrix(mat, tri):
+def mask_matrix(mat, tri) -> np.ma.MaskedArray:
     """Help for plot_matrix.
 
     This function masks the matrix depending on the provided
     value of ``tri``.
+
+    Returns
+    -------
+    :class:`numpy.ma.MaskedArray`
+        The input matrix with the requested triangle masked out.
+
     """
     if tri == "lower":
         mask = np.tri(mat.shape[0], k=-1, dtype=bool) ^ True
@@ -24,7 +30,7 @@ def mask_matrix(mat, tri):
     return np.ma.masked_array(mat, mask)
 
 
-def pad_contrast_matrix(contrast_def, design_matrix):
+def pad_contrast_matrix(contrast_def, design_matrix) -> np.ndarray:
     """Pad contrasts with zeros.
 
     Parameters
@@ -72,8 +78,15 @@ def pad_contrast_matrix(contrast_def, design_matrix):
     return contrast_def
 
 
-def sanitize_labels(mat_shape, labels):
-    """Help for plot_matrix."""
+def sanitize_labels(mat_shape, labels) -> list | None:
+    """Help for plot_matrix.
+
+    Returns
+    -------
+    :obj:`list` or None
+        The labels as a list, or None if no non-empty label was passed.
+
+    """
     # we need a list so an empty one will be cast to False
     if isinstance(labels, np.ndarray):
         labels = labels.tolist()
@@ -88,8 +101,16 @@ def sanitize_labels(mat_shape, labels):
     return labels
 
 
-def sanitize_reorder(reorder):
-    """Help for plot_matrix."""
+def sanitize_reorder(reorder) -> str | bool:
+    """Help for plot_matrix.
+
+    Returns
+    -------
+    :obj:`str` or :obj:`bool`
+        The validated ``reorder`` value,
+        with ``True`` replaced by the default ``"average"`` method.
+
+    """
     if reorder not in VALID_REORDER_VALUES:
         param_to_print = []
         for item in VALID_REORDER_VALUES:
@@ -112,10 +133,19 @@ def sanitize_tri(tri, allowed_values=None) -> None:
     check_parameter_in_allowed(tri, allowed_values, "tri")
 
 
-def reorder_matrix(mat, labels, reorder):
+def reorder_matrix(mat, labels, reorder) -> tuple[np.ndarray, list]:
     """Help for plot_matrix.
 
     This function reorders the provided matrix.
+
+    Returns
+    -------
+    mat : :class:`numpy.ndarray`
+        The reordered matrix.
+
+    labels : :obj:`list`
+        The labels reordered to match the matrix.
+
     """
     if not labels:
         raise ValueError("Labels are needed to show the reordering.")

--- a/nilearn/plotting/matrix/matrix_plotting.py
+++ b/nilearn/plotting/matrix/matrix_plotting.py
@@ -52,7 +52,7 @@ def _configure_axis(
             label.set_rotation(y_label_rotation)
 
 
-def _configure_grid(axes, tri, size):
+def _configure_grid(axes, tri, size) -> None:
     """Help for plot_matrix."""
     # Different grids for different layouts
     if tri == "lower":
@@ -106,8 +106,22 @@ def _fit_axes(axes) -> None:
         axes.set_position(new_position)
 
 
-def _sanitize_figure_and_axes(figure, axes):
-    """Help for plot_matrix."""
+def _sanitize_figure_and_axes(figure, axes) -> tuple[Figure, Axes, bool]:
+    """Help for plot_matrix.
+
+    Returns
+    -------
+    fig : :class:`matplotlib.figure.Figure`
+        The figure to plot on.
+
+    axes : :class:`matplotlib.axes.Axes`
+        The axes to plot on.
+
+    own_fig : :obj:`bool`
+        Whether the figure was created here
+        rather than passed in by the caller.
+
+    """
     if axes is not None and figure is not None:
         raise ValueError(
             "Parameters figure and axes cannot be specified together. "
@@ -138,10 +152,29 @@ def _sanitize_figure_and_axes(figure, axes):
 
 def _sanitize_inputs_plot_matrix(
     mat_shape, tri, labels, reorder, figure, axes
-):
+) -> tuple[list | None, str | bool, Figure, Axes, bool]:
     """Help for plot_matrix.
 
     This function makes sure the inputs to plot_matrix are valid.
+
+    Returns
+    -------
+    labels : :obj:`list` or None
+        The validated labels.
+
+    reorder : :obj:`str` or :obj:`bool`
+        The validated ``reorder`` value.
+
+    fig : :class:`matplotlib.figure.Figure`
+        The figure to plot on.
+
+    axes : :class:`matplotlib.axes.Axes`
+        The axes to plot on.
+
+    own_fig : :obj:`bool`
+        Whether the figure was created here
+        rather than passed in by the caller.
+
     """
     sanitize_tri(tri)
     labels = sanitize_labels(mat_shape, labels)

--- a/nilearn/plotting/matrix/matrix_plotting.py
+++ b/nilearn/plotting/matrix/matrix_plotting.py
@@ -58,21 +58,25 @@ def _configure_grid(axes, tri, size) -> None:
     if tri == "lower":
         for i in range(size):
             # Correct for weird mis-sizing
-            i = 1.001 * i
-            axes.plot([i + 0.5, i + 0.5], [size - 0.5, i + 0.5], color="gray")
-            axes.plot([i + 0.5, -0.5], [i + 0.5, i + 0.5], color="gray")
+            pos = 1.001 * i
+            axes.plot(
+                [pos + 0.5, pos + 0.5], [size - 0.5, pos + 0.5], color="gray"
+            )
+            axes.plot([pos + 0.5, -0.5], [pos + 0.5, pos + 0.5], color="gray")
     elif tri == "diag":
         for i in range(size):
             # Correct for weird mis-sizing
-            i = 1.001 * i
-            axes.plot([i + 0.5, i + 0.5], [size - 0.5, i - 0.5], color="gray")
-            axes.plot([i + 0.5, -0.5], [i - 0.5, i - 0.5], color="gray")
+            pos = 1.001 * i
+            axes.plot(
+                [pos + 0.5, pos + 0.5], [size - 0.5, pos - 0.5], color="gray"
+            )
+            axes.plot([pos + 0.5, -0.5], [pos - 0.5, pos - 0.5], color="gray")
     else:
         for i in range(size):
             # Correct for weird mis-sizing
-            i = 1.001 * i
-            axes.plot([i + 0.5, i + 0.5], [size - 0.5, -0.5], color="gray")
-            axes.plot([size - 0.5, -0.5], [i + 0.5, i + 0.5], color="gray")
+            pos = 1.001 * i
+            axes.plot([pos + 0.5, pos + 0.5], [size - 0.5, -0.5], color="gray")
+            axes.plot([size - 0.5, -0.5], [pos + 0.5, pos + 0.5], color="gray")
 
 
 def _fit_axes(axes) -> None:
@@ -273,11 +277,11 @@ def plot_matrix(
 
     """
     check_params(locals())
-    labels, reorder, fig, axes, _ = _sanitize_inputs_plot_matrix(
+    labels, reorder_method, fig, axes, _ = _sanitize_inputs_plot_matrix(
         mat.shape, tri, labels, reorder, figure, axes
     )
-    if reorder:
-        mat, labels = reorder_matrix(mat, labels, reorder)
+    if reorder_method:
+        mat, labels = reorder_matrix(mat, labels, reorder_method)
     if tri != "full":
         mat = mask_matrix(mat, tri)
 


### PR DESCRIPTION
## Changes proposed in this pull request

Adds return type annotations and the corresponding `Returns` docstring sections to the helper functions in `nilearn/plotting/matrix/`.

This continues the ongoing type-annotation effort (:gh:`6272`, :gh:`6408`, :gh:`6410`, :gh:`6439`, ...). `nilearn/plotting/matrix/` was still outstanding.

**`nilearn/plotting/matrix/_utils.py`**
- `mask_matrix` -> `np.ma.MaskedArray`
- `pad_contrast_matrix` -> `np.ndarray`
- `sanitize_labels` -> `list | None`
- `sanitize_reorder` -> `str | bool`
- `reorder_matrix` -> `tuple[np.ndarray, list]`

**`nilearn/plotting/matrix/matrix_plotting.py`**
- `_configure_grid` -> `None`
- `_sanitize_figure_and_axes` -> `tuple[Figure, Axes, bool]`
- `_sanitize_inputs_plot_matrix` -> `tuple[list | None, str | bool, Figure, Axes, bool]`

There is no behaviour change; only annotations and docstrings are touched.

## Checks

- `maint_tools/check_docstrings.py` no longer reports any finding for `nilearn/plotting/matrix` (15 before, 0 after)
- `pytest nilearn/plotting/matrix/tests/` — 50 passed
- `ruff check` and `ruff format --check` pass

Happy to adjust the wording of any of the `Returns` sections, or to narrow the annotations further (for example using `Literal` for `sanitize_reorder`) if you prefer.

This is my first contribution to nilearn, so please let me know if I have missed a step.

## AI assistance declaration

I used an AI coding assistant (Claude Code) while preparing this PR. I have
reviewed the diff, understand each change, and can explain the reasoning behind
it — in particular why adding return type annotations to these helpers caused
mypy to start checking their bodies (mypy skips the bodies of unannotated
functions by default) and so surfaced the two pre-existing type errors fixed
here: the loop variable rebound from `int` to `float` in `_configure_grid`, and
`plot_matrix` rebinding its `reorder` parameter (annotated `bool`) with the
sanitized value, which can be a `str`.

Flagging one thing I deliberately left alone: `plot_matrix` annotates
`reorder: bool`, but the parameter genuinely accepts `"single"`, `"complete"`
and `"average"` as well. That annotation looks incorrect to me, but fixing it
changes a public signature, so it felt out of scope here. Happy to open a
follow-up PR for it if you agree.
