### PR TITLE
[FIX] Fix flaky test when testing decomposition estimators

### DIFF
--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1630,66 +1630,70 @@ def check_img_estimator_pickle(estimator_orig) -> None:
     if isinstance(estimator_orig, SearchLight) and not is_gil_enabled():
         pytest.xfail("May fail without the GIL")
 
-    estimator = clone(estimator_orig)
+    def clone_and_fit_estimator(estimator_orig):
+        # clone and fit estimator
+        estimator = clone(estimator_orig)
+        X, y = generate_data_to_fit(estimator)
+        set_random_state(estimator)
+        if isinstance(estimator, NiftiSpheresMasker):
+            # NiftiSpheresMasker needs mask_img to run inverse_transform
+            mask_img = new_img_like(X, np.ones(X.shape[:3]))
+            estimator.mask_img = mask_img
+        fitted_estimator = fit_estimator(estimator)
+        return fitted_estimator, X, y
 
-    X, y = generate_data_to_fit(estimator)
+    input_data: list | tuple | np.ndarray
+    for method in [
+        "transform",
+        "predict",
+        "decision_function",
+        "inverse_transform",
+    ]:
+        if hasattr(estimator_orig, method):
+            fitted_estimator, X, y = clone_and_fit_estimator(estimator_orig)
 
-    if isinstance(estimator, NiftiSpheresMasker):
-        # NiftiSpheresMasker needs mask_img to run inverse_transform
-        mask_img = new_img_like(X, np.ones(X.shape[:3]))
-        estimator.mask_img = mask_img
+            if method == "transform":
+                input_data = (
+                    [X]
+                    if isinstance(
+                        estimator_orig, (SearchLight, _BaseDecomposition)
+                    )
+                    else [[X]]
+                )
+            elif method in ["predict", "decision_function"]:
+                input_data = X
+            elif method in "score":
+                input_data = (X, y)
+            elif method == "inverse_transform" and hasattr(
+                estimator_orig, "inverse_transform"
+            ):
+                signal = _rng().random((1, fitted_estimator.n_elements_))
+                if isinstance(estimator_orig, _BaseDecomposition):
+                    signal = [signal]
+                input_data = signal
 
-    set_random_state(estimator)
+            pickled_estimator = pickle.dumps(fitted_estimator)
+            unpickled_estimator = pickle.loads(pickled_estimator)
 
-    fitted_estimator = fit_estimator(estimator)
-
-    pickled_estimator = pickle.dumps(fitted_estimator)
-    unpickled_estimator = pickle.loads(pickled_estimator)
-
-    result = {}
-
-    check_methods = ["transform"]
-    input_data = [X] if isinstance(estimator, SearchLight) else [[X]]
-
-    for method in ["predict", "decision_function"]:
-        check_methods.append(method)
-        input_data.append(X)
-
-    check_methods.append("score")
-    input_data.append((X, y))
-
-    if hasattr(estimator, "inverse_transform"):
-        check_methods.append("inverse_transform")
-        signal = _rng().random((1, fitted_estimator.n_elements_))
-        if isinstance(estimator, _BaseDecomposition):
-            signal = [signal]
-        input_data.append(signal)
-
-    for method, input in zip(check_methods, input_data, strict=False):
-        if hasattr(estimator, method):
-            result["input"] = input
             if method == "score":
-                result[method] = getattr(estimator, method)(*input)
+                result = getattr(fitted_estimator, method)(*input_data)
+                unpickled_result = getattr(unpickled_estimator, method)(
+                    *input_data
+                )
             else:
-                result[method] = getattr(estimator, method)(input)
+                result = getattr(fitted_estimator, method)(input_data)
+                unpickled_result = getattr(unpickled_estimator, method)(
+                    input_data
+                )
 
