### PR TITLE
[MAINT] bump minimum pytest to 8.0.0

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -28,8 +28,6 @@ HIGHLIGHTS
 Fixes
 -----
 
-- :bdg-warning:`Test` Bump minimum supported ``pytest`` version to 8.0.0; earlier versions do not correctly report warnings when several ``pytest.warns`` context managers are combined in a single ``with`` statement, which made ``test_resampling_target`` fail spuriously under the ``min`` dependency set (:gh:`6566` by `Rémi Gau`_).
-
 
 Enhancements
 ------------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -28,6 +28,8 @@ HIGHLIGHTS
 Fixes
 -----
 
+- :bdg-warning:`Test` Bump minimum supported ``pytest`` version to 8.0.0; earlier versions do not correctly report warnings when several ``pytest.warns`` context managers are combined in a single ``with`` statement, which made ``test_resampling_target`` fail spuriously under the ``min`` dependency set (:gh:`XXXX` by `Rémi Gau`_).
+
 
 Enhancements
 ------------

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -28,7 +28,7 @@ HIGHLIGHTS
 Fixes
 -----
 
-- :bdg-warning:`Test` Bump minimum supported ``pytest`` version to 8.0.0; earlier versions do not correctly report warnings when several ``pytest.warns`` context managers are combined in a single ``with`` statement, which made ``test_resampling_target`` fail spuriously under the ``min`` dependency set (:gh:`XXXX` by `Rémi Gau`_).
+- :bdg-warning:`Test` Bump minimum supported ``pytest`` version to 8.0.0; earlier versions do not correctly report warnings when several ``pytest.warns`` context managers are combined in a single ``with`` statement, which made ``test_resampling_target`` fail spuriously under the ``min`` dependency set (:gh:`6566` by `Rémi Gau`_).
 
 
 Enhancements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ test = [
 test_common = [
     "numpydoc>=1.8.0",
     "polars>=1.0.0",
-    "pytest>=6.0.0",
+    "pytest>=8.0.0",
     "pytest-csv>=3.0.0",
     "pytest-randomly>=4.0.0",
     "pytest-reporter-html1>=0.9.2,<0.9.4",
@@ -371,7 +371,7 @@ markers = [
     "engines",  # used to specify engines for a test to be selected from available ones
     "mpl_image_compare"  # registered here so --strict-markers works without pytest-mpl installed
 ]
-minversion = "6.0"
+minversion = "8.0"
 testpaths = ["nilearn"]
 xfail_strict = true
 


### PR DESCRIPTION
- Closes #6565

Use of AI tools:
- [x] LLM tools were used to generate at least part of the content of this pull-request.
- [ ] No LLM tools were used to generate any part of the content of this pull-request.

Changes proposed in this pull request:

- Bump the `pytest` floor from `>=6.0.0` to `>=8.0.0` in the `test_common` dependency group and in `[tool.pytest.ini_options] minversion`.
- `tox -e min` resolves dependencies via `uv_resolution = lowest-direct`, so this previously installed `pytest==7.4.0` for the `min` environment.
- `pytest` `7.4.0`-`7.4.4` has a bug: combining two `pytest.warns()` context managers in a single `with (...)` statement causes the first one to silently miss the warning it should have caught, even though the warning genuinely was emitted (fixed starting in `pytest==8.0.0`, confirmed by bisecting releases).
- This made `nilearn/maskers/tests/test_multi_nifti_labels_masker.py::test_resampling_target` fail spuriously under `tox -e min` with `DID NOT WARN`, even though the masker's resampling/warning behavior is correct and identical across environments.
- See #6565 for the full investigation and a minimal reproduction of the underlying `pytest` bug.

## Test plan
- [x] `tox -e min --recreate -- nilearn/maskers/tests/test_multi_nifti_labels_masker.py::test_resampling_target` now installs `pytest==8.0.0` and passes.
- [x] `prek run --all-files` on the changed files.