### PR TITLE
[FIX] Clean non-finite surface values in smooth_img

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -42,6 +42,8 @@ Fixes
 
 - :bdg-dark:`Code` Fix :func:`~image.smooth_img` and ``smooth_array`` truncating the smoothed signal for unsigned integer input, because only signed integers were promoted to float before ``gaussian_filter1d`` wrote its float result back into the input buffer in place; unsigned is the common case since ``uint8`` is the standard on-disk dtype for masks and atlases (:gh:`6440` by `Andrew Chen`_).
 
+- :bdg-dark:`Code` Fix :func:`~image.smooth_img` leaving non-finite values in surface images untouched, so surface and volume inputs now share the documented finite-value behavior (:gh:`6487` by `AtomicGlance <https://github.com/AtomicGlance>`_).
+
 - :bdg-dark:`Code` Fix ``examples/04_glm_first_level/plot_bids_features.py``, ``doc/get_data_examples.py``, and ``doc/visual_testing/reporter_visual_inspection_suite.py`` downloading the full FSL derivatives for the ``bart`` and ``taskswitch`` tasks of the ``ds000030`` dataset in addition to ``stopsignal``, because the ``*task-task*`` exclusion filter did not match the ``derivatives/task/sub-*/taskswitch.feat`` folder name; switch to ``inclusion_filters`` to only fetch the files needed for the ``stopsignal`` analysis (:gh:`6432` by `Rémi Gau`_).
 
 - :bdg-dark:`Code` Fix :func:`~interfaces.bids.get_bids_files` missing subject-level anatomical derivatives in multi-session datasets (:gh:`6291` by `Mohammad Sadeghi Hardengi`_).

--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -560,7 +560,8 @@ def _smooth_surface_img(
     new_data = {}
     for hemi, n_iter in zip(img.mesh.parts, iterations, strict=False):
         mesh = img.mesh.parts[hemi]
-        data = img.data.parts[hemi]
+        data = img.data.parts[hemi].copy()
+        ensure_finite_data(data, raise_warning=False)
 
         if n_iter == 0:
             new_data[hemi] = data

--- a/nilearn/image/tests/test_image.py
+++ b/nilearn/image/tests/test_image.py
@@ -491,6 +491,27 @@ def test_smooth_img_surface(surf_img_1d):
     assert data.var() > smoothed_data.var()
 
 
+@pytest.mark.ai_generated
+@pytest.mark.parametrize("fwhm", [None, 0, 5])
+def test_smooth_img_surface_non_finite_values_are_replaced(surf_img_1d, fwhm):
+    """Replace non-finite surface values without modifying the input."""
+    data = {
+        hemi: values.copy() for hemi, values in surf_img_1d.data.parts.items()
+    }
+    data["left"][0] = np.nan
+    data["right"][1] = np.inf
+    img = SurfaceImage(surf_img_1d.mesh, data)
+
+    smoothed_img = smooth_img(img, fwhm=fwhm)
+
+    assert all(
+        np.isfinite(values).all()
+        for values in smoothed_img.data.parts.values()
+    )
+    assert np.isnan(img.data.parts["left"][0])
+    assert np.isinf(img.data.parts["right"][1])
+
+
 def test_smooth_list_img_surface(surf_img_1d):
     """Test smoothing list surface images."""
     smooth_ref = smooth_img(surf_img_1d, fwhm=5)


### PR DESCRIPTION
Closes #6487

## Summary

`image.smooth_img` documents that non-finite input values are replaced with zeros, but the surface-image path currently leaves NaN and Inf values in place. This change brings surface images in line with the existing volume behavior.

- Copy each surface data part before replacing non-finite values, so the input `SurfaceImage` is never mutated.
- Apply the cleanup for unsmoothed (`fwhm=None` and `fwhm=0`) and smoothed surface images.
- Add a regression test covering all three paths.

## Testing

- `python -m ruff check nilearn/image/image.py nilearn/image/tests/test_image.py`
- `python -m compileall -q nilearn/image/image.py nilearn/image/tests/test_image.py`
- The focused pytest run is blocked locally because `nibabel` is not installed; CI should provide the full test environment.

## Use of AI tools

- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.