-    for method, input in zip(check_methods, input_data, strict=False):
-        if method not in result:
-            continue
-
-        if method == "score":
-            unpickled_result = getattr(unpickled_estimator, method)(*input)
-        else:
-            unpickled_result = getattr(unpickled_estimator, method)(input)
-
-        if isinstance(unpickled_result, np.ndarray):
-            assert_allclose_dense_sparse(result[method], unpickled_result)
-        elif isinstance(unpickled_result, SurfaceImage):
-            assert_surface_image_equal(
-                cast(SurfaceImage, result[method]), unpickled_result
-            )
-        elif isinstance(unpickled_result, Nifti1Image):
-            check_imgs_equal(result[method], unpickled_result)
+            if isinstance(unpickled_result, np.ndarray):
+                assert_allclose_dense_sparse(result, unpickled_result)
+            elif isinstance(unpickled_result, SurfaceImage):
+                assert_surface_image_equal(
+                    cast(SurfaceImage, result), unpickled_result
+                )
+            elif isinstance(unpickled_result, Nifti1Image):
+                check_imgs_equal(result, unpickled_result)
 
 
 def check_img_estimator_pipeline_consistency(estimator_orig) -> None:

--- a/nilearn/_utils/estimator_checks.py
+++ b/nilearn/_utils/estimator_checks.py
@@ -1654,11 +1654,7 @@ def check_img_estimator_pickle(estimator_orig) -> None:
 
             if method == "transform":
                 input_data = (
-                    [X]
-                    if isinstance(
-                        estimator_orig, (SearchLight, _BaseDecomposition)
-                    )
-                    else [[X]]
+                    X if isinstance(estimator_orig, SearchLight) else [X]
                 )
             elif method in ["predict", "decision_function"]:
                 input_data = X

--- a/nilearn/decomposition/tests/test_decomposition_estimators.py
+++ b/nilearn/decomposition/tests/test_decomposition_estimators.py
@@ -21,7 +21,10 @@ from nilearn.decomposition.tests.conftest import (
 )
 from nilearn.maskers import NiftiMasker, SurfaceMasker
 
-ESTIMATORS_TO_CHECK = [DictLearning(), CanICA()]
+ESTIMATORS_TO_CHECK = [
+    DictLearning(random_state=RANDOM_STATE),
+    CanICA(random_state=RANDOM_STATE),
+]
 
 
 @parametrize_with_checks(
@@ -33,7 +36,6 @@ def test_check_estimator_sklearn(estimator, check):
     check(estimator)
 
 
-@pytest.mark.flaky(reruns=10, reruns_delay=1)
 @pytest.mark.parametrize(
     "estimator, check, name",
     nilearn_check_estimator(estimators=ESTIMATORS_TO_CHECK),
@@ -400,7 +402,7 @@ def test_with_globbing_patterns(
 
     Only for nifti as we cannot read surface from file.
     """
-    est = estimator(n_components=3)
+    est = estimator(n_components=3, random_state=RANDOM_STATE)
 
     est.fit(canica_data)
 

--- a/nilearn/decomposition/tests/test_decomposition_estimators.py
+++ b/nilearn/decomposition/tests/test_decomposition_estimators.py
@@ -36,6 +36,7 @@ def test_check_estimator_sklearn(estimator, check):
     check(estimator)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "estimator, check, name",
     nilearn_check_estimator(estimators=ESTIMATORS_TO_CHECK),


### PR DESCRIPTION
<!---
This is a suggested pull request template for nilearn.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please make sure your pull request also follows the
[contribution guidelines](https://nilearn.github.io/stable/development.html#contribution-guidelines) that
will be enforced during the review process.
-->

<!-- Please indicate after the # which issue you're closing with this pull request.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
If the pull request closes multiple issues, includes "closes" before each one is listed.
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->
- Closes #6542 

<!-- Please indicate whether LLM tools were used for this pull request
by adding a 'x' in one of the following check box.
Work made with LLM tools has a very different set of typical failure modes
than work done entirely by humans,
it helps others to better trace eventual issues when reviewing the code.
-->
Use of AI tools:
- [ ] LLM tools were used to generate at least part of the content of this pull-request.
- [x] No LLM tools were used to generate any part of the content of this pull-request.

<!-- Please give a brief overview of what has changed in the pull request.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Instantiate estimators in `nilearn.decomposition.tests.test_decomposition_estimators` with random_state to have more deterministic results
- Remove `flaky` mark from `nilearn.decomposition.tests.test_decomposition_estimators.test_check_estimator_nilearn`

Nilearn estimator checks clone the same estimator many times to run the tests. When no `random_state` is specified for the estimator, the clone might have different random_state depending on the order of the tests run. Setting random_state, it is expected to have more deterministic results.
